### PR TITLE
fix: block nested sql execution functions

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -156,4 +156,24 @@ describe('getRunSql', () => {
         );
         expect(dependencies.runSqlJob).not.toHaveBeenCalled();
     });
+
+    it('rejects nested SQL execution functions before approval', async () => {
+        const { tool, dependencies } = makeTool();
+
+        const output = (await tool.execute!(
+            {
+                sql: "SELECT * FROM query('INSTALL shellfs')",
+                limit: 500,
+            },
+            {
+                messages: [],
+                toolCallId: 'tool-call-1',
+            },
+        )) as RunSqlOutput;
+
+        expect(output.metadata?.status).toBe('error');
+        expect(output.result).toContain('forbidden functions');
+        expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
+        expect(dependencies.runSqlJob).not.toHaveBeenCalled();
+    });
 });

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -51,6 +51,7 @@ const stripCommentsAndStrings = (sql: string): string =>
 const STARTS_WITH_SELECT_OR_WITH = /^\s*(WITH|SELECT)\b/i;
 const FORBIDDEN_STATEMENTS =
     /\b(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|GRANT|REVOKE|MERGE|CALL|EXECUTE)\b/i;
+const FORBIDDEN_FUNCTIONS = /\b(query|query_table)\s*\(/i;
 const INFORMATION_SCHEMA = /\binformation_schema\b/i;
 
 const PREVIEW_ROW_LIMIT = 50;
@@ -65,6 +66,11 @@ const validateSelectOnly = (sql: string) => {
     if (FORBIDDEN_STATEMENTS.test(stripped)) {
         throw new Error(
             'SQL contains forbidden statements (INSERT/UPDATE/DELETE/DDL). Only SELECT queries are allowed.',
+        );
+    }
+    if (FORBIDDEN_FUNCTIONS.test(stripped)) {
+        throw new Error(
+            'SQL contains forbidden functions. Only direct SELECT queries are allowed.',
         );
     }
     if (INFORMATION_SCHEMA.test(stripped)) {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -637,28 +637,28 @@ describe('DuckdbWarehouseClient', () => {
             );
         });
 
-        it.each(['current_setting', 'duckdb_settings', 'duckdb_secrets'])(
-            'should reject queries with %s()',
-            async (blockedFunction) => {
-                const streamMock = vi.fn(async () =>
-                    getMockStreamResult(
-                        [[{ val: 1 }]],
-                        [DUCKDB_TYPE_IDS.INTEGER],
-                    ),
-                );
+        it.each([
+            'current_setting',
+            'duckdb_settings',
+            'duckdb_secrets',
+            'query',
+            'query_table',
+        ])('should reject queries with %s()', async (blockedFunction) => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
 
-                createInstanceMock.mockResolvedValue(
-                    createMockConnection(streamMock),
-                );
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
 
-                const client = new DuckdbWarehouseClient();
-                await expect(
-                    client.runQuery(`SELECT * FROM ${blockedFunction}()`),
-                ).rejects.toThrow(
-                    `SQL validation error: function '${blockedFunction}' is not allowed`,
-                );
-            },
-        );
+            const client = new DuckdbWarehouseClient();
+            await expect(
+                client.runQuery(`SELECT * FROM ${blockedFunction}()`),
+            ).rejects.toThrow(
+                `SQL validation error: function '${blockedFunction}' is not allowed`,
+            );
+        });
 
         it.each([
             'read_csv',

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -274,7 +274,7 @@ const BLOCKED_STATEMENT_TYPES_INTERNAL_SQL = new Set([
 ]);
 
 const BLOCKED_FUNCTION_PATTERN =
-    /\b(current_setting|duckdb_settings|duckdb_secrets)\s*\(/i;
+    /\b(current_setting|duckdb_settings|duckdb_secrets|query|query_table)\s*\(/i;
 
 const BLOCKED_USER_SQL_FILE_FUNCTION_PATTERN =
     /\b(read_(?:blob|csv(?:_auto)?|json(?:_auto|_objects(?:_auto)?)?|ndjson(?:_auto|_objects(?:_auto)?)?|parquet|text|xlsx))\s*\(/i;


### PR DESCRIPTION
## Summary
- Reject nested SQL execution functions in AI runSql before approval
- Block the same DuckDB functions in warehouse user SQL validation
- Add focused coverage for AI runSql and DuckDB validation

## Testing
- corepack pnpm -F backend exec vitest run --config vitest.config.ts src/ee/services/ai/tools/runSql.test.ts
- corepack pnpm -F warehouses exec vitest run --config vitest.config.ts src/warehouseClients/DuckdbWarehouseClient.test.ts
- corepack pnpm -F backend linter --fix /Users/javier/work/lightdash/packages/backend/src/ee/services/ai/tools/runSql.ts /Users/javier/work/lightdash/packages/backend/src/ee/services/ai/tools/runSql.test.ts
- corepack pnpm -F warehouses linter --fix /Users/javier/work/lightdash/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts /Users/javier/work/lightdash/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
- corepack pnpm -F warehouses typecheck
- corepack pnpm -F backend typecheck (fails on main-existing apiAccess embed permission type errors in EmbedService.ts and PermissionsService.ts)

Closes: SPK-526