### PR TITLE
fix: improve command bar text contrast in dark mode

### DIFF
--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.module.css
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.module.css
@@ -31,3 +31,10 @@
     flex-grow: 1;
     overflow: hidden;
 }
+
+.secondaryText {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+}

--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
@@ -79,11 +79,11 @@ const OmnibarItem: FC<Props> = ({
                 </Group>
 
                 {item.contextLabel ? (
-                    <Text size="xs" truncate c="dimmed">
+                    <Text size="xs" truncate className={classes.secondaryText}>
                         {item.contextLabel}
                     </Text>
                 ) : item.description || item.typeLabel ? (
-                    <Text size="xs" truncate c="dimmed">
+                    <Text size="xs" truncate className={classes.secondaryText}>
                         {item.typeLabel}
                         {item.typeLabel && item.description ? <> · </> : null}
                         {item.description}

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.module.css
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.module.css
@@ -19,6 +19,13 @@
     padding: 0;
 }
 
+.groupLabel {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+}
+
 .accordionContent {
     padding: var(--mantine-spacing-xs);
 }

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.tsx
@@ -65,7 +65,7 @@ const OmnibarItemGroups: FC<Props> = ({
             {groupedItems.map(([groupType, groupItems], groupIndex) => (
                 <Accordion.Item key={groupType} value={groupType}>
                     <Accordion.Control>
-                        <Text c="dimmed" fw={500} fz="xs">
+                        <Text className={classes.groupLabel} fw={500} fz="xs">
                             {getSearchItemLabel(groupType)}
                         </Text>
                     </Accordion.Control>


### PR DESCRIPTION
The command bar (omnibar) group labels and result description text used Mantine's `dimmed` color, which resolves to `dark-2` (`#686868`) in dark mode. Against the group-row background (`ldDark-2`, `#242424`) that's a contrast ratio of ~2.7 — failing WCAG AA and making results hard to scan.

This swaps those to a higher-contrast secondary color in dark mode (`ldGray-7`) while keeping the existing subtle gray in light mode (light mode is unchanged — `ldGray-6` matches what `dimmed` already resolved to there).

Affected: result grouping row labels (`OmnibarItemGroups`) and per-result description/context text (`OmnibarItem`).
