### PR TITLE
chore: remove exposed port from headless browser service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,8 +133,6 @@ services:
         build:
             dockerfile: docker/Dockerfile.headless-browser
         restart: always
-        ports:
-            - '3001:3000'
 
 volumes:
     db-data:


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-532/veria-40-unauthenticated-headless-browser-exposure-enabling-server

### Description:
Removes the exposed port mapping (`3001:3000`) from the headless browser service in `docker-compose.yml`. This prevents the headless browser service from being directly accessible on the host machine, keeping it as an internal service only.