### PR TITLE
fix: restore MotherDuck direct query compatibility

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -679,9 +679,12 @@ describe('DuckdbWarehouseClient', () => {
             const streamMock = vi.fn(async () =>
                 getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
             );
+            const extractStatementsMock = createMockExtractStatements();
 
             createInstanceMock.mockResolvedValue(
-                createMockConnection(streamMock),
+                createMockConnection(streamMock, vi.fn(), {
+                    extractStatements: extractStatementsMock,
+                }),
             );
 
             const client = new DuckdbWarehouseClient();
@@ -690,6 +693,7 @@ describe('DuckdbWarehouseClient', () => {
             ).rejects.toThrow(
                 `SQL validation error: function '${blockedFunction}' is not allowed`,
             );
+            expect(extractStatementsMock).not.toHaveBeenCalled();
             expect(streamMock).not.toHaveBeenCalled();
         });
 
@@ -898,17 +902,17 @@ describe('DuckdbWarehouseClient', () => {
         await client.runQuery('SELECT 1 AS id');
 
         expect(createInstanceMock).toHaveBeenCalledWith(expectedPath);
-        expect(runMock).toHaveBeenCalledWith(
-            'SET allow_community_extensions = false;',
+        expect(runMock).not.toHaveBeenCalledWith(
+            expect.stringContaining('allow_community_extensions'),
         );
-        expect(runMock).toHaveBeenCalledWith(
-            'SET autoinstall_known_extensions = false;',
+        expect(runMock).not.toHaveBeenCalledWith(
+            expect.stringContaining('autoinstall_known_extensions'),
         );
-        expect(runMock).toHaveBeenCalledWith(
-            'SET autoload_known_extensions = false;',
+        expect(runMock).not.toHaveBeenCalledWith(
+            expect.stringContaining('autoload_known_extensions'),
         );
-        expect(runMock).toHaveBeenCalledWith(
-            'SET allow_unredacted_secrets = false;',
+        expect(runMock).not.toHaveBeenCalledWith(
+            expect.stringContaining('allow_unredacted_secrets'),
         );
     });
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -1264,7 +1264,6 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         const connectMs = performance.now() - connectStart;
 
         try {
-            await DuckdbWarehouseClient.hardenInstance(connection);
             const queryStart = performance.now();
             const result = await callback(connection);
             const queryMs = performance.now() - queryStart;
@@ -1465,6 +1464,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         db: DuckdbConnection,
         sql: string,
     ): Promise<void> {
+        DuckdbWarehouseClient.validateSqlFunctions(sql);
         DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
 
         const extracted = await db.extractStatements(sql);
@@ -1489,8 +1489,6 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         } finally {
             stmt.destroySync();
         }
-
-        DuckdbWarehouseClient.validateSqlFunctions(sql);
     }
 
     private async validateInternalSql(


### PR DESCRIPTION
## Summary

- Restore direct MotherDuck query compatibility by skipping local DuckDB hardening settings for MotherDuck sessions.
- Run DuckDB file-access validation before statement preparation so guarded functions fail before column discovery can bind them.

## Testing

- `CI=true corepack pnpm -F warehouses test -- DuckdbWarehouseClient.test.ts`
- `corepack pnpm -F warehouses lint -- /Users/javier/work/lightdash/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts /Users/javier/work/lightdash/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts`

Closes: [https://linear.app/lightdash/issue/PROD-8593/fix-potential-regression-on-duckdb-connector](https://linear.app/lightdash/issue/PROD-8593/fix-potential-regression-on-duckdb-connector)