### PR TITLE
fix: require verified oidc emails

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/oidcStrategy.test.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oidcStrategy.test.ts
@@ -1,0 +1,46 @@
+import { OpenIdIdentityIssuerType } from '@lightdash/common';
+import { Request } from 'express';
+import { Profile as PassportProfile } from 'passport';
+import { genericOidcHandler } from './oidcStrategy';
+
+const makeRequest = (loginWithOpenId = vi.fn()) =>
+    ({
+        session: { oauth: {} },
+        services: {
+            getUserService: () => ({
+                loginWithOpenId,
+            }),
+        },
+        ip: '127.0.0.1',
+        get: vi.fn(() => 'test-user-agent'),
+    }) as unknown as Request;
+
+describe('genericOidcHandler', () => {
+    test('rejects profiles with explicitly unverified email claims', async () => {
+        const loginWithOpenId = vi.fn();
+        const done = vi.fn();
+        const handler = genericOidcHandler(
+            OpenIdIdentityIssuerType.GENERIC_OIDC,
+        );
+        const profile = {
+            id: 'subject-1',
+            emails: [{ value: 'user@example.com' }],
+            _json: {
+                email_verified: false,
+            },
+        } as unknown as PassportProfile;
+
+        await handler(
+            makeRequest(loginWithOpenId),
+            'https://issuer.example.com',
+            profile,
+            done,
+        );
+
+        expect(loginWithOpenId).not.toHaveBeenCalled();
+        expect(done).toHaveBeenCalledWith(null, false, {
+            message:
+                'Authentication failed: email is not verified in OpenID profile.',
+        });
+    });
+});

--- a/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts
@@ -25,7 +25,9 @@ export const isGenericOidcPassportStrategyAvailableToUse =
 
 const createOpenIdUserFromProfile = (
     profile: PassportProfile & {
+        email_verified?: boolean;
         _json?: {
+            email_verified?: boolean;
             given_name?: string;
             family_name?: string;
             [key: string]: unknown;
@@ -37,6 +39,8 @@ const createOpenIdUserFromProfile = (
 ) => {
     const email = profile.emails?.[0]?.value || profile.email;
     const subject = profile.id || profile.sub;
+    const emailVerified =
+        profile.email_verified ?? profile._json?.email_verified;
 
     if (!email) {
         Logger.error(
@@ -46,6 +50,18 @@ const createOpenIdUserFromProfile = (
         );
         return done(null, false, {
             message: 'Authentication failed: missing email in OpenID profile.',
+        });
+    }
+
+    if (emailVerified === false) {
+        Logger.error(
+            `Authentication failed: email is not verified in OpenID profile. ${JSON.stringify(
+                profile,
+            )}`,
+        );
+        return done(null, false, {
+            message:
+                'Authentication failed: email is not verified in OpenID profile.',
         });
     }
 

--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
@@ -27,6 +27,16 @@ const createOpenIdUserFromUserInfo = (
     issuerType: OpenIdIdentityIssuerType,
     fail: OpenIDClientOktaStrategy['fail'],
 ) => {
+    if (userInfo.email_verified === false) {
+        return fail(
+            {
+                message:
+                    'Authentication failed: email is not verified in OpenID profile.',
+            },
+            401,
+        );
+    }
+
     if (!userInfo.email || !userInfo.sub) {
         return fail(
             {


### PR DESCRIPTION
## Summary
- Reject OIDC profiles that explicitly report an unverified email
- Apply the same check to generic OIDC, Azure AD/OneLogin shared handler, and Okta userinfo
- Preserve compatibility for providers that omit the email verification claim

## Testing
- corepack pnpm -F backend exec vitest run --config vitest.config.ts src/controllers/authentication/strategies/oidcStrategy.test.ts src/services/UserService.test.ts
- corepack pnpm -F backend linter --fix /Users/javier/work/lightdash/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts /Users/javier/work/lightdash/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts /Users/javier/work/lightdash/packages/backend/src/controllers/authentication/strategies/oidcStrategy.test.ts
- corepack pnpm -F backend typecheck (fails on main-existing apiAccess embed permission type errors in EmbedService.ts and PermissionsService.ts)

Closes: SPK-529