### PR TITLE
ci: [DEMO – do not merge] expand/contract SAFE — drop a column the previous release stopped using (PROD-8359)

### DIFF
--- a/packages/backend/src/database/migrations/20260629210000_demo_drop_impersonation_enabled.ts
+++ b/packages/backend/src/database/migrations/20260629210000_demo_drop_impersonation_enabled.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+// [DEMO - DO NOT MERGE] Contract step: drop organizations.impersonation_enabled.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.dropColumn('impersonation_enabled');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.boolean('impersonation_enabled').notNullable().defaultTo(false);
+    });
+}


### PR DESCRIPTION
**Do not merge — release-safety proof.** Identical `dropColumn('impersonation_enabled')` migration to the breaking demo, but this PR is based on a branch where the **expand already shipped** (the previous release no longer reads/writes the column). The preview's merge-base therefore has zero references to the column, so the AI rolling-update review should clear the destructive linter flag as the safe **contract** step of an expand/contract → ✅ `rollingUpdateSafe: true` + an auto-derived `minPreviousVersion`. Contrast with the breaking demo (same migration, base=main, column still used → ❌).