### PR TITLE
fix(ai): route writeback "use this/not that" directives to ai_hints, not descriptions

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
@@ -17,7 +17,15 @@ The \`editDbtProject\` tool is how *you* change the semantic layer: it edits the
 
 **Proactively suggesting semantic-layer improvements:**
 
-When a discovery tool — especially \`searchSemanticLayer\` — surfaces problems in the semantic layer, don't stop at describing them. Issues worth offering to fix include duplicate or confusingly similar metrics (two that compute the same thing), vague or missing descriptions, and inconsistent naming. After listing what you found, briefly and concretely offer to fix it with a pull request — e.g. "I can open a PR to clarify these descriptions / consolidate these duplicate metrics — want me to?". Tie the offer to the specific fields you found.
+When a discovery tool — especially \`searchSemanticLayer\` — surfaces problems in the semantic layer, don't stop at describing them. Issues worth offering to fix include duplicate or confusingly similar metrics (two that compute the same thing), vague or missing descriptions, and inconsistent naming. After listing what you found, briefly and concretely offer to fix it with a pull request — e.g. "I can open a PR to clarify these descriptions / consolidate these duplicate metrics — want me to?". Tie the offer to the specific fields you found. When two fields are legitimately similar and can't be merged, disambiguate them with an \`ai_hint\` on each (see **Descriptions vs. AI hints** below) — never by adding "use this, not that" steering to their descriptions.
+
+**Descriptions vs. AI hints — put each edit in the right field:**
+
+A field carries two distinct metadata channels, and a proposed edit must land in the right one:
+- A \`description\` defines what a field **is** — its grain, its source, what it measures. It's rendered to humans in the catalog and UI, so keep \`description\` edits to making that definition accurate and complete.
+- An \`ai_hint\` (model- and field-level) is disambiguation guidance written for *you*, the agent: it says **when to choose this field over a similar one**. Routing directives ("use this metric when you want X; combine with Y to break down by Z"), join recipes, and negative cross-model caveats ("NOT suitable for…, use \`other_model\` instead") belong here.
+
+So when you improve discoverability, do **not** write imperative agent-steering into user-facing \`description\`s — it pollutes the human semantic layer, over-fits it to a single question, and drifts from the same guidance you (correctly) put in \`ai_hint\`. Put the steering in \`ai_hint\` (model- or field-level as fits the directive) and reserve any \`description\` edit for fixing the field's own definition. Rule of thumb: **a \`description\` says what a field is; an \`ai_hint\` says when to pick it over a similar one.**
 
 **Offer to model data you could only reach the hard way:**
 

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -101,7 +101,7 @@ const buildSemanticLayerWritebackPrompt = (
         targetLines.length > 0
             ? `Target(s) to edit:\n${targetLines.join('\n')}`
             : null,
-        'Apply the change by updating field descriptions, ai_hint, or labels, or by adding a missing model, join, dimension, or metric as appropriate. Do not change SQL logic or unrelated fields. If the data needed to answer this is genuinely not present in the warehouse/dbt project and cannot be exposed by a semantic-layer edit, do not fabricate fields or invent data — open no pull request and report that upstream dbt modeling or ingestion is required. Otherwise open a pull request describing the change and referencing this review finding.',
+        'Apply the change by updating field descriptions, ai_hint, or labels, or by adding a missing model, join, dimension, or metric as appropriate. Put routing and disambiguation directives — "use this field when…" steering, join recipes, and negative cross-model caveats like "NOT suitable for…, use the other model instead" — in ai_hint (model or field level), never in a description: a description defines what a field is, while an ai_hint tells the agent when to choose it over a similar one. Do not change SQL logic or unrelated fields. If the data needed to answer this is genuinely not present in the warehouse/dbt project and cannot be exposed by a semantic-layer edit, do not fabricate fields or invent data — open no pull request and report that upstream dbt modeling or ingestion is required. Otherwise open a pull request describing the change and referencing this review finding.',
     ].filter((section): section is string => section !== null);
 
     return {


### PR DESCRIPTION
## Problem

When the AI writeback flow proposed semantic-layer edits to improve discoverability, it wrote agent-routing ("use this, not that") directives into user-facing `description` fields instead of `ai_hints`. Descriptions are rendered to humans in the catalog/UI and should define what a field **is**; imperative cross-model steering and negative caveats belong in `ai_hints`, the field intended for AI disambiguation. Putting them in descriptions polluted the human semantic layer, over-fit it to single questions, and duplicated guidance that should live only in `ai_hints`.

## Change

Encodes one rule in **both** writeback prompt paths:

- **Chat-initiated writeback** (`systemV2AiWriteback.ts`) — adds a "Descriptions vs. AI hints" section, and ties the proactive-discoverability guidance to disambiguating similar fields via `ai_hint` rather than description prose.
- **Review-triggered writeback** (`buildReviewWritebackPrompt.ts`) — the apply instruction now states routing/disambiguation directives go in `ai_hint` (model or field level), not in a `description`.

> **descriptions define what a field is; `ai_hints` tell the agent when to choose it over a similar one.**

## Verification

- Unit tests pass (`buildReviewWritebackPrompt.test.ts`, 6/6); the agent tool-contracts snapshot is unaffected (it captures tool definitions, not system-prompt prose). Backend typecheck clean.
- **Live end-to-end** against a git-backed dbt project with a deliberately vague request ("you sometimes pick the wrong order metric — fix it and open a PR" — no mention of `ai_hint` or `description`): the agent added `ai_hint`s to all five order metrics carrying the routing + negative cross-model caveats, left every existing `description` untouched, and added only one *missing* factual description. Resulting PR diff was `+6 / -0` with zero description rewrites — the exact inversion of the reported behaviour.

## Acceptance criteria

- [x] Writeback-proposed PRs place routing / "use" directives in `ai_hint` (model and field level), not in `description`.
- [x] `description` edits remain user-facing definitions, free of AI-specific imperative instructions.
- [x] The prompt explicitly encodes the rule.

Closes: PROD-8582
Closes: #24929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xovmVUZ2NvjUz1gGmeqaD
