### PR TITLE
fix: adjust DuckDB SQL validation order

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -1450,6 +1450,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         db: DuckdbConnection,
         sql: string,
     ): Promise<void> {
+        DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
+
         const extracted = await db.extractStatements(sql);
 
         if (extracted.count === 0) {
@@ -1474,7 +1476,6 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         }
 
         DuckdbWarehouseClient.validateSqlFunctions(sql);
-        DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
     }
 
     private async validateInternalSql(


### PR DESCRIPTION
## Summary

- Validate DuckDB user SQL file-reader patterns before statement extraction
- Keeps normal DuckDB SQL behavior unchanged

## Testing

- pnpm -F warehouses exec vitest run --config vitest.config.ts src/warehouseClients/DuckdbWarehouseClient.test.ts
- pnpm -F warehouses linter --fix /Users/javier/work/lightdash/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts /Users/javier/work/lightdash/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
- pnpm -F warehouses typecheck

Relates: https://linear.app/lightdash/issue/SPK-533/veria-41-arbitrary-local-file-read-and-ssrf-via-duckdb-warehouse