### PR TITLE
fix: validate liquid parameter keys

### DIFF
--- a/packages/common/src/templating/liquidSql.test.ts
+++ b/packages/common/src/templating/liquidSql.test.ts
@@ -47,6 +47,32 @@ describe('buildLiquidContext', () => {
         });
     });
 
+    it('should not pollute object prototypes with dotted parameter keys', () => {
+        delete (Object.prototype as Record<string, unknown>).veriaPolluted;
+
+        buildLiquidContext({ '__proto__.veriaPolluted': 'yes' });
+
+        expect(({} as Record<string, unknown>).veriaPolluted).toBeUndefined();
+    });
+
+    it('should ignore parameter keys with unsafe prototype segments', () => {
+        const context = buildLiquidContext({
+            safe: 'ok',
+            'events.grain': 'day',
+            '__proto__.polluted': 'yes',
+            'constructor.polluted': 'yes',
+            'events.prototype': 'yes',
+        });
+
+        expect(context.ld.parameters).toEqual({
+            safe: 'ok',
+            'events.grain': 'day',
+            grain: 'day',
+            events: { grain: 'day' },
+        });
+        expect(context.lightdash.parameters).toEqual(context.ld.parameters);
+    });
+
     it('should handle multiple parameters', () => {
         const context = buildLiquidContext({
             grain: 'day',

--- a/packages/common/src/templating/liquidSql.ts
+++ b/packages/common/src/templating/liquidSql.ts
@@ -26,6 +26,15 @@ const LIGHTDASH_LIQUID_PATTERN =
 
 type ParameterValue = string | number | string[] | number[];
 
+const UNSAFE_PARAMETER_KEY_PARTS = new Set([
+    '__proto__',
+    'constructor',
+    'prototype',
+]);
+
+const isSafeParameterKey = (key: string) =>
+    !key.split('.').some((part) => UNSAFE_PARAMETER_KEY_PARTS.has(part));
+
 const escapeLiquidParameterValue = (
     value: ParameterValue,
     escapeString?: (value: string) => string,
@@ -97,29 +106,34 @@ export const buildLiquidContext = (
     > = {};
 
     for (const [key, value] of Object.entries(parameterValuesMap)) {
-        const escapedValue = escapeLiquidParameterValue(value, escapeString);
+        if (isSafeParameterKey(key)) {
+            const escapedValue = escapeLiquidParameterValue(
+                value,
+                escapeString,
+            );
 
-        parameters[key] = escapedValue;
+            parameters[key] = escapedValue;
 
-        // For dotted names like "model.grain":
-        // - expose as short name ("grain") for backwards compatibility
-        // - expose as nested object ({ model: { grain: value } }) so Liquid
-        //   dot access like ld.parameters.model.grain works
-        const parts = key.split('.');
-        const shortName = parts[parts.length - 1];
-        if (shortName !== key) {
-            parameters[shortName] = escapedValue;
+            // For dotted names like "model.grain":
+            // - expose as short name ("grain") for backwards compatibility
+            // - expose as nested object ({ model: { grain: value } }) so Liquid
+            //   dot access like ld.parameters.model.grain works
+            const parts = key.split('.');
+            const shortName = parts[parts.length - 1];
+            if (shortName !== key) {
+                parameters[shortName] = escapedValue;
 
-            const [tableName, paramName] = parts;
-            const existing = parameters[tableName];
-            if (
-                existing !== undefined &&
-                typeof existing === 'object' &&
-                !Array.isArray(existing)
-            ) {
-                existing[paramName] = escapedValue;
-            } else {
-                parameters[tableName] = { [paramName]: escapedValue };
+                const [tableName, paramName] = parts;
+                const existing = parameters[tableName];
+                if (
+                    existing !== undefined &&
+                    typeof existing === 'object' &&
+                    !Array.isArray(existing)
+                ) {
+                    existing[paramName] = escapedValue;
+                } else {
+                    parameters[tableName] = { [paramName]: escapedValue };
+                }
             }
         }
     }


### PR DESCRIPTION
### Closes: https://linear.app/lightdash/issue/SPK-528/veria-39-server-side-prototype-pollution-via-dotted-parameter-keys-in  
  
Summary

- Validate Liquid parameter key segments before building the render context.
- Keep existing dotted parameter behavior for allowed keys.

### Testing

- pnpm -F common linter --fix /Users/javier/work/lightdash/packages/common/src/templating/liquidSql.test.ts /Users/javier/work/lightdash/packages/common/src/templating/liquidSql.ts
- pnpm -F common exec vitest run --config vitest.config.ts src/templating/liquidSql.test.ts
- pnpm -F common typecheck

