### PR TITLE
fix: harden MotherDuck connection options

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -860,15 +860,28 @@ describe('DuckdbWarehouseClient', () => {
 
     it.each([
         {
-            name: 'pass token in connection string for MotherDuck',
+            name: 'pass encoded token in SaaS-mode connection string for MotherDuck',
             credentials: {
                 type: WarehouseTypes.DUCKDB as const,
                 connectionType: DuckdbConnectionType.MOTHERDUCK as const,
                 database: 'my_database',
                 schema: 'main',
+                token: 'my_motherduck_token+with=symbols',
+            },
+            expectedPath:
+                'md:my_database?motherduck_token=my_motherduck_token%2Bwith%3Dsymbols&saas_mode=true',
+        },
+        {
+            name: 'encode MotherDuck database names before adding connection parameters',
+            credentials: {
+                type: WarehouseTypes.DUCKDB as const,
+                connectionType: DuckdbConnectionType.MOTHERDUCK as const,
+                database: 'analytics?motherduck_token=other&saas_mode=false',
+                schema: 'main',
                 token: 'my_motherduck_token',
             },
-            expectedPath: 'md:my_database?motherduck_token=my_motherduck_token',
+            expectedPath:
+                'md:analytics%3Fmotherduck_token%3Dother%26saas_mode%3Dfalse?motherduck_token=my_motherduck_token&saas_mode=true',
         },
     ])('should $name', async ({ credentials, expectedPath }) => {
         const runMock = vi.fn();

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -281,6 +281,18 @@ const BLOCKED_USER_SQL_FILE_FUNCTION_PATTERN =
 
 const BLOCKED_USER_SQL_FILE_TABLE_PATTERN = /\b(?:from|join)\s+'[^']*'/i;
 
+const buildMotherduckConnectionString = ({
+    database,
+    token,
+}: Pick<CreateDuckdbMotherduckCredentials, 'database' | 'token'>): string => {
+    const params = new URLSearchParams({
+        motherduck_token: token,
+        saas_mode: 'true',
+    });
+
+    return `md:${encodeURIComponent(database)}?${params.toString()}`;
+};
+
 export type DuckdbWarehouseClientArgs = {
     databasePath?: string;
     s3Config?: DuckdbS3SessionConfig;
@@ -382,7 +394,10 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
                     'MotherDuck token is required for DuckDB warehouse connections',
                 );
             }
-            this.databasePath = `md:${effectiveCredentials.database}?motherduck_token=${token}`;
+            this.databasePath = buildMotherduckConnectionString({
+                database: effectiveCredentials.database,
+                token,
+            });
         }
 
         this.resourceLimits = options?.resourceLimits;


### PR DESCRIPTION
## Summary

- Build MotherDuck connection strings with encoded parameters
- Enable MotherDuck SaaS mode for direct MotherDuck sessions
- 

## Testing

- pnpm -F warehouses exec vitest run --config vitest.config.ts src/warehouseClients/DuckdbWarehouseClient.test.ts
- pnpm -F warehouses linter --fix /Users/javier/work/lightdash/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts /Users/javier/work/lightdash/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
- pnpm -F warehouses typecheck

Closes: SPK-531