### PR TITLE
fix: prioritize path project UUID over query params in JWT auth middleware

### DIFF
--- a/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.test.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.test.ts
@@ -54,6 +54,33 @@ describe('Embed Auth Middleware', () => {
             expect(mockRequest.account).toBe(mockAccount);
             expect(mockNext).toHaveBeenCalledWith();
         });
+
+        it.each([
+            { query: { projectUuid: mockProjectUuid } },
+            { query: { projectUuids: [mockProjectUuid] } },
+        ])(
+            'authenticates against the path project when query params include a different project UUID: $query',
+            async ({ query }) => {
+                const victimProjectUuid = 'victim-project-uuid';
+                mockRequest.path = `/api/v1/embed/${victimProjectUuid}/dashboard`;
+                mockRequest.query = query;
+                mockRequest.headers = { [JWT_HEADER_NAME]: mockEmbedToken };
+
+                await jwtAuthMiddleware(
+                    mockRequest as express.Request,
+                    mockResponse as express.Response,
+                    mockNext,
+                );
+
+                expect(mockEmbedService.getAccountFromJwt).toHaveBeenCalledWith(
+                    victimProjectUuid,
+                    mockEmbedToken,
+                );
+                expect(mockRequest.project).toEqual({
+                    projectUuid: victimProjectUuid,
+                });
+            },
+        );
     });
 
     describe('Fallback to regular auth scenarios', () => {
@@ -211,26 +238,32 @@ describe('Embed Auth Middleware', () => {
             },
         );
 
-        it('should extract project UUID from projectUuids query param', async () => {
-            mockRequest.path = '/api/v2/content';
-            mockRequest.query = { projectUuids: [mockProjectUuid] };
-            mockRequest.headers = { [JWT_HEADER_NAME]: mockEmbedToken };
+        it.each([
+            { query: { projectUuid: mockProjectUuid } },
+            { query: { projectUuids: [mockProjectUuid] } },
+        ])(
+            'should extract project UUID from query params when the path has no project UUID: $query',
+            async ({ query }) => {
+                mockRequest.path = '/api/v2/content';
+                mockRequest.query = query;
+                mockRequest.headers = { [JWT_HEADER_NAME]: mockEmbedToken };
 
-            await jwtAuthMiddleware(
-                mockRequest as express.Request,
-                mockResponse as express.Response,
-                mockNext,
-            );
+                await jwtAuthMiddleware(
+                    mockRequest as express.Request,
+                    mockResponse as express.Response,
+                    mockNext,
+                );
 
-            expect(mockEmbedService.getAccountFromJwt).toHaveBeenCalledWith(
-                mockProjectUuid,
-                mockEmbedToken,
-            );
-            expect(mockRequest.project).toEqual({
-                projectUuid: mockProjectUuid,
-            });
-            expect(mockRequest.account).toBe(mockAccount);
-        });
+                expect(mockEmbedService.getAccountFromJwt).toHaveBeenCalledWith(
+                    mockProjectUuid,
+                    mockEmbedToken,
+                );
+                expect(mockRequest.project).toEqual({
+                    projectUuid: mockProjectUuid,
+                });
+                expect(mockRequest.account).toBe(mockAccount);
+            },
+        );
 
         it('should handle paths without embed segment', async () => {
             mockRequest.path = '/api/v1/some-other-path';

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
@@ -34,26 +34,23 @@ const getSingleQueryValue = (value: unknown): string | undefined => {
     return undefined;
 };
 
-const parseProjectUuid = (req: Pick<Request, 'query' | 'path'>) => {
-    const queryProjectUuid =
-        getSingleQueryValue(req.query.projectUuid) ??
-        getSingleQueryValue(req.query.projectUuids);
-
-    if (queryProjectUuid) {
-        return queryProjectUuid;
-    }
-
-    const pathParts = req.path.split('/');
+const getPathProjectUuid = (path: string): string | undefined => {
+    const pathParts = path.split('/');
     const projectParams = ['embed', 'projects'];
     const projectUuidIndex =
         pathParts.findIndex((part) => projectParams.includes(part)) + 1;
 
-    if (projectUuidIndex < 1) {
+    if (projectUuidIndex < 1 || !pathParts[projectUuidIndex]) {
         return undefined;
     }
 
     return pathParts[projectUuidIndex];
 };
+
+const parseProjectUuid = (req: Pick<Request, 'query' | 'path'>) =>
+    getPathProjectUuid(req.path) ??
+    getSingleQueryValue(req.query.projectUuid) ??
+    getSingleQueryValue(req.query.projectUuids);
 
 // This is the only embed endpoint that requires a user to be authenticated.
 // All other embed endpoints run off of the JWT.


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-546/veria-50-cross-tenant-dashboard-data-leakage-via-jwt-embed-principal

### Description:


The project UUID extraction logic has been updated to prioritize the path-based project UUID over query parameter values. 

Additionally, tests have been expanded to cover both `projectUuid` and `projectUuids` query param variants using `it.each`, and a fix was added to ensure an empty path segment is not mistakenly returned as a valid project UUID.