### PR TITLE
fix(dashboard): keep one route Component so adding the first tab persists

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -1,4 +1,5 @@
 import { Stack } from '@mantine/core';
+import { type FC } from 'react';
 import { Navigate, Outlet, type RouteObject } from 'react-router';
 import AppRoute from './components/AppRoute';
 import ProjectLayout from './components/common/ProjectLayout';
@@ -270,6 +271,23 @@ const DASHBOARD_LIST_ROUTES: RouteObject[] = [
 ];
 
 // Dashboard view routes (use handle.navBarFixed=false for non-fixed NavBar)
+// Both dashboard routes (`:mode?` and `:mode/tabs/:tabUuid?`) must resolve to the
+// SAME Component identity. Otherwise navigating between them (e.g. adding the first
+// tab navigates `/edit` -> `/edit/tabs/:uuid`) swaps the component type at the Outlet
+// and React remounts DashboardProvider, discarding unsaved tabs.
+let DashboardRouteComponent: FC | undefined;
+const loadDashboardRoute = async () => {
+    if (!DashboardRouteComponent) {
+        const { default: Dashboard } = await import('./pages/Dashboard');
+        DashboardRouteComponent = () => (
+            <TrackPage name={PageName.DASHBOARD}>
+                <Dashboard />
+            </TrackPage>
+        );
+    }
+    return { Component: DashboardRouteComponent };
+};
+
 const DASHBOARD_VIEW_ROUTES: RouteObject[] = [
     {
         path: 'dashboards/:dashboardUuid',
@@ -278,31 +296,11 @@ const DASHBOARD_VIEW_ROUTES: RouteObject[] = [
             {
                 path: ':mode?',
                 index: false,
-                lazy: async () => {
-                    const { default: Dashboard } =
-                        await import('./pages/Dashboard');
-                    return {
-                        Component: () => (
-                            <TrackPage name={PageName.DASHBOARD}>
-                                <Dashboard />
-                            </TrackPage>
-                        ),
-                    };
-                },
+                lazy: loadDashboardRoute,
             },
             {
                 path: ':mode/tabs/:tabUuid?',
-                lazy: async () => {
-                    const { default: Dashboard } =
-                        await import('./pages/Dashboard');
-                    return {
-                        Component: () => (
-                            <TrackPage name={PageName.DASHBOARD}>
-                                <Dashboard />
-                            </TrackPage>
-                        ),
-                    };
-                },
+                lazy: loadDashboardRoute,
             },
         ],
     },


### PR DESCRIPTION
## Problem

On a dashboard with **no tabs yet** (whether it has tiles or is empty), clicking **Add tab** silently fails — the new tab is created in state for a moment, then the tab bar never appears. Dashboards that already have tabs are unaffected.

## Root cause

Regression from #24493 (lazy route-bundle split). The two dashboard routes under `dashboards/:dashboardUuid`:

```
:mode?               -> <Dashboard/>   (/edit, /view — no tab in URL)
:mode/tabs/:tabUuid? -> <Dashboard/>   (/edit/tabs/:uuid)
```

were each converted from a shared `element` to their **own** `lazy: () => ({ Component: () => (...) })` closure. That gives the two routes **distinct component types** even though the JSX is identical.

Adding the *first* tab is the only action that navigates `/edit` → `/edit/tabs/:uuid`, i.e. crosses from the first route to the second. Because the component type at the `<Outlet>` now changes, React **unmounts and remounts `DashboardProvider`**, resetting its in-memory `dashboardTabs` to `[]` and re-seeding from the server (which has zero tabs) — so the just-added, unsaved tab is discarded.

Previously both routes rendered the same `TrackPage` type at the Outlet, so the same navigation **reconciled in place** with no remount. A dashboard that already has tabs stays within `:mode/tabs/:tabUuid?`, so it never crosses routes and isn't affected — which is why this only reproduces when adding the first tab.

## Fix

Resolve both routes to a **single shared `Component` identity** (`loadDashboardRoute`). The route swap then reconciles in place instead of remounting, so unsaved tabs survive.

## Verification

Reproduced locally (dashboard with a tile, no tabs): instrumenting the provider showed `setTabs 0→2` → `PROVIDER_UNMOUNT`/`MOUNT` → `setTabs 0→0`. With this change: **0 remounts**, both tabs persist and the tab bar renders. Frontend `typecheck` passes.

Closes: PROD-8567
Closes: #24916