### PR TITLE
ci: go live with the release-safety marker (PROD-8359)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,14 @@ jobs:
           # audited egress; absent the key, the generator skips it and leaves the
           # honest "unknown" verdict. Never fails the release.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # PROD-8359 kill-switch: the marker is DARK-LAUNCHED. While "false" the
-          # generator computes + logs the marker but writes no file (so no release
-          # asset is published) and skips the paid AI review. Flip to "true" to go
-          # live. The PR preview workflow is unaffected (it runs the generator with
-          # its own enabled=true against a throwaway file).
-          RELEASE_SAFETY_MARKER_ENABLED: 'false'
+          # PROD-8359 kill-switch (GO-LIVE). "true" → on every release the generator
+          # writes release-safety.json, runs the gated (paid) AI rolling-update
+          # review on any flagged change, and @semantic-release/github attaches the
+          # file as a release asset at releases/download/<tag>/release-safety.json.
+          # Flip back to "false" to instantly dark it again (no file, no asset, no
+          # AI spend) — this is the single revert. The PR preview workflow is
+          # independent (it always runs with its own enabled=true throwaway file).
+          RELEASE_SAFETY_MARKER_ENABLED: 'true'
         with:
           semantic_version: 19
           extra_plugins: |

--- a/docs/superpowers/specs/2026-06-29-prod-8359-release-safety-marker-design.md
+++ b/docs/superpowers/specs/2026-06-29-prod-8359-release-safety-marker-design.md
@@ -1,6 +1,6 @@
 # Release-Safety Marker — Design (PROD-8359 / #24441)
 
-**Status:** Feature-complete — P1–P4 + P6 + the deterministic SQL-shape linter all built; P6 activated. P6 EXTENDED so the AI is the validation layer for ALL deterministic detectors (migrations AND flagged REST/MCP breaking changes), not migrations alone. Marker DARK-LAUNCHED behind a kill-switch (publishes nothing yet) with a PR preview comment for visibility. P5 (Helm) parked; the config-only/serialization blind-spot blast-radius scan is a deliberate follow-up.
+**Status:** Feature-complete — P1–P4 + P6 + the deterministic SQL-shape linter all built; P6 activated. P6 EXTENDED so the AI is the validation layer for ALL deterministic detectors (migrations AND flagged REST/MCP breaking changes), not migrations alone. Marker GONE LIVE — `RELEASE_SAFETY_MARKER_ENABLED='true'` in `release.yml`, so each release now writes `release-safety.json`, runs the gated AI review, and attaches the asset at `releases/download/<tag>/release-safety.json` (flip back to `'false'` to dark it again — the single revert). PR preview comment still posts for shift-left visibility. P5 (Helm) parked; the config-only/serialization blind-spot blast-radius scan is a deliberate follow-up.
 **Ticket:** PROD-8359 · GitHub issue lightdash/lightdash#24441
 **Branch / PR:** `prod-8359-release-safety` (merged) → continued on `prod-8359-ai-breaking-changes`
 
@@ -158,8 +158,10 @@
 - **Operator/maintainer docs:** publish the `jq`-gating recipes + the
   `release-safety.overrides.json` required-stop authoring flow (the only manual
   step in the system).
-- **Go-live:** flip `RELEASE_SAFETY_MARKER_ENABLED` to `'true'` in `release.yml`
-  once a consumer commits to reading the marker.
+- **Go-live: DONE** — `RELEASE_SAFETY_MARKER_ENABLED` is `'true'` in `release.yml`;
+  each release publishes the asset and runs the gated AI review. Revert by flipping
+  it back to `'false'`. Next: confirm a consumer (operator CI/CD) actually `jq`-gates
+  on it, and watch per-release AI cost now that the review is live on releases.
 
 **Parked (deliberately, per Charlie):**
 - **P5** — Helm `backend.deployment.strategy` Recreate switch + operator docs

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -278,7 +278,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         '</details>',
         '',
         '---',
-        'ℹ️ The published release asset is currently **disabled** (dark-launch: `RELEASE_SAFETY_MARKER_ENABLED=false`), so this preview is informational and does not affect releases yet.',
+        'ℹ️ Once merged, the release that ships this change will publish `release-safety.json` as a GitHub release asset (at `releases/download/<tag>/release-safety.json`); this preview shows what that marker will say. Self-hosted operators’ CI/CD can `jq`-gate on it before upgrading.',
         '_Blind spot: only the checks above are covered — code-only/config-only breaking changes (env defaults, removed Helm values, serialization changes) are not detected._',
         '',
     ].join('\n');


### PR DESCRIPTION
## What

Flips the PROD-8359 kill-switch: `RELEASE_SAFETY_MARKER_ENABLED: 'false' → 'true'` in `release.yml`.

## What this turns on (from the next release)

On every release, semantic-release already runs the generator; with the switch on it now also:
1. **Writes `release-safety.json`** (was compute-and-log only).
2. **Runs the gated AI rolling-update review** on any flagged change (migration / REST / MCP break) — this is **paid** Anthropic usage, per qualifying release.
3. **Attaches the marker as a GitHub release asset** at the stable URL `releases/download/<tag>/release-safety.json`, for self-hosted operators' CI/CD to `jq`-gate on (RollingUpdate vs Recreate / required-stop) before upgrading.

A clean release (no migration, no API break) still produces a marker that says ✅ safe — and spends nothing on AI (the review only runs when something is flagged).

## Revert

Single line: flip `RELEASE_SAFETY_MARKER_ENABLED` back to `'false'` → no file, no asset, no AI spend. Nothing else depends on it.

## Also

- PR-preview footer no longer says "dark-launched / does not affect releases" — it now explains the published asset.
- Design doc status updated to "gone live".

## Note

The original design gated go-live on *a consumer committing to read the marker*. Enabling now means the asset is published and per-release AI cost starts even before a consumer is wired up — intentional per request; easy to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)