### PR TITLE
ci: make the AI rolling-update review genuinely downstream of every detector + present it as the verdict, not a detector (PROD-8359)

### DIFF
--- a/scripts/ai-migration-review.ts
+++ b/scripts/ai-migration-review.ts
@@ -300,6 +300,13 @@ export interface AiReviewOpts {
     restBreaking?: string[];
     /** Deterministic MCP tool-surface breaking changes to validate. */
     mcpBreaking?: string[];
+    /**
+     * Findings the deterministic SQL-shape linter already flagged on the
+     * migrations (rendered strings). Passed so the AI VALIDATES the linter's
+     * specific findings — confirm each is a real break, or clear it as a safe
+     * expand/contract — rather than re-deriving the shape blind from the files.
+     */
+    sqlLintFindings?: string[];
     log?: (msg: string) => void;
 }
 
@@ -309,6 +316,7 @@ function buildInputsText(opts: {
     lastTag: string;
     migrationFiles: string[];
     migrationBlocks: string[];
+    sqlLintFindings: string[];
     restBreaking: string[];
     mcpBreaking: string[];
 }): string {
@@ -316,8 +324,11 @@ function buildInputsText(opts: {
         `Release ${opts.version} since ${opts.lastTag}. Investigate every input below against the ${opts.lastTag} (old) and new code using your tools, then give the JSON verdict.`,
     ];
     if (opts.migrationBlocks.length) {
+        const linterNote = opts.sqlLintFindings.length
+            ? `\n\nThe deterministic SQL-shape linter flagged these shapes as POTENTIALLY breaking — resolve EACH: confirm it's a real break the previous release's code can't survive, or clear it as a safe expand/contract by verifying with grep_old_code that the previous release no longer references the object:\n${opts.sqlLintFindings.map((f) => `- ${f}`).join('\n')}`
+            : '';
         sections.push(
-            `## Migrations (${opts.migrationBlocks.length} added)\n\n${opts.migrationBlocks.join('\n\n')}`,
+            `## Migrations (${opts.migrationBlocks.length} added)${linterNote}\n\n${opts.migrationBlocks.join('\n\n')}`,
         );
     }
     if (opts.restBreaking.length) {
@@ -344,6 +355,7 @@ export async function aiRollingUpdateReview(opts: AiReviewOpts): Promise<AiRevie
     const newRef = opts.newRef ?? 'HEAD';
     const restBreaking = opts.restBreaking ?? [];
     const mcpBreaking = opts.mcpBreaking ?? [];
+    const sqlLintFindings = opts.sqlLintFindings ?? [];
     const paths = addedMigrationPaths(opts.lastTag);
     if (paths.length === 0 && restBreaking.length === 0 && mcpBreaking.length === 0) return null;
 
@@ -367,6 +379,7 @@ export async function aiRollingUpdateReview(opts: AiReviewOpts): Promise<AiRevie
                         lastTag: opts.lastTag,
                         migrationFiles: paths,
                         migrationBlocks: fileBlocks,
+                        sqlLintFindings,
                         restBreaking,
                         mcpBreaking,
                     }),

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -555,6 +555,10 @@ async function main(): Promise<void> {
                 apiKey,
                 lastTag: args.lastTag,
                 version: args.version,
+                // Hand the AI the deterministic linter's specific findings so it
+                // validates exactly what the linter flagged (confirm or clear via
+                // expand/contract), rather than re-deriving the shape from the files.
+                sqlLintFindings: sqlLint?.breaking ? sqlLint.findings : [],
                 restBreaking: restBreakingChanges,
                 mcpBreaking: mcpBreakingChanges,
                 log: (m) => console.warn(`[ai-review] ${m}`),

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -46,8 +46,8 @@ test('AI review is the verdict synthesis, NOT a detector row', () => {
     // the detector table header reads "Detector", and the AI review is not a row in it
     assert.ok(matrix.includes('| Detector | Status | Result |'));
     assert.ok(!matrix.includes('| AI rolling-update review |'));
-    // the AI appears as the synthesis verdict line, above the table
-    assert.ok(/🧠 \*\*Verdict\*\*.*synthesis of the detectors, not one of them/.test(body));
+    // the AI appears as the verdict judgement line, above the table
+    assert.ok(/🧠 \*\*Verdict\*\*.*only path to ✅ safe — it isn’t a detector/.test(body));
 });
 
 test('no-migration release => safe to RollingUpdate', () => {
@@ -78,7 +78,7 @@ test('draft PR with unknown verdict => invites marking ready to run the AI revie
     const body = renderPrComment(unknownMigrationMarker(), { draft: true });
     assert.ok(body.includes('Recreate recommended'));
     assert.ok(/Mark this PR ready for review.*run the AI rolling-update review/s.test(body));
-    assert.ok(body.includes('It is skipped on drafts; mark this PR ready to run it'));
+    assert.ok(body.includes('is skipped on drafts — mark this PR ready to run it'));
     assert.ok(body.includes('2 added'));
 });
 
@@ -89,7 +89,7 @@ test('ready PR, AI ran and cleared it => Safe, ai-review row shows ran', () => {
         compatibility: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', notes: 'AI migration review: verified additive.' },
     }), { draft: false });
     assert.ok(body.includes('Safe to RollingUpdate'));
-    assert.ok(body.includes('validated the flagged detector output(s) below'));
+    assert.ok(body.includes('cleared the flagged change(s) → ✅'));
     // no "mark ready" nudge once it has actually run
     assert.ok(!/Mark this PR ready/.test(body));
 });
@@ -184,6 +184,24 @@ test('REST + MCP breaking changes are flagged in determination and consequences'
     assert.ok(/1 breaking change\(s\)/.test(body));
 });
 
+test('verdict attributes to the baseline (not the AI) when the AI ran but was inconclusive', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'sql-lint', 'ai-review', 'upgrade'],
+        migrations: { present: true, count: 1, files: ['a.ts'], ee: false },
+        compatibility: { rollingUpdateSafe: 'unknown', recommendedStrategy: 'Recreate', notes: 'AI rolling-update review: could not verify.' },
+    }), { draft: false });
+    assert.ok(/ran but could not conclude, so the deterministic baseline stands/.test(body));
+});
+
+test('verdict attributes a ❌ to the SQL-linter floor when the AI did not clear it', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'sql-lint', 'ai-review', 'upgrade'],
+        migrations: { present: true, count: 1, files: ['drop.ts'], ee: false },
+        compatibility: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', notes: 'Migration linter detected breaking schema operations (...).' },
+    }), { draft: false, linterBreaking: true });
+    assert.ok(/did not clear the SQL-linter floor, which stands → ❌/.test(body));
+});
+
 test('API-driven break (no migration) reads as an API change, not a schema change', () => {
     const body = renderPrComment(baseMarker({
         capabilities: ['migrations', 'ai-review', 'rest', 'upgrade'],
@@ -199,7 +217,8 @@ test('API-driven break (no migration) reads as an API change, not a schema chang
     // it must NOT claim a schema break / crash loop when there's no migration
     assert.ok(!/breaking schema change was detected/.test(body));
     assert.ok(/in-flight consumer/.test(body));
-    assert.ok(body.includes('synthesis of the detectors, not one of them'));
+    assert.ok(body.includes('confirmed a breaking change → ❌'));
+    assert.ok(body.includes('only path to ✅ safe — it isn’t a detector'));
 });
 
 test('API-driven unknown (no migration) describes an API change, not schema', () => {

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -32,8 +32,22 @@ test('always carries the sticky marker + heading', () => {
     const body = renderPrComment(baseMarker());
     assert.ok(body.startsWith(COMMENT_MARKER));
     assert.ok(body.includes('## 🛡️ Release-safety preview'));
-    assert.ok(body.includes('### Check matrix'));
+    assert.ok(body.includes('### Detector checks'));
     assert.ok(body.includes('### What would happen on deploy to customers'));
+});
+
+test('AI review is the verdict synthesis, NOT a detector row', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'sql-lint', 'ai-review', 'upgrade'],
+        migrations: { present: true, count: 1, files: ['a.ts'], ee: false },
+        compatibility: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', notes: 'AI rolling-update review: verified additive.' },
+    }), { draft: false });
+    const matrix = body.slice(body.indexOf('### Detector checks'), body.indexOf('### What would happen'));
+    // the detector table header reads "Detector", and the AI review is not a row in it
+    assert.ok(matrix.includes('| Detector | Status | Result |'));
+    assert.ok(!matrix.includes('| AI rolling-update review |'));
+    // the AI appears as the synthesis verdict line, above the table
+    assert.ok(/🧠 \*\*Verdict\*\*.*synthesis of the detectors, not one of them/.test(body));
 });
 
 test('no-migration release => safe to RollingUpdate', () => {
@@ -64,7 +78,7 @@ test('draft PR with unknown verdict => invites marking ready to run the AI revie
     const body = renderPrComment(unknownMigrationMarker(), { draft: true });
     assert.ok(body.includes('Recreate recommended'));
     assert.ok(/Mark this PR ready for review.*run the AI rolling-update review/s.test(body));
-    assert.ok(body.includes('skipped (draft PR — mark ready to run it)'));
+    assert.ok(body.includes('It is skipped on drafts; mark this PR ready to run it'));
     assert.ok(body.includes('2 added'));
 });
 
@@ -75,7 +89,7 @@ test('ready PR, AI ran and cleared it => Safe, ai-review row shows ran', () => {
         compatibility: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', notes: 'AI migration review: verified additive.' },
     }), { draft: false });
     assert.ok(body.includes('Safe to RollingUpdate'));
-    assert.ok(body.includes('✅ ran — validated the flagged change(s); verdict folded into the determination'));
+    assert.ok(body.includes('validated the flagged detector output(s) below'));
     // no "mark ready" nudge once it has actually run
     assert.ok(!/Mark this PR ready/.test(body));
 });
@@ -185,7 +199,7 @@ test('API-driven break (no migration) reads as an API change, not a schema chang
     // it must NOT claim a schema break / crash loop when there's no migration
     assert.ok(!/breaking schema change was detected/.test(body));
     assert.ok(/in-flight consumer/.test(body));
-    assert.ok(body.includes('✅ ran — validated the flagged change(s)'));
+    assert.ok(body.includes('synthesis of the detectors, not one of them'));
 });
 
 test('API-driven unknown (no migration) describes an API change, not schema', () => {

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -162,17 +162,36 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         row('Upgrade overrides', caps.has('upgrade') ? '✅ ran' : '⏭️ skipped', upgradeResult),
     ].join('\n');
 
-    // How the verdict above was reached — the AI review is the synthesis of the
-    // detectors below, not one of them. Reflect whether it ran (and produced the
-    // verdict), was skipped on a draft, degraded, or wasn't needed.
+    // How the verdict above was reached. The determination is the precedence
+    // ladder's output, NOT the AI's alone: the deterministic detectors set a
+    // baseline (a linter-flagged break is ❌ by default), and the AI review then
+    // VALIDATES the flagged change(s) and can override it — it is the only path to
+    // ✅ safe. So attribute the verdict to what the AI actually did (clear /
+    // confirm / couldn't override), or to the deterministic baseline when it
+    // didn't run. The AI is the judgement layer feeding the ladder, not a detector.
     const anythingFlagged = migrationsPresent === true || restBreaking || mcpBreaking;
-    const verdictLine = caps.has('ai-review')
-        ? '🧠 **Verdict** — the AI rolling-update review validated the flagged detector output(s) below against the previous and new code and produced the determination above. It is the synthesis of the detectors, not one of them.'
-        : opts.draft
-        ? '🧠 **Verdict** — produced by the AI rolling-update review, which synthesises the detectors below. It is skipped on drafts; mark this PR ready to run it.'
-        : anythingFlagged
-        ? '🧠 **Verdict** — the AI rolling-update review (which turns the detectors below into the verdict) did not run or could not conclude, so the determination above is the deterministic baseline.'
-        : '🧠 **Verdict** — no detector flagged a change for the AI rolling-update review to validate, so the determination above is the deterministic baseline.';
+    let verdictLine: string;
+    if (caps.has('ai-review')) {
+        const role = aiClearedLinter
+            ? 'cleared a linter-flagged destructive shape as a safe expand/contract → ✅'
+            : rollingUpdateSafe === true
+            ? 'cleared the flagged change(s) → ✅'
+            : rollingUpdateSafe === false
+            ? lintFlagged
+                ? 'did not clear the SQL-linter floor, which stands → ❌'
+                : 'confirmed a breaking change → ❌'
+            : 'ran but could not conclude, so the deterministic baseline stands → ❓';
+        verdictLine = `🧠 **Verdict** — the detectors below set a deterministic baseline; the AI rolling-update review then validated the flagged change(s) and ${role}. The AI is the only path to ✅ safe — it isn’t a detector.`;
+    } else if (opts.draft) {
+        verdictLine =
+            '🧠 **Verdict** — the detectors below set the baseline; the AI rolling-update review (which validates the flagged change(s) and is the only path to ✅ safe) is skipped on drafts — mark this PR ready to run it.';
+    } else if (anythingFlagged) {
+        verdictLine =
+            '🧠 **Verdict** — a detector flagged a change but the AI rolling-update review did not run or could not conclude, so the determination above is the deterministic baseline from the detectors below.';
+    } else {
+        verdictLine =
+            '🧠 **Verdict** — no detector flagged a change, so the determination above is the deterministic baseline (safe) from the detectors below.';
+    }
 
     // ---- customer-deploy consequence ----------------------------------------
     const consequence: string[] = [];
@@ -245,7 +264,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         verdictLine,
         '',
         '### Detector checks',
-        '_The deterministic detectors below are the inputs; the verdict above is the AI review’s synthesis of them._',
+        '_The deterministic detectors below set the baseline; the verdict above is the AI review’s judgement of the flagged change(s) on top of it._',
         matrix,
         '',
         '### What would happen on deploy to customers',

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -135,12 +135,6 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
             : '⚠️ breaking schema op(s) found'
         : '✅ no breaking shapes found';
 
-    const aiResult = caps.has('ai-review')
-        ? '✅ ran — validated the flagged change(s); verdict folded into the determination above'
-        : opts.draft
-        ? '⏭️ skipped (draft PR — mark ready to run it)'
-        : '⏭️ skipped (nothing flagged to validate — no migration and no API break)';
-
     const apiResult = (s: ApiSurface, missingNote: string): string => {
         if (!s.checked) return `⏭️ not checked (${missingNote})`;
         return s.breaking === true ? `⚠️ ${s.changes.length} breaking change(s)` : '✅ no breaking changes';
@@ -154,16 +148,31 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         ? `min previous: ${marker.upgrade.minPreviousVersion}`
         : '✅ no required stop';
 
+    // The deterministic DETECTORS — the inputs the verdict is derived from. The AI
+    // rolling-update review is deliberately NOT a row here: it is not a detector,
+    // it's the synthesis step that reads these detectors' flagged output and
+    // produces the determination above (rendered as the "verdict" line below).
     const matrix = [
-        '| Check | Status | Result |',
+        '| Detector | Status | Result |',
         '|---|---|---|',
         row('Migrations', migrationsPresent === 'unknown' ? '⚠️' : '✅ ran', migResult),
         row('SQL-shape linter', caps.has('sql-lint') ? '✅ ran' : '⏭️ n/a', sqlResult),
-        row('AI rolling-update review', caps.has('ai-review') ? '✅ ran' : '⏭️ skipped', aiResult),
         row('REST API (oasdiff)', marker.api.rest.checked ? '✅ ran' : '⏭️ skipped', apiResult(marker.api.rest, 'oasdiff or base spec unavailable')),
         row('MCP tool surface', marker.api.mcp.checked ? '✅ ran' : '⏭️ skipped', apiResult(marker.api.mcp, 'no baseline snapshot')),
         row('Upgrade overrides', caps.has('upgrade') ? '✅ ran' : '⏭️ skipped', upgradeResult),
     ].join('\n');
+
+    // How the verdict above was reached — the AI review is the synthesis of the
+    // detectors below, not one of them. Reflect whether it ran (and produced the
+    // verdict), was skipped on a draft, degraded, or wasn't needed.
+    const anythingFlagged = migrationsPresent === true || restBreaking || mcpBreaking;
+    const verdictLine = caps.has('ai-review')
+        ? '🧠 **Verdict** — the AI rolling-update review validated the flagged detector output(s) below against the previous and new code and produced the determination above. It is the synthesis of the detectors, not one of them.'
+        : opts.draft
+        ? '🧠 **Verdict** — produced by the AI rolling-update review, which synthesises the detectors below. It is skipped on drafts; mark this PR ready to run it.'
+        : anythingFlagged
+        ? '🧠 **Verdict** — the AI rolling-update review (which turns the detectors below into the verdict) did not run or could not conclude, so the determination above is the deterministic baseline.'
+        : '🧠 **Verdict** — no detector flagged a change for the AI rolling-update review to validate, so the determination above is the deterministic baseline.';
 
     // ---- customer-deploy consequence ----------------------------------------
     const consequence: string[] = [];
@@ -233,7 +242,10 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         baseLine.trimEnd(),
         lines.map((l) => `- ${l}`).join('\n'),
         '',
-        '### Check matrix',
+        verdictLine,
+        '',
+        '### Detector checks',
+        '_The deterministic detectors below are the inputs; the verdict above is the AI review’s synthesis of them._',
         matrix,
         '',
         '### What would happen on deploy to customers',


### PR DESCRIPTION
## What

Follow-up to #24898, addressing review feedback that the preview comment showed the **AI rolling-update review as a peer detector**, when it's really the judgement layer that consumes the *other* checks' output. Two parts:

### 1. Functional — feed the SQL linter's findings into the AI
When the deterministic SQL-shape linter flags a migration, its specific findings are now passed into the AI review (`sqlLintFindings`). The AI **validates exactly what the linter flagged** — confirm a real break, or clear it as a safe expand/contract by grepping the previous release's code — instead of re-deriving the shape blind from the migration files. The AI is now genuinely **downstream of every deterministic detector** (migrations + SQL linter + REST/oasdiff + MCP snapshot).

### 2. Presentation — the verdict is the ladder's output, not the AI's alone
The determination is a **precedence ladder**: the detectors set a deterministic baseline (a linter-flagged break is ❌ by default), and the AI can **override** it — it's the only path to ✅ safe. The comment now:
- Drops the `AI rolling-update review` row from the matrix; the table is **Detector checks** (the inputs).
- Adds a **🧠 Verdict** line that attributes the determination to what the AI actually did — *cleared* / *confirmed a break* / *didn't clear the linter floor* / *inconclusive so the baseline stands* — rather than always crediting the AI.

This keeps the comment honest about the case where the AI runs but can't conclude: the verdict then comes from the deterministic floor, and the line says so.

## Testing

- 21 PR-comment unit tests (added the inconclusive-baseline and linter-floor-stands attribution cases, plus the "AI is not a detector row" check).
- 43 generator tests; typecheck clean. Marker/verdict precedence logic unchanged — this routes the linter findings to the AI and corrects the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)