### PR TITLE
feat(ai): standardized OTel attribution on every AI call (ZAP-558)

### DIFF
--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -5,8 +5,10 @@ import type {
     BetaManagedAgentsAgent,
 } from '@anthropic-ai/sdk/resources/beta/agents';
 import { ParameterError } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import type { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
+import { traceSpan } from '../../tracing/tracing';
 import {
     getManagedAgentConfigHash,
     renderManagedAgentConfig,
@@ -287,6 +289,42 @@ export class ManagedAgentClient {
         sessionId: string;
         slackSummary: string | null;
     }> {
+        // Managed-agent sessions run on Anthropic's Agents API (not the Vercel
+        // AI SDK), so they need a manual span to show up in tracing alongside
+        // the auto-instrumented AI-SDK calls. Token usage isn't surfaced in the
+        // session event stream — attribution + latency only for now.
+        return traceSpan(
+            {
+                name: 'managed_agent.session',
+                op: 'ai.managed_agent',
+                attributes: {
+                    feature: 'managed-agent',
+                    'gen_ai.system': 'anthropic',
+                    'lightdash.resource_name': sessionConfig.resourceName,
+                    'lightdash.project_name': projectName,
+                },
+            },
+            (span) =>
+                this.runManagedAgentSession(
+                    sessionConfig,
+                    projectName,
+                    onCustomToolUse,
+                    span,
+                    onSessionCreated,
+                ),
+        );
+    }
+
+    private async runManagedAgentSession(
+        sessionConfig: ManagedAgentSessionConfig,
+        projectName: string,
+        onCustomToolUse: CustomToolHandler,
+        span: Sentry.Span,
+        onSessionCreated?: (sessionId: string) => void,
+    ): Promise<{
+        sessionId: string;
+        slackSummary: string | null;
+    }> {
         const client = this.getAnthropicClient();
         const { agentId, environmentId, vaultId } =
             await this.ensureAgentAndEnvironment(client, sessionConfig);
@@ -299,6 +337,10 @@ export class ManagedAgentClient {
         });
 
         Logger.info(`[ManagedAgent] Session created: ${session.id}`);
+        span.setAttributes({
+            'gen_ai.agent.id': agentId,
+            'gen_ai.session.id': session.id,
+        });
         onSessionCreated?.(session.id);
 
         const stream = await client.beta.sessions.events.stream(session.id);

--- a/packages/backend/src/ee/services/AiAgentDocumentService.ts
+++ b/packages/backend/src/ee/services/AiAgentDocumentService.ts
@@ -261,10 +261,16 @@ export class AiAgentDocumentService extends BaseService {
             user,
             body,
         );
-        const modelOptions = getModel(this.lightdashConfig.ai.copilot, {
-            enableReasoning: false,
-            useFastModel: true,
-        });
+        const modelOptions = {
+            ...getModel(this.lightdashConfig.ai.copilot, {
+                enableReasoning: false,
+                useFastModel: true,
+            }),
+            telemetry: {
+                organizationUuid,
+                userUuid: user.userUuid,
+            },
+        };
         let summary: AiAgentDocument['summary'];
         try {
             summary = await generateDocumentSummary(modelOptions, {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -36,6 +36,7 @@ import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassi
 import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
+import { getAiCallTelemetry } from './ai/utils/aiCallTelemetry';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
@@ -1026,6 +1027,15 @@ export class AiAgentReviewClassifierService extends BaseService {
             ...defaultAgentOptions,
             ...model.callOptions,
             providerOptions: model.providerOptions,
+            experimental_telemetry: getAiCallTelemetry({
+                functionId: 'aiAgentReviewClassifierJudge',
+                feature: 'review-classifier',
+                organizationUuid: candidate.subject.organizationUuid,
+                projectUuid: candidate.subject.projectUuid,
+                agentUuid: candidate.subject.agentUuid,
+                threadUuid: candidate.subject.threadUuid,
+                promptUuid: candidate.subject.assistantPromptUuid,
+            }),
             schema: aiAgentReviewClassifierJudgeOutputSchema,
             messages: [
                 {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1586,10 +1586,9 @@ export class AiAgentService extends BaseService {
                     thread: threadContext ?? undefined,
                 },
                 {
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
-                    agentId: agentUuid,
-                    mode: threadContext ? 'post-response' : 'empty-state',
+                    organizationUuid,
+                    projectUuid,
+                    agentUuid,
                 },
             );
 
@@ -3924,11 +3923,18 @@ export class AiAgentService extends BaseService {
             return latestCompaction ?? null;
         }
 
-        const compactionModel = getModel(this.lightdashConfig.ai.copilot, {
-            provider: prompt.modelConfig?.modelProvider as AnyType,
-            modelName: prompt.modelConfig?.modelName,
-            useFastModel: true,
-        });
+        const compactionModel = {
+            ...getModel(this.lightdashConfig.ai.copilot, {
+                provider: prompt.modelConfig?.modelProvider as AnyType,
+                modelName: prompt.modelConfig?.modelName,
+                useFastModel: true,
+            }),
+            telemetry: {
+                organizationUuid: user.organizationUuid ?? null,
+                threadUuid,
+                promptUuid: previousPrompt.ai_prompt_uuid,
+            },
+        };
 
         const serializedInput =
             Compaction.serializeConversation(messagesToCompact);
@@ -4571,10 +4577,18 @@ export class AiAgentService extends BaseService {
                 });
 
             // Use fast model for title generation (lightweight task)
-            const modelOptions = getModel(this.lightdashConfig.ai.copilot, {
-                enableReasoning: false,
-                useFastModel: true,
-            });
+            const modelOptions = {
+                ...getModel(this.lightdashConfig.ai.copilot, {
+                    enableReasoning: false,
+                    useFastModel: true,
+                }),
+                telemetry: {
+                    organizationUuid: user.organizationUuid ?? null,
+                    agentUuid,
+                    threadUuid,
+                    userUuid: user.userUuid,
+                },
+            };
 
             // Generate title using the dedicated title generator
             const title = await generateTitleFromMessages(

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -56,6 +56,7 @@ import { generateTooltip as generateTooltipFromContext } from '../ai/agents/tool
 import { getModel } from '../ai/models';
 import { getAnthropicModel } from '../ai/models/anthropic-claude';
 import { getModelPreset } from '../ai/models/presets';
+import { AiCallAttribution } from '../ai/utils/aiCallTelemetry';
 import { convertQueryResultsToCsv } from '../ai/utils/convertQueryResultsToCsv';
 import { fieldDesc, formatSummaryArray } from './utils/prepareData';
 import {
@@ -124,7 +125,16 @@ export class AiService {
      *
      * @returns The full AiModel with model, callOptions, and providerOptions
      */
-    private async getAmbientAiModel(user: SessionUser) {
+    private async getAmbientAiModel(
+        user: SessionUser,
+        telemetry?: { projectUuid?: string | null },
+    ) {
+        const attribution: AiCallAttribution = {
+            organizationUuid: user.organizationUuid ?? null,
+            userUuid: user.userUuid,
+            projectUuid: telemetry?.projectUuid ?? null,
+        };
+
         const anthropicConfig =
             this.lightdashConfig.ai.copilot.providers.anthropic;
 
@@ -135,9 +145,12 @@ export class AiService {
                     'claude-haiku-4-5 preset not found',
                 );
             }
-            return getAnthropicModel(anthropicConfig, preset, {
-                enableReasoning: false,
-            });
+            return {
+                ...getAnthropicModel(anthropicConfig, preset, {
+                    enableReasoning: false,
+                }),
+                telemetry: attribution,
+            };
         }
 
         const aiCopilotFlag = await this.featureFlagService.get({
@@ -149,10 +162,13 @@ export class AiService {
             throw new ForbiddenError('Ambient AI is not available');
         }
 
-        return getModel(this.lightdashConfig.ai.copilot, {
-            enableReasoning: false,
-            useFastModel: true,
-        });
+        return {
+            ...getModel(this.lightdashConfig.ai.copilot, {
+                enableReasoning: false,
+                useFastModel: true,
+            }),
+            telemetry: attribution,
+        };
     }
 
     private async throwOnFeatureDisabled(user: SessionUser) {
@@ -465,7 +481,9 @@ export class AiService {
         projectUuid: string,
         payload: GenerateChartMetadataRequest,
     ): Promise<GeneratedChartMetadata> {
-        const modelOptions = await this.getAmbientAiModel(user);
+        const modelOptions = await this.getAmbientAiModel(user, {
+            projectUuid,
+        });
 
         const result = await generateChartMetadataFromContext(modelOptions, {
             tableName: payload.tableName,
@@ -495,7 +513,9 @@ export class AiService {
         projectUuid: string,
         payload: GenerateTableCalculationRequest,
     ): Promise<GeneratedTableCalculation> {
-        const modelOptions = await this.getAmbientAiModel(user);
+        const modelOptions = await this.getAmbientAiModel(user, {
+            projectUuid,
+        });
         const project = await this.projectService.getProject(
             projectUuid,
             fromSession(user),
@@ -538,7 +558,9 @@ export class AiService {
         projectUuid: string,
         payload: GenerateFormulaTableCalculationRequest,
     ): Promise<GeneratedFormulaTableCalculation> {
-        const modelOptions = await this.getAmbientAiModel(user);
+        const modelOptions = await this.getAmbientAiModel(user, {
+            projectUuid,
+        });
 
         const result = await generateFormulaTableCalculationFromContext(
             modelOptions,
@@ -580,7 +602,9 @@ export class AiService {
         projectUuid: string,
         payload: GenerateTooltipRequest,
     ): Promise<GeneratedTooltip> {
-        const modelOptions = await this.getAmbientAiModel(user);
+        const modelOptions = await this.getAmbientAiModel(user, {
+            projectUuid,
+        });
 
         const result = await generateTooltipFromContext(modelOptions, {
             prompt: payload.prompt,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -86,6 +86,7 @@ import type { SpacePermissionService } from '../../../services/SpaceService/Spac
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
+import { getAiCallTelemetry } from '../ai/utils/aiCallTelemetry';
 import {
     createSandboxProvider,
     SandboxCommandError,
@@ -3310,6 +3311,13 @@ export class AppGenerateService extends BaseService {
                 model: modelOptions.model,
                 ...modelOptions.callOptions,
                 providerOptions: modelOptions.providerOptions,
+                experimental_telemetry: getAiCallTelemetry({
+                    functionId: 'clarifyApp',
+                    feature: 'data-app',
+                    organizationUuid,
+                    projectUuid,
+                    userUuid: user.userUuid,
+                }),
                 schema: clarifySchema,
                 abortSignal: AbortSignal.timeout(CLARIFY_TIMEOUT_MS),
                 messages: [

--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -1,6 +1,7 @@
 import { AiAgentWithContext } from '@lightdash/common';
 import { generateObject, LanguageModel } from 'ai';
 import { z } from 'zod';
+import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
 
 const AgentSelectionSchema = z.object({
     agentUuid: z
@@ -147,6 +148,10 @@ export async function selectAgent({
 
     const result = await generateObject({
         model,
+        experimental_telemetry: getAiCallTelemetry({
+            functionId: 'selectAgent',
+            feature: 'agent-selector',
+        }),
         schema: AgentSelectionSchema,
         messages: [
             { role: 'system', content: systemPrompt },

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -231,6 +231,8 @@ const getAgentTools = (
                 agentSettings: args.agentSettings,
                 threadUuid: args.threadUuid,
                 promptUuid: args.promptUuid,
+                organizationId: args.organizationId,
+                userId: args.userId,
                 telemetryEnabled: args.telemetryEnabled,
                 model: args.model,
             },

--- a/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
@@ -2,6 +2,7 @@ import { Field, Filters } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 import { GeneratorModelOptions } from '../models/types';
+import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
 const TITLE_MAX_LENGTH_CHARS = 140;
 const DESCRIPTION_MAX_LENGTH_CHARS = 500;
@@ -67,6 +68,11 @@ export async function generateChartMetadata(
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
         schema: ChartMetadataSchema,
+        experimental_telemetry: getGeneratorTelemetry(
+            modelOptions,
+            'generateChartMetadata',
+            'chart-metadata',
+        ),
         messages: [
             {
                 role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/compactionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/compactionGenerator.ts
@@ -1,5 +1,6 @@
 import { generateText } from 'ai';
 import { GeneratorModelOptions } from '../models/types';
+import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
 export async function generateCompactionSummary(
     modelOptions: GeneratorModelOptions,
@@ -15,6 +16,11 @@ export async function generateCompactionSummary(
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
+        experimental_telemetry: getGeneratorTelemetry(
+            modelOptions,
+            'generateCompactionSummary',
+            'compaction',
+        ),
         messages: [
             {
                 role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -55,6 +55,8 @@ export type DiscoverFieldsAgentArgs = {
         | 'agentSettings'
         | 'threadUuid'
         | 'promptUuid'
+        | 'organizationId'
+        | 'userId'
         | 'telemetryEnabled'
         | 'model'
     >;
@@ -141,6 +143,7 @@ export const runDiscoverFieldsAgent = (
         experimental_telemetry: getAgentTelemetryConfig(
             'discoverFieldsSubagent',
             args.telemetry,
+            'agent-subtask',
         ),
         onChunk: ({ chunk }) => {
             if (chunk.type === 'tool-call') {

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -176,6 +176,8 @@ type ToolArgs = {
         | 'agentSettings'
         | 'threadUuid'
         | 'promptUuid'
+        | 'organizationId'
+        | 'userId'
         | 'telemetryEnabled'
         | 'model'
     >;

--- a/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
@@ -6,6 +6,7 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 import { GeneratorModelOptions } from '../models/types';
 import { renderAvailableExplores } from '../prompts/availableExplores';
+import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
 const DEFINED_TERMS_LIMIT = 30;
 const RELATED_EXPLORE_NAMES_LIMIT = 20;
@@ -84,6 +85,11 @@ export async function generateDocumentSummary(
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
+        experimental_telemetry: getGeneratorTelemetry(
+            modelOptions,
+            'generateDocumentSummary',
+            'document-summary',
+        ),
         schema: DocumentSummarySchema,
         messages: [
             {

--- a/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
@@ -4,6 +4,7 @@ import { LightdashConfig } from '../../../../config/parseConfig';
 import { getAzureProvider } from '../models/azure-openai-gpt-4.1';
 import { getBedrockEmbeddingModel } from '../models/bedrock';
 import { getOpenAIEmbeddingModel } from '../models/openai-embedding';
+import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
 
 const EMBEDDING_DIMENSIONS = 1536;
 
@@ -76,13 +77,11 @@ export async function generateEmbedding(
     let { embedding } = await embed({
         model,
         value: trimmedText,
-        experimental_telemetry: {
+        experimental_telemetry: getAiCallTelemetry({
             functionId: 'generateEmbedding',
-            isEnabled: true,
-            recordInputs: false,
-            recordOutputs: false,
-            metadata,
-        },
+            feature: 'embedding',
+            extra: metadata,
+        }),
         // TODO :: provider options to set dimensions
     });
 

--- a/packages/backend/src/ee/services/ai/agents/formulaTableCalculationGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/formulaTableCalculationGenerator.ts
@@ -10,6 +10,7 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 import Logger from '../../../../logging/logger';
 import { GeneratorModelOptions } from '../models/types';
+import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 import {
     CustomFormatSchema,
     sanitizeCustomFormat,
@@ -343,6 +344,11 @@ export async function generateFormulaTableCalculation(
             model: modelOptions.model,
             ...modelOptions.callOptions,
             providerOptions: modelOptions.providerOptions,
+            experimental_telemetry: getGeneratorTelemetry(
+                modelOptions,
+                'generateFormulaTableCalculation',
+                'formula-table-calc',
+            ),
             schema: FormulaTableCalculationSchema,
             messages: [
                 { role: 'system', content: systemPrompt },

--- a/packages/backend/src/ee/services/ai/agents/projectRouter.ts
+++ b/packages/backend/src/ee/services/ai/agents/projectRouter.ts
@@ -1,5 +1,6 @@
 import { generateObject, LanguageModel } from 'ai';
 import { z } from 'zod';
+import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
 
 const ProjectRoutingSchema = z.object({
     reasoning: z
@@ -41,6 +42,10 @@ export async function routeProjectForSlack(
 
     const result = await generateObject({
         model,
+        experimental_telemetry: getAiCallTelemetry({
+            functionId: 'routeProjectForSlack',
+            feature: 'project-router',
+        }),
         schema: ProjectRoutingSchema,
         messages: [
             {

--- a/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
@@ -1,6 +1,7 @@
 import { generateObject } from 'ai';
 import { z } from 'zod';
 import { GeneratorModelOptions } from '../models/types';
+import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
 
 const QUESTION_MAX_LENGTH_CHARS = 200;
 const QuestionSchema = z.object({
@@ -49,13 +50,11 @@ Title: ${title || 'N/A'}
 Description: ${description || 'N/A'}`,
             },
         ],
-        experimental_telemetry: {
+        experimental_telemetry: getAiCallTelemetry({
             functionId: 'generateArtifactQuestion',
-            isEnabled: true,
-            recordInputs: false,
-            recordOutputs: false,
-            metadata,
-        },
+            feature: 'artifact-question',
+            extra: metadata,
+        }),
     });
 
     return result.object.question;

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { GeneratorModelOptions } from '../models/types';
+import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
 
 const EMPTY_STATE_PROMPT = `You write 3-6 starter "chips" that appear above an empty AI agent chat input in a business-intelligence tool.
 
@@ -241,16 +242,14 @@ export async function generateAgentSuggestions(
                     : `Generate empty-state suggestion chips for this agent.\n\nContext:\n${userContent}`,
             },
         ],
-        experimental_telemetry: {
+        experimental_telemetry: getAiCallTelemetry({
             functionId: 'generateAgentSuggestions',
-            isEnabled: true,
-            recordInputs: false,
-            recordOutputs: false,
-            metadata: {
+            feature: 'agent-suggestions',
+            extra: {
                 ...metadata,
                 mode: isPostResponse ? 'post-response' : 'empty-state',
             },
-        },
+        }),
     });
 
     return result.object;

--- a/packages/backend/src/ee/services/ai/agents/tableCalculationGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/tableCalculationGenerator.ts
@@ -13,6 +13,7 @@ import {
 import { generateObject } from 'ai';
 import { z } from 'zod';
 import { GeneratorModelOptions } from '../models/types';
+import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
 export const CustomFormatSchema = z.object({
     type: z
@@ -264,6 +265,11 @@ export async function generateTableCalculation(
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
+        experimental_telemetry: getGeneratorTelemetry(
+            modelOptions,
+            'generateTableCalculation',
+            'table-calc',
+        ),
         schema: TableCalculationSchema,
         messages: [
             {

--- a/packages/backend/src/ee/services/ai/agents/telemetry.ts
+++ b/packages/backend/src/ee/services/ai/agents/telemetry.ts
@@ -1,4 +1,5 @@
 import type { AiAgentArgs } from '../types/aiAgent';
+import { AiCallFeature, getAiCallTelemetry } from '../utils/aiCallTelemetry';
 
 export const getAiAgentModelName = (model: AiAgentArgs['model']) =>
     typeof model === 'string' ? model : model.modelId;
@@ -10,8 +11,11 @@ export const getAiAgentModelName = (model: AiAgentArgs['model']) =>
  * Passing distinct `functionId`s — e.g. `generateAgentResponse`,
  * `streamAgentResponse`, `discoverFieldsSubagent` — lets observability
  * stacks separate parent vs. subagent latency, token usage, and step
- * counts. The metadata pins each call back to the agent/thread/prompt for
- * cross-referencing with persisted tool calls.
+ * counts. The metadata pins each call to the org/project/agent/thread/prompt
+ * for cost attribution and cross-referencing with persisted tool calls.
+ *
+ * Spans always emit; `telemetryEnabled` only controls whether prompt/response
+ * content is recorded (it can contain user data) — see `getAiCallTelemetry`.
  */
 export const getAgentTelemetryConfig = (
     functionId: string,
@@ -19,6 +23,8 @@ export const getAgentTelemetryConfig = (
         agentSettings,
         threadUuid,
         promptUuid,
+        organizationId,
+        userId,
         telemetryEnabled,
         model,
     }: Pick<
@@ -26,19 +32,22 @@ export const getAgentTelemetryConfig = (
         | 'agentSettings'
         | 'threadUuid'
         | 'promptUuid'
+        | 'organizationId'
+        | 'userId'
         | 'telemetryEnabled'
         | 'model'
     >,
+    feature: AiCallFeature = 'agent',
 ) =>
-    ({
+    getAiCallTelemetry({
         functionId,
-        isEnabled: telemetryEnabled,
-        recordInputs: telemetryEnabled,
-        recordOutputs: telemetryEnabled,
-        metadata: {
-            agentUuid: agentSettings.uuid,
-            threadUuid,
-            promptUuid,
-            model: getAiAgentModelName(model),
-        },
-    }) as const;
+        feature,
+        organizationUuid: organizationId,
+        projectUuid: agentSettings.projectUuid,
+        agentUuid: agentSettings.uuid,
+        threadUuid,
+        promptUuid,
+        userUuid: userId,
+        model: getAiAgentModelName(model),
+        recordIO: telemetryEnabled,
+    });

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -1,6 +1,7 @@
 import { generateObject, ModelMessage } from 'ai';
 import { z } from 'zod';
 import { GeneratorModelOptions } from '../models/types';
+import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
 const TITLE_MAX_LENGTH_CHARS = 60;
 const TitleSchema = z.object({
@@ -24,6 +25,11 @@ export async function generateThreadTitle(
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
+        experimental_telemetry: getGeneratorTelemetry(
+            modelOptions,
+            'generateThreadTitle',
+            'thread-title',
+        ),
         schema: TitleSchema,
         messages: [
             {

--- a/packages/backend/src/ee/services/ai/agents/tooltipGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/tooltipGenerator.ts
@@ -2,6 +2,7 @@ import { GenerateTooltipRequest, TooltipFieldContext } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 import { GeneratorModelOptions } from '../models/types';
+import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
 const TooltipSchema = z.object({
     html: z
@@ -39,6 +40,11 @@ export async function generateTooltip(
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
+        experimental_telemetry: getGeneratorTelemetry(
+            modelOptions,
+            'generateTooltip',
+            'tooltip',
+        ),
         schema: TooltipSchema,
         messages: [
             {

--- a/packages/backend/src/ee/services/ai/models/types.ts
+++ b/packages/backend/src/ee/services/ai/models/types.ts
@@ -3,6 +3,7 @@ import { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
 import { JSONValue, LanguageModel, type CallSettings } from 'ai';
 import { AiCopilotConfigSchemaType } from '../../../../config/aiConfigSchema';
+import { AiCallAttribution } from '../utils/aiCallTelemetry';
 
 export type AiProvider = keyof AiCopilotConfigSchemaType['providers'];
 
@@ -32,4 +33,8 @@ export type GeneratorModelOptions = {
     model: LanguageModel;
     callOptions?: CallSettings;
     providerOptions?: Record<string, Record<string, JSONValue>>;
+    // Attribution stamped on the AI-call span (org/project/user). Set at the
+    // construction point where that context is in scope; read via
+    // getGeneratorTelemetry. See utils/aiCallTelemetry.
+    telemetry?: AiCallAttribution;
 };

--- a/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
+++ b/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
@@ -1,0 +1,122 @@
+/**
+ * Coarse feature bucket for an AI call. Lets us attribute token usage and cost
+ * to a product surface (data apps vs the agent vs metadata generation, etc.) in
+ * tracing, independently of the fine-grained `functionId`.
+ */
+export type AiCallFeature =
+    | 'agent'
+    | 'agent-subtask'
+    | 'chart-metadata'
+    | 'document-summary'
+    | 'thread-title'
+    | 'tooltip'
+    | 'artifact-question'
+    | 'agent-suggestions'
+    | 'table-calc'
+    | 'formula-table-calc'
+    | 'compaction'
+    | 'embedding'
+    | 'project-router'
+    | 'agent-selector'
+    | 'review-classifier'
+    | 'llm-judge'
+    | 'data-app'
+    | 'managed-agent';
+
+/**
+ * Attribution dimensions stamped on an AI-call span. All optional because not
+ * every call site has every dimension (e.g. an org-level router has no thread),
+ * but `organizationUuid` + `projectUuid` should be set wherever they're in scope
+ * so spend can be sliced by customer instance and project.
+ */
+export type AiCallAttribution = {
+    organizationUuid?: string | null;
+    projectUuid?: string | null;
+    agentUuid?: string | null;
+    threadUuid?: string | null;
+    promptUuid?: string | null;
+    userUuid?: string | null;
+    model?: string | null;
+};
+
+export type AiCallTelemetryOptions = AiCallAttribution & {
+    functionId: string;
+    feature: AiCallFeature;
+    /**
+     * Record the prompt/response content on the span. Gated separately from span
+     * emission because content can contain user data — emission (token usage +
+     * attribution) is always on, content capture is opt-in.
+     */
+    recordIO?: boolean;
+    /** Extra span metadata (e.g. a mode flag). Nullish values are dropped. */
+    extra?: Record<string, string | number | boolean | null | undefined>;
+};
+
+const ATTRIBUTION_KEYS: (keyof AiCallAttribution)[] = [
+    'organizationUuid',
+    'projectUuid',
+    'agentUuid',
+    'threadUuid',
+    'promptUuid',
+    'userUuid',
+    'model',
+];
+
+/**
+ * Builds an `experimental_telemetry` config for any Vercel AI SDK call
+ * (generateText / streamText / generateObject / embed).
+ *
+ * Spans always emit (`isEnabled: true`) so token usage is never silently lost;
+ * only input/output content capture is gated (`recordIO`). The metadata pins
+ * each call to a `feature` + org/project (+ agent/thread/prompt where available)
+ * so token usage and cost can be attributed in tracing. Nullish dimensions are
+ * dropped so the AI SDK doesn't reject the metadata.
+ */
+export const getAiCallTelemetry = ({
+    functionId,
+    feature,
+    recordIO = false,
+    extra,
+    ...attribution
+}: AiCallTelemetryOptions) => {
+    const metadata: Record<string, string | number | boolean> = { feature };
+
+    ATTRIBUTION_KEYS.forEach((key) => {
+        const value = attribution[key];
+        if (value != null) {
+            metadata[key] = value;
+        }
+    });
+
+    if (extra) {
+        Object.entries(extra).forEach(([key, value]) => {
+            if (value != null) {
+                metadata[key] = value;
+            }
+        });
+    }
+
+    return {
+        functionId,
+        isEnabled: true,
+        recordInputs: recordIO,
+        recordOutputs: recordIO,
+        metadata,
+    } as const;
+};
+
+/**
+ * Convenience wrapper for generator-style calls that carry their attribution on
+ * `modelOptions.telemetry`. Structural param (not `GeneratorModelOptions`) to
+ * avoid an import cycle with the models package.
+ */
+export const getGeneratorTelemetry = (
+    modelOptions: { telemetry?: AiCallAttribution },
+    functionId: string,
+    feature: AiCallFeature,
+) =>
+    getAiCallTelemetry({
+        functionId,
+        feature,
+        ...(modelOptions.telemetry ?? {}),
+    });

--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -4,6 +4,7 @@ import { JSONDiff, Score } from 'autoevals';
 import { z } from 'zod';
 import { defaultAgentOptions } from '../agents/agentV2';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
+import { getAiCallTelemetry } from './aiCallTelemetry';
 
 export const factualityScores = {
     A: 0.4,
@@ -182,6 +183,10 @@ export async function llmAsAJudge({
                 model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
+                experimental_telemetry: getAiCallTelemetry({
+                    functionId: 'llmAsAJudge',
+                    feature: 'llm-judge',
+                }),
                 schema: z.object({
                     answer: z
                         .enum(['A', 'B', 'C', 'D', 'E'])
@@ -260,6 +265,10 @@ ${
                 model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
+                experimental_telemetry: getAiCallTelemetry({
+                    functionId: 'llmAsAJudge',
+                    feature: 'llm-judge',
+                }),
                 schema: z.object({
                     score: z
                         .number()

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { DbAiAgentToolCall } from '../../../database/entities/ai';
 import { defaultAgentOptions } from '../agents/agentV2';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
+import { getAiCallTelemetry } from './aiCallTelemetry';
 
 const TOOL_NAME_TO_DB_TOOL_NAME = {
     findExplores: 'find_explores',
@@ -282,6 +283,10 @@ export const evaluateToolCallSequence = async (
         model: judge,
         ...defaultAgentOptions,
         ...callOptions,
+        experimental_telemetry: getAiCallTelemetry({
+            functionId: 'evaluateToolCallSequence',
+            feature: 'llm-judge',
+        }),
         schema: toolEvaluationSchema,
         prompt: `
 You are evaluating AI agent tool usage for business logic testing. Here is the data:


### PR DESCRIPTION
## What

Routes every Vercel AI SDK call (`generateText`/`streamText`/`generateObject`/`embed`) through a shared `getAiCallTelemetry` helper that always emits a span tagged with `feature` + `organizationUuid`/`projectUuid` (+ agent/thread/prompt/user/model where in scope), so LLM token usage can be attributed by feature and customer instance in tracing.

## Why

We can't attribute LLM token spend in prod today. Verified against Cloud Trace: only the two call sites that hardcoded `isEnabled: true` emitted spans; the agent (our biggest consumer) and ~11 other call sites emitted nothing, and no spans carried feature/org/project. Span emission was gated on `AI_COPILOT_TELEMETRY_ENABLED`, which wasn't taking effect on the deployment running the agent.

## Changes

- New `getAiCallTelemetry` helper (`ee/services/ai/utils/aiCallTelemetry.ts`). **Span emission is decoupled from `AI_COPILOT_TELEMETRY_ENABLED`** — `isEnabled: true` always. The flag now only gates prompt/response **content** capture (`recordIO`), which stays off by default (no PII).
- All 20 AI-SDK call sites routed through it, including ~11 previously untraced: chart metadata, titles, tooltips, doc summaries, table calcs, compaction, project router, agent selector, llm-judges, review classifier, data-app clarify.
- Generators read attribution off `GeneratorModelOptions.telemetry`, stamped at the construction points that have org/project in scope (no generator signature churn).
- Managed-agent Agents API (direct `@anthropic-ai/sdk`) wrapped in a manual `traceSpan` (attribution + latency; token usage isn't surfaced by the session event stream — follow-up).

## Verification

- `pnpm -F backend typecheck:fast` + eslint green (also after merging current main).
- Runtime-verified locally against Jaeger: a `generateTableCalculation` call (previously untraced) emitted a span with `feature=table-calc`, `organizationUuid`, `projectUuid`, `userUuid`, and `promptTokens`/`completionTokens` — **with `AI_COPILOT_TELEMETRY_ENABLED` off**, proving the decoupling.

## Deploy note

This deploy is itself what makes agent span capture work in prod, independent of the telemetry env flag. Expect increased span volume (all AI calls now emit); span content stays gated so size is bounded.

## Out of scope (tracked separately)

- $ cost rollup (tokens × price table) — follow-up ticket.
- Managed-agent token usage (needs a session-usage fetch).
- Trace-noise / mega-trace fix — ZAP-562.
- Data-app sandbox tracing — GLITCH-521.

Closes: ZAP-558
