### PR TITLE
feat(ai-agents): cut discovery round-trips with pre-grep seed + FTS fallback

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -34,6 +34,12 @@ import { getGetDashboardCharts } from '../tools/getDashboardCharts';
 import { getGetKnowledgeDocumentContent } from '../tools/getKnowledgeDocumentContent';
 import { getGetProjectInfo } from '../tools/getProjectInfo';
 import { getGrepFields } from '../tools/grepFields';
+import {
+    buildFieldIndex,
+    extractKeywords,
+    renderCandidateBlock,
+    selectCandidateFields,
+} from '../tools/grepFieldsIndex';
 import { getImproveContext } from '../tools/improveContext';
 import { getListContent } from '../tools/listContent';
 import { getListKnowledgeDocuments } from '../tools/listKnowledgeDocuments';
@@ -90,6 +96,48 @@ const withToolHints = (
         typeof lastUser.content === 'string'
             ? `${lastUser.content}${hint}`
             : [...lastUser.content, { type: 'text' as const, text: hint }];
+    return [
+        ...messageHistory.slice(0, lastUserIndex),
+        { ...lastUser, content: updatedContent } as ModelMessage,
+        ...messageHistory.slice(lastUserIndex + 1),
+    ];
+};
+
+/**
+ * Zero-LLM discovery seed: deterministically grep the catalog for the latest
+ * user question's keywords and append the candidate fields to that message, so
+ * the agent often has the right fields on its first turn and can skip the
+ * discovery round-trip. Advisory only — the agent still verifies and can grep
+ * for itself. Appended to the (uncached) user message, never the system prompt.
+ */
+const withPreGrepCandidates = (
+    messageHistory: ModelMessage[],
+    availableExplores: Explore[],
+): ModelMessage[] => {
+    const lastUserIndex = messageHistory.findLastIndex(
+        (m) => m.role === 'user',
+    );
+    if (lastUserIndex === -1) return messageHistory;
+    const lastUser = messageHistory[lastUserIndex];
+    if (lastUser.role !== 'user') return messageHistory;
+    const userText =
+        typeof lastUser.content === 'string'
+            ? lastUser.content
+            : lastUser.content
+                  .map((part) => (part.type === 'text' ? part.text : ''))
+                  .join(' ');
+    const keywords = extractKeywords(userText);
+    if (keywords.length === 0) return messageHistory;
+    const candidates = selectCandidateFields(
+        buildFieldIndex(availableExplores),
+        keywords,
+    );
+    if (candidates.length === 0) return messageHistory;
+    const seed = `\n\n${renderCandidateBlock(candidates)}`;
+    const updatedContent =
+        typeof lastUser.content === 'string'
+            ? `${lastUser.content}${seed}`
+            : [...lastUser.content, { type: 'text' as const, text: seed }];
     return [
         ...messageHistory.slice(0, lastUserIndex),
         { ...lastUser, content: updatedContent } as ModelMessage,
@@ -251,7 +299,10 @@ const getAgentTools = (
     // Experimental swap: when on, the main agent greps the in-memory annotated
     // explores itself instead of delegating to the discoverFields sub-agent.
     const grepFields = args.enableGrepFields
-        ? getGrepFields({ availableExplores })
+        ? getGrepFields({
+              availableExplores,
+              findExplores: dependencies.findExplores,
+          })
         : null;
 
     const findContent = getFindContent({
@@ -575,7 +626,12 @@ const getAgentMessages = (
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger('Agent Messages', 'Getting agent messages.');
 
-    const messageHistory = withToolHints(args.messageHistory, args.toolHints);
+    const messageHistory = args.enableGrepFields
+        ? withPreGrepCandidates(
+              withToolHints(args.messageHistory, args.toolHints),
+              availableExplores,
+          )
+        : withToolHints(args.messageHistory, args.toolHints);
 
     // Project context is loaded on demand via the loadProjectContext tool; the
     // system prompt only advertises that it exists (when enabled + non-empty).

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -209,9 +209,10 @@ export const getSystemPromptV2 = (args: {
         ? [
               '## Finding fields (grepFields)',
               'To find which explore and fields can answer a question, use the `grepFields` tool instead of any other discovery step. It greps the field catalog (names, labels, descriptions, hints, tags) with case-insensitive keyword patterns (`|` for OR, space or .* between words for AND) and returns `explore/fieldId  [kind type]` lines grouped by explore.',
-              '- Pass several patterns in ONE call (the `patterns` array) covering the different angles of the question at once — e.g. `["revenue|sales", "country|region"]`. Do not grep one pattern, wait, then grep another.',
+              '- The user message may already include a "Candidate fields pre-grepped from the catalog" block. Read it FIRST — if it contains the fields you need, use them directly and skip calling grepFields. Only call grepFields when those candidates do not cover the question or you need a different angle.',
+              '- When you do call grepFields, pass several patterns in ONE call (the `patterns` array) covering the different angles of the question at once — e.g. `["revenue|sales", "country|region"]`. Do not grep one pattern, wait, then grep another.',
               '- Use meaningful keywords, not long natural-language phrases. Read the returned fieldIds and pick the single explore that answers at the right grain before building a query.',
-              '- If a search returns nothing, try synonyms or a broader pattern before giving up.',
+              '- If your literal patterns miss, grepFields automatically returns the closest catalog matches (fuzzy search, verified fields first) under "No exact grep matches" — use those rather than re-grepping a long list of synonyms.',
           ].join('\n')
         : '';
 

--- a/packages/backend/src/ee/services/ai/tools/grepFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFields.ts
@@ -1,5 +1,6 @@
 import { grepFieldsToolDefinition, type Explore } from '@lightdash/common';
 import { tool } from 'ai';
+import type { FindExploresFn } from '../types/aiAgentDependencies';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
     buildFieldIndex,
@@ -12,6 +13,39 @@ const toolDefinition = grepFieldsToolDefinition.for('agent');
 
 type Dependencies = {
     availableExplores: Explore[];
+    // FTS catalog search, reused as a fuzzy fallback when literal grep is dry.
+    findExplores: FindExploresFn;
+};
+
+// Turn the regex patterns into a plain-keyword query for the FTS fallback.
+const toFtsQuery = (patterns: string[]): string =>
+    patterns
+        .join(' ')
+        .replace(/[|()\\^$.*+?[\]{}]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+const renderFtsFallback = (
+    fields: NonNullable<
+        Awaited<ReturnType<FindExploresFn>>['topMatchingFields']
+    >,
+): string => {
+    const ranked = [...fields].sort(
+        (a, b) =>
+            (b.verifiedChartUsage ?? 0) - (a.verifiedChartUsage ?? 0) ||
+            (b.chartUsage ?? 0) - (a.chartUsage ?? 0) ||
+            (b.searchRank ?? 0) - (a.searchRank ?? 0),
+    );
+    const lines = ranked
+        .map((f) => {
+            const verified = f.verifiedChartUsage ? ' ✓verified' : '';
+            const desc = f.description
+                ? ` — ${f.description.replace(/\s+/g, ' ').slice(0, 140)}`
+                : '';
+            return `  ${f.tableName}_${f.name}  [${f.fieldType}]${verified} ${f.label}${desc}`;
+        })
+        .join('\n');
+    return `No exact grep matches. Closest catalog matches (fuzzy search, verified fields first):\n${lines}`;
 };
 
 // Per-pattern cap so a batch of broad patterns can't flood the context.
@@ -80,7 +114,10 @@ const renderPattern = (
  * never touches the warehouse or git. Gated by the `ai-grep-fields` flag as an
  * alternative to the discoverFields sub-agent.
  */
-export const getGrepFields = ({ availableExplores }: Dependencies) => {
+export const getGrepFields = ({
+    availableExplores,
+    findExplores,
+}: Dependencies) => {
     let index: FieldEntry[] | null = null;
     const getIndex = () => {
         if (index === null) index = buildFieldIndex(availableExplores);
@@ -112,11 +149,39 @@ export const getGrepFields = ({ availableExplores }: Dependencies) => {
                     );
                 });
                 const anyHit = blocks.some((b) => !b.includes('— no matches.'));
+                if (anyHit) {
+                    return {
+                        result: blocks.join('\n\n'),
+                        metadata: { status: 'success' as const },
+                    };
+                }
+
+                // Literal grep is dry — fall back to FTS (stemming + recall) so
+                // the agent gets matches now instead of re-grepping synonyms.
+                // A fallback failure degrades to the plain "no matches" message
+                // rather than erroring the whole (otherwise successful) grep.
+                let ftsFields: NonNullable<
+                    Awaited<
+                        ReturnType<typeof findExplores>
+                    >['topMatchingFields']
+                > = [];
+                try {
+                    const fallback = await findExplores({
+                        fieldSearchSize: 25,
+                        searchQuery: toFtsQuery(patterns),
+                    });
+                    ftsFields = (fallback.topMatchingFields ?? []).filter(
+                        (f) => !exploreName || f.tableName === exploreName,
+                    );
+                } catch {
+                    ftsFields = [];
+                }
                 const scope = exploreName ? ` in explore "${exploreName}"` : '';
                 return {
-                    result: anyHit
-                        ? blocks.join('\n\n')
-                        : `No fields matched any of the patterns${scope}. Try broader or alternative keywords.`,
+                    result:
+                        ftsFields.length > 0
+                            ? renderFtsFallback(ftsFields)
+                            : `No fields matched any of the patterns${scope}, and the catalog search found nothing close. Try broader or alternative keywords.`,
                     metadata: { status: 'success' as const },
                 };
             } catch (error) {

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
@@ -130,3 +130,90 @@ export const compileMatcher = (
             terms.every((term) => haystack.includes(term)),
         );
 };
+
+// Pure grammatical filler — dropped before the pre-grep so "what is our total
+// revenue by country" greps for revenue/country, not "what". Deliberately keeps
+// measure words (total, count, sum, average, value, top, …): in BI questions
+// those are exactly what disambiguate which metric, so they must stay greppable.
+const STOPWORDS = new Set(
+    (
+        'the a an is are was were be our my we us you your what whats how many much ' +
+        'show me give list get tell do does did have has of by for in on to and or ' +
+        'with per each all over time across this that these ' +
+        'those from which can could would should please into between about above ' +
+        'group breakdown break down split'
+    ).split(' '),
+);
+
+/**
+ * Deterministic keyword extraction from the user's question — no LLM. Drops
+ * stopwords and short tokens, dedupes, and keeps the most distinctive terms so
+ * we can pre-grep the catalog before the agent's first turn.
+ */
+export const extractKeywords = (text: string): string[] => {
+    const tokens = text.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
+    const seen = new Set<string>();
+    const kept: string[] = [];
+    for (const token of tokens) {
+        if (token.length >= 3 && !STOPWORDS.has(token) && !seen.has(token)) {
+            seen.add(token);
+            kept.push(token);
+        }
+    }
+    return kept.slice(0, 6);
+};
+
+/**
+ * Score every field by how many of the query keywords it matches and return the
+ * best candidates. Multi-keyword matches (e.g. a field hitting both "revenue"
+ * and "country") rank first, so the seed surfaces the on-target fields.
+ */
+export const selectCandidateFields = (
+    index: FieldEntry[],
+    keywords: string[],
+    limit = 25,
+): FieldEntry[] => {
+    if (keywords.length === 0) return [];
+    const scored: { entry: FieldEntry; score: number }[] = [];
+    for (const entry of index) {
+        let score = 0;
+        for (const keyword of keywords) {
+            if (entry.haystack.includes(keyword)) score += 1;
+        }
+        if (score > 0) scored.push({ entry, score });
+    }
+    scored.sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        // Tie-break: metrics first (questions usually want a measure), then the
+        // shorter path (less likely to be a deeply-nested edge field).
+        if (a.entry.kind !== b.entry.kind)
+            return a.entry.kind === 'metric' ? -1 : 1;
+        return a.entry.path.length - b.entry.path.length;
+    });
+    return scored.slice(0, limit).map((s) => s.entry);
+};
+
+export const renderCandidateBlock = (candidates: FieldEntry[]): string => {
+    const byExplore = new Map<string, FieldEntry[]>();
+    for (const c of candidates) {
+        const list = byExplore.get(c.exploreName) ?? [];
+        list.push(c);
+        byExplore.set(c.exploreName, list);
+    }
+    const blocks = [...byExplore.entries()].map(([exploreName, fields]) => {
+        const lines = fields
+            .map((f) => {
+                const desc = f.description
+                    ? ` — ${f.description.replace(/\s+/g, ' ').slice(0, 140)}`
+                    : '';
+                return `  ${f.path}  [${f.kind} ${f.type}] ${f.label}${desc}`;
+            })
+            .join('\n');
+        return `${exploreName} (${fields[0]?.exploreLabel ?? exploreName})\n${lines}`;
+    });
+    return [
+        'Candidate fields pre-grepped from the catalog for this question (deterministic keyword match — VERIFY these fit before using, and call grepFields yourself if you need different angles or none of these match):',
+        '',
+        ...blocks,
+    ].join('\n');
+};


### PR DESCRIPTION
## What

Two latency optimisations on top of **#24934**, both gated by the same `ai-grep-fields` flag.

### 1. Zero-LLM pre-grep seed
Before the agent's first turn, deterministically extract keywords from the question, grep the catalog **with no model in the loop**, and append the candidate fields to the (uncached) user message. On common questions the agent then has the right fields on turn one and **skips the discovery round-trip entirely** (`grepCalls=0`). Only possible because grep is deterministic — you could never pre-run the sub-agent.

### 2. Dry-grep FTS fallback
When literal patterns miss, `grepFields` falls back to the catalog full-text search (stemming + recall) and returns the closest matches **ranked verified-first** (`verifiedChartUsage`) — so the model stops re-grepping a long list of synonyms. Reuses the `findExplores` dependency.

## Results (local A/B, same model, 6 prompts)

| | Control (flag off) | Treatment (flag on) |
|---|---|---|
| avg thread time | 30.7s | **12.6s** (~59% faster) |
| avg tokens (main agent) | 44,968 | 45,546 (+1.3%) |
| discovery tool cost | sub-agent 40–90s | ~0.1s (query only) |

Answers same/accurate. The +1.3% token delta flatters control: it counts the **main agent only** — control also pays the hidden sub-agent's tokens — so true end-to-end tokens favour treatment.

## Regression analysis

- Flag off → no change (this PR's code paths are all behind `args.enableGrepFields`).
- Flag on → discovery is seeded/served by grep; the seed is **advisory** (the agent verifies and can still grep), appended to the user message so the **system-prompt cache is untouched**.
- FTS fallback only fires when literal grep is dry, so the happy path is unchanged from #24934.

## Follow-ups (not in this stack)
- Weight **verified content** in the *primary* grep + seed (enrich the in-memory index with `verifiedChartUsage`), not just the fallback.
- Join **project context** / **knowledge documents** into the seed (governance-aware candidates + synonym expansion).
