### PR TITLE
ci: [DEMO – do not merge] MCP tool removed, no migration (PROD-8359 retest)

### DIFF
--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -182,11 +182,17 @@
                     },
                     "type": {
                         "description": "Type of Lightdash content to create.",
-                        "enum": ["dashboard", "chart"],
+                        "enum": [
+                            "dashboard",
+                            "chart"
+                        ],
                         "type": "string"
                     }
                 },
-                "required": ["type", "content"],
+                "required": [
+                    "type",
+                    "content"
+                ],
                 "type": "object"
             },
             "name": "create_content",
@@ -216,11 +222,18 @@
                     },
                     "type": {
                         "description": "Type of Lightdash content to edit",
-                        "enum": ["dashboard", "chart"],
+                        "enum": [
+                            "dashboard",
+                            "chart"
+                        ],
                         "type": "string"
                     }
                 },
-                "required": ["slug", "type", "patch"],
+                "required": [
+                    "slug",
+                    "type",
+                    "patch"
+                ],
                 "type": "object"
             },
             "name": "edit_content",
@@ -233,7 +246,7 @@
                 "idempotentHint": true,
                 "readOnlyHint": true
             },
-            "description": "Tool: \"findContent\"\nPurpose:\nFinds spaces, charts, or dashboards by name or description within a project, returning detailed information about each.\n\nUsage tips:\n- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., \"revenue based on campaigns\" instead of just \"campaigns\").\n- The search engine understands natural language and context — more descriptive queries yield better results.\n- You can provide multiple search queries to look for different topics simultaneously (e.g., [\"monthly revenue\", \"user acquisition trends\"]).\n- Pass spaceSlug to search only inside that space and its descendants.\n- If results aren't relevant, retry with the full user query or more specific terms.\n- Dashboards with validation errors will be deprioritized.\n- Returns space breadcrumb/path metadata and chart/dashboard URLs when available.\n- Dashboards show a preview of the first 5 charts and the total chart count. Use \"getDashboardCharts\" to see all charts for a specific dashboard.\n- It doesn't provide summaries for dashboards yet, so don't suggest this capability.",
+            "description": "Tool: \"findContent\"\nPurpose:\nFinds spaces, charts, or dashboards by name or description within a project, returning detailed information about each.\n\nUsage tips:\n- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., \"revenue based on campaigns\" instead of just \"campaigns\").\n- The search engine understands natural language and context \u2014 more descriptive queries yield better results.\n- You can provide multiple search queries to look for different topics simultaneously (e.g., [\"monthly revenue\", \"user acquisition trends\"]).\n- Pass spaceSlug to search only inside that space and its descendants.\n- If results aren't relevant, retry with the full user query or more specific terms.\n- Dashboards with validation errors will be deprioritized.\n- Returns space breadcrumb/path metadata and chart/dashboard URLs when available.\n- Dashboards show a preview of the first 5 charts and the total chart count. Use \"getDashboardCharts\" to see all charts for a specific dashboard.\n- It doesn't provide summaries for dashboards yet, so don't suggest this capability.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -247,7 +260,9 @@
                                     "type": "string"
                                 }
                             },
-                            "required": ["label"],
+                            "required": [
+                                "label"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
@@ -257,7 +272,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["searchQueries"],
+                "required": [
+                    "searchQueries"
+                ],
                 "type": "object"
             },
             "name": "find_content",
@@ -280,7 +297,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["searchQuery"],
+                "required": [
+                    "searchQuery"
+                ],
                 "type": "object"
             },
             "name": "find_explores",
@@ -293,7 +312,7 @@
                 "idempotentHint": true,
                 "readOnlyHint": true
             },
-            "description": "Tool: \"findFields\"\n\nPurpose:\nFinds the most relevant Fields (Metrics & Dimensions) within Explores, returning detailed info about each.\n\nUsage tips:\n- Use \"findExplores\" first to discover available Explores and their field labels.\n- Use full field labels in search terms (e.g. \"Total Revenue\", \"Order Date\").\n- Pass all needed fields in one request.\n- Fields are sorted by relevance, with a maximum score of 1 and a minimum of 0, so the top results are the most relevant.\n- If results aren't relevant, retry with clearer or more specific terms.\n- Results are paginated — use the next page token to get more results if needed.\n",
+            "description": "Tool: \"findFields\"\n\nPurpose:\nFinds the most relevant Fields (Metrics & Dimensions) within Explores, returning detailed info about each.\n\nUsage tips:\n- Use \"findExplores\" first to discover available Explores and their field labels.\n- Use full field labels in search terms (e.g. \"Total Revenue\", \"Order Date\").\n- Pass all needed fields in one request.\n- Fields are sorted by relevance, with a maximum score of 1 and a minimum of 0, so the top results are the most relevant.\n- If results aren't relevant, retry with clearer or more specific terms.\n- Results are paginated \u2014 use the next page token to get more results if needed.\n",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -307,7 +326,9 @@
                                     "type": "string"
                                 }
                             },
-                            "required": ["label"],
+                            "required": [
+                                "label"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
@@ -322,7 +343,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["table", "fieldSearchQueries"],
+                "required": [
+                    "table",
+                    "fieldSearchQueries"
+                ],
                 "type": "object"
             },
             "name": "find_fields",
@@ -397,7 +421,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["queryUuid"],
+                "required": [
+                    "queryUuid"
+                ],
                 "type": "object"
             },
             "name": "get_query_result",
@@ -466,7 +492,10 @@
                                         "type": "array"
                                     },
                                     "sqlRunnerUrl": {
-                                        "type": ["string", "null"]
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
                                     },
                                     "status": {
                                         "const": "done",
@@ -487,7 +516,10 @@
                                 "additionalProperties": false,
                                 "properties": {
                                     "exploreUrl": {
-                                        "type": ["string", "null"]
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
                                     },
                                     "fields": {
                                         "additionalProperties": {},
@@ -522,7 +554,10 @@
                                 "additionalProperties": false,
                                 "properties": {
                                     "error": {
-                                        "type": ["string", "null"]
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
                                     },
                                     "queryUuid": {
                                         "format": "uuid",
@@ -537,13 +572,19 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["status", "queryUuid", "error"],
+                                "required": [
+                                    "status",
+                                    "queryUuid",
+                                    "error"
+                                ],
                                 "type": "object"
                             }
                         ]
                     }
                 },
-                "required": ["result"],
+                "required": [
+                    "result"
+                ],
                 "type": "object"
             },
             "title": "Get query result"
@@ -732,7 +773,9 @@
                         "type": "array"
                     }
                 },
-                "required": ["skills"],
+                "required": [
+                    "skills"
+                ],
                 "type": "object"
             },
             "title": "List Skills"
@@ -743,7 +786,7 @@
                 "idempotentHint": true,
                 "readOnlyHint": true
             },
-            "description": "List all verified charts and dashboards in the active project. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Requires an active project set via set_project. Each item includes contentType (chart or dashboard), contentUuid, name, space, and verification metadata (who verified it and when).",
+            "description": "List all verified charts and dashboards in the active project. Verified content has been reviewed and marked as trusted \u2014 use this to discover reference examples of sanctioned metrics and visualizations when building new content. Requires an active project set via set_project. Each item includes contentType (chart or dashboard), contentUuid, name, space, and verification metadata (who verified it and when).",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -772,11 +815,17 @@
                     },
                     "type": {
                         "description": "Type of Lightdash content to read.",
-                        "enum": ["dashboard", "chart"],
+                        "enum": [
+                            "dashboard",
+                            "chart"
+                        ],
                         "type": "string"
                     }
                 },
-                "required": ["slug", "type"],
+                "required": [
+                    "slug",
+                    "type"
+                ],
                 "type": "object"
             },
             "name": "read_content",
@@ -799,7 +848,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["name"],
+                "required": [
+                    "name"
+                ],
                 "type": "object"
             },
             "name": "read_skill",
@@ -891,7 +942,10 @@
                         "type": "object"
                     }
                 },
-                "required": ["skill", "body"],
+                "required": [
+                    "skill",
+                    "body"
+                ],
                 "type": "object"
             },
             "title": "Read Skill"
@@ -916,7 +970,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["name", "path"],
+                "required": [
+                    "name",
+                    "path"
+                ],
                 "type": "object"
             },
             "name": "read_skill_resource",
@@ -1011,7 +1068,11 @@
                         "type": "object"
                     }
                 },
-                "required": ["skill", "resource", "body"],
+                "required": [
+                    "skill",
+                    "resource",
+                    "body"
+                ],
                 "type": "object"
             },
             "title": "Read Skill Resource"
@@ -1022,7 +1083,7 @@
                 "idempotentHint": true,
                 "readOnlyHint": true
             },
-            "description": "Render a chart for a completed query result in MCP App-capable clients.\n\nUse this after a query tool or get_query_result returns done and the user wants a visual chart. This tool does not start, poll, or rerun the query. If the query is still running, call get_query_result first. Pass the exact queryUuid that run_metric_query (or get_query_result) returned for this query in the current conversation — it is included in that tool's response as a `queryUuid: <id>` text block. Never invent, guess, or reuse a queryUuid from a different query or session; an unknown id fails with \"not found\". Lightdash loads the completed metric query from query history.\n\nCurrent support: completed run_metric_query results. SQL Runner/run_sql results are not supported by render_chart. Other query result types are rejected until their chart rendering path is implemented.\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: string }] — short render status message.\n- structuredContent: {\n    result: {\n      status: \"done\",\n      queryUuid: string,\n      exploreUrl: string | null,\n      echartsOption: Record<string, unknown> | null // lightweight placeholder; full chart payload is app metadata\n    }\n  }",
+            "description": "Render a chart for a completed query result in MCP App-capable clients.\n\nUse this after a query tool or get_query_result returns done and the user wants a visual chart. This tool does not start, poll, or rerun the query. If the query is still running, call get_query_result first. Pass the exact queryUuid that run_metric_query (or get_query_result) returned for this query in the current conversation \u2014 it is included in that tool's response as a `queryUuid: <id>` text block. Never invent, guess, or reuse a queryUuid from a different query or session; an unknown id fails with \"not found\". Lightdash loads the completed metric query from query history.\n\nCurrent support: completed run_metric_query results. SQL Runner/run_sql results are not supported by render_chart. Other query result types are rejected until their chart rendering path is implemented.\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: string }] \u2014 short render status message.\n- structuredContent: {\n    result: {\n      status: \"done\",\n      queryUuid: string,\n      exploreUrl: string | null,\n      echartsOption: Record<string, unknown> | null // lightweight placeholder; full chart payload is app metadata\n    }\n  }",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -1047,7 +1108,10 @@
                             },
                             "funnelDataInput": {
                                 "description": "How to interpret funnel data. Use \"row\" when each row represents a funnel stage (most common). Use \"column\" when comparing multiple funnels side-by-side., ",
-                                "enum": ["row", "column"],
+                                "enum": [
+                                    "row",
+                                    "column"
+                                ],
                                 "type": "string"
                             },
                             "groupBy": {
@@ -1060,7 +1124,10 @@
                             },
                             "lineType": {
                                 "description": "default line. The type of line to display. If area then the area under the line will be filled in., ",
-                                "enum": ["line", "area"],
+                                "enum": [
+                                    "line",
+                                    "area"
+                                ],
                                 "type": "string"
                             },
                             "secondaryYAxisLabel": {
@@ -1085,7 +1152,10 @@
                             },
                             "xAxisType": {
                                 "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts., ",
-                                "enum": ["category", "time"],
+                                "enum": [
+                                    "category",
+                                    "time"
+                                ],
                                 "type": "string"
                             },
                             "yAxisLabel": {
@@ -1122,7 +1192,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["queryUuid"],
+                "required": [
+                    "queryUuid"
+                ],
                 "type": "object"
             },
             "name": "render_chart",
@@ -1143,7 +1215,10 @@
                                 ]
                             },
                             "exploreUrl": {
-                                "type": ["string", "null"]
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
                             },
                             "queryUuid": {
                                 "format": "uuid",
@@ -1154,11 +1229,17 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["status", "queryUuid", "exploreUrl"],
+                        "required": [
+                            "status",
+                            "queryUuid",
+                            "exploreUrl"
+                        ],
                         "type": "object"
                     }
                 },
-                "required": ["result"],
+                "required": [
+                    "result"
+                ],
                 "type": "object"
             },
             "title": "Render chart"
@@ -1181,7 +1262,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["prompt"],
+                "required": [
+                    "prompt"
+                ],
                 "type": "object"
             },
             "name": "route_agent",
@@ -1190,7 +1273,10 @@
                 "additionalProperties": false,
                 "properties": {
                     "agentDescription": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     },
                     "agentName": {
                         "type": "string"
@@ -1228,19 +1314,30 @@
                                     "type": "string"
                                 },
                                 "description": {
-                                    "type": ["string", "null"]
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
                                 },
                                 "name": {
                                     "type": "string"
                                 }
                             },
-                            "required": ["agentUuid", "name", "description"],
+                            "required": [
+                                "agentUuid",
+                                "name",
+                                "description"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
                     },
                     "confidence": {
-                        "enum": ["high", "medium", "low"],
+                        "enum": [
+                            "high",
+                            "medium",
+                            "low"
+                        ],
                         "type": "string"
                     },
                     "explores": {
@@ -1250,7 +1347,10 @@
                         "type": "array"
                     },
                     "instruction": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     },
                     "reasoning": {
                         "type": "string"
@@ -1286,7 +1386,7 @@
                 "idempotentHint": false,
                 "readOnlyHint": false
             },
-            "description": "Tool: run_ai_writeback\n\nPurpose:\nMake a change to the dbt project that backs the active Lightdash project by describing it in natural language, then open a pull request with the result. The target GitHub repository and dbt sub-folder are resolved server-side from the active project's dbt connection — you never specify them.\n\nHow it works:\n- A sandbox is created, the project's GitHub repository is cloned, and the prompt is executed by the Claude Code CLI against the dbt project.\n- If the agent changes any files, a branch is committed, pushed, and a pull request is opened. The PR URL is returned.\n- If the agent makes no file changes, no PR is opened and prUrl is null.\n\nRequirements:\n- An active project must be set first via set_project (or the X-Lightdash-Project header).\n- The project's dbt connection must be GitHub-backed, and the organization must have the GitHub App installed.\n- The AI writeback feature must be enabled for the organization.\n\nImportant:\n- This tool is NOT read-only and NOT idempotent — each call can open a new pull request. Use it only when the user explicitly wants to change their dbt project.\n- The run is synchronous and can take a few minutes (cloning, running the agent, opening the PR).\n\nParameters:\n- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. \"Add a 'total_revenue' metric to the orders model as the sum of amount\").\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: \"<human-readable summary including the PR URL>\" }]\n- structuredContent: {\n    output:   string,           // the agent's text output\n    exitCode: number,           // the sandbox command's exit status\n    prUrl:    string | null     // URL of the opened pull request, or null when no changes were made\n  }\n",
+            "description": "Tool: run_ai_writeback\n\nPurpose:\nMake a change to the dbt project that backs the active Lightdash project by describing it in natural language, then open a pull request with the result. The target GitHub repository and dbt sub-folder are resolved server-side from the active project's dbt connection \u2014 you never specify them.\n\nHow it works:\n- A sandbox is created, the project's GitHub repository is cloned, and the prompt is executed by the Claude Code CLI against the dbt project.\n- If the agent changes any files, a branch is committed, pushed, and a pull request is opened. The PR URL is returned.\n- If the agent makes no file changes, no PR is opened and prUrl is null.\n\nRequirements:\n- An active project must be set first via set_project (or the X-Lightdash-Project header).\n- The project's dbt connection must be GitHub-backed, and the organization must have the GitHub App installed.\n- The AI writeback feature must be enabled for the organization.\n\nImportant:\n- This tool is NOT read-only and NOT idempotent \u2014 each call can open a new pull request. Use it only when the user explicitly wants to change their dbt project.\n- The run is synchronous and can take a few minutes (cloning, running the agent, opening the PR).\n\nParameters:\n- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. \"Add a 'total_revenue' metric to the orders model as the sum of amount\").\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: \"<human-readable summary including the PR URL>\" }]\n- structuredContent: {\n    output:   string,           // the agent's text output\n    exitCode: number,           // the sandbox command's exit status\n    prUrl:    string | null     // URL of the opened pull request, or null when no changes were made\n  }\n",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -1297,7 +1397,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["prompt"],
+                "required": [
+                    "prompt"
+                ],
                 "type": "object"
             },
             "name": "run_ai_writeback",
@@ -1315,10 +1417,17 @@
                     },
                     "prUrl": {
                         "description": "URL of the pull request opened from the agent changes, or null when the agent made no file changes.",
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
-                "required": ["output", "exitCode", "prUrl"],
+                "required": [
+                    "output",
+                    "exitCode",
+                    "prUrl"
+                ],
                 "type": "object"
             },
             "title": "Run AI writeback"
@@ -1329,3202 +1438,7 @@
                 "idempotentHint": true,
                 "readOnlyHint": true
             },
-            "description": "Execute a metric query.\n\nThis tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.\n- If the query finishes before the MCP wait window, structuredContent: {\n    result: {\n      status: \"done\",\n      queryUuid: string,\n      rows: Array<Record<string, unknown>>,\n      fields: Record<string, unknown>,\n      exploreUrl: string | null\n    }\n  }\n- If the query is still running, structuredContent: {\n    result: {\n      status: \"running\",\n      queryUuid: string,\n      nextPollAfterMs: number,\n      heartbeatAt: string\n    }\n  }\n  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.\n\nNotes:\n- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.\n- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.\n- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.\n",
-            "inputSchema": {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "additionalProperties": false,
-                "properties": {
-                    "chartConfig": {
-                        "additionalProperties": false,
-                        "description": ", ",
-                        "properties": {
-                            "defaultVizType": {
-                                "description": "The default visualization type to render",
-                                "enum": [
-                                    "table",
-                                    "bar",
-                                    "horizontal",
-                                    "line",
-                                    "scatter",
-                                    "pie",
-                                    "funnel"
-                                ],
-                                "type": "string"
-                            },
-                            "funnelDataInput": {
-                                "description": "How to interpret funnel data. Use \"row\" when each row represents a funnel stage (most common). Use \"column\" when comparing multiple funnels side-by-side., ",
-                                "enum": ["row", "column"],
-                                "type": "string"
-                            },
-                            "groupBy": {
-                                "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=[\"order_date\", \"status\"], groupBy=[\"status\"] creates separate series for each status value. Leave null for simple single-series charts., ",
-                                "items": {
-                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            "lineType": {
-                                "description": "default line. The type of line to display. If area then the area under the line will be filled in., ",
-                                "enum": ["line", "area"],
-                                "type": "string"
-                            },
-                            "secondaryYAxisLabel": {
-                                "description": "A helpful label for the secondary y-axis, ",
-                                "type": "string"
-                            },
-                            "secondaryYAxisMetric": {
-                                "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count)., ",
-                                "type": "string"
-                            },
-                            "stackBars": {
-                                "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts., ",
-                                "type": "boolean"
-                            },
-                            "xAxisDimension": {
-                                "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions, ",
-                                "type": "string"
-                            },
-                            "xAxisLabel": {
-                                "description": "A helpful label to explain the x-axis",
-                                "type": "string"
-                            },
-                            "xAxisType": {
-                                "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts., ",
-                                "enum": ["category", "time"],
-                                "type": "string"
-                            },
-                            "yAxisLabel": {
-                                "description": "A helpful label to explain the y-axis",
-                                "type": "string"
-                            },
-                            "yAxisMetrics": {
-                                "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations, ",
-                                "items": {
-                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": [
-                            "defaultVizType",
-                            "xAxisLabel",
-                            "yAxisLabel"
-                        ],
-                        "type": "object"
-                    },
-                    "description": {
-                        "description": "A descriptive summary or explanation for the chart.",
-                        "type": "string"
-                    },
-                    "queryConfig": {
-                        "additionalProperties": false,
-                        "properties": {
-                            "customMetrics": {
-                                "description": "Define new metric columns the explore doesn't already have. Two kinds:\n\n(1) kind: \"aggregation\" — a NEW metric built by aggregating a base dimension\n    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).\n    Use when the requested metric doesn't exist in the explore.\n\n(2) kind: \"periodComparison\" — a column that is an EXISTING metric shifted\n    back in time. Use whenever the user asks for \"year-over-year\",\n    \"month-over-month\", \"vs last quarter\", \"compare to previous period\",\n    \"N periods ago\".\n\nFor period comparisons, every successful chart has three things:\n- The time dimension in queryConfig.dimensions\n- The base metric in queryConfig.metrics\n- A customMetric of kind \"periodComparison\" pointing at that base metric and time dimension\n\nThe server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.\n\nDO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: \"periodComparison\" customMetric.\n\nFor aggregation entries:\n1. Add the entry to customMetrics with kind: \"aggregation\"\n2. Reference it in queryConfig.metrics using the format \"table_name\" (e.g. \"customers_avg_customer_age\")\n3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics\n\nExample A — \"Average customer age sorted descending\"\n  customMetrics: [{ kind: \"aggregation\", name: \"avg_customer_age\", label: \"Average Customer Age\", description: \"...\", type: \"AVERAGE\", baseDimensionName: \"age\", table: \"customers\", filters: null }]\n  queryConfig.metrics: [\"customers_avg_customer_age\"]\n  sorts: [{ fieldId: \"customers_avg_customer_age\", descending: true }]\n\nExample B — \"Revenue by month with year-over-year comparison\"\n  queryConfig.dimensions: [\"orders_order_date_month\"]\n  queryConfig.metrics: [\"orders_revenue\"]\n  customMetrics: [{ kind: \"periodComparison\", baseMetricId: \"orders_revenue\", timeDimensionId: \"orders_order_date_month\", granularity: \"MONTH\", periodOffset: 12 }], ",
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "baseDimensionName": {
-                                                    "description": "Name of the base dimension/column this metric calculates from",
-                                                    "type": "string"
-                                                },
-                                                "description": {
-                                                    "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
-                                                    "type": "string"
-                                                },
-                                                "filters": {
-                                                    "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name., ",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "filter": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"isNull\"}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notNull\"}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "boolean",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "boolean"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use isNull for missing values, notNull for present values.",
-                                                                                        "enum": [
-                                                                                            "isNull",
-                                                                                            "notNull"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for boolean fields when matching or excluding true/false values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"equals\",\"values\":[true]}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notEquals\",\"values\":[false]}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "boolean",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "boolean"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use equals/notEquals to match true or false.",
-                                                                                        "enum": [
-                                                                                            "equals",
-                                                                                            "notEquals"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "Exactly one boolean value, e.g. [true] or [false].",
-                                                                                        "items": {
-                                                                                            "type": "boolean"
-                                                                                        },
-                                                                                        "maxItems": 1,
-                                                                                        "minItems": 1,
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notNull\"}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "string",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "string"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use isNull for missing values, notNull for present values.",
-                                                                                        "enum": [
-                                                                                            "isNull",
-                                                                                            "notNull"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"equals\",\"values\":[\"complete\",\"paid\"]}; {\"fieldId\":\"customers_email\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"include\",\"values\":[\"@lightdash.com\"]}; {\"fieldId\":\"products_sku\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"startsWith\",\"values\":[\"SKU-\"]}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notEquals\",\"values\":[\"cancelled\"]}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "string",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "string"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
-                                                                                        "enum": [
-                                                                                            "equals",
-                                                                                            "notEquals",
-                                                                                            "startsWith",
-                                                                                            "endsWith",
-                                                                                            "include",
-                                                                                            "doesNotInclude"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "String values to match. Do not put natural-language date ranges here.",
-                                                                                        "items": {
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "number",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "number",
-                                                                                            "percentile",
-                                                                                            "median",
-                                                                                            "average",
-                                                                                            "count",
-                                                                                            "count_distinct",
-                                                                                            "sum",
-                                                                                            "sum_distinct",
-                                                                                            "average_distinct",
-                                                                                            "min",
-                                                                                            "max"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use isNull for missing values, notNull for present values.",
-                                                                                        "enum": [
-                                                                                            "isNull",
-                                                                                            "notNull"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "number",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "number",
-                                                                                            "percentile",
-                                                                                            "median",
-                                                                                            "average",
-                                                                                            "count",
-                                                                                            "count_distinct",
-                                                                                            "sum",
-                                                                                            "sum_distinct",
-                                                                                            "average_distinct",
-                                                                                            "min",
-                                                                                            "max"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use equals/notEquals for exact numeric matches.",
-                                                                                        "enum": [
-                                                                                            "equals",
-                                                                                            "notEquals"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "One or more exact numeric values to match.",
-                                                                                        "items": {
-                                                                                            "type": "number"
-                                                                                        },
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "number",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "number",
-                                                                                            "percentile",
-                                                                                            "median",
-                                                                                            "average",
-                                                                                            "count",
-                                                                                            "count_distinct",
-                                                                                            "sum",
-                                                                                            "sum_distinct",
-                                                                                            "average_distinct",
-                                                                                            "min",
-                                                                                            "max"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use for threshold comparisons such as greater than 100.",
-                                                                                        "enum": [
-                                                                                            "lessThan",
-                                                                                            "lessThanOrEqual",
-                                                                                            "greaterThan",
-                                                                                            "greaterThanOrEqual"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "Exactly one numeric threshold value.",
-                                                                                        "items": {
-                                                                                            "type": "number"
-                                                                                        },
-                                                                                        "maxItems": 1,
-                                                                                        "minItems": 1,
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "number",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "number",
-                                                                                            "percentile",
-                                                                                            "median",
-                                                                                            "average",
-                                                                                            "count",
-                                                                                            "count_distinct",
-                                                                                            "sum",
-                                                                                            "sum_distinct",
-                                                                                            "average_distinct",
-                                                                                            "min",
-                                                                                            "max"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use for ranges between two numeric bounds.",
-                                                                                        "enum": [
-                                                                                            "inBetween",
-                                                                                            "notInBetween"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "Exactly two numeric bounds: [lower, upper].",
-                                                                                        "items": {
-                                                                                            "type": "number"
-                                                                                        },
-                                                                                        "maxItems": 2,
-                                                                                        "minItems": 2,
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notNull\"}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "date",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "date",
-                                                                                            "timestamp"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use isNull for missing dates, notNull for present dates.",
-                                                                                        "enum": [
-                                                                                            "isNull",
-                                                                                            "notNull"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"equals\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notEquals\",\"values\":[\"2024-01-01T00:00:00Z\"]}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "date",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "date",
-                                                                                            "timestamp"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use equals/notEquals for explicit dates or datetimes.",
-                                                                                        "enum": [
-                                                                                            "equals",
-                                                                                            "notEquals"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "One or more explicit ISO dates/datetimes.",
-                                                                                        "items": {
-                                                                                            "anyOf": [
-                                                                                                {
-                                                                                                    "format": "date",
-                                                                                                    "type": "string"
-                                                                                                },
-                                                                                                {
-                                                                                                    "format": "date-time",
-                                                                                                    "type": "string"
-                                                                                                }
-                                                                                            ],
-                                                                                            "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                                        },
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[2],\"settings\":{\"completed\":false,\"unitOfTime\":\"weeks\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[3],\"settings\":{\"completed\":true,\"unitOfTime\":\"months\"}}; {\"fieldId\":\"orders_ship_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheNext\",\"values\":[14],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInThePast\",\"values\":[7],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "date",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "date",
-                                                                                            "timestamp"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
-                                                                                        "enum": [
-                                                                                            "inThePast",
-                                                                                            "notInThePast",
-                                                                                            "inTheNext"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "settings": {
-                                                                                        "additionalProperties": false,
-                                                                                        "description": "Relative period settings.",
-                                                                                        "properties": {
-                                                                                            "completed": {
-                                                                                                "description": "false for rolling periods including the current partial period; true for completed periods only.",
-                                                                                                "type": "boolean"
-                                                                                            },
-                                                                                            "unitOfTime": {
-                                                                                                "description": "Period unit for the relative date filter.",
-                                                                                                "enum": [
-                                                                                                    "days",
-                                                                                                    "weeks",
-                                                                                                    "months",
-                                                                                                    "quarters",
-                                                                                                    "years"
-                                                                                                ],
-                                                                                                "type": "string"
-                                                                                            }
-                                                                                        },
-                                                                                        "required": [
-                                                                                            "completed",
-                                                                                            "unitOfTime"
-                                                                                        ],
-                                                                                        "type": "object"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "Exactly one positive number of periods, e.g. [2].",
-                                                                                        "items": {
-                                                                                            "type": "number"
-                                                                                        },
-                                                                                        "maxItems": 1,
-                                                                                        "minItems": 1,
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values",
-                                                                                    "settings"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"months\"}}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "date",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "date",
-                                                                                            "timestamp"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use for this/current period or to exclude this/current period.",
-                                                                                        "enum": [
-                                                                                            "inTheCurrent",
-                                                                                            "notInTheCurrent"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "settings": {
-                                                                                        "additionalProperties": false,
-                                                                                        "description": "Current-period settings.",
-                                                                                        "properties": {
-                                                                                            "completed": {
-                                                                                                "const": false,
-                                                                                                "description": "Always false for current-period filters.",
-                                                                                                "type": "boolean"
-                                                                                            },
-                                                                                            "unitOfTime": {
-                                                                                                "description": "Current period unit, e.g. weeks for this week.",
-                                                                                                "enum": [
-                                                                                                    "days",
-                                                                                                    "weeks",
-                                                                                                    "months",
-                                                                                                    "quarters",
-                                                                                                    "years"
-                                                                                                ],
-                                                                                                "type": "string"
-                                                                                            }
-                                                                                        },
-                                                                                        "required": [
-                                                                                            "completed",
-                                                                                            "unitOfTime"
-                                                                                        ],
-                                                                                        "type": "object"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "Always [1] for current-period filters.",
-                                                                                        "items": {
-                                                                                            "const": 1,
-                                                                                            "type": "number"
-                                                                                        },
-                                                                                        "maxItems": 1,
-                                                                                        "minItems": 1,
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values",
-                                                                                    "settings"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"greaterThanOrEqual\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"lessThan\",\"values\":[\"2024-02-01T00:00:00Z\"]}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "date",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "date",
-                                                                                            "timestamp"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "description": "Use for before/after comparisons against one explicit date or datetime.",
-                                                                                        "enum": [
-                                                                                            "lessThan",
-                                                                                            "lessThanOrEqual",
-                                                                                            "greaterThan",
-                                                                                            "greaterThanOrEqual"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "Exactly one explicit ISO date/datetime threshold.",
-                                                                                        "items": {
-                                                                                            "anyOf": [
-                                                                                                {
-                                                                                                    "format": "date",
-                                                                                                    "type": "string"
-                                                                                                },
-                                                                                                {
-                                                                                                    "format": "date-time",
-                                                                                                    "type": "string"
-                                                                                                }
-                                                                                            ],
-                                                                                            "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                                        },
-                                                                                        "maxItems": 1,
-                                                                                        "minItems": 1,
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            {
-                                                                                "additionalProperties": false,
-                                                                                "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01\",\"2024-01-31\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01T00:00:00Z\",\"2024-01-31T23:59:59Z\"]}",
-                                                                                "properties": {
-                                                                                    "fieldFilterType": {
-                                                                                        "const": "date",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldId": {
-                                                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "enum": [
-                                                                                            "date",
-                                                                                            "timestamp"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "const": "inBetween",
-                                                                                        "description": "Use for explicit date ranges between two dates/datetimes.",
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "values": {
-                                                                                        "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
-                                                                                        "items": {
-                                                                                            "anyOf": [
-                                                                                                {
-                                                                                                    "format": "date",
-                                                                                                    "type": "string"
-                                                                                                },
-                                                                                                {
-                                                                                                    "format": "date-time",
-                                                                                                    "type": "string"
-                                                                                                }
-                                                                                            ],
-                                                                                            "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                                        },
-                                                                                        "maxItems": 2,
-                                                                                        "minItems": 2,
-                                                                                        "type": "array"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "fieldId",
-                                                                                    "fieldType",
-                                                                                    "fieldFilterType",
-                                                                                    "operator",
-                                                                                    "values"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            }
-                                                                        ]
-                                                                    }
-                                                                ]
-                                                            },
-                                                            "table": {
-                                                                "description": "Table name this filter field belongs to",
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "filter",
-                                                            "table"
-                                                        ],
-                                                        "type": "object"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "kind": {
-                                                    "const": "aggregation",
-                                                    "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. \"average customer age\", \"count of completed orders\").",
-                                                    "type": "string"
-                                                },
-                                                "label": {
-                                                    "description": "Human-readable label for the metric (e.g., \"Average Customer Age\", \"Total Revenue\")",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique metric name using snake_case (e.g., \"avg_customer_age\", \"total_revenue\")",
-                                                    "type": "string"
-                                                },
-                                                "table": {
-                                                    "description": "Table name where the base column exists. Match with available dimensions in the explore.",
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
-                                                    "enum": [
-                                                        "average",
-                                                        "count",
-                                                        "count_distinct",
-                                                        "max",
-                                                        "min",
-                                                        "sum",
-                                                        "percentile",
-                                                        "median"
-                                                    ],
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "kind",
-                                                "name",
-                                                "label",
-                                                "description",
-                                                "baseDimensionName",
-                                                "table",
-                                                "type"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "baseMetricId": {
-                                                    "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: \"table_metric_name\".",
-                                                    "type": "string"
-                                                },
-                                                "granularity": {
-                                                    "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
-                                                    "enum": [
-                                                        "DAY",
-                                                        "WEEK",
-                                                        "MONTH",
-                                                        "QUARTER",
-                                                        "YEAR"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "kind": {
-                                                    "const": "periodComparison",
-                                                    "description": "Custom metric that compares a base metric against itself shifted back in time. Use for \"month-over-month\", \"year-over-year\", \"vs last quarter\", \"compared to N periods ago\".",
-                                                    "type": "string"
-                                                },
-                                                "periodOffset": {
-                                                    "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "timeDimensionId": {
-                                                    "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: \"table_column_granularity\" — the suffix encodes the bucket (e.g. \"..._month\" → MONTH bucket).",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "kind",
-                                                "baseMetricId",
-                                                "timeDimensionId",
-                                                "granularity",
-                                                "periodOffset"
-                                            ],
-                                            "type": "object"
-                                        }
-                                    ]
-                                },
-                                "type": "array"
-                            },
-                            "dimensions": {
-                                "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
-                                "items": {
-                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            "exploreName": {
-                                "description": "The name of the explore containing the metrics and dimensions used for the chart.",
-                                "type": "string"
-                            },
-                            "filters": {
-                                "additionalProperties": false,
-                                "description": ", ",
-                                "properties": {
-                                    "dimensions": {
-                                        "description": ", ",
-                                        "items": {
-                                            "anyOf": [
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"isNull\"}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notNull\"}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "boolean",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "boolean"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use isNull for missing values, notNull for present values.",
-                                                                    "enum": [
-                                                                        "isNull",
-                                                                        "notNull"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for boolean fields when matching or excluding true/false values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"equals\",\"values\":[true]}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notEquals\",\"values\":[false]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "boolean",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "boolean"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use equals/notEquals to match true or false.",
-                                                                    "enum": [
-                                                                        "equals",
-                                                                        "notEquals"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly one boolean value, e.g. [true] or [false].",
-                                                                    "items": {
-                                                                        "type": "boolean"
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notNull\"}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "string",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "string"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use isNull for missing values, notNull for present values.",
-                                                                    "enum": [
-                                                                        "isNull",
-                                                                        "notNull"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"equals\",\"values\":[\"complete\",\"paid\"]}; {\"fieldId\":\"customers_email\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"include\",\"values\":[\"@lightdash.com\"]}; {\"fieldId\":\"products_sku\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"startsWith\",\"values\":[\"SKU-\"]}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notEquals\",\"values\":[\"cancelled\"]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "string",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "string"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
-                                                                    "enum": [
-                                                                        "equals",
-                                                                        "notEquals",
-                                                                        "startsWith",
-                                                                        "endsWith",
-                                                                        "include",
-                                                                        "doesNotInclude"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "String values to match. Do not put natural-language date ranges here.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "number",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "number",
-                                                                        "percentile",
-                                                                        "median",
-                                                                        "average",
-                                                                        "count",
-                                                                        "count_distinct",
-                                                                        "sum",
-                                                                        "sum_distinct",
-                                                                        "average_distinct",
-                                                                        "min",
-                                                                        "max"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use isNull for missing values, notNull for present values.",
-                                                                    "enum": [
-                                                                        "isNull",
-                                                                        "notNull"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "number",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "number",
-                                                                        "percentile",
-                                                                        "median",
-                                                                        "average",
-                                                                        "count",
-                                                                        "count_distinct",
-                                                                        "sum",
-                                                                        "sum_distinct",
-                                                                        "average_distinct",
-                                                                        "min",
-                                                                        "max"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use equals/notEquals for exact numeric matches.",
-                                                                    "enum": [
-                                                                        "equals",
-                                                                        "notEquals"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "One or more exact numeric values to match.",
-                                                                    "items": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "number",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "number",
-                                                                        "percentile",
-                                                                        "median",
-                                                                        "average",
-                                                                        "count",
-                                                                        "count_distinct",
-                                                                        "sum",
-                                                                        "sum_distinct",
-                                                                        "average_distinct",
-                                                                        "min",
-                                                                        "max"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use for threshold comparisons such as greater than 100.",
-                                                                    "enum": [
-                                                                        "lessThan",
-                                                                        "lessThanOrEqual",
-                                                                        "greaterThan",
-                                                                        "greaterThanOrEqual"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly one numeric threshold value.",
-                                                                    "items": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "number",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "number",
-                                                                        "percentile",
-                                                                        "median",
-                                                                        "average",
-                                                                        "count",
-                                                                        "count_distinct",
-                                                                        "sum",
-                                                                        "sum_distinct",
-                                                                        "average_distinct",
-                                                                        "min",
-                                                                        "max"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use for ranges between two numeric bounds.",
-                                                                    "enum": [
-                                                                        "inBetween",
-                                                                        "notInBetween"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly two numeric bounds: [lower, upper].",
-                                                                    "items": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "maxItems": 2,
-                                                                    "minItems": 2,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notNull\"}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use isNull for missing dates, notNull for present dates.",
-                                                                    "enum": [
-                                                                        "isNull",
-                                                                        "notNull"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"equals\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notEquals\",\"values\":[\"2024-01-01T00:00:00Z\"]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use equals/notEquals for explicit dates or datetimes.",
-                                                                    "enum": [
-                                                                        "equals",
-                                                                        "notEquals"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "One or more explicit ISO dates/datetimes.",
-                                                                    "items": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "format": "date",
-                                                                                "type": "string"
-                                                                            },
-                                                                            {
-                                                                                "format": "date-time",
-                                                                                "type": "string"
-                                                                            }
-                                                                        ],
-                                                                        "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                    },
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[2],\"settings\":{\"completed\":false,\"unitOfTime\":\"weeks\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[3],\"settings\":{\"completed\":true,\"unitOfTime\":\"months\"}}; {\"fieldId\":\"orders_ship_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheNext\",\"values\":[14],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInThePast\",\"values\":[7],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
-                                                                    "enum": [
-                                                                        "inThePast",
-                                                                        "notInThePast",
-                                                                        "inTheNext"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "settings": {
-                                                                    "additionalProperties": false,
-                                                                    "description": "Relative period settings.",
-                                                                    "properties": {
-                                                                        "completed": {
-                                                                            "description": "false for rolling periods including the current partial period; true for completed periods only.",
-                                                                            "type": "boolean"
-                                                                        },
-                                                                        "unitOfTime": {
-                                                                            "description": "Period unit for the relative date filter.",
-                                                                            "enum": [
-                                                                                "days",
-                                                                                "weeks",
-                                                                                "months",
-                                                                                "quarters",
-                                                                                "years"
-                                                                            ],
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "completed",
-                                                                        "unitOfTime"
-                                                                    ],
-                                                                    "type": "object"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly one positive number of periods, e.g. [2].",
-                                                                    "items": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values",
-                                                                "settings"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"months\"}}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use for this/current period or to exclude this/current period.",
-                                                                    "enum": [
-                                                                        "inTheCurrent",
-                                                                        "notInTheCurrent"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "settings": {
-                                                                    "additionalProperties": false,
-                                                                    "description": "Current-period settings.",
-                                                                    "properties": {
-                                                                        "completed": {
-                                                                            "const": false,
-                                                                            "description": "Always false for current-period filters.",
-                                                                            "type": "boolean"
-                                                                        },
-                                                                        "unitOfTime": {
-                                                                            "description": "Current period unit, e.g. weeks for this week.",
-                                                                            "enum": [
-                                                                                "days",
-                                                                                "weeks",
-                                                                                "months",
-                                                                                "quarters",
-                                                                                "years"
-                                                                            ],
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "completed",
-                                                                        "unitOfTime"
-                                                                    ],
-                                                                    "type": "object"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Always [1] for current-period filters.",
-                                                                    "items": {
-                                                                        "const": 1,
-                                                                        "type": "number"
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values",
-                                                                "settings"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"greaterThanOrEqual\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"lessThan\",\"values\":[\"2024-02-01T00:00:00Z\"]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use for before/after comparisons against one explicit date or datetime.",
-                                                                    "enum": [
-                                                                        "lessThan",
-                                                                        "lessThanOrEqual",
-                                                                        "greaterThan",
-                                                                        "greaterThanOrEqual"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly one explicit ISO date/datetime threshold.",
-                                                                    "items": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "format": "date",
-                                                                                "type": "string"
-                                                                            },
-                                                                            {
-                                                                                "format": "date-time",
-                                                                                "type": "string"
-                                                                            }
-                                                                        ],
-                                                                        "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01\",\"2024-01-31\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01T00:00:00Z\",\"2024-01-31T23:59:59Z\"]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "const": "inBetween",
-                                                                    "description": "Use for explicit date ranges between two dates/datetimes.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
-                                                                    "items": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "format": "date",
-                                                                                "type": "string"
-                                                                            },
-                                                                            {
-                                                                                "format": "date-time",
-                                                                                "type": "string"
-                                                                            }
-                                                                        ],
-                                                                        "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                    },
-                                                                    "maxItems": 2,
-                                                                    "minItems": 2,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "type": "array"
-                                    },
-                                    "metrics": {
-                                        "description": ", ",
-                                        "items": {
-                                            "anyOf": [
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"isNull\"}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notNull\"}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "boolean",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "boolean"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use isNull for missing values, notNull for present values.",
-                                                                    "enum": [
-                                                                        "isNull",
-                                                                        "notNull"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for boolean fields when matching or excluding true/false values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"equals\",\"values\":[true]}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notEquals\",\"values\":[false]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "boolean",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "boolean"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use equals/notEquals to match true or false.",
-                                                                    "enum": [
-                                                                        "equals",
-                                                                        "notEquals"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly one boolean value, e.g. [true] or [false].",
-                                                                    "items": {
-                                                                        "type": "boolean"
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notNull\"}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "string",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "string"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use isNull for missing values, notNull for present values.",
-                                                                    "enum": [
-                                                                        "isNull",
-                                                                        "notNull"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"equals\",\"values\":[\"complete\",\"paid\"]}; {\"fieldId\":\"customers_email\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"include\",\"values\":[\"@lightdash.com\"]}; {\"fieldId\":\"products_sku\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"startsWith\",\"values\":[\"SKU-\"]}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notEquals\",\"values\":[\"cancelled\"]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "string",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "string"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
-                                                                    "enum": [
-                                                                        "equals",
-                                                                        "notEquals",
-                                                                        "startsWith",
-                                                                        "endsWith",
-                                                                        "include",
-                                                                        "doesNotInclude"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "String values to match. Do not put natural-language date ranges here.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "number",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "number",
-                                                                        "percentile",
-                                                                        "median",
-                                                                        "average",
-                                                                        "count",
-                                                                        "count_distinct",
-                                                                        "sum",
-                                                                        "sum_distinct",
-                                                                        "average_distinct",
-                                                                        "min",
-                                                                        "max"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use isNull for missing values, notNull for present values.",
-                                                                    "enum": [
-                                                                        "isNull",
-                                                                        "notNull"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "number",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "number",
-                                                                        "percentile",
-                                                                        "median",
-                                                                        "average",
-                                                                        "count",
-                                                                        "count_distinct",
-                                                                        "sum",
-                                                                        "sum_distinct",
-                                                                        "average_distinct",
-                                                                        "min",
-                                                                        "max"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use equals/notEquals for exact numeric matches.",
-                                                                    "enum": [
-                                                                        "equals",
-                                                                        "notEquals"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "One or more exact numeric values to match.",
-                                                                    "items": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "number",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "number",
-                                                                        "percentile",
-                                                                        "median",
-                                                                        "average",
-                                                                        "count",
-                                                                        "count_distinct",
-                                                                        "sum",
-                                                                        "sum_distinct",
-                                                                        "average_distinct",
-                                                                        "min",
-                                                                        "max"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use for threshold comparisons such as greater than 100.",
-                                                                    "enum": [
-                                                                        "lessThan",
-                                                                        "lessThanOrEqual",
-                                                                        "greaterThan",
-                                                                        "greaterThanOrEqual"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly one numeric threshold value.",
-                                                                    "items": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "number",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "number",
-                                                                        "percentile",
-                                                                        "median",
-                                                                        "average",
-                                                                        "count",
-                                                                        "count_distinct",
-                                                                        "sum",
-                                                                        "sum_distinct",
-                                                                        "average_distinct",
-                                                                        "min",
-                                                                        "max"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use for ranges between two numeric bounds.",
-                                                                    "enum": [
-                                                                        "inBetween",
-                                                                        "notInBetween"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly two numeric bounds: [lower, upper].",
-                                                                    "items": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "maxItems": 2,
-                                                                    "minItems": 2,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notNull\"}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use isNull for missing dates, notNull for present dates.",
-                                                                    "enum": [
-                                                                        "isNull",
-                                                                        "notNull"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"equals\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notEquals\",\"values\":[\"2024-01-01T00:00:00Z\"]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use equals/notEquals for explicit dates or datetimes.",
-                                                                    "enum": [
-                                                                        "equals",
-                                                                        "notEquals"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "One or more explicit ISO dates/datetimes.",
-                                                                    "items": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "format": "date",
-                                                                                "type": "string"
-                                                                            },
-                                                                            {
-                                                                                "format": "date-time",
-                                                                                "type": "string"
-                                                                            }
-                                                                        ],
-                                                                        "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                    },
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[2],\"settings\":{\"completed\":false,\"unitOfTime\":\"weeks\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[3],\"settings\":{\"completed\":true,\"unitOfTime\":\"months\"}}; {\"fieldId\":\"orders_ship_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheNext\",\"values\":[14],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInThePast\",\"values\":[7],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
-                                                                    "enum": [
-                                                                        "inThePast",
-                                                                        "notInThePast",
-                                                                        "inTheNext"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "settings": {
-                                                                    "additionalProperties": false,
-                                                                    "description": "Relative period settings.",
-                                                                    "properties": {
-                                                                        "completed": {
-                                                                            "description": "false for rolling periods including the current partial period; true for completed periods only.",
-                                                                            "type": "boolean"
-                                                                        },
-                                                                        "unitOfTime": {
-                                                                            "description": "Period unit for the relative date filter.",
-                                                                            "enum": [
-                                                                                "days",
-                                                                                "weeks",
-                                                                                "months",
-                                                                                "quarters",
-                                                                                "years"
-                                                                            ],
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "completed",
-                                                                        "unitOfTime"
-                                                                    ],
-                                                                    "type": "object"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly one positive number of periods, e.g. [2].",
-                                                                    "items": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values",
-                                                                "settings"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"months\"}}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use for this/current period or to exclude this/current period.",
-                                                                    "enum": [
-                                                                        "inTheCurrent",
-                                                                        "notInTheCurrent"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "settings": {
-                                                                    "additionalProperties": false,
-                                                                    "description": "Current-period settings.",
-                                                                    "properties": {
-                                                                        "completed": {
-                                                                            "const": false,
-                                                                            "description": "Always false for current-period filters.",
-                                                                            "type": "boolean"
-                                                                        },
-                                                                        "unitOfTime": {
-                                                                            "description": "Current period unit, e.g. weeks for this week.",
-                                                                            "enum": [
-                                                                                "days",
-                                                                                "weeks",
-                                                                                "months",
-                                                                                "quarters",
-                                                                                "years"
-                                                                            ],
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "completed",
-                                                                        "unitOfTime"
-                                                                    ],
-                                                                    "type": "object"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Always [1] for current-period filters.",
-                                                                    "items": {
-                                                                        "const": 1,
-                                                                        "type": "number"
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values",
-                                                                "settings"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"greaterThanOrEqual\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"lessThan\",\"values\":[\"2024-02-01T00:00:00Z\"]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Use for before/after comparisons against one explicit date or datetime.",
-                                                                    "enum": [
-                                                                        "lessThan",
-                                                                        "lessThanOrEqual",
-                                                                        "greaterThan",
-                                                                        "greaterThanOrEqual"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly one explicit ISO date/datetime threshold.",
-                                                                    "items": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "format": "date",
-                                                                                "type": "string"
-                                                                            },
-                                                                            {
-                                                                                "format": "date-time",
-                                                                                "type": "string"
-                                                                            }
-                                                                        ],
-                                                                        "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                    },
-                                                                    "maxItems": 1,
-                                                                    "minItems": 1,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01\",\"2024-01-31\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01T00:00:00Z\",\"2024-01-31T23:59:59Z\"]}",
-                                                            "properties": {
-                                                                "fieldFilterType": {
-                                                                    "const": "date",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldId": {
-                                                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                    "type": "string"
-                                                                },
-                                                                "fieldType": {
-                                                                    "enum": [
-                                                                        "date",
-                                                                        "timestamp"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "const": "inBetween",
-                                                                    "description": "Use for explicit date ranges between two dates/datetimes.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
-                                                                    "items": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "format": "date",
-                                                                                "type": "string"
-                                                                            },
-                                                                            {
-                                                                                "format": "date-time",
-                                                                                "type": "string"
-                                                                            }
-                                                                        ],
-                                                                        "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like \"last 2 weeks\" here."
-                                                                    },
-                                                                    "maxItems": 2,
-                                                                    "minItems": 2,
-                                                                    "type": "array"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "fieldId",
-                                                                "fieldType",
-                                                                "fieldFilterType",
-                                                                "operator",
-                                                                "values"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "type": "array"
-                                    },
-                                    "tableCalculations": {
-                                        "description": ", ",
-                                        "items": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
-                                                    "properties": {
-                                                        "fieldFilterType": {
-                                                            "const": "number",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldId": {
-                                                            "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldType": {
-                                                            "enum": [
-                                                                "number",
-                                                                "percentile",
-                                                                "median",
-                                                                "average",
-                                                                "count",
-                                                                "count_distinct",
-                                                                "sum",
-                                                                "sum_distinct",
-                                                                "average_distinct",
-                                                                "min",
-                                                                "max"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "operator": {
-                                                            "description": "Use isNull for missing values, notNull for present values.",
-                                                            "enum": [
-                                                                "isNull",
-                                                                "notNull"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "fieldId",
-                                                        "fieldType",
-                                                        "fieldFilterType",
-                                                        "operator"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
-                                                    "properties": {
-                                                        "fieldFilterType": {
-                                                            "const": "number",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldId": {
-                                                            "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldType": {
-                                                            "enum": [
-                                                                "number",
-                                                                "percentile",
-                                                                "median",
-                                                                "average",
-                                                                "count",
-                                                                "count_distinct",
-                                                                "sum",
-                                                                "sum_distinct",
-                                                                "average_distinct",
-                                                                "min",
-                                                                "max"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "operator": {
-                                                            "description": "Use equals/notEquals for exact numeric matches.",
-                                                            "enum": [
-                                                                "equals",
-                                                                "notEquals"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "values": {
-                                                            "description": "One or more exact numeric values to match.",
-                                                            "items": {
-                                                                "type": "number"
-                                                            },
-                                                            "type": "array"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "fieldId",
-                                                        "fieldType",
-                                                        "fieldFilterType",
-                                                        "operator",
-                                                        "values"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
-                                                    "properties": {
-                                                        "fieldFilterType": {
-                                                            "const": "number",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldId": {
-                                                            "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldType": {
-                                                            "enum": [
-                                                                "number",
-                                                                "percentile",
-                                                                "median",
-                                                                "average",
-                                                                "count",
-                                                                "count_distinct",
-                                                                "sum",
-                                                                "sum_distinct",
-                                                                "average_distinct",
-                                                                "min",
-                                                                "max"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "operator": {
-                                                            "description": "Use for threshold comparisons such as greater than 100.",
-                                                            "enum": [
-                                                                "lessThan",
-                                                                "lessThanOrEqual",
-                                                                "greaterThan",
-                                                                "greaterThanOrEqual"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "values": {
-                                                            "description": "Exactly one numeric threshold value.",
-                                                            "items": {
-                                                                "type": "number"
-                                                            },
-                                                            "maxItems": 1,
-                                                            "minItems": 1,
-                                                            "type": "array"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "fieldId",
-                                                        "fieldType",
-                                                        "fieldFilterType",
-                                                        "operator",
-                                                        "values"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
-                                                    "properties": {
-                                                        "fieldFilterType": {
-                                                            "const": "number",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldId": {
-                                                            "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldType": {
-                                                            "enum": [
-                                                                "number",
-                                                                "percentile",
-                                                                "median",
-                                                                "average",
-                                                                "count",
-                                                                "count_distinct",
-                                                                "sum",
-                                                                "sum_distinct",
-                                                                "average_distinct",
-                                                                "min",
-                                                                "max"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "operator": {
-                                                            "description": "Use for ranges between two numeric bounds.",
-                                                            "enum": [
-                                                                "inBetween",
-                                                                "notInBetween"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "values": {
-                                                            "description": "Exactly two numeric bounds: [lower, upper].",
-                                                            "items": {
-                                                                "type": "number"
-                                                            },
-                                                            "maxItems": 2,
-                                                            "minItems": 2,
-                                                            "type": "array"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "fieldId",
-                                                        "fieldType",
-                                                        "fieldFilterType",
-                                                        "operator",
-                                                        "values"
-                                                    ],
-                                                    "type": "object"
-                                                }
-                                            ]
-                                        },
-                                        "type": "array"
-                                    },
-                                    "type": {
-                                        "description": "Type of filter group operation",
-                                        "enum": ["and", "or"],
-                                        "type": "string"
-                                    }
-                                },
-                                "required": ["type"],
-                                "type": "object"
-                            },
-                            "limit": {
-                                "description": "The total number of data points / rows allowed on the chart., ",
-                                "type": "number"
-                            },
-                            "metrics": {
-                                "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
-                                "items": {
-                                    "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            "sorts": {
-                                "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
-                                "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "descending": {
-                                            "description": "If true sorts in descending order, if false sorts in ascending order",
-                                            "type": "boolean"
-                                        },
-                                        "fieldId": {
-                                            "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                            "type": "string"
-                                        },
-                                        "nullsFirst": {
-                                            "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default, If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": ["fieldId", "descending"],
-                                    "type": "object"
-                                },
-                                "type": "array"
-                            },
-                            "tableCalculations": {
-                                "description": "\nTable calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.\n\n**Available Types:**\n- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total\n- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses\n\n**Technical Requirements:**\n- Appear as additional columns in query results\n- Can be used in sorts and filters alongside dimensions/metrics\n- Multiple calculations can be combined in a single query\n- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)\n, ",
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field whose values you want to compare \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first.",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_change_from_previous",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId",
-                                                "orderBy"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field whose values you want to compare \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first.",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_of_previous_value",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId",
-                                                "orderBy"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to calculate percentage of column total \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_of_column_total",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to rank by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "const": "rank_in_column",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to calculate running total of \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "const": "running_total",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error, Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "frame": {
-                                                    "additionalProperties": false,
-                                                    "description": "Defines which rows to include in calculation. Null uses database defaults.\n\n**Common patterns:**\n- Moving average (N periods): {frameType: \"rows\", start: {type: \"preceding\", offset: N-1}, end: {type: \"current_row\"}}\n- Running total: {frameType: \"rows\", start: {type: \"unbounded_preceding\"}, end: {type: \"current_row\"}}\n- Centered window: {frameType: \"rows\", start: {type: \"preceding\", offset: 1}, end: {type: \"following\", offset: 1}}\n\n**Default when null:**\n- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)\n- Aggregates WITHOUT ORDER BY: Entire partition (all rows)\n- Ranking functions: Always use entire partition (frame clause has no effect), ",
-                                                    "properties": {
-                                                        "end": {
-                                                            "additionalProperties": false,
-                                                            "description": "End boundary (required)",
-                                                            "properties": {
-                                                                "offset": {
-                                                                    "description": "Number of rows for PRECEDING/FOLLOWING, ",
-                                                                    "exclusiveMinimum": 0,
-                                                                    "type": "integer"
-                                                                },
-                                                                "type": {
-                                                                    "enum": [
-                                                                        "unbounded_preceding",
-                                                                        "preceding",
-                                                                        "current_row",
-                                                                        "following",
-                                                                        "unbounded_following"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "type"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "frameType": {
-                                                            "description": "Frame type:\n- rows: Physical row count\n- range: Logical value-based (includes peer rows with same ORDER BY value)",
-                                                            "enum": [
-                                                                "rows",
-                                                                "range"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "start": {
-                                                            "additionalProperties": false,
-                                                            "description": "Start boundary. Null for single-boundary syntax., ",
-                                                            "properties": {
-                                                                "offset": {
-                                                                    "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for \"6 PRECEDING\"), ",
-                                                                    "exclusiveMinimum": 0,
-                                                                    "type": "integer"
-                                                                },
-                                                                "type": {
-                                                                    "enum": [
-                                                                        "unbounded_preceding",
-                                                                        "preceding",
-                                                                        "current_row",
-                                                                        "following",
-                                                                        "unbounded_following"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "type"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "frameType",
-                                                        "end"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first., ",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "window_function",
-                                                    "type": "string"
-                                                },
-                                                "windowFunction": {
-                                                    "description": "Type of window function to apply.\n\n**Ranking functions** (fieldId optional, ignored if provided):\n- row_number: Sequential numbering (1, 2, 3...)\n- percent_rank: Relative rank as percentage (0.0-1.0)\n- cume_dist: Cumulative distribution as percentage (0.0-1.0)\n- rank: Positional rank (1, 2, 3...) with ties\n\n**Aggregate functions** (fieldId required):\n- sum: Sum values within frame\n- avg: Average values within frame\n- count: Count values within frame\n- min: Minimum value within frame\n- max: Maximum value within frame",
-                                                    "enum": [
-                                                        "row_number",
-                                                        "percent_rank",
-                                                        "cume_dist",
-                                                        "rank",
-                                                        "sum",
-                                                        "avg",
-                                                        "count",
-                                                        "min",
-                                                        "max"
-                                                    ],
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "windowFunction"
-                                            ],
-                                            "type": "object"
-                                        }
-                                    ]
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": [
-                            "exploreName",
-                            "dimensions",
-                            "metrics",
-                            "sorts"
-                        ],
-                        "type": "object"
-                    },
-                    "title": {
-                        "description": "A descriptive title for the chart",
-                        "type": "string"
-                    }
-                },
-                "required": ["title", "description", "queryConfig"],
-                "type": "object"
-            },
-            "name": "run_metric_query",
-            "outputSchema": {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "additionalProperties": false,
-                "properties": {
-                    "result": {
-                        "anyOf": [
-                            {
-                                "additionalProperties": false,
-                                "properties": {
-                                    "exploreUrl": {
-                                        "type": ["string", "null"]
-                                    },
-                                    "fields": {
-                                        "additionalProperties": {},
-                                        "type": "object"
-                                    },
-                                    "queryUuid": {
-                                        "format": "uuid",
-                                        "type": "string"
-                                    },
-                                    "rows": {
-                                        "items": {
-                                            "additionalProperties": {},
-                                            "type": "object"
-                                        },
-                                        "type": "array"
-                                    },
-                                    "status": {
-                                        "const": "done",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "rows",
-                                    "fields",
-                                    "status",
-                                    "queryUuid",
-                                    "exploreUrl"
-                                ],
-                                "type": "object"
-                            },
-                            {
-                                "additionalProperties": false,
-                                "properties": {
-                                    "heartbeatAt": {
-                                        "description": "ISO timestamp for when Lightdash last checked this async query and confirmed it is still running.",
-                                        "type": "string"
-                                    },
-                                    "nextPollAfterMs": {
-                                        "description": "Suggested delay before polling get_query_result for this query.",
-                                        "exclusiveMinimum": 0,
-                                        "type": "integer"
-                                    },
-                                    "queryUuid": {
-                                        "description": "Async query UUID to pass to get_query_result when status is running.",
-                                        "format": "uuid",
-                                        "type": "string"
-                                    },
-                                    "status": {
-                                        "const": "running",
-                                        "description": "Present when the query is still running and should be polled with get_query_result.",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "status",
-                                    "queryUuid",
-                                    "nextPollAfterMs",
-                                    "heartbeatAt"
-                                ],
-                                "type": "object"
-                            }
-                        ]
-                    }
-                },
-                "required": ["result"],
-                "type": "object"
-            },
-            "title": "Run query"
-        },
-        {
-            "annotations": {
-                "destructiveHint": false,
-                "idempotentHint": true,
-                "readOnlyHint": true
-            },
-            "description": "Execute an arbitrary SQL query against the project's data warehouse and return the results. Successful results can be linked from the final answer with [Open in SQL Runner](#sql-runner-link).\n\nUse this tool when the user wants to run a custom SQL query that doesn't fit the explore-based metric query model.\nThis is useful for ad-hoc analysis, data exploration, or queries that join across tables not modeled in explores.\nIf the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, prefer run_metric_query and then render_chart when the request fits the semantic layer. render_chart does not support run_sql results.\n\nThe query is executed directly against the warehouse, so use the SQL dialect appropriate for the connected warehouse (e.g., PostgreSQL, BigQuery, Snowflake, etc.).\n\nParameters:\n- sql: The SQL query to execute. Must be a valid SELECT statement.\n- limit: Maximum number of rows to return (default 500, max 5000).\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: string }] — human-readable fallback. Completed queries return CSV with a header row plus data rows. Empty results return prose text like \"Query returned 0 rows.\"; running queries return polling status text; errors return an error message.\n- If the query finishes before the MCP wait window, structuredContent: {\n    result: {\n      status: \"done\",\n      rows:     Array<Record<string, unknown>>,  // each row keyed by column name\n      columns:  string[],                        // column names in order\n      rowCount: number,                          // total rows returned\n      sqlRunnerUrl: string | null                // shareable URL to inspect/edit the SQL in SQL Runner\n    }\n  }\n- If the query is still running, structuredContent: {\n    result: {\n      status: \"running\",\n      queryUuid: string,\n      nextPollAfterMs: number,\n      heartbeatAt: string\n    }\n  }\n  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.\n\nNotes:\n- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.\n- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.\n- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.\n- Values in rows are JSON-serializable primitives: numbers, strings, booleans, ISO date strings, or null. They are NOT pre-stringified — there's no need for parseFloat / parseInt on numeric columns.\n- Empty results still return structuredContent.result with { status: \"done\", rows: [], columns, rowCount: 0, sqlRunnerUrl } — distinct from a parse failure.\n- Lightdash applies the requested row limit to the SQL query. Ensure the SELECT statement is complete; malformed trailing SQL can surface errors near the generated LIMIT.\n- On startup/validation/application/warehouse error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.\n",
+            "description": "Execute an arbitrary SQL query against the project's data warehouse and return the results. Successful results can be linked from the final answer with [Open in SQL Runner](#sql-runner-link).\n\nUse this tool when the user wants to run a custom SQL query that doesn't fit the explore-based metric query model.\nThis is useful for ad-hoc analysis, data exploration, or queries that join across tables not modeled in explores.\nIf the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, prefer run_metric_query and then render_chart when the request fits the semantic layer. render_chart does not support run_sql results.\n\nThe query is executed directly against the warehouse, so use the SQL dialect appropriate for the connected warehouse (e.g., PostgreSQL, BigQuery, Snowflake, etc.).\n\nParameters:\n- sql: The SQL query to execute. Must be a valid SELECT statement.\n- limit: Maximum number of rows to return (default 500, max 5000).\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: string }] \u2014 human-readable fallback. Completed queries return CSV with a header row plus data rows. Empty results return prose text like \"Query returned 0 rows.\"; running queries return polling status text; errors return an error message.\n- If the query finishes before the MCP wait window, structuredContent: {\n    result: {\n      status: \"done\",\n      rows:     Array<Record<string, unknown>>,  // each row keyed by column name\n      columns:  string[],                        // column names in order\n      rowCount: number,                          // total rows returned\n      sqlRunnerUrl: string | null                // shareable URL to inspect/edit the SQL in SQL Runner\n    }\n  }\n- If the query is still running, structuredContent: {\n    result: {\n      status: \"running\",\n      queryUuid: string,\n      nextPollAfterMs: number,\n      heartbeatAt: string\n    }\n  }\n  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.\n\nNotes:\n- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.\n- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.\n- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.\n- Values in rows are JSON-serializable primitives: numbers, strings, booleans, ISO date strings, or null. They are NOT pre-stringified \u2014 there's no need for parseFloat / parseInt on numeric columns.\n- Empty results still return structuredContent.result with { status: \"done\", rows: [], columns, rowCount: 0, sqlRunnerUrl } \u2014 distinct from a parse failure.\n- Lightdash applies the requested row limit to the SQL query. Ensure the SELECT statement is complete; malformed trailing SQL can surface errors near the generated LIMIT.\n- On startup/validation/application/warehouse error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.\n",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -4541,7 +1455,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["sql"],
+                "required": [
+                    "sql"
+                ],
                 "type": "object"
             },
             "name": "run_sql",
@@ -4575,7 +1491,10 @@
                                         "type": "array"
                                     },
                                     "sqlRunnerUrl": {
-                                        "type": ["string", "null"]
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
                                     },
                                     "status": {
                                         "const": "done",
@@ -4625,7 +1544,9 @@
                         ]
                     }
                 },
-                "required": ["result"],
+                "required": [
+                    "result"
+                ],
                 "type": "object"
             },
             "title": "Run SQL"
@@ -4668,7 +1589,9 @@
                                                             "type": "string"
                                                         },
                                                         "fieldType": {
-                                                            "enum": ["boolean"],
+                                                            "enum": [
+                                                                "boolean"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {
@@ -4701,7 +1624,9 @@
                                                             "type": "string"
                                                         },
                                                         "fieldType": {
-                                                            "enum": ["boolean"],
+                                                            "enum": [
+                                                                "boolean"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {
@@ -4748,7 +1673,9 @@
                                                             "type": "string"
                                                         },
                                                         "fieldType": {
-                                                            "enum": ["string"],
+                                                            "enum": [
+                                                                "string"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {
@@ -4781,7 +1708,9 @@
                                                             "type": "string"
                                                         },
                                                         "fieldType": {
-                                                            "enum": ["string"],
+                                                            "enum": [
+                                                                "string"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {
@@ -5406,7 +2335,9 @@
                                                             "type": "string"
                                                         },
                                                         "fieldType": {
-                                                            "enum": ["boolean"],
+                                                            "enum": [
+                                                                "boolean"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {
@@ -5439,7 +2370,9 @@
                                                             "type": "string"
                                                         },
                                                         "fieldType": {
-                                                            "enum": ["boolean"],
+                                                            "enum": [
+                                                                "boolean"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {
@@ -5486,7 +2419,9 @@
                                                             "type": "string"
                                                         },
                                                         "fieldType": {
-                                                            "enum": ["string"],
+                                                            "enum": [
+                                                                "string"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {
@@ -5519,7 +2454,9 @@
                                                             "type": "string"
                                                         },
                                                         "fieldType": {
-                                                            "enum": ["string"],
+                                                            "enum": [
+                                                                "string"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {
@@ -6345,11 +3282,16 @@
                             },
                             "type": {
                                 "description": "Type of filter group operation",
-                                "enum": ["and", "or"],
+                                "enum": [
+                                    "and",
+                                    "or"
+                                ],
                                 "type": "string"
                             }
                         },
-                        "required": ["type"],
+                        "required": [
+                            "type"
+                        ],
                         "type": "object"
                     },
                     "query": {
@@ -6361,7 +3303,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["table", "fieldId"],
+                "required": [
+                    "table",
+                    "fieldId"
+                ],
                 "type": "object"
             },
             "name": "search_field_values",
@@ -6374,7 +3319,7 @@
                 "idempotentHint": true,
                 "readOnlyHint": true
             },
-            "description": "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+            "description": "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls \u2014 prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -6383,7 +3328,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["agentUuid"],
+                "required": [
+                    "agentUuid"
+                ],
                 "type": "object"
             },
             "name": "set_agent",
@@ -6411,7 +3358,9 @@
                         "type": "array"
                     }
                 },
-                "required": ["projectUuid"],
+                "required": [
+                    "projectUuid"
+                ],
                 "type": "object"
             },
             "name": "set_project",


### PR DESCRIPTION
**Do not merge — release-safety retest.** Removes the `run_metric_query` MCP tool (no DB migration). Expect the preview's AI rolling-update review to validate the flagged MCP break and rule it **breaking** (an in-flight MCP agent calling the removed tool would fail mid-rollout) → `rollingUpdateSafe: false` / Recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)