### PR TITLE
feat: block file reader functions and table paths in user SQL for DuckDB

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -660,6 +660,57 @@ describe('DuckdbWarehouseClient', () => {
             },
         );
 
+        it.each([
+            'read_csv',
+            'read_csv_auto',
+            'read_json',
+            'read_json_auto',
+            'read_json_objects',
+            'read_json_objects_auto',
+            'read_ndjson',
+            'read_ndjson_auto',
+            'read_ndjson_objects',
+            'read_ndjson_objects_auto',
+            'read_parquet',
+            'read_text',
+            'read_blob',
+            'read_xlsx',
+        ])('should reject user queries with %s()', async (blockedFunction) => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await expect(
+                client.runQuery(`SELECT * FROM ${blockedFunction}('/tmp/a')`),
+            ).rejects.toThrow(
+                `SQL validation error: function '${blockedFunction}' is not allowed`,
+            );
+            expect(streamMock).not.toHaveBeenCalled();
+        });
+
+        it('should reject user queries that use file table paths', async () => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await expect(
+                client.runQuery("SELECT * FROM '/tmp/data.parquet'"),
+            ).rejects.toThrow(
+                'SQL validation error: file table paths are not allowed',
+            );
+            expect(streamMock).not.toHaveBeenCalled();
+        });
+
         it('should ignore blocked functions inside SQL comments', async () => {
             const streamMock = vi.fn(async () =>
                 getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
@@ -673,6 +724,22 @@ describe('DuckdbWarehouseClient', () => {
             // Should NOT throw because current_setting is in a comment
             const result = await client.runQuery(
                 "SELECT 1 -- current_setting('s3_secret_access_key')",
+            );
+            expect(result.rows).toEqual([{ val: 1 }]);
+        });
+
+        it('should ignore blocked file readers inside SQL comments', async () => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            const result = await client.runQuery(
+                "SELECT 1 -- SELECT * FROM read_parquet('/tmp/data.parquet')",
             );
             expect(result.rows).toEqual([{ val: 1 }]);
         });
@@ -695,6 +762,23 @@ describe('DuckdbWarehouseClient', () => {
             );
             expect(runMock).toHaveBeenCalledWith(
                 "COPY table TO 's3://bucket/data.parquet' (FORMAT PARQUET)",
+            );
+        });
+
+        it('should allow internal SQL to read staged files', async () => {
+            const streamMock = vi.fn();
+            const runMock = vi.fn();
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock, runMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await client.runSql(
+                "CREATE TABLE staged AS SELECT * FROM read_parquet('s3://bucket/data.parquet')",
+            );
+            expect(runMock).toHaveBeenCalledWith(
+                "CREATE TABLE staged AS SELECT * FROM read_parquet('s3://bucket/data.parquet')",
             );
         });
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -276,6 +276,11 @@ const BLOCKED_STATEMENT_TYPES_INTERNAL_SQL = new Set([
 const BLOCKED_FUNCTION_PATTERN =
     /\b(current_setting|duckdb_settings|duckdb_secrets)\s*\(/i;
 
+const BLOCKED_USER_SQL_FILE_FUNCTION_PATTERN =
+    /\b(read_(?:blob|csv(?:_auto)?|json(?:_auto|_objects(?:_auto)?)?|ndjson(?:_auto|_objects(?:_auto)?)?|parquet|text|xlsx))\s*\(/i;
+
+const BLOCKED_USER_SQL_FILE_TABLE_PATTERN = /\b(?:from|join)\s+'[^']*'/i;
+
 export type DuckdbWarehouseClientArgs = {
     databasePath?: string;
     s3Config?: DuckdbS3SessionConfig;
@@ -1423,6 +1428,24 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         }
     }
 
+    private static validateUserSqlFileAccess(sql: string): void {
+        const stripped = DuckdbWarehouseClient.stripSqlComments(sql);
+        const functionMatch = stripped.match(
+            BLOCKED_USER_SQL_FILE_FUNCTION_PATTERN,
+        );
+        if (functionMatch) {
+            throw new Error(
+                `SQL validation error: function '${functionMatch[1]}' is not allowed`,
+            );
+        }
+
+        if (BLOCKED_USER_SQL_FILE_TABLE_PATTERN.test(stripped)) {
+            throw new Error(
+                'SQL validation error: file table paths are not allowed',
+            );
+        }
+    }
+
     private async validateUserSql(
         db: DuckdbConnection,
         sql: string,
@@ -1451,6 +1474,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         }
 
         DuckdbWarehouseClient.validateSqlFunctions(sql);
+        DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
     }
 
     private async validateInternalSql(


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-533/veria-41-arbitrary-local-file-read-and-ssrf-via-duckdb-warehouse



![CleanShot 2026-06-30 at 13.19.43.png](https://app.graphite.com/user-attachments/assets/05ba4ec1-0a1a-4081-b971-75904215b40b.png)



### Description:

Adds SQL validation to block user queries from accessing local or remote files directly via DuckDB's file reader functions

Validation correctly ignores blocked patterns that appear inside SQL comments, ensuring legitimate queries are not incorrectly rejected.