### PR TITLE
feat: align edit connection UI with onboarding wizard

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -7,10 +7,6 @@ import {
     type ExternalFetchResponse,
 } from '@lightdash/common';
 import {
-    ActionIcon,
-    Button,
-    Chip,
-    Group,
     PasswordInput,
     SegmentedControl,
     Select,
@@ -20,12 +16,17 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import { useForm, type UseFormReturnType } from '@mantine/form';
-import { IconPlugConnected, IconPlus, IconTrash } from '@tabler/icons-react';
+import { IconPlugConnected } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import { MethodsField } from '../../../features/externalConnections/components/MethodsField';
+import { PathRulesField } from '../../../features/externalConnections/components/PathRulesField';
 import { useCreateExternalConnection } from '../../../features/externalConnections/hooks/useCreateExternalConnection';
 import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
-import MantineIcon from '../../common/MantineIcon';
+import {
+    resolvePathPrefixes,
+    type PathMode,
+    type PathPrefix,
+} from '../../../features/externalConnections/utils/pathRules';
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
@@ -34,16 +35,11 @@ import { WizardTestStep } from './WizardTestStep';
 // Content types stay hidden in the onboarding wizard and the optional numeric
 // limits fall back to server defaults. Power users tune them in the Edit form.
 const DEFAULT_ALLOWED_CONTENT_TYPES = ['application/json'];
-// "Allow all paths" maps to a single root prefix — any path under the pinned
-// host. The host is the real security boundary, enforced by the SSRF guard.
-const ALLOW_ALL_PATH_PREFIXES = ['/'];
 
 // RFC 7230 token chars — must match the backend's apiKeyName validator.
 const HTTP_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 
 const TEST_STEP = 3;
-
-type PathMode = 'all' | 'restricted';
 
 type WizardValues = {
     name: string;
@@ -54,9 +50,7 @@ type WizardValues = {
     apiKeyLocation: ApiKeyLocation;
     allowedMethods: ExternalConnectionMethod[];
     pathMode: PathMode;
-    // Each prefix carries a stable uuid so the dynamic input list keys on
-    // identity, not array index (removing a row would otherwise misreconcile).
-    allowedPathPrefixes: { uuid: string; value: string }[];
+    allowedPathPrefixes: PathPrefix[];
 };
 
 export type ConnectionTestResult = {
@@ -80,16 +74,6 @@ const validateOrigin = (value: string): string | null => {
     return null;
 };
 
-const resolvePathPrefixes = (values: WizardValues): string[] => {
-    if (values.pathMode === 'all') {
-        return ALLOW_ALL_PATH_PREFIXES;
-    }
-    return values.allowedPathPrefixes
-        .map((p) => p.value.trim())
-        .filter(Boolean)
-        .map((p) => (p.startsWith('/') ? p : `/${p}`));
-};
-
 const toCreatePayload = (values: WizardValues): CreateExternalConnection => ({
     name: values.name.trim(),
     origin: values.origin,
@@ -98,7 +82,10 @@ const toCreatePayload = (values: WizardValues): CreateExternalConnection => ({
     apiKeyName: values.type === 'api_key' ? values.apiKeyName.trim() : null,
     apiKeyLocation: values.type === 'api_key' ? values.apiKeyLocation : null,
     allowedMethods: values.allowedMethods,
-    allowedPathPrefixes: resolvePathPrefixes(values),
+    allowedPathPrefixes: resolvePathPrefixes(
+        values.pathMode,
+        values.allowedPathPrefixes,
+    ),
     allowedContentTypes: DEFAULT_ALLOWED_CONTENT_TYPES,
 });
 
@@ -190,118 +177,26 @@ const AuthStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({ form }) => {
 
 const AccessStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({
     form,
-}) => {
-    const restricted = form.values.pathMode === 'restricted';
-    return (
-        <Stack gap="lg" mt="xl">
-            <Stack gap={4}>
-                <Text fz="sm" fw={500}>
-                    Which methods can apps use?
-                </Text>
-                <Chip.Group
-                    multiple
-                    value={form.values.allowedMethods}
-                    onChange={(value) =>
-                        form.setFieldValue(
-                            'allowedMethods',
-                            value as ExternalConnectionMethod[],
-                        )
-                    }
-                >
-                    <Group gap="xs" mt={4}>
-                        <Chip value="GET">GET</Chip>
-                        <Chip value="POST">POST</Chip>
-                    </Group>
-                </Chip.Group>
-                {form.errors.allowedMethods && (
-                    <Text c="red" fz="xs">
-                        {form.errors.allowedMethods}
-                    </Text>
-                )}
-            </Stack>
-
-            <Stack gap={4}>
-                <Text fz="sm" fw={500}>
-                    Which paths can apps call?
-                </Text>
-                <SegmentedControl
-                    fullWidth
-                    data={[
-                        { value: 'all', label: 'Allow all paths' },
-                        {
-                            value: 'restricted',
-                            label: 'Restrict to specific paths',
-                        },
-                    ]}
-                    value={form.values.pathMode}
-                    onChange={(value) => {
-                        form.setFieldValue('pathMode', value as PathMode);
-                        if (
-                            value === 'restricted' &&
-                            form.values.allowedPathPrefixes.length === 0
-                        ) {
-                            form.insertListItem('allowedPathPrefixes', {
-                                uuid: uuidv4(),
-                                value: '',
-                            });
-                        }
-                    }}
-                />
-            </Stack>
-
-            {restricted && (
-                <Stack gap="xs">
-                    <Text c="ldGray.6" fz="xs">
-                        Apps may only call paths that start with one of these
-                        prefixes.
-                    </Text>
-                    {form.values.allowedPathPrefixes.map((item, index) => (
-                        <Group key={item.uuid} gap="xs" wrap="nowrap">
-                            <TextInput
-                                w="100%"
-                                placeholder="/v1/"
-                                {...form.getInputProps(
-                                    `allowedPathPrefixes.${index}.value`,
-                                )}
-                            />
-                            <ActionIcon
-                                color="red"
-                                variant="subtle"
-                                onClick={() =>
-                                    form.removeListItem(
-                                        'allowedPathPrefixes',
-                                        index,
-                                    )
-                                }
-                            >
-                                <MantineIcon icon={IconTrash} />
-                            </ActionIcon>
-                        </Group>
-                    ))}
-                    {form.errors.allowedPathPrefixes && (
-                        <Text c="red" fz="xs">
-                            {form.errors.allowedPathPrefixes}
-                        </Text>
-                    )}
-                    <Button
-                        variant="subtle"
-                        size="compact-sm"
-                        leftSection={<MantineIcon icon={IconPlus} />}
-                        style={{ alignSelf: 'flex-start' }}
-                        onClick={() =>
-                            form.insertListItem('allowedPathPrefixes', {
-                                uuid: uuidv4(),
-                                value: '',
-                            })
-                        }
-                    >
-                        Add path prefix
-                    </Button>
-                </Stack>
-            )}
-        </Stack>
-    );
-};
+}) => (
+    <Stack gap="lg" mt="xl">
+        <MethodsField
+            label="Which methods can apps use?"
+            value={form.values.allowedMethods}
+            onChange={(value) => form.setFieldValue('allowedMethods', value)}
+            error={form.errors.allowedMethods}
+        />
+        <PathRulesField
+            label="Which paths can apps call?"
+            mode={form.values.pathMode}
+            onModeChange={(mode) => form.setFieldValue('pathMode', mode)}
+            prefixes={form.values.allowedPathPrefixes}
+            onPrefixesChange={(prefixes) =>
+                form.setFieldValue('allowedPathPrefixes', prefixes)
+            }
+            error={form.errors.allowedPathPrefixes}
+        />
+    </Stack>
+);
 
 type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     projectUuid: string;

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
@@ -17,8 +17,9 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { IconTrash } from '@tabler/icons-react';
-import { type FC, useState } from 'react';
+import { IconPlus, IconTrash } from '@tabler/icons-react';
+import { type ClipboardEvent, type FC, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { ConnectionTestResult } from '../../../features/externalConnections/components/ConnectionTestResult';
 import { useConnectionSamples } from '../../../features/externalConnections/hooks/useConnectionSamples';
@@ -29,29 +30,13 @@ import MantineIcon from '../../common/MantineIcon';
 
 const MAX_SAMPLE_PREVIEW_CHARS = 200;
 
+type QueryParam = { uuid: string; key: string; value: string };
+
 const parseJson = (value: string): unknown => {
     if (!value.trim()) {
         return undefined;
     }
     return JSON.parse(value);
-};
-
-const parseQueryParams = (
-    value: string,
-): Record<string, string> | undefined => {
-    const parsed = parseJson(value);
-    if (parsed === undefined) {
-        return undefined;
-    }
-    if (
-        parsed === null ||
-        typeof parsed !== 'object' ||
-        Array.isArray(parsed) ||
-        !Object.values(parsed).every((v) => typeof v === 'string')
-    ) {
-        throw new Error('Query params must be a JSON object of strings');
-    }
-    return parsed as Record<string, string>;
 };
 
 const isValidJson = (value: string): boolean => {
@@ -63,21 +48,56 @@ const isValidJson = (value: string): boolean => {
     }
 };
 
-const isValidQueryParams = (value: string): boolean => {
-    try {
-        parseQueryParams(value);
-        return true;
-    } catch {
-        return false;
+/** Collapse the key/value rows into the `Record<string, string>` the API
+ *  expects, dropping rows with a blank key. Returns undefined when empty. */
+const buildQuery = (
+    params: QueryParam[],
+): Record<string, string> | undefined => {
+    const entries = params
+        .map((p) => [p.key.trim(), p.value] as const)
+        .filter(([key]) => key.length > 0);
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
+/** Split a pasted path or full URL into its path and any query params, so the
+ *  user doesn't have to hand-enter query params they already have in a URL. */
+const parsePathInput = (
+    raw: string,
+): { path: string; query: { key: string; value: string }[] } => {
+    let pathPart = raw;
+    let search = '';
+    const queryIndex = raw.indexOf('?');
+    if (queryIndex >= 0) {
+        pathPart = raw.slice(0, queryIndex);
+        search = raw.slice(queryIndex + 1);
     }
+    // A full URL was pasted — reduce it to pathname + search.
+    try {
+        const url = new URL(raw);
+        pathPart = url.pathname;
+        search = url.search.replace(/^\?/, '');
+    } catch {
+        // Not an absolute URL; keep the parts from the '?' split above.
+    }
+    const query: { key: string; value: string }[] = [];
+    if (search) {
+        new URLSearchParams(search).forEach((value, key) => {
+            query.push({ key, value });
+        });
+    }
+    return { path: pathPart, query };
 };
 
 const exampleFormSchema = z.object({
     method: z.enum(['GET', 'POST']),
     path: z.string().min(1, 'Path is required'),
-    queryParams: z.string().refine(isValidQueryParams, {
-        message: 'Query params must be a JSON object with string values',
-    }),
+    queryParams: z.array(
+        z.object({
+            uuid: z.string(),
+            key: z.string(),
+            value: z.string(),
+        }),
+    ),
     requestBody: z.string().refine(isValidJson, {
         message: 'Request body must be valid JSON',
     }),
@@ -181,7 +201,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
         initialValues: {
             method: 'GET',
             path: '/',
-            queryParams: '',
+            queryParams: [],
             requestBody: '',
             sampleLabel: '',
         },
@@ -201,12 +221,28 @@ export const ConnectionExamplesPanel: FC<Props> = ({
         connection.externalConnectionUuid,
     );
 
+    // Pasting a URL (or path) with a query string splits the query out into the
+    // key/value rows instead of leaving it stuck in the path. The pasted URL is
+    // treated as the whole request, so it replaces any existing query params.
+    // Only intercept when there's a query to extract; otherwise paste normally.
+    const handlePathPaste = (event: ClipboardEvent<HTMLInputElement>) => {
+        const pasted = event.clipboardData.getData('text');
+        if (!pasted.includes('?')) return;
+        event.preventDefault();
+        const { path, query } = parsePathInput(pasted);
+        form.setFieldValue('path', path);
+        form.setFieldValue(
+            'queryParams',
+            query.map((q) => ({ uuid: uuidv4(), ...q })),
+        );
+    };
+
     const handleTest = () => {
         form.onSubmit((values) => {
             const request: ExternalConnectionSampleRequest = {
                 method: values.method,
                 path: values.path,
-                query: parseQueryParams(values.queryParams),
+                query: buildQuery(values.queryParams),
                 body:
                     values.method === 'POST'
                         ? parseJson(values.requestBody)
@@ -263,18 +299,62 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                     label="Path"
                     placeholder="/v1/endpoint"
                     style={{ flexGrow: 1 }}
+                    onPaste={handlePathPaste}
                     {...form.getInputProps('path')}
                 />
             </Group>
 
-            <Textarea
-                label="Query params (JSON)"
-                description="Sent as URL query params. Values must be strings."
-                placeholder='{"latitude": "52.52", "longitude": "13.41"}'
-                rows={3}
-                ff="monospace"
-                {...form.getInputProps('queryParams')}
-            />
+            <Stack gap={4}>
+                <Text fz="sm" fw={500}>
+                    Query params
+                </Text>
+                <Text c="ldGray.6" fz="xs">
+                    Sent as URL query params. Tip: paste a URL with a query
+                    string into the path field to fill these in automatically.
+                </Text>
+                {form.values.queryParams.map((param, index) => (
+                    <Group key={param.uuid} gap="xs" wrap="nowrap">
+                        <TextInput
+                            size="xs"
+                            placeholder="key"
+                            style={{ flex: 1 }}
+                            {...form.getInputProps(`queryParams.${index}.key`)}
+                        />
+                        <TextInput
+                            size="xs"
+                            placeholder="value"
+                            style={{ flex: 1 }}
+                            {...form.getInputProps(
+                                `queryParams.${index}.value`,
+                            )}
+                        />
+                        <ActionIcon
+                            variant="subtle"
+                            color="red"
+                            onClick={() =>
+                                form.removeListItem('queryParams', index)
+                            }
+                        >
+                            <MantineIcon icon={IconTrash} />
+                        </ActionIcon>
+                    </Group>
+                ))}
+                <Button
+                    variant="subtle"
+                    size="compact-sm"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    style={{ alignSelf: 'flex-start' }}
+                    onClick={() =>
+                        form.insertListItem('queryParams', {
+                            uuid: uuidv4(),
+                            key: '',
+                            value: '',
+                        })
+                    }
+                >
+                    Add query param
+                </Button>
+            </Stack>
 
             {form.values.method === 'POST' && (
                 <Textarea

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -7,6 +7,10 @@ import { useForm } from '@mantine/form';
 import { IconPencil } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useUpdateExternalConnection } from '../../../features/externalConnections/hooks/useUpdateExternalConnection';
+import {
+    derivePathRules,
+    resolvePathPrefixes,
+} from '../../../features/externalConnections/utils/pathRules';
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
@@ -30,6 +34,7 @@ const EditConnectionModalContent: FC<Props> = ({
     connection,
 }) => {
     const { mutateAsync, isLoading: isSaving } = useUpdateExternalConnection();
+    const pathRules = derivePathRules(connection.allowedPathPrefixes);
     const form = useForm<ExternalConnectionFormValues>({
         initialValues: {
             name: connection.name,
@@ -39,7 +44,8 @@ const EditConnectionModalContent: FC<Props> = ({
             apiKeyName: connection.apiKeyName ?? '',
             apiKeyLocation: connection.apiKeyLocation ?? 'header',
             allowedMethods: connection.allowedMethods,
-            allowedPathPrefixes: connection.allowedPathPrefixes,
+            pathMode: pathRules.mode,
+            allowedPathPrefixes: pathRules.prefixes,
             allowedContentTypes: connection.allowedContentTypes,
             responseMaxBytes: connection.responseMaxBytes,
             requestMaxBytes: connection.requestMaxBytes,
@@ -53,6 +59,17 @@ const EditConnectionModalContent: FC<Props> = ({
                 value.startsWith('https://')
                     ? null
                     : 'Origin must start with https://',
+            allowedMethods: (value) =>
+                value.length === 0 ? 'Select at least one method' : null,
+            allowedPathPrefixes: (value, values) => {
+                if (values.pathMode !== 'restricted') return null;
+                const nonEmpty = value
+                    .map((p) => p.value.trim())
+                    .filter(Boolean);
+                return nonEmpty.length === 0
+                    ? 'Add at least one path, or allow all paths'
+                    : null;
+            },
         },
     });
 
@@ -62,8 +79,9 @@ const EditConnectionModalContent: FC<Props> = ({
             origin: values.origin,
             type: values.type,
             allowedMethods: values.allowedMethods,
-            allowedPathPrefixes: values.allowedPathPrefixes.filter(
-                (p) => p.trim().length > 0,
+            allowedPathPrefixes: resolvePathPrefixes(
+                values.pathMode,
+                values.allowedPathPrefixes,
             ),
             allowedContentTypes: values.allowedContentTypes,
             responseMaxBytes: values.responseMaxBytes,

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.module.css
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.module.css
@@ -1,5 +1,0 @@
-.pathPrefixRow {
-    display: flex;
-    gap: var(--mantine-spacing-xs);
-    align-items: center;
-}

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
@@ -1,6 +1,5 @@
+import { type ExternalConnectionMethod } from '@lightdash/common';
 import {
-    ActionIcon,
-    Button,
     Divider,
     Group,
     MultiSelect,
@@ -8,14 +7,18 @@ import {
     PasswordInput,
     Select,
     Stack,
-    Text,
     TextInput,
 } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
-import { IconPlus, IconTrash } from '@tabler/icons-react';
-import { type FC } from 'react';
-import MantineIcon from '../../common/MantineIcon';
-import classes from './ExternalConnectionForm.module.css';
+import { type FC, useState } from 'react';
+import { MethodsField } from '../../../features/externalConnections/components/MethodsField';
+import { PathRulesField } from '../../../features/externalConnections/components/PathRulesField';
+import {
+    type PathMode,
+    type PathPrefix,
+} from '../../../features/externalConnections/utils/pathRules';
+import FormCollapseButton from '../../ProjectConnection/FormCollapseButton';
+import FormSection from '../../ProjectConnection/Inputs/FormSection';
 
 export type ExternalConnectionFormValues = {
     name: string;
@@ -24,8 +27,9 @@ export type ExternalConnectionFormValues = {
     secret: string;
     apiKeyName: string;
     apiKeyLocation: 'header' | 'query';
-    allowedMethods: ('GET' | 'POST')[];
-    allowedPathPrefixes: string[];
+    allowedMethods: ExternalConnectionMethod[];
+    pathMode: PathMode;
+    allowedPathPrefixes: PathPrefix[];
     allowedContentTypes: string[];
     responseMaxBytes: number;
     requestMaxBytes: number;
@@ -57,6 +61,7 @@ export const ExternalConnectionForm: FC<Props> = ({
 }) => {
     const { type, allowedMethods } = form.values;
     const allowsPost = allowedMethods.includes('POST');
+    const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
     const secretPlaceholder =
         hasSecret && type !== 'none'
             ? '•••• set (leave blank to keep current)'
@@ -124,100 +129,79 @@ export const ExternalConnectionForm: FC<Props> = ({
 
             <Divider label="Request policy" labelPosition="left" />
 
-            <MultiSelect
-                required
+            <MethodsField
                 label="Allowed methods"
+                value={allowedMethods}
+                onChange={(value) =>
+                    form.setFieldValue('allowedMethods', value)
+                }
+                error={form.errors.allowedMethods}
                 disabled={disabled}
-                data={[
-                    { value: 'GET', label: 'GET' },
-                    { value: 'POST', label: 'POST' },
-                ]}
-                {...form.getInputProps('allowedMethods')}
             />
 
-            <Stack gap={4}>
-                <Text fz="sm" fw={500}>
-                    Allowed path prefixes
-                </Text>
-                {form.values.allowedPathPrefixes.map((_prefix, index) => (
-                    <div key={index} className={classes.pathPrefixRow}>
-                        <TextInput
-                            w="100%"
-                            placeholder="/v1/"
+            <PathRulesField
+                label="Allowed paths"
+                mode={form.values.pathMode}
+                onModeChange={(mode) => form.setFieldValue('pathMode', mode)}
+                prefixes={form.values.allowedPathPrefixes}
+                onPrefixesChange={(prefixes) =>
+                    form.setFieldValue('allowedPathPrefixes', prefixes)
+                }
+                error={form.errors.allowedPathPrefixes}
+                disabled={disabled}
+            />
+
+            <FormSection name="advanced" isOpen={isAdvancedOpen}>
+                <Stack gap="sm" mt="xs">
+                    <MultiSelect
+                        label="Allowed response content types"
+                        disabled={disabled}
+                        data={CONTENT_TYPE_OPTIONS}
+                        searchable
+                        {...form.getInputProps('allowedContentTypes')}
+                    />
+
+                    <Group grow align="flex-start">
+                        <NumberInput
+                            label="Response max bytes"
+                            min={0}
                             disabled={disabled}
-                            {...form.getInputProps(
-                                `allowedPathPrefixes.${index}`,
-                            )}
+                            {...form.getInputProps('responseMaxBytes')}
                         />
-                        <ActionIcon
-                            color="red"
-                            variant="subtle"
+                        {allowsPost && (
+                            <NumberInput
+                                label="Request max bytes"
+                                min={0}
+                                disabled={disabled}
+                                {...form.getInputProps('requestMaxBytes')}
+                            />
+                        )}
+                    </Group>
+
+                    <Group grow align="flex-start">
+                        <NumberInput
+                            label="Timeout (ms)"
+                            min={0}
                             disabled={disabled}
-                            onClick={() =>
-                                form.removeListItem(
-                                    'allowedPathPrefixes',
-                                    index,
-                                )
-                            }
-                        >
-                            <MantineIcon icon={IconTrash} />
-                        </ActionIcon>
-                    </div>
-                ))}
-                <Button
-                    variant="subtle"
-                    size="compact-sm"
-                    leftSection={<MantineIcon icon={IconPlus} />}
-                    disabled={disabled}
-                    onClick={() =>
-                        form.insertListItem('allowedPathPrefixes', '')
-                    }
-                >
-                    Add path prefix
-                </Button>
-            </Stack>
-
-            <MultiSelect
-                label="Allowed response content types"
-                disabled={disabled}
-                data={CONTENT_TYPE_OPTIONS}
-                searchable
-                {...form.getInputProps('allowedContentTypes')}
-            />
-
-            <Group grow align="flex-start">
-                <NumberInput
-                    label="Response max bytes"
-                    min={0}
-                    disabled={disabled}
-                    {...form.getInputProps('responseMaxBytes')}
-                />
-                {allowsPost && (
-                    <NumberInput
-                        label="Request max bytes"
-                        min={0}
-                        disabled={disabled}
-                        {...form.getInputProps('requestMaxBytes')}
-                    />
-                )}
-            </Group>
-
-            <Group grow align="flex-start">
-                <NumberInput
-                    label="Timeout (ms)"
-                    min={0}
-                    disabled={disabled}
-                    {...form.getInputProps('timeoutMs')}
-                />
-                {allowsPost && (
-                    <NumberInput
-                        label="Rate limit (per minute)"
-                        min={0}
-                        disabled={disabled}
-                        {...form.getInputProps('rateLimitPerMinute')}
-                    />
-                )}
-            </Group>
+                            {...form.getInputProps('timeoutMs')}
+                        />
+                        {allowsPost && (
+                            <NumberInput
+                                label="Rate limit (per minute)"
+                                min={0}
+                                disabled={disabled}
+                                {...form.getInputProps('rateLimitPerMinute')}
+                            />
+                        )}
+                    </Group>
+                </Stack>
+            </FormSection>
+            <FormCollapseButton
+                isSectionOpen={isAdvancedOpen}
+                onClick={() => setIsAdvancedOpen((open) => !open)}
+            >
+                Advanced settings
+            </FormCollapseButton>
         </Stack>
     );
 };

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
@@ -36,7 +36,7 @@ export const WizardTestStep: FC<Props> = ({
     saveSample,
     onSaveSampleChange,
 }) => {
-    const [path, setPath] = useState('/');
+    const [path, setPath] = useState('');
     const testMutation = useTestConnectionConfig();
 
     const handleTest = async () => {

--- a/packages/frontend/src/features/externalConnections/components/MethodsField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/MethodsField.tsx
@@ -1,0 +1,48 @@
+import { type ExternalConnectionMethod } from '@lightdash/common';
+import { Chip, Group, Stack, Text } from '@mantine-8/core';
+import { type FC, type ReactNode } from 'react';
+
+// Extend here when the backend's supported-method set grows (e.g. PATCH/DELETE).
+const METHOD_OPTIONS: ExternalConnectionMethod[] = ['GET', 'POST'];
+
+type Props = {
+    label: string;
+    value: ExternalConnectionMethod[];
+    onChange: (value: ExternalConnectionMethod[]) => void;
+    error?: ReactNode;
+    disabled?: boolean;
+};
+
+/** Multi-select method chips (GET/POST). Shared by the onboarding wizard's
+ *  Rules step and the Edit connection form. */
+export const MethodsField: FC<Props> = ({
+    label,
+    value,
+    onChange,
+    error,
+    disabled,
+}) => (
+    <Stack gap={4}>
+        <Text fz="sm" fw={500}>
+            {label}
+        </Text>
+        <Chip.Group
+            multiple
+            value={value}
+            onChange={(next) => onChange(next as ExternalConnectionMethod[])}
+        >
+            <Group gap="xs" mt={4}>
+                {METHOD_OPTIONS.map((method) => (
+                    <Chip key={method} value={method} disabled={disabled}>
+                        {method}
+                    </Chip>
+                ))}
+            </Group>
+        </Chip.Group>
+        {error && (
+            <Text c="red" fz="xs">
+                {error}
+            </Text>
+        )}
+    </Stack>
+);

--- a/packages/frontend/src/features/externalConnections/components/PathRulesField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/PathRulesField.tsx
@@ -1,0 +1,124 @@
+import {
+    ActionIcon,
+    Button,
+    Group,
+    SegmentedControl,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import { IconPlus, IconTrash } from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import {
+    makePathPrefix,
+    type PathMode,
+    type PathPrefix,
+} from '../utils/pathRules';
+
+type Props = {
+    label: string;
+    mode: PathMode;
+    onModeChange: (mode: PathMode) => void;
+    prefixes: PathPrefix[];
+    onPrefixesChange: (prefixes: PathPrefix[]) => void;
+    error?: ReactNode;
+    disabled?: boolean;
+};
+
+/** "Allow all paths" vs "Restrict to specific paths" toggle plus the dynamic
+ *  prefix list. Controlled, so the wizard and Edit form can each wire it into
+ *  their own form state. */
+export const PathRulesField: FC<Props> = ({
+    label,
+    mode,
+    onModeChange,
+    prefixes,
+    onPrefixesChange,
+    error,
+    disabled,
+}) => (
+    <Stack gap={4}>
+        <Text fz="sm" fw={500}>
+            {label}
+        </Text>
+        <SegmentedControl
+            fullWidth
+            disabled={disabled}
+            data={[
+                { value: 'all', label: 'Allow all paths' },
+                { value: 'restricted', label: 'Restrict to specific paths' },
+            ]}
+            value={mode}
+            onChange={(value) => {
+                const next = value as PathMode;
+                onModeChange(next);
+                // Surface an empty row immediately so the user has somewhere to type.
+                if (next === 'restricted' && prefixes.length === 0) {
+                    onPrefixesChange([makePathPrefix()]);
+                }
+            }}
+        />
+        {mode === 'restricted' && (
+            <Stack gap="xs" mt="xs">
+                <Text c="ldGray.6" fz="xs">
+                    Apps may only call paths that start with one of these
+                    prefixes.
+                </Text>
+                {prefixes.map((prefix) => (
+                    <Group key={prefix.uuid} gap="xs" wrap="nowrap">
+                        <TextInput
+                            w="100%"
+                            placeholder="/v1/"
+                            disabled={disabled}
+                            value={prefix.value}
+                            onChange={(e) =>
+                                onPrefixesChange(
+                                    prefixes.map((p) =>
+                                        p.uuid === prefix.uuid
+                                            ? {
+                                                  ...p,
+                                                  value: e.currentTarget.value,
+                                              }
+                                            : p,
+                                    ),
+                                )
+                            }
+                        />
+                        <ActionIcon
+                            color="red"
+                            variant="subtle"
+                            disabled={disabled}
+                            onClick={() =>
+                                onPrefixesChange(
+                                    prefixes.filter(
+                                        (p) => p.uuid !== prefix.uuid,
+                                    ),
+                                )
+                            }
+                        >
+                            <MantineIcon icon={IconTrash} />
+                        </ActionIcon>
+                    </Group>
+                ))}
+                {error && (
+                    <Text c="red" fz="xs">
+                        {error}
+                    </Text>
+                )}
+                <Button
+                    variant="subtle"
+                    size="compact-sm"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    style={{ alignSelf: 'flex-start' }}
+                    disabled={disabled}
+                    onClick={() =>
+                        onPrefixesChange([...prefixes, makePathPrefix()])
+                    }
+                >
+                    Add path prefix
+                </Button>
+            </Stack>
+        )}
+    </Stack>
+);

--- a/packages/frontend/src/features/externalConnections/utils/pathRules.ts
+++ b/packages/frontend/src/features/externalConnections/utils/pathRules.ts
@@ -1,0 +1,47 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export type PathMode = 'all' | 'restricted';
+// Each prefix carries a stable uuid so the dynamic input list keys on identity,
+// not array index (removing a row would otherwise misreconcile inputs below it).
+export type PathPrefix = { uuid: string; value: string };
+
+const ALLOW_ALL_PATH_PREFIXES = ['/'];
+
+export const makePathPrefix = (value = ''): PathPrefix => ({
+    uuid: uuidv4(),
+    value,
+});
+
+/** Build the API payload's `allowedPathPrefixes` from the editor state.
+ *  "Allow all" maps to the single root prefix — any path under the pinned host
+ *  (the host is the real security boundary, enforced by the SSRF guard). */
+export const resolvePathPrefixes = (
+    mode: PathMode,
+    prefixes: PathPrefix[],
+): string[] => {
+    if (mode === 'all') {
+        return ALLOW_ALL_PATH_PREFIXES;
+    }
+    return prefixes
+        .map((p) => p.value.trim())
+        .filter(Boolean)
+        .map((p) => (p.startsWith('/') ? p : `/${p}`));
+};
+
+/** Derive editor state from an existing connection's `allowedPathPrefixes`.
+ *  `['/']` (or an empty list, which would reject everything) reads as "allow
+ *  all"; anything else is treated as a specific restriction. */
+export const derivePathRules = (
+    allowedPathPrefixes: string[],
+): { mode: PathMode; prefixes: PathPrefix[] } => {
+    const isAllowAll =
+        allowedPathPrefixes.length === 0 ||
+        (allowedPathPrefixes.length === 1 && allowedPathPrefixes[0] === '/');
+    if (isAllowAll) {
+        return { mode: 'all', prefixes: [] };
+    }
+    return {
+        mode: 'restricted',
+        prefixes: allowedPathPrefixes.map((p) => makePathPrefix(p)),
+    };
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-544/create-oboarding-wizard

### Description:
Bring the Edit connection form and its Examples tab closer to the new onboarding wizard, and extract the shared controls so both can use them.

Connection details:
- Allowed methods is now a GET/POST chip multi-select (was a MultiSelect).
- Allowed paths is now an "Allow all paths / Restrict to specific paths" toggle plus a uuid-keyed prefix list, derived from the stored prefixes on open and resolved back on save.
- Content types, byte caps, timeout and rate limit are collapsed behind an "Advanced settings" section (FormSection + FormCollapseButton).

Examples:
- Query params are edited as key/value rows instead of raw JSON.
- Pasting a URL (or path) with a query string into the Path field splits the query out into rows; a new paste replaces any existing params.

Shared, controlled MethodsField / PathRulesField components and a pathRules util (resolve/derive) are extracted under features/ externalConnections so the wizard can adopt them next.
