### PR TITLE
ci: [DEMO – do not merge] expand/contract BREAKING — same drop, but the column is still used (PROD-8359)

### DIFF
--- a/packages/backend/src/database/migrations/20260629210000_demo_drop_impersonation_enabled.ts
+++ b/packages/backend/src/database/migrations/20260629210000_demo_drop_impersonation_enabled.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+// [DEMO - DO NOT MERGE] Contract step: drop organizations.impersonation_enabled.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.dropColumn('impersonation_enabled');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.boolean('impersonation_enabled').notNullable().defaultTo(false);
+    });
+}


### PR DESCRIPTION
**Do not merge — release-safety proof.** The **same** `dropColumn('impersonation_enabled')` migration as the safe demo, but based on `main` where the previous release still reads/writes the column (`OrganizationModel`). The AI should grep the previous release, find it still used, and confirm **breaking** → ❌ `rollingUpdateSafe: false` / Recreate. The only difference from the safe demo is whether the expand has shipped — proving the AI reads the code, not the operation shape.