### PR TITLE
ci: [DEMO – do not merge] drop a still-used column, exercises the SQL-linter → AI feed (PROD-8359 retest)

### DIFF
--- a/packages/backend/src/database/migrations/20260629203000_demo_drop_org_name.ts
+++ b/packages/backend/src/database/migrations/20260629203000_demo_drop_org_name.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+// [DEMO - DO NOT MERGE] Drops a column the previous release still reads/writes,
+// to exercise the release-safety SQL linter -> AI rolling-update review feed.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.dropColumn('organization_name');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.string('organization_name').notNullable().defaultTo('');
+    });
+}


### PR DESCRIPTION
**Do not merge — release-safety retest.** Adds a migration dropping `organizations.organization_name`, a column the previous release still reads/writes. Exercises the new path: the SQL-shape linter flags `drop-column`, hands its finding to the AI rolling-update review, which greps the previous release, finds the column still used, and **confirms breaking** → `rollingUpdateSafe: false` / Recreate. The preview's 🧠 Verdict line should attribute the ❌ to the AI confirming the break (or the linter floor it didn't clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)