### PR TITLE
ci: tighten the cleared-verdict wording in the release-safety comment (PROD-8359)

### DIFF
--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -89,7 +89,7 @@ test('ready PR, AI ran and cleared it => Safe, ai-review row shows ran', () => {
         compatibility: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', notes: 'AI migration review: verified additive.' },
     }), { draft: false });
     assert.ok(body.includes('Safe to RollingUpdate'));
-    assert.ok(body.includes('cleared the flagged change(s) → ✅'));
+    assert.ok(body.includes('validated the flagged change(s) and cleared them → ✅'));
     // no "mark ready" nudge once it has actually run
     assert.ok(!/Mark this PR ready/.test(body));
 });

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -175,7 +175,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         const role = aiClearedLinter
             ? 'cleared a linter-flagged destructive shape as a safe expand/contract → ✅'
             : rollingUpdateSafe === true
-            ? 'cleared the flagged change(s) → ✅'
+            ? 'cleared them → ✅'
             : rollingUpdateSafe === false
             ? lintFlagged
                 ? 'did not clear the SQL-linter floor, which stands → ❌'


### PR DESCRIPTION
Trivial wording fix spotted while retesting the demos: the 🧠 Verdict line for a cleared change read *"validated the flagged change(s) and cleared the flagged change(s) → ✅"* — repeated itself. Now reads *"…and cleared them → ✅"*. 21 PR-comment tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)