### PR TITLE
fix(ai): add mcp structured tool content

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -13,7 +13,10 @@ import {
 } from '@lightdash/common';
 import { CatalogSearchContext } from '../../../models/CatalogModel/CatalogModel';
 import { AiAgentContentValidation } from '../ai/utils/AiAgentContentValidation';
-import { AiAgentToolsService } from './AiAgentToolsService';
+import {
+    AiAgentToolsService,
+    type AiAgentToolsRuntimeContext,
+} from './AiAgentToolsService';
 
 const organizationUuid = 'organization-uuid';
 const projectUuid = 'project-uuid';
@@ -170,12 +173,16 @@ const makeService = ({
         asyncQueryService,
     } as unknown as ConstructorParameters<typeof AiAgentToolsService>[0]);
 
-const makeRuntimeContext = (
-    overrides: Partial<
-        Parameters<AiAgentToolsService['createRuntime']>[0]
-    > = {},
-): Parameters<AiAgentToolsService['createRuntime']>[0] =>
-    ({
+function makeRuntimeContext(
+    overrides: Partial<AiAgentToolsRuntimeContext> & { source: 'mcp' },
+): AiAgentToolsRuntimeContext & { source: 'mcp' };
+function makeRuntimeContext(
+    overrides?: Partial<AiAgentToolsRuntimeContext> & { source?: 'ai_agent' },
+): AiAgentToolsRuntimeContext & { source: 'ai_agent' };
+function makeRuntimeContext(
+    overrides: Partial<AiAgentToolsRuntimeContext> = {},
+): AiAgentToolsRuntimeContext {
+    return {
         user,
         account,
         organizationUuid,
@@ -186,7 +193,8 @@ const makeRuntimeContext = (
         tags: null,
         spaceAccess: null,
         ...overrides,
-    }) as Parameters<AiAgentToolsService['createRuntime']>[0];
+    };
+}
 
 describe('AiAgentToolsService', () => {
     it('filters explores by tags and merged user attribute overrides', async () => {
@@ -284,9 +292,102 @@ describe('AiAgentToolsService', () => {
             fieldSearchSize: 50,
             searchQuery: 'orders',
         });
-        expect(mcpResults.topMatchingFields?.[0]).not.toHaveProperty(
-            'verifiedChartUsage',
+        expect(mcpResults.status).toBe('success');
+        if (mcpResults.status === 'success') {
+            expect(mcpResults.data.topMatchingFields?.[0]).not.toHaveProperty(
+                'verifiedChartUsage',
+            );
+        }
+    });
+
+    it('returns MCP runtime errors from findExplores instead of throwing', async () => {
+        const service = makeService({
+            explores: { orders: makeExplore({ name: 'orders' }) },
+            searchCatalog: vi
+                .fn()
+                .mockRejectedValue(new Error('Catalog failed')),
+        });
+        const runtime = service.createRuntime(
+            makeRuntimeContext({
+                source: 'mcp',
+                catalogSearchContext: CatalogSearchContext.MCP,
+                defaultQueryExecutionContext:
+                    QueryExecutionContext.MCP_RUN_METRIC_QUERY,
+            }),
         );
+
+        const result = await runtime.findExplores({
+            fieldSearchSize: 50,
+            searchQuery: 'orders',
+        });
+
+        expect(result.status).toBe('error');
+        if (result.status !== 'error') {
+            throw new Error('Expected explore search to fail');
+        }
+        expect(result.error).toEqual(new Error('Catalog failed'));
+    });
+
+    it('returns MCP runtime errors from getExplore instead of throwing', async () => {
+        const service = makeService();
+        const runtime = service.createRuntime(
+            makeRuntimeContext({
+                source: 'mcp',
+                catalogSearchContext: CatalogSearchContext.MCP,
+                defaultQueryExecutionContext:
+                    QueryExecutionContext.MCP_RUN_METRIC_QUERY,
+            }),
+        );
+
+        const result = await runtime.getExplore({ table: 'orders' });
+
+        expect(result.status).toBe('error');
+        if (result.status !== 'error') {
+            throw new Error('Expected explore lookup to fail');
+        }
+        expect(result.error).toBeInstanceOf(NotFoundError);
+    });
+
+    it('returns MCP runtime per-query errors from findFields instead of throwing', async () => {
+        const service = makeService({
+            explores: { orders: makeExplore({ name: 'orders' }) },
+            searchCatalog: vi
+                .fn()
+                .mockRejectedValue(new Error('Catalog failed')),
+        });
+        const runtime = service.createRuntime(
+            makeRuntimeContext({
+                source: 'mcp',
+                catalogSearchContext: CatalogSearchContext.MCP,
+                defaultQueryExecutionContext:
+                    QueryExecutionContext.MCP_RUN_METRIC_QUERY,
+            }),
+        );
+        const exploreResult = await runtime.getExplore({ table: 'orders' });
+        expect(exploreResult.status).toBe('success');
+        if (exploreResult.status !== 'success') {
+            throw new Error('Expected explore lookup to succeed');
+        }
+
+        const result = await runtime.findFields({
+            table: 'orders',
+            fieldSearchQueries: [{ label: 'orders count' }],
+            page: 1,
+            pageSize: 15,
+            explore: exploreResult.data,
+        });
+
+        expect(result.status).toBe('success');
+        if (result.status !== 'success') {
+            throw new Error('Expected field search to return partial results');
+        }
+        expect(result.data).toEqual([
+            {
+                status: 'error',
+                searchQuery: 'orders count',
+                error: 'Catalog failed',
+            },
+        ]);
     });
 
     it('adds required filters to AI runtime explore search metadata only', async () => {

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -10,6 +10,7 @@ import {
     filterExploreByTags,
     ForbiddenError,
     getContentAsCodePathFromLtreePath,
+    getErrorMessage,
     getItemMap,
     getLtreePathFromContentAsCodePath,
     getValidAiQueryLimit,
@@ -72,6 +73,7 @@ import {
     FindContentSpaceMetadata,
     FindExploresFn,
     FindFieldFn,
+    FindFieldsFn,
     GetDashboardChartsFn,
     GetExploreFn,
     GetProjectInfoFn,
@@ -127,12 +129,41 @@ export type AiAgentToolsRuntimeContext = {
     agentUuid?: string;
 };
 
+export type McpRuntimeSuccess<TData> = {
+    status: 'success';
+    data: TData;
+};
+
+export type McpRuntimeError = {
+    status: 'error';
+    error: unknown;
+};
+
+export type McpRuntimeResult<TData> =
+    | McpRuntimeSuccess<TData>
+    | McpRuntimeError;
+
+export const unwrapMcpRuntimeResult = <TData>(
+    result: McpRuntimeResult<TData>,
+): TData => {
+    if (result.status === 'error') {
+        throw result.error;
+    }
+    return result.data;
+};
+
+type FindExploresRuntimeResult = Awaited<ReturnType<FindExploresFn>>;
+
+type FindFieldsRuntimeResult = Awaited<ReturnType<FindFieldsFn>>;
+
+type GetExploreRuntimeResult = Awaited<ReturnType<GetExploreFn>>;
+
 export type AiAgentToolsRuntime = {
     listExplores: ListExploresFn;
     getExplore: GetExploreFn;
     findExplores: FindExploresFn;
     getVerifiedFieldUsage: GetVerifiedFieldUsageFn;
-    findFields: FindFieldFn;
+    findFields: FindFieldsFn;
     findContent: FindContentFn;
     searchFieldValues: SearchFieldValuesFn;
     searchSemanticLayer: SearchSemanticLayerFn;
@@ -160,6 +191,21 @@ export type AiAgentToolsRuntime = {
     listProjects: ListProjectsFn;
     getProjectInfo: GetProjectInfoFn;
     loadSkill: LoadAgentSkillFn;
+};
+
+export type McpAiAgentToolsRuntime = Omit<
+    AiAgentToolsRuntime,
+    'getExplore' | 'findExplores' | 'findFields'
+> & {
+    getExplore: (
+        args: Parameters<GetExploreFn>[0],
+    ) => Promise<McpRuntimeResult<GetExploreRuntimeResult>>;
+    findExplores: (
+        args: Parameters<FindExploresFn>[0],
+    ) => Promise<McpRuntimeResult<FindExploresRuntimeResult>>;
+    findFields: (
+        args: Parameters<FindFieldsFn>[0],
+    ) => Promise<McpRuntimeResult<FindFieldsRuntimeResult>>;
 };
 
 type BuiltInSkillsClient = Pick<
@@ -421,8 +467,16 @@ export class AiAgentToolsService extends BaseService {
         return explore;
     }
 
-    createRuntime(context: AiAgentToolsRuntimeContext): AiAgentToolsRuntime {
-        return {
+    createRuntime(
+        context: AiAgentToolsRuntimeContext & { source: 'mcp' },
+    ): McpAiAgentToolsRuntime;
+    createRuntime(
+        context: AiAgentToolsRuntimeContext & { source: 'ai_agent' },
+    ): AiAgentToolsRuntime;
+    createRuntime(
+        context: AiAgentToolsRuntimeContext,
+    ): AiAgentToolsRuntime | McpAiAgentToolsRuntime {
+        const runtime: AiAgentToolsRuntime = {
             listExplores: () => this.listExplores(context),
             getExplore: (args) => this.getExploreForRuntime(context, args),
             findExplores: (args) => this.findExplores(context, args),
@@ -465,6 +519,54 @@ export class AiAgentToolsService extends BaseService {
             getProjectInfo: () => this.getProjectInfo(context),
             loadSkill: (name) => this.loadAgentSkill(name),
         };
+
+        return context.source === 'mcp'
+            ? this.withMcpRuntimeResults(runtime)
+            : runtime;
+    }
+
+    private withMcpRuntimeResults(
+        runtime: AiAgentToolsRuntime,
+    ): McpAiAgentToolsRuntime {
+        return {
+            ...runtime,
+            getExplore: this.withMcpRuntimeResult(
+                'get_explore',
+                runtime.getExplore,
+            ),
+            findExplores: this.withMcpRuntimeResult(
+                'find_explores',
+                runtime.findExplores,
+            ),
+            findFields: this.withMcpRuntimeResult(
+                'find_fields',
+                runtime.findFields,
+            ),
+        };
+    }
+
+    private withMcpRuntimeResult<TArgs extends unknown[], TData>(
+        toolName: string,
+        run: (...args: TArgs) => Promise<TData>,
+    ) {
+        return (...args: TArgs) =>
+            this.runMcpRuntimeTool(toolName, () => run(...args));
+    }
+
+    private async runMcpRuntimeTool<TData>(
+        toolName: string,
+        getData: () => Promise<TData>,
+    ): Promise<McpRuntimeResult<TData>> {
+        try {
+            return { status: 'success', data: await getData() };
+        } catch (error) {
+            const message = getErrorMessage(error);
+            this.logger.error(
+                `[AiAgentToolsService] Error in MCP ${toolName}: ${message}`,
+                { error },
+            );
+            return { status: 'error', error };
+        }
     }
 
     private listExplores(
@@ -591,10 +693,45 @@ export class AiAgentToolsService extends BaseService {
 
     private findFields(
         context: AiAgentToolsRuntimeContext,
+        args: Parameters<FindFieldsFn>[0],
+    ): ReturnType<FindFieldsFn> {
+        return wrapSentryTransaction(
+            `${AiAgentToolsService.transactionPrefix(context)}.findFields`,
+            args,
+            async () =>
+                Promise.all(
+                    args.fieldSearchQueries.map(async (fieldSearchQuery) => {
+                        try {
+                            const result = await this.findField(context, {
+                                table: args.table,
+                                fieldSearchQuery,
+                                page: args.page,
+                                pageSize: args.pageSize,
+                                explore: args.explore,
+                            });
+                            return {
+                                status: 'success',
+                                searchQuery: fieldSearchQuery.label,
+                                ...result,
+                            };
+                        } catch (error) {
+                            return {
+                                status: 'error',
+                                searchQuery: fieldSearchQuery.label,
+                                error: getErrorMessage(error),
+                            };
+                        }
+                    }),
+                ),
+        );
+    }
+
+    private findField(
+        context: AiAgentToolsRuntimeContext,
         args: Parameters<FindFieldFn>[0],
     ): ReturnType<FindFieldFn> {
         return wrapSentryTransaction(
-            `${AiAgentToolsService.transactionPrefix(context)}.findFields`,
+            `${AiAgentToolsService.transactionPrefix(context)}.findField`,
             args,
             async () => {
                 const { data: catalogItems, pagination } =

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -205,6 +205,7 @@ const makeMcpService = ({
     dashboardSearchResults = [],
     chartSearchResults = [],
     verifiedContent = [],
+    runtimeErrors = {},
 }: {
     context?: {
         projectUuid: string;
@@ -225,6 +226,11 @@ const makeMcpService = ({
     })[];
     chartSearchResults?: ReturnType<typeof makeChartSearchResult>[];
     verifiedContent?: Record<string, unknown>[];
+    runtimeErrors?: {
+        findExplores?: string;
+        findFields?: string;
+        findFieldsByQuery?: Record<string, string>;
+    };
 } = {}) => {
     const asyncQueryService = {
         executeAsyncSqlQuery: vi.fn(),
@@ -345,7 +351,20 @@ const makeMcpService = ({
                     ),
             );
 
-        return {
+        const toMcpRuntimeResult = async <TData>(
+            getData: () => Promise<TData>,
+        ) => {
+            try {
+                return { status: 'success' as const, data: await getData() };
+            } catch (error) {
+                return {
+                    status: 'error' as const,
+                    error,
+                };
+            }
+        };
+
+        const runtime = {
             listExplores: vi.fn(listScopedExplores),
             getExplore: vi.fn(async ({ table }: { table: string }) => {
                 const scopedExplores = await listScopedExplores();
@@ -355,32 +374,45 @@ const makeMcpService = ({
                 if (!explore) throw new NotFoundError('Explore not found');
                 return explore;
             }),
-            findExplores: vi.fn(async () => {
-                const scopedExplores = await listScopedExplores();
-                return {
-                    exploreSearchResults: scopedExplores.map((explore) => ({
-                        name: explore.name,
-                        label:
-                            (explore as { label?: string }).label ??
-                            explore.name,
-                        description: null,
-                        aiHints: undefined,
-                        searchRank: 1,
-                        joinedTables: [],
-                    })),
-                    topMatchingFields: [
-                        {
-                            name: 'orders_count',
-                            label: 'Orders Count',
-                            tableName: 'orders',
-                            fieldType: 'metric',
-                            searchRank: 1,
+            findExplores: vi.fn(
+                async (_args: {
+                    fieldSearchSize: number;
+                    searchQuery?: string;
+                }) => {
+                    const scopedExplores = await listScopedExplores();
+                    return {
+                        exploreSearchResults: scopedExplores.map((explore) => ({
+                            name: explore.name,
+                            label:
+                                (explore as { label?: string }).label ??
+                                explore.name,
                             description: null,
-                        },
-                    ],
-                };
-            }),
-            findFields: vi.fn(async () => ({ fields: [], pagination: {} })),
+                            aiHints: undefined,
+                            searchRank: 1,
+                            joinedTables: [],
+                        })),
+                        topMatchingFields: [
+                            {
+                                name: 'orders_count',
+                                label: 'Orders Count',
+                                tableName: 'orders',
+                                fieldType: 'metric',
+                                searchRank: 1,
+                                description: null,
+                            },
+                        ],
+                    };
+                },
+            ),
+            findField: vi.fn(
+                async (_args: {
+                    table: string;
+                    fieldSearchQuery: { label: string };
+                    page?: number;
+                    pageSize?: number;
+                    explore: ReturnType<typeof makeExplore>;
+                }) => ({ fields: [], pagination: {} }),
+            ),
             findContent: vi.fn(async () => ({
                 content: [
                     ...dashboardSearchResults.map((dashboard) => ({
@@ -414,6 +446,62 @@ const makeMcpService = ({
                     );
                 return results;
             }),
+        };
+
+        return {
+            ...runtime,
+            getExplore: vi.fn((args: { table: string }) =>
+                toMcpRuntimeResult(() => runtime.getExplore(args)),
+            ),
+            findExplores: vi.fn(
+                (args: { fieldSearchSize: number; searchQuery?: string }) =>
+                    toMcpRuntimeResult(() => {
+                        if (runtimeErrors.findExplores) {
+                            throw new Error(runtimeErrors.findExplores);
+                        }
+                        return runtime.findExplores(args);
+                    }),
+            ),
+            findFields: vi.fn(
+                (args: {
+                    table: string;
+                    fieldSearchQueries: Array<{ label: string }>;
+                    page?: number;
+                    pageSize?: number;
+                    explore: ReturnType<typeof makeExplore>;
+                }) =>
+                    toMcpRuntimeResult(async () =>
+                        Promise.all(
+                            args.fieldSearchQueries.map(
+                                async (fieldSearchQuery) => {
+                                    const fieldSearchError =
+                                        runtimeErrors.findFieldsByQuery?.[
+                                            fieldSearchQuery.label
+                                        ] ?? runtimeErrors.findFields;
+                                    if (fieldSearchError) {
+                                        return {
+                                            status: 'error' as const,
+                                            searchQuery: fieldSearchQuery.label,
+                                            error: fieldSearchError,
+                                        };
+                                    }
+                                    const result = await runtime.findField({
+                                        table: args.table,
+                                        fieldSearchQuery,
+                                        page: args.page,
+                                        pageSize: args.pageSize,
+                                        explore: args.explore,
+                                    });
+                                    return {
+                                        status: 'success' as const,
+                                        searchQuery: fieldSearchQuery.label,
+                                        ...result,
+                                    };
+                                },
+                            ),
+                        ),
+                    ),
+            ),
         };
     };
     const aiAgentToolsService = {
@@ -719,6 +807,7 @@ describe('MCP async query polling', () => {
             structuredContent: {
                 searchResults: [
                     expect.objectContaining({
+                        status: 'success',
                         searchQuery: 'orders count',
                         fields: [],
                     }),
@@ -727,11 +816,8 @@ describe('MCP async query polling', () => {
         });
     });
 
-    it('returns MCP error content when find_explores fails', async () => {
-        const { aiAgentToolsService } = makeMcpService();
-        aiAgentToolsService.createRuntime.mockImplementation(() => {
-            throw new Error('Runtime failed');
-        });
+    it('returns MCP error content when find_explores runtime returns error', async () => {
+        makeMcpService({ runtimeErrors: { findExplores: 'Runtime failed' } });
 
         const result = await getToolCallback(McpToolName.FIND_EXPLORES)(
             { searchQuery: 'orders' },
@@ -748,27 +834,39 @@ describe('MCP async query polling', () => {
         });
     });
 
-    it('returns MCP error content when find_fields fails', async () => {
-        const { aiAgentToolsService } = makeMcpService();
-        aiAgentToolsService.createRuntime.mockImplementation(() => {
-            throw new Error('Runtime failed');
+    it('returns mixed per-query results when find_fields runtime returns errors', async () => {
+        makeMcpService({
+            runtimeErrors: {
+                findFieldsByQuery: { 'bad field': 'Runtime failed' },
+            },
         });
 
         const result = await getToolCallback(McpToolName.FIND_FIELDS)(
             {
                 table: 'orders',
-                fieldSearchQueries: [{ label: 'orders count' }],
+                fieldSearchQueries: [
+                    { label: 'orders count' },
+                    { label: 'bad field' },
+                ],
             },
             extra,
         );
 
         expect(result).toMatchObject({
-            isError: true,
-            content: [
-                expect.objectContaining({
-                    text: 'Error finding fields: Runtime failed',
-                }),
-            ],
+            structuredContent: {
+                searchResults: [
+                    expect.objectContaining({
+                        status: 'success',
+                        searchQuery: 'orders count',
+                        fields: [],
+                    }),
+                    {
+                        status: 'error',
+                        searchQuery: 'bad field',
+                        error: 'Runtime failed',
+                    },
+                ],
+            },
         });
     });
 

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -727,6 +727,51 @@ describe('MCP async query polling', () => {
         });
     });
 
+    it('returns MCP error content when find_explores fails', async () => {
+        const { aiAgentToolsService } = makeMcpService();
+        aiAgentToolsService.createRuntime.mockImplementation(() => {
+            throw new Error('Runtime failed');
+        });
+
+        const result = await getToolCallback(McpToolName.FIND_EXPLORES)(
+            { searchQuery: 'orders' },
+            extra,
+        );
+
+        expect(result).toMatchObject({
+            isError: true,
+            content: [
+                expect.objectContaining({
+                    text: 'Error finding explores: Runtime failed',
+                }),
+            ],
+        });
+    });
+
+    it('returns MCP error content when find_fields fails', async () => {
+        const { aiAgentToolsService } = makeMcpService();
+        aiAgentToolsService.createRuntime.mockImplementation(() => {
+            throw new Error('Runtime failed');
+        });
+
+        const result = await getToolCallback(McpToolName.FIND_FIELDS)(
+            {
+                table: 'orders',
+                fieldSearchQueries: [{ label: 'orders count' }],
+            },
+            extra,
+        );
+
+        expect(result).toMatchObject({
+            isError: true,
+            content: [
+                expect.objectContaining({
+                    text: 'Error finding fields: Runtime failed',
+                }),
+            ],
+        });
+    });
+
     it('filters content by active agent space access', async () => {
         const allowedChart = makeChartSearchResult({
             name: 'Allowed Chart',

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -681,7 +681,48 @@ describe('MCP async query polling', () => {
         expect(getTextResult(result)).toContain('Revenue by month');
         expect(result).toMatchObject({
             structuredContent: {
+                searchQuery: 'Show me revenue by month',
+                searchResults: expect.objectContaining({
+                    results: expect.any(Array),
+                }),
+                topMatchingFields: {
+                    count: 1,
+                    fields: [
+                        expect.objectContaining({
+                            name: 'orders_count',
+                            exploreName: 'orders',
+                        }),
+                    ],
+                },
                 relevantVerifiedAnswers: [relevantVerifiedAnswer],
+            },
+        });
+    });
+
+    it('returns structured field search content in find_fields', async () => {
+        makeMcpService();
+
+        const result = await getToolCallback(McpToolName.FIND_FIELDS)(
+            {
+                table: 'orders',
+                fieldSearchQueries: [{ label: 'orders count' }],
+            },
+            extra,
+        );
+
+        expect(result).toMatchObject({
+            content: [
+                expect.objectContaining({
+                    text: expect.stringContaining('"searchResults"'),
+                }),
+            ],
+            structuredContent: {
+                searchResults: [
+                    expect.objectContaining({
+                        searchQuery: 'orders count',
+                        fields: [],
+                    }),
+                ],
             },
         });
     });

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -174,6 +174,8 @@ export enum McpToolName {
 // Skills-over-MCP extension identifier (SEP-2640).
 const MCP_SKILLS_EXTENSION_NAME = 'io.modelcontextprotocol/skills';
 
+const structuredToolContentSchema = z.record(z.string(), z.unknown());
+
 const mcpRunAiWritebackTool = runAiWritebackToolDefinition.for('mcp');
 const mcpGetLightdashVersionTool = getLightdashVersionToolDefinition.for('mcp');
 const mcpListExploresTool = listExploresToolDefinition.for('mcp');
@@ -473,14 +475,46 @@ export class McpService extends BaseService {
     static async streamToolResult<T extends { result: string }>(
         result: T | AsyncIterable<T>,
     ) {
-        if (Symbol.asyncIterator in result) {
-            let out = '';
-            for await (const chunk of result) {
-                out += chunk.result;
-            }
-            return out;
+        const { resultText } = await McpService.streamToolResponse(result);
+        return resultText;
+    }
+
+    private static parseToolStructuredContent(
+        toolResult: string,
+    ): Record<string, unknown> | undefined {
+        try {
+            const parsed: unknown = JSON.parse(toolResult);
+            const structuredContent =
+                structuredToolContentSchema.safeParse(parsed);
+            return structuredContent.success
+                ? structuredContent.data
+                : undefined;
+        } catch {
+            return undefined;
         }
-        return result.result;
+    }
+
+    static async streamToolResponse<T extends { result: string }>(
+        result: T | AsyncIterable<T>,
+    ): Promise<{
+        resultText: string;
+        structuredContent?: Record<string, unknown>;
+    }> {
+        let resultText = '';
+
+        if (Symbol.asyncIterator in result) {
+            for await (const chunk of result) {
+                resultText += chunk.result;
+            }
+        } else {
+            resultText = result.result;
+        }
+
+        return {
+            resultText,
+            structuredContent:
+                McpService.parseToolStructuredContent(resultText),
+        };
     }
 
     private static getMcpQueryWaitMs(
@@ -1354,7 +1388,8 @@ export class McpService extends BaseService {
                         experimental_context: { availableExplores },
                     },
                 );
-                const resultText = await McpService.streamToolResult(result);
+                const { resultText, structuredContent } =
+                    await McpService.streamToolResponse(result);
                 const metadata = await this.getActiveContextMetadata(ctx);
 
                 const verifiedAnswerContext = metadata.agentUuid
@@ -1380,7 +1415,11 @@ export class McpService extends BaseService {
                 return this.buildScopedResponse(
                     ctx,
                     `${resultText}${verifiedAnswersText}`,
-                    verifiedAnswerContext,
+                    {
+                        ...(structuredContent ?? {}),
+                        relevantVerifiedAnswers:
+                            verifiedAnswerContext.relevantVerifiedAnswers,
+                    },
                     projectUuid,
                 );
             },
@@ -1419,11 +1458,13 @@ export class McpService extends BaseService {
                     toolCallId: '',
                     messages: [],
                 });
+                const { resultText, structuredContent } =
+                    await McpService.streamToolResponse(result);
 
                 return this.buildScopedResponse(
                     ctx,
-                    await McpService.streamToolResult(result),
-                    undefined,
+                    resultText,
+                    structuredContent,
                     projectUuid,
                 );
             },

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -114,13 +114,14 @@ import {
 import { getCreateContent } from '../ai/tools/createContent';
 import { getEditContent } from '../ai/tools/editContent';
 import { getFindContent } from '../ai/tools/findContent';
-import { getFindExplores } from '../ai/tools/findExplores';
-import { getFindFields } from '../ai/tools/findFields';
+import { buildFindExploresStructuredContent } from '../ai/tools/findExplores';
+import { buildFindFieldsStructuredContent } from '../ai/tools/findFields';
 import { getListContent } from '../ai/tools/listContent';
 import { getMcpListExplores } from '../ai/tools/mcpListExplores';
 import { getReadContent } from '../ai/tools/readContent';
 import { validateRunQueryTool } from '../ai/tools/runQuery';
 import { getSearchFieldValues } from '../ai/tools/searchFieldValues';
+import { formatToolJsonOutput } from '../ai/tools/toolOutputFormat';
 import { getPivotedResults } from '../ai/utils/getPivotedResults';
 import {
     expandMetricsWithPopAdditionalMetrics,
@@ -173,8 +174,6 @@ export enum McpToolName {
 
 // Skills-over-MCP extension identifier (SEP-2640).
 const MCP_SKILLS_EXTENSION_NAME = 'io.modelcontextprotocol/skills';
-
-const structuredToolContentSchema = z.record(z.string(), z.unknown());
 
 const mcpRunAiWritebackTool = runAiWritebackToolDefinition.for('mcp');
 const mcpGetLightdashVersionTool = getLightdashVersionToolDefinition.for('mcp');
@@ -475,46 +474,14 @@ export class McpService extends BaseService {
     static async streamToolResult<T extends { result: string }>(
         result: T | AsyncIterable<T>,
     ) {
-        const { resultText } = await McpService.streamToolResponse(result);
-        return resultText;
-    }
-
-    private static parseToolStructuredContent(
-        toolResult: string,
-    ): Record<string, unknown> | undefined {
-        try {
-            const parsed: unknown = JSON.parse(toolResult);
-            const structuredContent =
-                structuredToolContentSchema.safeParse(parsed);
-            return structuredContent.success
-                ? structuredContent.data
-                : undefined;
-        } catch {
-            return undefined;
-        }
-    }
-
-    static async streamToolResponse<T extends { result: string }>(
-        result: T | AsyncIterable<T>,
-    ): Promise<{
-        resultText: string;
-        structuredContent?: Record<string, unknown>;
-    }> {
-        let resultText = '';
-
         if (Symbol.asyncIterator in result) {
+            let out = '';
             for await (const chunk of result) {
-                resultText += chunk.result;
+                out += chunk.result;
             }
-        } else {
-            resultText = result.result;
+            return out;
         }
-
-        return {
-            resultText,
-            structuredContent:
-                McpService.parseToolStructuredContent(resultText),
-        };
+        return result.result;
     }
 
     private static getMcpQueryWaitMs(
@@ -1353,6 +1320,7 @@ export class McpService extends BaseService {
                 title: mcpFindExploresTool.title,
                 description: mcpFindExploresTool.description,
                 inputSchema: mcpFindExploresTool.inputSchema.shape,
+                outputSchema: mcpFindExploresTool.outputSchema.shape,
                 annotations: mcpFindExploresTool.annotations,
             },
             async (args, extra) => {
@@ -1360,7 +1328,6 @@ export class McpService extends BaseService {
                 const { user } = McpService.getAccount(ctx);
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
-                const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(ctx, McpToolName.FIND_EXPLORES, projectUuid);
 
@@ -1368,28 +1335,19 @@ export class McpService extends BaseService {
                     ctx,
                     projectUuid,
                 );
-                const availableExplores = await toolsRuntime.listExplores();
-
-                const findExploresTool = getFindExplores({
-                    findExplores: toolsRuntime.findExplores,
-                    updateProgress: async () => {}, // No-op for MCP context
-                    fieldSearchSize: 200,
+                const { exploreSearchResults, topMatchingFields } =
+                    await toolsRuntime.findExplores({
+                        fieldSearchSize: 200,
+                        searchQuery: args.searchQuery,
+                    });
+                const structuredContent = buildFindExploresStructuredContent({
+                    searchQuery: args.searchQuery,
+                    exploreSearchResults,
+                    topMatchingFields,
                     toolDescriptionMaxChars:
                         this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
                 });
-                const result = await findExploresTool.execute!(
-                    {
-                        ...argsWithProject,
-                        searchQuery: args.searchQuery,
-                    },
-                    {
-                        toolCallId: '',
-                        messages: [],
-                        experimental_context: { availableExplores },
-                    },
-                );
-                const { resultText, structuredContent } =
-                    await McpService.streamToolResponse(result);
+                const resultText = formatToolJsonOutput(structuredContent);
                 const metadata = await this.getActiveContextMetadata(ctx);
 
                 const verifiedAnswerContext = metadata.agentUuid
@@ -1416,7 +1374,7 @@ export class McpService extends BaseService {
                     ctx,
                     `${resultText}${verifiedAnswersText}`,
                     {
-                        ...(structuredContent ?? {}),
+                        ...structuredContent,
                         relevantVerifiedAnswers:
                             verifiedAnswerContext.relevantVerifiedAnswers,
                     },
@@ -1431,13 +1389,13 @@ export class McpService extends BaseService {
                 title: mcpFindFieldsTool.title,
                 description: mcpFindFieldsTool.description,
                 inputSchema: mcpFindFieldsTool.inputSchema.shape,
+                outputSchema: mcpFindFieldsTool.outputSchema.shape,
                 annotations: mcpFindFieldsTool.annotations,
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
-                const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(ctx, McpToolName.FIND_FIELDS, projectUuid);
 
@@ -1446,24 +1404,34 @@ export class McpService extends BaseService {
                     projectUuid,
                 );
 
-                const findFieldsTool = getFindFields({
-                    getExplore: toolsRuntime.getExplore,
-                    findFields: toolsRuntime.findFields,
-                    updateProgress: async () => {}, // No-op for MCP context
-                    pageSize: 15,
+                const explore = await toolsRuntime.getExplore({
+                    table: args.table,
+                });
+                const fieldSearchQueryResults = await Promise.all(
+                    args.fieldSearchQueries.map(async (fieldSearchQuery) => {
+                        const result = await toolsRuntime.findFields({
+                            table: args.table,
+                            fieldSearchQuery,
+                            page: args.page ?? 1,
+                            pageSize: 15,
+                            explore,
+                        });
+                        return {
+                            searchQuery: fieldSearchQuery.label,
+                            ...result,
+                        };
+                    }),
+                );
+                const structuredContent = buildFindFieldsStructuredContent({
+                    fieldSearchQueryResults,
                     toolDescriptionMaxChars:
                         this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
+                    explore,
                 });
-                const result = await findFieldsTool.execute!(argsWithProject, {
-                    toolCallId: '',
-                    messages: [],
-                });
-                const { resultText, structuredContent } =
-                    await McpService.streamToolResponse(result);
 
                 return this.buildScopedResponse(
                     ctx,
-                    resultText,
+                    formatToolJsonOutput(structuredContent),
                     structuredContent,
                     projectUuid,
                 );

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1331,55 +1331,68 @@ export class McpService extends BaseService {
 
                 this.trackToolCall(ctx, McpToolName.FIND_EXPLORES, projectUuid);
 
-                const toolsRuntime = await this.getToolsRuntime(
-                    ctx,
-                    projectUuid,
-                );
-                const { exploreSearchResults, topMatchingFields } =
-                    await toolsRuntime.findExplores({
-                        fieldSearchSize: 200,
-                        searchQuery: args.searchQuery,
-                    });
-                const structuredContent = buildFindExploresStructuredContent({
-                    searchQuery: args.searchQuery,
-                    exploreSearchResults,
-                    topMatchingFields,
-                    toolDescriptionMaxChars:
-                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
-                });
-                const resultText = formatToolJsonOutput(structuredContent);
-                const metadata = await this.getActiveContextMetadata(ctx);
+                try {
+                    const toolsRuntime = await this.getToolsRuntime(
+                        ctx,
+                        projectUuid,
+                    );
+                    const { exploreSearchResults, topMatchingFields } =
+                        await toolsRuntime.findExplores({
+                            fieldSearchSize: 200,
+                            searchQuery: args.searchQuery,
+                        });
+                    const structuredContent =
+                        buildFindExploresStructuredContent({
+                            searchQuery: args.searchQuery,
+                            exploreSearchResults,
+                            topMatchingFields,
+                            toolDescriptionMaxChars:
+                                this.lightdashConfig.ai.copilot
+                                    .toolDescriptionMaxChars,
+                        });
+                    const resultText = formatToolJsonOutput(structuredContent);
+                    const metadata = await this.getActiveContextMetadata(ctx);
 
-                const verifiedAnswerContext = metadata.agentUuid
-                    ? await this.aiAgentService.getRelevantVerifiedAnswerContextForAgent(
-                          user,
-                          {
-                              projectUuid,
-                              agentUuid: metadata.agentUuid,
-                              searchQuery: args.searchQuery,
-                          },
-                      )
-                    : { relevantVerifiedAnswers: [] };
+                    const verifiedAnswerContext = metadata.agentUuid
+                        ? await this.aiAgentService.getRelevantVerifiedAnswerContextForAgent(
+                              user,
+                              {
+                                  projectUuid,
+                                  agentUuid: metadata.agentUuid,
+                                  searchQuery: args.searchQuery,
+                              },
+                          )
+                        : { relevantVerifiedAnswers: [] };
 
-                const verifiedAnswersText =
-                    verifiedAnswerContext.relevantVerifiedAnswers.length > 0
-                        ? `\n\n<verifiedAnswers count="${verifiedAnswerContext.relevantVerifiedAnswers.length}">\n${JSON.stringify(
-                              verifiedAnswerContext.relevantVerifiedAnswers,
-                              null,
-                              2,
-                          )}\n</verifiedAnswers>`
-                        : '';
+                    const verifiedAnswersText =
+                        verifiedAnswerContext.relevantVerifiedAnswers.length > 0
+                            ? `\n\n<verifiedAnswers count="${verifiedAnswerContext.relevantVerifiedAnswers.length}">\n${JSON.stringify(
+                                  verifiedAnswerContext.relevantVerifiedAnswers,
+                                  null,
+                                  2,
+                              )}\n</verifiedAnswers>`
+                            : '';
 
-                return this.buildScopedResponse(
-                    ctx,
-                    `${resultText}${verifiedAnswersText}`,
-                    {
-                        ...structuredContent,
-                        relevantVerifiedAnswers:
-                            verifiedAnswerContext.relevantVerifiedAnswers,
-                    },
-                    projectUuid,
-                );
+                    return await this.buildScopedResponse(
+                        ctx,
+                        `${resultText}${verifiedAnswersText}`,
+                        {
+                            ...structuredContent,
+                            relevantVerifiedAnswers:
+                                verifiedAnswerContext.relevantVerifiedAnswers,
+                        },
+                        projectUuid,
+                    );
+                } catch (e) {
+                    const errorMessage =
+                        e instanceof Error ? e.message : String(e);
+                    this.logger.error(
+                        `[McpService] Error in find_explores tool: ${errorMessage}`,
+                    );
+                    return mcpFindExploresTool.result.error(
+                        `Error finding explores: ${errorMessage}`,
+                    );
+                }
             },
         );
 
@@ -1399,42 +1412,56 @@ export class McpService extends BaseService {
 
                 this.trackToolCall(ctx, McpToolName.FIND_FIELDS, projectUuid);
 
-                const toolsRuntime = await this.getToolsRuntime(
-                    ctx,
-                    projectUuid,
-                );
+                try {
+                    const toolsRuntime = await this.getToolsRuntime(
+                        ctx,
+                        projectUuid,
+                    );
 
-                const explore = await toolsRuntime.getExplore({
-                    table: args.table,
-                });
-                const fieldSearchQueryResults = await Promise.all(
-                    args.fieldSearchQueries.map(async (fieldSearchQuery) => {
-                        const result = await toolsRuntime.findFields({
-                            table: args.table,
-                            fieldSearchQuery,
-                            page: args.page ?? 1,
-                            pageSize: 15,
-                            explore,
-                        });
-                        return {
-                            searchQuery: fieldSearchQuery.label,
-                            ...result,
-                        };
-                    }),
-                );
-                const structuredContent = buildFindFieldsStructuredContent({
-                    fieldSearchQueryResults,
-                    toolDescriptionMaxChars:
-                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
-                    explore,
-                });
+                    const explore = await toolsRuntime.getExplore({
+                        table: args.table,
+                    });
+                    const fieldSearchQueryResults = await Promise.all(
+                        args.fieldSearchQueries.map(
+                            async (fieldSearchQuery) => {
+                                const result = await toolsRuntime.findFields({
+                                    table: args.table,
+                                    fieldSearchQuery,
+                                    page: args.page ?? 1,
+                                    pageSize: 15,
+                                    explore,
+                                });
+                                return {
+                                    searchQuery: fieldSearchQuery.label,
+                                    ...result,
+                                };
+                            },
+                        ),
+                    );
+                    const structuredContent = buildFindFieldsStructuredContent({
+                        fieldSearchQueryResults,
+                        toolDescriptionMaxChars:
+                            this.lightdashConfig.ai.copilot
+                                .toolDescriptionMaxChars,
+                        explore,
+                    });
 
-                return this.buildScopedResponse(
-                    ctx,
-                    formatToolJsonOutput(structuredContent),
-                    structuredContent,
-                    projectUuid,
-                );
+                    return await this.buildScopedResponse(
+                        ctx,
+                        formatToolJsonOutput(structuredContent),
+                        structuredContent,
+                        projectUuid,
+                    );
+                } catch (e) {
+                    const errorMessage =
+                        e instanceof Error ? e.message : String(e);
+                    this.logger.error(
+                        `[McpService] Error in find_fields tool: ${errorMessage}`,
+                    );
+                    return mcpFindFieldsTool.result.error(
+                        `Error finding fields: ${errorMessage}`,
+                    );
+                }
             },
         );
 

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -23,6 +23,7 @@ import {
     ForbiddenError,
     getCurrentAgentToolDefinition,
     getCurrentProjectToolDefinition,
+    getErrorMessage,
     getItemLabelWithoutTableName,
     getItemMap,
     getLightdashVersionToolDefinition,
@@ -129,8 +130,9 @@ import {
 } from '../ai/utils/populateCustomMetricsSQL';
 import { AiAgentService } from '../AiAgentService/AiAgentService';
 import {
-    AiAgentToolsRuntime,
     AiAgentToolsService,
+    McpAiAgentToolsRuntime,
+    unwrapMcpRuntimeResult,
 } from '../AiAgentToolsService/AiAgentToolsService';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
 import { AiRouterService } from '../AiRouterService/AiRouterService';
@@ -554,9 +556,11 @@ export class McpService extends BaseService {
         userAttributeOverrides: UserAttributeValueMap | undefined;
     }> {
         const toolsRuntime = await this.getToolsRuntime(ctx, projectUuid);
-        const explore = await toolsRuntime.getExplore({
-            table: queryTool.queryConfig.exploreName,
-        });
+        const explore = unwrapMcpRuntimeResult(
+            await toolsRuntime.getExplore({
+                table: queryTool.queryConfig.exploreName,
+            }),
+        );
 
         // Full validation including groupBy, axis, and tableCalcs
         validateRunQueryTool(queryTool, explore);
@@ -598,7 +602,7 @@ export class McpService extends BaseService {
     private async getToolsRuntime(
         context: McpProtocolContext,
         projectUuid: string,
-    ): Promise<AiAgentToolsRuntime> {
+    ): Promise<McpAiAgentToolsRuntime> {
         const { user, account, organizationUuid } =
             McpService.getAccount(context);
 
@@ -653,9 +657,11 @@ export class McpService extends BaseService {
         metricQuery: MetricQuery;
     }) {
         const toolsRuntime = await this.getToolsRuntime(ctx, projectUuid);
-        const explore = await toolsRuntime.getExplore({
-            table: metricQuery.exploreName,
-        });
+        const explore = unwrapMcpRuntimeResult(
+            await toolsRuntime.getExplore({
+                table: metricQuery.exploreName,
+            }),
+        );
         McpService.assertMetricQueryFieldsInExplore(metricQuery, explore);
     }
 
@@ -1331,68 +1337,62 @@ export class McpService extends BaseService {
 
                 this.trackToolCall(ctx, McpToolName.FIND_EXPLORES, projectUuid);
 
-                try {
-                    const toolsRuntime = await this.getToolsRuntime(
-                        ctx,
-                        projectUuid,
-                    );
-                    const { exploreSearchResults, topMatchingFields } =
-                        await toolsRuntime.findExplores({
-                            fieldSearchSize: 200,
-                            searchQuery: args.searchQuery,
-                        });
-                    const structuredContent =
-                        buildFindExploresStructuredContent({
-                            searchQuery: args.searchQuery,
-                            exploreSearchResults,
-                            topMatchingFields,
-                            toolDescriptionMaxChars:
-                                this.lightdashConfig.ai.copilot
-                                    .toolDescriptionMaxChars,
-                        });
-                    const resultText = formatToolJsonOutput(structuredContent);
-                    const metadata = await this.getActiveContextMetadata(ctx);
-
-                    const verifiedAnswerContext = metadata.agentUuid
-                        ? await this.aiAgentService.getRelevantVerifiedAnswerContextForAgent(
-                              user,
-                              {
-                                  projectUuid,
-                                  agentUuid: metadata.agentUuid,
-                                  searchQuery: args.searchQuery,
-                              },
-                          )
-                        : { relevantVerifiedAnswers: [] };
-
-                    const verifiedAnswersText =
-                        verifiedAnswerContext.relevantVerifiedAnswers.length > 0
-                            ? `\n\n<verifiedAnswers count="${verifiedAnswerContext.relevantVerifiedAnswers.length}">\n${JSON.stringify(
-                                  verifiedAnswerContext.relevantVerifiedAnswers,
-                                  null,
-                                  2,
-                              )}\n</verifiedAnswers>`
-                            : '';
-
-                    return await this.buildScopedResponse(
-                        ctx,
-                        `${resultText}${verifiedAnswersText}`,
-                        {
-                            ...structuredContent,
-                            relevantVerifiedAnswers:
-                                verifiedAnswerContext.relevantVerifiedAnswers,
-                        },
-                        projectUuid,
-                    );
-                } catch (e) {
-                    const errorMessage =
-                        e instanceof Error ? e.message : String(e);
-                    this.logger.error(
-                        `[McpService] Error in find_explores tool: ${errorMessage}`,
-                    );
+                const toolsRuntime = await this.getToolsRuntime(
+                    ctx,
+                    projectUuid,
+                );
+                const runtimeResult = await toolsRuntime.findExplores({
+                    fieldSearchSize: 200,
+                    searchQuery: args.searchQuery,
+                });
+                if (runtimeResult.status === 'error') {
                     return mcpFindExploresTool.result.error(
-                        `Error finding explores: ${errorMessage}`,
+                        `Error finding explores: ${getErrorMessage(runtimeResult.error)}`,
                     );
                 }
+
+                const { exploreSearchResults, topMatchingFields } =
+                    runtimeResult.data;
+                const structuredContent = buildFindExploresStructuredContent({
+                    searchQuery: args.searchQuery,
+                    exploreSearchResults,
+                    topMatchingFields,
+                    toolDescriptionMaxChars:
+                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
+                });
+                const resultText = formatToolJsonOutput(structuredContent);
+                const metadata = await this.getActiveContextMetadata(ctx);
+
+                const verifiedAnswerContext = metadata.agentUuid
+                    ? await this.aiAgentService.getRelevantVerifiedAnswerContextForAgent(
+                          user,
+                          {
+                              projectUuid,
+                              agentUuid: metadata.agentUuid,
+                              searchQuery: args.searchQuery,
+                          },
+                      )
+                    : { relevantVerifiedAnswers: [] };
+
+                const verifiedAnswersText =
+                    verifiedAnswerContext.relevantVerifiedAnswers.length > 0
+                        ? `\n\n<verifiedAnswers count="${verifiedAnswerContext.relevantVerifiedAnswers.length}">\n${JSON.stringify(
+                              verifiedAnswerContext.relevantVerifiedAnswers,
+                              null,
+                              2,
+                          )}\n</verifiedAnswers>`
+                        : '';
+
+                return this.buildScopedResponse(
+                    ctx,
+                    `${resultText}${verifiedAnswersText}`,
+                    {
+                        ...structuredContent,
+                        relevantVerifiedAnswers:
+                            verifiedAnswerContext.relevantVerifiedAnswers,
+                    },
+                    projectUuid,
+                );
             },
         );
 
@@ -1412,56 +1412,47 @@ export class McpService extends BaseService {
 
                 this.trackToolCall(ctx, McpToolName.FIND_FIELDS, projectUuid);
 
-                try {
-                    const toolsRuntime = await this.getToolsRuntime(
-                        ctx,
-                        projectUuid,
-                    );
-
-                    const explore = await toolsRuntime.getExplore({
-                        table: args.table,
-                    });
-                    const fieldSearchQueryResults = await Promise.all(
-                        args.fieldSearchQueries.map(
-                            async (fieldSearchQuery) => {
-                                const result = await toolsRuntime.findFields({
-                                    table: args.table,
-                                    fieldSearchQuery,
-                                    page: args.page ?? 1,
-                                    pageSize: 15,
-                                    explore,
-                                });
-                                return {
-                                    searchQuery: fieldSearchQuery.label,
-                                    ...result,
-                                };
-                            },
-                        ),
-                    );
-                    const structuredContent = buildFindFieldsStructuredContent({
-                        fieldSearchQueryResults,
-                        toolDescriptionMaxChars:
-                            this.lightdashConfig.ai.copilot
-                                .toolDescriptionMaxChars,
-                        explore,
-                    });
-
-                    return await this.buildScopedResponse(
-                        ctx,
-                        formatToolJsonOutput(structuredContent),
-                        structuredContent,
-                        projectUuid,
-                    );
-                } catch (e) {
-                    const errorMessage =
-                        e instanceof Error ? e.message : String(e);
-                    this.logger.error(
-                        `[McpService] Error in find_fields tool: ${errorMessage}`,
-                    );
+                const toolsRuntime = await this.getToolsRuntime(
+                    ctx,
+                    projectUuid,
+                );
+                const exploreResult = await toolsRuntime.getExplore({
+                    table: args.table,
+                });
+                if (exploreResult.status === 'error') {
                     return mcpFindFieldsTool.result.error(
-                        `Error finding fields: ${errorMessage}`,
+                        `Error finding fields: ${getErrorMessage(exploreResult.error)}`,
                     );
                 }
+
+                const runtimeResult = await toolsRuntime.findFields({
+                    table: args.table,
+                    fieldSearchQueries: args.fieldSearchQueries,
+                    page: args.page ?? 1,
+                    pageSize: 15,
+                    explore: exploreResult.data,
+                });
+                if (runtimeResult.status === 'error') {
+                    return mcpFindFieldsTool.result.error(
+                        `Error finding fields: ${getErrorMessage(runtimeResult.error)}`,
+                    );
+                }
+
+                const fieldSearchQueryResults = runtimeResult.data;
+
+                const structuredContent = buildFindFieldsStructuredContent({
+                    fieldSearchQueryResults,
+                    toolDescriptionMaxChars:
+                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
+                    explore: exploreResult.data,
+                });
+
+                return this.buildScopedResponse(
+                    ctx,
+                    formatToolJsonOutput(structuredContent),
+                    structuredContent,
+                    projectUuid,
+                );
             },
         );
 

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -164,6 +164,252 @@ Output:
         "type": "object",
       },
       "name": "find_explores",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string",
+          },
+          "relevantVerifiedAnswers": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "artifactType": {
+                  "enum": [
+                    "chart",
+                    "dashboard",
+                  ],
+                  "type": "string",
+                },
+                "artifactVersionUuid": {
+                  "type": "string",
+                },
+                "chartConfig": {
+                  "additionalProperties": {},
+                  "type": "object",
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "similarity": {
+                  "type": "number",
+                },
+                "title": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "verifiedQuestion": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+              },
+              "required": [
+                "artifactVersionUuid",
+                "chartConfig",
+                "artifactType",
+                "verifiedQuestion",
+                "title",
+                "description",
+                "similarity",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "searchQuery": {
+            "type": "string",
+          },
+          "searchResults": {
+            "additionalProperties": false,
+            "properties": {
+              "count": {
+                "type": "number",
+              },
+              "note": {
+                "type": "string",
+              },
+              "results": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "aiHints": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "description": {
+                      "type": [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    "joinedTables": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "count": {
+                          "type": "number",
+                        },
+                        "note": {
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "tables": {
+                          "items": {
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "count",
+                        "note",
+                        "tables",
+                      ],
+                      "type": "object",
+                    },
+                    "label": {
+                      "type": "string",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "requiredFilters": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "type": "string",
+                          },
+                          "fieldRef": {
+                            "type": "string",
+                          },
+                          "operator": {
+                            "type": "string",
+                          },
+                          "required": {
+                            "type": "boolean",
+                          },
+                          "settings": {},
+                          "tableName": {
+                            "type": "string",
+                          },
+                          "values": {
+                            "items": {},
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "fieldId",
+                          "fieldRef",
+                          "tableName",
+                          "operator",
+                          "required",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "searchRank": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "label",
+                    "searchRank",
+                    "description",
+                    "aiHints",
+                    "joinedTables",
+                    "requiredFilters",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+            },
+            "required": [
+              "count",
+              "note",
+              "results",
+            ],
+            "type": "object",
+          },
+          "topMatchingFields": {
+            "additionalProperties": false,
+            "properties": {
+              "count": {
+                "type": "number",
+              },
+              "fields": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "exploreName": {
+                      "type": "string",
+                    },
+                    "fieldType": {
+                      "type": "string",
+                    },
+                    "label": {
+                      "type": "string",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "searchRank": {
+                      "type": "string",
+                    },
+                    "usageInCharts": {
+                      "type": "number",
+                    },
+                    "usageInVerifiedCharts": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "label",
+                    "exploreName",
+                    "fieldType",
+                    "searchRank",
+                    "usageInCharts",
+                    "usageInVerifiedCharts",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "note": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "count",
+              "note",
+              "fields",
+            ],
+            "type": "object",
+          },
+        },
+        "required": [
+          "searchQuery",
+          "description",
+          "searchResults",
+          "topMatchingFields",
+        ],
+        "type": "object",
+      },
       "title": "Find explores",
     },
     {
@@ -223,6 +469,161 @@ Usage tips:
         "type": "object",
       },
       "name": "find_fields",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "searchResults": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "fields": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "aiHints": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "baseTable": {
+                        "type": "string",
+                      },
+                      "caseSensitiveFilters": {
+                        "type": [
+                          "boolean",
+                          "null",
+                        ],
+                      },
+                      "categories": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "chartUsage": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null",
+                        ],
+                      },
+                      "emoji": {
+                        "type": [
+                          "string",
+                          "null",
+                        ],
+                      },
+                      "fieldFilterType": {
+                        "type": "string",
+                      },
+                      "fieldId": {
+                        "type": "string",
+                      },
+                      "fieldType": {
+                        "type": "string",
+                      },
+                      "isFromJoinedTable": {
+                        "type": "boolean",
+                      },
+                      "label": {
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "note": {
+                        "type": [
+                          "string",
+                          "null",
+                        ],
+                      },
+                      "searchRank": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                      "type": {
+                        "type": "string",
+                      },
+                      "usageInVerifiedCharts": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "type",
+                      "baseTable",
+                      "name",
+                      "fieldId",
+                      "fieldType",
+                      "fieldFilterType",
+                      "usageInVerifiedCharts",
+                      "isFromJoinedTable",
+                      "caseSensitiveFilters",
+                      "note",
+                      "label",
+                      "aiHints",
+                      "description",
+                      "categories",
+                      "emoji",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "page": {
+                  "type": [
+                    "number",
+                    "null",
+                  ],
+                },
+                "pageSize": {
+                  "type": [
+                    "number",
+                    "null",
+                  ],
+                },
+                "searchQuery": {
+                  "type": "string",
+                },
+                "totalPageCount": {
+                  "type": [
+                    "number",
+                    "null",
+                  ],
+                },
+                "totalResults": {
+                  "type": [
+                    "number",
+                    "null",
+                  ],
+                },
+              },
+              "required": [
+                "searchQuery",
+                "page",
+                "pageSize",
+                "totalPageCount",
+                "totalResults",
+                "fields",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "searchResults",
+        ],
+        "type": "object",
+      },
       "title": "Find fields",
     },
     {

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -321,7 +321,10 @@ Output:
                       "type": "array",
                     },
                     "searchRank": {
-                      "type": "string",
+                      "type": [
+                        "number",
+                        "null",
+                      ],
                     },
                   },
                   "required": [
@@ -368,7 +371,10 @@ Output:
                       "type": "string",
                     },
                     "searchRank": {
-                      "type": "string",
+                      "type": [
+                        "number",
+                        "null",
+                      ],
                     },
                     "usageInCharts": {
                       "type": "number",
@@ -475,146 +481,176 @@ Usage tips:
         "properties": {
           "searchResults": {
             "items": {
-              "additionalProperties": false,
-              "properties": {
-                "fields": {
-                  "items": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "aiHints": {
-                        "items": {
-                          "type": "string",
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "fields": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "aiHints": {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          "baseTable": {
+                            "type": "string",
+                          },
+                          "caseSensitiveFilters": {
+                            "type": [
+                              "boolean",
+                              "null",
+                            ],
+                          },
+                          "categories": {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          "chartUsage": {
+                            "type": [
+                              "number",
+                              "null",
+                            ],
+                          },
+                          "description": {
+                            "type": [
+                              "string",
+                              "null",
+                            ],
+                          },
+                          "emoji": {
+                            "type": [
+                              "string",
+                              "null",
+                            ],
+                          },
+                          "fieldFilterType": {
+                            "type": "string",
+                          },
+                          "fieldId": {
+                            "type": "string",
+                          },
+                          "fieldType": {
+                            "type": "string",
+                          },
+                          "isFromJoinedTable": {
+                            "type": "boolean",
+                          },
+                          "label": {
+                            "type": "string",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                          "note": {
+                            "type": [
+                              "string",
+                              "null",
+                            ],
+                          },
+                          "searchRank": {
+                            "type": [
+                              "number",
+                              "null",
+                            ],
+                          },
+                          "type": {
+                            "type": "string",
+                          },
+                          "usageInVerifiedCharts": {
+                            "type": "number",
+                          },
                         },
-                        "type": "array",
-                      },
-                      "baseTable": {
-                        "type": "string",
-                      },
-                      "caseSensitiveFilters": {
-                        "type": [
-                          "boolean",
-                          "null",
+                        "required": [
+                          "type",
+                          "baseTable",
+                          "name",
+                          "fieldId",
+                          "fieldType",
+                          "fieldFilterType",
+                          "usageInVerifiedCharts",
+                          "isFromJoinedTable",
+                          "caseSensitiveFilters",
+                          "note",
+                          "label",
+                          "aiHints",
+                          "description",
+                          "categories",
+                          "emoji",
                         ],
+                        "type": "object",
                       },
-                      "categories": {
-                        "items": {
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                      "chartUsage": {
-                        "type": [
-                          "number",
-                          "null",
-                        ],
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null",
-                        ],
-                      },
-                      "emoji": {
-                        "type": [
-                          "string",
-                          "null",
-                        ],
-                      },
-                      "fieldFilterType": {
-                        "type": "string",
-                      },
-                      "fieldId": {
-                        "type": "string",
-                      },
-                      "fieldType": {
-                        "type": "string",
-                      },
-                      "isFromJoinedTable": {
-                        "type": "boolean",
-                      },
-                      "label": {
-                        "type": "string",
-                      },
-                      "name": {
-                        "type": "string",
-                      },
-                      "note": {
-                        "type": [
-                          "string",
-                          "null",
-                        ],
-                      },
-                      "searchRank": {
-                        "type": [
-                          "number",
-                          "null",
-                        ],
-                      },
-                      "type": {
-                        "type": "string",
-                      },
-                      "usageInVerifiedCharts": {
-                        "type": "number",
-                      },
+                      "type": "array",
                     },
-                    "required": [
-                      "type",
-                      "baseTable",
-                      "name",
-                      "fieldId",
-                      "fieldType",
-                      "fieldFilterType",
-                      "usageInVerifiedCharts",
-                      "isFromJoinedTable",
-                      "caseSensitiveFilters",
-                      "note",
-                      "label",
-                      "aiHints",
-                      "description",
-                      "categories",
-                      "emoji",
-                    ],
-                    "type": "object",
+                    "page": {
+                      "type": [
+                        "number",
+                        "null",
+                      ],
+                    },
+                    "pageSize": {
+                      "type": [
+                        "number",
+                        "null",
+                      ],
+                    },
+                    "searchQuery": {
+                      "type": "string",
+                    },
+                    "status": {
+                      "const": "success",
+                      "type": "string",
+                    },
+                    "totalPageCount": {
+                      "type": [
+                        "number",
+                        "null",
+                      ],
+                    },
+                    "totalResults": {
+                      "type": [
+                        "number",
+                        "null",
+                      ],
+                    },
                   },
-                  "type": "array",
-                },
-                "page": {
-                  "type": [
-                    "number",
-                    "null",
+                  "required": [
+                    "status",
+                    "searchQuery",
+                    "page",
+                    "pageSize",
+                    "totalPageCount",
+                    "totalResults",
+                    "fields",
                   ],
+                  "type": "object",
                 },
-                "pageSize": {
-                  "type": [
-                    "number",
-                    "null",
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                    },
+                    "searchQuery": {
+                      "type": "string",
+                    },
+                    "status": {
+                      "const": "error",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "status",
+                    "searchQuery",
+                    "error",
                   ],
+                  "type": "object",
                 },
-                "searchQuery": {
-                  "type": "string",
-                },
-                "totalPageCount": {
-                  "type": [
-                    "number",
-                    "null",
-                  ],
-                },
-                "totalResults": {
-                  "type": [
-                    "number",
-                    "null",
-                  ],
-                },
-              },
-              "required": [
-                "searchQuery",
-                "page",
-                "pageSize",
-                "totalPageCount",
-                "totalResults",
-                "fields",
               ],
-              "type": "object",
             },
             "type": "array",
           },

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1140,6 +1140,9 @@ Usage tips:
                   "items": {
                     "additionalProperties": false,
                     "properties": {
+                      "error": {
+                        "type": "string",
+                      },
                       "label": {
                         "type": "string",
                       },
@@ -1211,6 +1214,13 @@ Usage tips:
                           "type": "object",
                         },
                         "type": "array",
+                      },
+                      "status": {
+                        "enum": [
+                          "success",
+                          "error",
+                        ],
+                        "type": "string",
                       },
                     },
                     "required": [

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -1,4 +1,7 @@
-import { findExploresToolDefinition } from '@lightdash/common';
+import {
+    findExploresToolDefinition,
+    type McpFindExploresStructuredOutput,
+} from '@lightdash/common';
 import { tool } from 'ai';
 import type {
     FindExploresFn,
@@ -18,7 +21,7 @@ type Dependencies = {
 
 const toolDefinition = findExploresToolDefinition.for('agent');
 
-const generateExploreResponse = ({
+export const buildFindExploresStructuredContent = ({
     searchQuery,
     exploreSearchResults,
     topMatchingFields,
@@ -26,7 +29,7 @@ const generateExploreResponse = ({
 }: Awaited<ReturnType<FindExploresFn>> & {
     searchQuery: string;
     toolDescriptionMaxChars: number;
-}) => {
+}): McpFindExploresStructuredOutput => {
     const exploreCount = exploreSearchResults?.length ?? 0;
     const fieldCount = topMatchingFields?.length ?? 0;
 
@@ -47,7 +50,7 @@ const generateExploreResponse = ({
             ? 'No field-level matches either.'
             : "Per-field matches across all explores. Each field's `exploreName` shows where it lives — pick the explore whose fields can answer the user's question.";
 
-    return formatToolJsonOutput({
+    return {
         searchQuery,
         description:
             "Two-pass catalog search whose goal is to identify the single explore for a follow-up query: a query runs against exactly one explore, so the chosen explore must contain the fields needed to answer the user's question. `searchResults` lists explores whose name/label/description/aiHints matched the query. `topMatchingFields` lists individual fields whose name/label/description matched, across all explores — use it to identify or disambiguate the explore to dig into when no explore matched directly, or when several matched.",
@@ -89,7 +92,7 @@ const generateExploreResponse = ({
                     usageInVerifiedCharts: field.verifiedChartUsage ?? 0,
                 })) ?? [],
         },
-    });
+    };
 };
 export const getFindExplores = ({
     findExplores,
@@ -111,13 +114,15 @@ export const getFindExplores = ({
                         searchQuery: args.searchQuery,
                     });
 
+                const structuredContent = buildFindExploresStructuredContent({
+                    searchQuery: args.searchQuery,
+                    exploreSearchResults,
+                    topMatchingFields,
+                    toolDescriptionMaxChars,
+                });
+
                 return {
-                    result: generateExploreResponse({
-                        searchQuery: args.searchQuery,
-                        exploreSearchResults,
-                        topMatchingFields,
-                        toolDescriptionMaxChars,
-                    }),
+                    result: formatToolJsonOutput(structuredContent),
                     metadata: {
                         status: 'success',
                         ranking: {

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -1,7 +1,4 @@
-import {
-    findExploresToolDefinition,
-    type McpFindExploresStructuredOutput,
-} from '@lightdash/common';
+import { findExploresToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
     FindExploresFn,
@@ -29,7 +26,7 @@ export const buildFindExploresStructuredContent = ({
 }: Awaited<ReturnType<FindExploresFn>> & {
     searchQuery: string;
     toolDescriptionMaxChars: number;
-}): McpFindExploresStructuredOutput => {
+}) => {
     const exploreCount = exploreSearchResults?.length ?? 0;
     const fieldCount = topMatchingFields?.length ?? 0;
 
@@ -61,7 +58,7 @@ export const buildFindExploresStructuredContent = ({
                 exploreSearchResults?.map((result) => ({
                     name: result.name,
                     label: result.label,
-                    searchRank: result.searchRank?.toFixed(3) ?? 'N/A',
+                    searchRank: result.searchRank ?? null,
                     description: result.description
                         ? truncate(result.description, toolDescriptionMaxChars)
                         : null,
@@ -87,7 +84,7 @@ export const buildFindExploresStructuredContent = ({
                     label: field.label,
                     exploreName: field.tableName,
                     fieldType: field.fieldType,
-                    searchRank: field.searchRank?.toFixed(3) ?? 'N/A',
+                    searchRank: field.searchRank ?? null,
                     usageInCharts: field.chartUsage ?? 0,
                     usageInVerifiedCharts: field.verifiedChartUsage ?? 0,
                 })) ?? [],

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -9,6 +9,7 @@ import {
     getFilterTypeFromItemType,
     getItemId,
     isEmojiIcon,
+    type McpFindFieldsStructuredOutput,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
@@ -98,11 +99,15 @@ const formatField = (
     };
 };
 
-const getFieldsText = (
-    args: Awaited<ReturnType<FindFieldFn>> & { searchQuery: string },
+type FindFieldsSearchQueryResult = Awaited<ReturnType<FindFieldFn>> & {
+    searchQuery: string;
+};
+
+const buildFindFieldsSearchResult = (
+    args: FindFieldsSearchQueryResult,
     toolDescriptionMaxChars: number,
     explore?: Explore,
-) => ({
+): McpFindFieldsStructuredOutput['searchResults'][number] => ({
     searchQuery: args.searchQuery,
     page: args.pagination?.page ?? null,
     pageSize: args.pagination?.pageSize ?? null,
@@ -110,6 +115,24 @@ const getFieldsText = (
     totalResults: args.pagination?.totalResults ?? null,
     fields: args.fields.map((field) =>
         formatField(field, toolDescriptionMaxChars, explore),
+    ),
+});
+
+export const buildFindFieldsStructuredContent = ({
+    fieldSearchQueryResults,
+    toolDescriptionMaxChars,
+    explore,
+}: {
+    fieldSearchQueryResults: FindFieldsSearchQueryResult[];
+    toolDescriptionMaxChars: number;
+    explore?: Explore;
+}): McpFindFieldsStructuredOutput => ({
+    searchResults: fieldSearchQueryResults.map((fieldSearchQueryResult) =>
+        buildFindFieldsSearchResult(
+            fieldSearchQueryResult,
+            toolDescriptionMaxChars,
+            explore,
+        ),
     ),
 });
 
@@ -151,17 +174,14 @@ export const getFindFields = ({
                     }),
                 );
 
-                const searchResults = fieldSearchQueryResults.map(
-                    (fieldSearchQueryResult) =>
-                        getFieldsText(
-                            fieldSearchQueryResult,
-                            toolDescriptionMaxChars,
-                            explore,
-                        ),
-                );
+                const structuredContent = buildFindFieldsStructuredContent({
+                    fieldSearchQueryResults,
+                    toolDescriptionMaxChars,
+                    explore,
+                });
 
                 return {
-                    result: formatToolJsonOutput({ searchResults }),
+                    result: formatToolJsonOutput(structuredContent),
                     metadata: {
                         status: 'success',
                         ranking: {

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -9,11 +9,12 @@ import {
     getFilterTypeFromItemType,
     getItemId,
     isEmojiIcon,
-    type McpFindFieldsStructuredOutput,
+    type FindFieldsResult,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
-    FindFieldFn,
+    FindFieldsFn,
+    FindFieldsSearchQueryResult,
     GetExploreFn,
     UpdateProgressFn,
 } from '../types/aiAgentDependencies';
@@ -24,7 +25,7 @@ import { formatToolJsonOutput } from './toolOutputFormat';
 
 type Dependencies = {
     getExplore: GetExploreFn;
-    findFields: FindFieldFn;
+    findFields: FindFieldsFn;
     updateProgress: UpdateProgressFn;
     pageSize: number;
     toolDescriptionMaxChars: number;
@@ -34,7 +35,7 @@ const toolDefinition = findFieldsToolDefinition.for('agent');
 
 const getFieldCaseSensitive = (
     catalogField: CatalogField,
-    explore?: Explore,
+    explore: Explore,
 ): boolean | undefined => {
     if (
         catalogField.fieldType !== FieldType.DIMENSION ||
@@ -44,11 +45,11 @@ const getFieldCaseSensitive = (
     }
 
     const dimension =
-        explore?.tables[catalogField.tableName]?.dimensions[catalogField.name];
+        explore.tables[catalogField.tableName]?.dimensions[catalogField.name];
 
     return (
         dimension?.caseSensitive ??
-        explore?.caseSensitive ??
+        explore.caseSensitive ??
         DEFAULT_FILTER_CASE_SENSITIVE
     );
 };
@@ -56,10 +57,9 @@ const getFieldCaseSensitive = (
 const formatField = (
     catalogField: CatalogField,
     toolDescriptionMaxChars: number,
-    explore?: Explore,
+    explore: Explore,
 ) => {
     const isFromJoinedTable =
-        explore &&
         catalogField.tableName !== explore.baseTable &&
         explore.joinedTables.some(
             (join) => join.table === catalogField.tableName,
@@ -81,12 +81,11 @@ const formatField = (
         searchRank: catalogField.searchRank,
         chartUsage: catalogField.chartUsage,
         usageInVerifiedCharts: catalogField.verifiedChartUsage ?? 0,
-        isFromJoinedTable: Boolean(isFromJoinedTable),
+        isFromJoinedTable,
         caseSensitiveFilters: caseSensitiveFilters ?? null,
-        note:
-            isFromJoinedTable && explore
-                ? `This field is from the "${catalogField.tableName}" table, which is joined to the "${explore.name}" explore. You can use this field in queries and filters just like fields from the base table.`
-                : null,
+        note: isFromJoinedTable
+            ? `This field is from the "${catalogField.tableName}" table, which is joined to the "${explore.name}" explore. You can use this field in queries and filters just like fields from the base table.`
+            : null,
         label: catalogField.label,
         aiHints: aiHints ?? [],
         description: catalogField.description
@@ -99,24 +98,31 @@ const formatField = (
     };
 };
 
-type FindFieldsSearchQueryResult = Awaited<ReturnType<FindFieldFn>> & {
-    searchQuery: string;
-};
-
 const buildFindFieldsSearchResult = (
     args: FindFieldsSearchQueryResult,
     toolDescriptionMaxChars: number,
-    explore?: Explore,
-): McpFindFieldsStructuredOutput['searchResults'][number] => ({
-    searchQuery: args.searchQuery,
-    page: args.pagination?.page ?? null,
-    pageSize: args.pagination?.pageSize ?? null,
-    totalPageCount: args.pagination?.totalPageCount ?? null,
-    totalResults: args.pagination?.totalResults ?? null,
-    fields: args.fields.map((field) =>
-        formatField(field, toolDescriptionMaxChars, explore),
-    ),
-});
+    explore: Explore,
+): FindFieldsResult['searchResults'][number] => {
+    if (args.status === 'error') {
+        return {
+            status: 'error',
+            searchQuery: args.searchQuery,
+            error: args.error,
+        };
+    }
+
+    return {
+        status: 'success',
+        searchQuery: args.searchQuery,
+        page: args.pagination?.page ?? null,
+        pageSize: args.pagination?.pageSize ?? null,
+        totalPageCount: args.pagination?.totalPageCount ?? null,
+        totalResults: args.pagination?.totalResults ?? null,
+        fields: args.fields.map((field) =>
+            formatField(field, toolDescriptionMaxChars, explore),
+        ),
+    };
+};
 
 export const buildFindFieldsStructuredContent = ({
     fieldSearchQueryResults,
@@ -125,8 +131,8 @@ export const buildFindFieldsStructuredContent = ({
 }: {
     fieldSearchQueryResults: FindFieldsSearchQueryResult[];
     toolDescriptionMaxChars: number;
-    explore?: Explore;
-}): McpFindFieldsStructuredOutput => ({
+    explore: Explore;
+}) => ({
     searchResults: fieldSearchQueryResults.map((fieldSearchQueryResult) =>
         buildFindFieldsSearchResult(
             fieldSearchQueryResult,
@@ -158,21 +164,13 @@ export const getFindFields = ({
 
                 const explore = await getExplore({ table: args.table });
 
-                const fieldSearchQueryResults = await Promise.all(
-                    args.fieldSearchQueries.map(async (fieldSearchQuery) => {
-                        const result = await findFields({
-                            table: args.table,
-                            fieldSearchQuery,
-                            page: args.page ?? 1,
-                            pageSize,
-                            explore,
-                        });
-                        return {
-                            searchQuery: fieldSearchQuery.label,
-                            ...result,
-                        };
-                    }),
-                );
+                const fieldSearchQueryResults = await findFields({
+                    table: args.table,
+                    fieldSearchQueries: args.fieldSearchQueries,
+                    page: args.page ?? 1,
+                    pageSize,
+                    explore,
+                });
 
                 const structuredContent = buildFindFieldsStructuredContent({
                     fieldSearchQueryResults,
@@ -186,23 +184,41 @@ export const getFindFields = ({
                         status: 'success',
                         ranking: {
                             searchQueries: fieldSearchQueryResults.map(
-                                (fieldSearchQueryResult) => ({
-                                    label: fieldSearchQueryResult.searchQuery,
-                                    results: fieldSearchQueryResult.fields.map(
-                                        (field) => ({
-                                            name: field.name,
-                                            label: field.label,
-                                            tableName: field.tableName,
-                                            fieldType: field.fieldType,
-                                            searchRank: field.searchRank,
-                                            chartUsage: field.chartUsage,
-                                            verifiedChartUsage:
-                                                field.verifiedChartUsage,
-                                        }),
-                                    ),
-                                    pagination:
-                                        fieldSearchQueryResult.pagination,
-                                }),
+                                (fieldSearchQueryResult) => {
+                                    if (
+                                        fieldSearchQueryResult.status ===
+                                        'error'
+                                    ) {
+                                        return {
+                                            status: 'error',
+                                            label: fieldSearchQueryResult.searchQuery,
+                                            error: fieldSearchQueryResult.error,
+                                            results: [],
+                                        };
+                                    }
+
+                                    return {
+                                        status: 'success',
+                                        label: fieldSearchQueryResult.searchQuery,
+                                        results:
+                                            fieldSearchQueryResult.fields.map(
+                                                (field) => ({
+                                                    name: field.name,
+                                                    label: field.label,
+                                                    tableName: field.tableName,
+                                                    fieldType: field.fieldType,
+                                                    searchRank:
+                                                        field.searchRank,
+                                                    chartUsage:
+                                                        field.chartUsage,
+                                                    verifiedChartUsage:
+                                                        field.verifiedChartUsage,
+                                                }),
+                                            ),
+                                        pagination:
+                                            fieldSearchQueryResult.pagination,
+                                    };
+                                },
                             ),
                         },
                     },

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -26,7 +26,7 @@ import {
     ExploreRepoFn,
     FindContentFn,
     FindExploresFn,
-    FindFieldFn,
+    FindFieldsFn,
     GetDashboardChartsFn,
     GetExploreFn,
     GetKnowledgeDocumentContentFn,
@@ -168,7 +168,7 @@ export type AiAgentDependencies = {
     getDashboardCharts: GetDashboardChartsFn;
     findExplores: FindExploresFn;
     getVerifiedFieldUsage: GetVerifiedFieldUsageFn;
-    findFields: FindFieldFn;
+    findFields: FindFieldsFn;
     searchSemanticLayer: SearchSemanticLayerFn;
     analyzeFieldImpact: AnalyzeFieldImpactFn;
     getExplore: GetExploreFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -89,16 +89,41 @@ export type FindExploresFn = (args: {
 // Used to rank verified/governed fields first in grep discovery.
 export type GetVerifiedFieldUsageFn = () => Promise<Map<string, number>>;
 
+export type FindFieldResult = {
+    fields: CatalogField[];
+    pagination: Pagination | undefined;
+};
+
 export type FindFieldFn = (
     args: KnexPaginateArgs & {
         table: ToolFindFieldsArgs['table'];
         fieldSearchQuery: ToolFindFieldsArgs['fieldSearchQueries'][number];
         explore: Explore;
     },
-) => Promise<{
-    fields: CatalogField[];
-    pagination: Pagination | undefined;
-}>;
+) => Promise<FindFieldResult>;
+
+export type FindFieldsSearchQuerySuccess = FindFieldResult & {
+    status: 'success';
+    searchQuery: string;
+};
+
+export type FindFieldsSearchQueryError = {
+    status: 'error';
+    searchQuery: string;
+    error: string;
+};
+
+export type FindFieldsSearchQueryResult =
+    | FindFieldsSearchQuerySuccess
+    | FindFieldsSearchQueryError;
+
+export type FindFieldsFn = (
+    args: KnexPaginateArgs & {
+        table: ToolFindFieldsArgs['table'];
+        fieldSearchQueries: ToolFindFieldsArgs['fieldSearchQueries'];
+        explore: Explore;
+    },
+) => Promise<FindFieldsSearchQueryResult[]>;
 
 export type SearchSemanticLayerFn = (args: {
     searchQuery: string | null;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2109,6 +2109,7 @@ const models: TsoaRoute.Models = {
             validators: {},
         },
     },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ExternalConnectionSampleRequest: {
         dataType: 'refAlias',
         type: {
@@ -14153,6 +14154,8 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['searchSemanticLayer'] },
                 { dataType: 'enum', enums: ['analyzeFieldImpact'] },
                 { dataType: 'enum', enums: ['discoverFields'] },
+                { dataType: 'enum', enums: ['grepFields'] },
+                { dataType: 'enum', enums: ['getMetadata'] },
                 { dataType: 'enum', enums: ['searchFieldValues'] },
                 { dataType: 'enum', enums: ['findDashboards'] },
                 { dataType: 'enum', enums: ['findCharts'] },
@@ -14310,11 +14313,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14329,11 +14332,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14348,11 +14351,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14367,11 +14370,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14483,12 +14486,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -14516,56 +14519,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                joinedTables:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -14610,7 +14563,7 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                tableName:
+                                                                                                                                operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
@@ -14622,13 +14575,13 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                operator:
+                                                                                                                                fieldId:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                fieldId:
+                                                                                                                                tableName:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
@@ -14643,12 +14596,62 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                label: {
+                                                                                                joinedTables:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -14680,11 +14683,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14751,6 +14754,46 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
+                                                                                status: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'success',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'error',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 results:
                                                                                     {
                                                                                         dataType:
@@ -14841,12 +14884,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
+                                                                                                    name: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    name: {
+                                                                                                    label: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
@@ -14877,11 +14920,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14896,11 +14939,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14915,11 +14958,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14933,13 +14976,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -14962,11 +15005,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15024,130 +15067,6 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
-                                                                    required: true,
-                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -15197,7 +15116,7 @@ const models: TsoaRoute.Models = {
                                                                                                                         'boolean',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            tableName:
+                                                                                                            operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
@@ -15209,13 +15128,13 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            operator:
+                                                                                                            fieldId:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            fieldId:
+                                                                                                            tableName:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
@@ -15246,17 +15165,141 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
                                                                             name: {
                                                                                 dataType:
                                                                                     'string',
                                                                                 required: true,
                                                                             },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
                                                                         },
+                                                                    required: true,
+                                                                },
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -15411,13 +15454,15 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
+                                                warnings: {
+                                                    dataType: 'array',
+                                                    array: {
+                                                        dataType: 'string',
+                                                    },
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
+                                                href: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 slug: {
@@ -15428,17 +15473,15 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                warnings: {
-                                                    dataType: 'array',
-                                                    array: {
-                                                        dataType: 'string',
-                                                    },
-                                                    required: true,
-                                                },
                                                 name: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                    required: true,
+                                                },
                                             },
                                         },
                                         {
@@ -15449,11 +15492,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15468,11 +15511,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15487,11 +15530,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15506,11 +15549,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15539,13 +15582,6 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
                                                                                             'read',
                                                                                         ],
                                                                                     },
@@ -15554,6 +15590,13 @@ const models: TsoaRoute.Models = {
                                                                                             'enum',
                                                                                         enums: [
                                                                                             'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -15751,11 +15794,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15779,17 +15822,17 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
-                                                    required: true,
-                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
                                                     dataType: 'string',
+                                                    required: true,
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -15816,11 +15859,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15835,11 +15878,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15854,11 +15897,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15881,11 +15924,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15902,25 +15945,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15987,18 +16011,37 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                name: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -16010,14 +16053,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
@@ -16043,11 +16086,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16062,11 +16105,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16081,11 +16124,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16100,11 +16143,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16119,11 +16162,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -31153,7 +31196,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31163,7 +31206,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31173,7 +31216,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -31186,7 +31229,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -44528,6 +44571,7 @@ export function RegisterRoutes(app: Router) {
             }
         },
     );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsExternalConnectionController_saveExternalConnectionSample: Record<
         string,
         TsoaRoute.ParameterSchema

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15706,6 +15706,8 @@
                     "searchSemanticLayer",
                     "analyzeFieldImpact",
                     "discoverFields",
+                    "grepFields",
+                    "getMetadata",
                     "searchFieldValues",
                     "findDashboards",
                     "findCharts",
@@ -15845,8 +15847,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -15881,18 +15883,18 @@
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
                                                                         "tableName",
-                                                                        "label",
-                                                                        "name"
+                                                                        "name",
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -15901,18 +15903,6 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "joinedTables": {
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "nullable": true
-                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -15924,40 +15914,52 @@
                                                                                     "required": {
                                                                                         "type": "boolean"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "operator": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "operator": {
+                                                                                    "fieldId": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldId": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "required",
-                                                                                    "tableName",
-                                                                                    "fieldRef",
                                                                                     "operator",
-                                                                                    "fieldId"
+                                                                                    "fieldRef",
+                                                                                    "fieldId",
+                                                                                    "tableName"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
                                                                             "type": "array"
                                                                         },
-                                                                        "label": {
-                                                                            "type": "string"
+                                                                        "joinedTables": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
                                                                         },
                                                                         "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "label",
-                                                                        "name"
+                                                                        "name",
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -15975,8 +15977,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16017,6 +16019,16 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "status": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "success",
+                                                                                "error"
+                                                                            ]
+                                                                        },
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
@@ -16041,18 +16053,18 @@
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "name": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "name": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
                                                                                     "tableName",
-                                                                                    "label",
-                                                                                    "name"
+                                                                                    "name",
+                                                                                    "label"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -16079,8 +16091,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16093,19 +16105,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -16114,8 +16126,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
                                                             "success",
+                                                            "error",
                                                             "not_found"
                                                         ]
                                                     }
@@ -16146,66 +16158,6 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
-                                                                                "description",
-                                                                                "label",
-                                                                                "name"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "requiredFilters": {
@@ -16219,25 +16171,25 @@
                                                                                         "required": {
                                                                                             "type": "boolean"
                                                                                         },
-                                                                                        "tableName": {
+                                                                                        "operator": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "operator": {
+                                                                                        "fieldId": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "fieldId": {
+                                                                                        "tableName": {
                                                                                             "type": "string"
                                                                                         }
                                                                                     },
                                                                                     "required": [
                                                                                         "required",
-                                                                                        "tableName",
-                                                                                        "fieldRef",
                                                                                         "operator",
-                                                                                        "fieldId"
+                                                                                        "fieldRef",
+                                                                                        "fieldId",
+                                                                                        "tableName"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -16252,20 +16204,80 @@
                                                                             "baseTable": {
                                                                                 "type": "string"
                                                                             },
-                                                                            "label": {
+                                                                            "name": {
                                                                                 "type": "string"
                                                                             },
-                                                                            "name": {
+                                                                            "label": {
                                                                                 "type": "string"
                                                                             }
                                                                         },
                                                                         "required": [
                                                                             "joinedTables",
                                                                             "baseTable",
-                                                                            "label",
-                                                                            "name"
+                                                                            "name",
+                                                                            "label"
                                                                         ],
                                                                         "type": "object"
+                                                                    },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "metric",
+                                                                                        "dimension"
+                                                                                    ]
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "fieldValueType",
+                                                                                "description",
+                                                                                "caseSensitiveFilters",
+                                                                                "isFromJoinedTable",
+                                                                                "fieldFilterType",
+                                                                                "fieldId",
+                                                                                "fieldType",
+                                                                                "name",
+                                                                                "label",
+                                                                                "table"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -16277,8 +16289,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "fields",
                                                                     "explore",
+                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -16377,13 +16389,14 @@
                                                         ],
                                                         "type": "object"
                                                     },
+                                                    "warnings": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
                                                     "href": {
                                                         "type": "string"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
                                                     },
                                                     "slug": {
                                                         "type": "string"
@@ -16391,24 +16404,23 @@
                                                     "uuid": {
                                                         "type": "string"
                                                     },
-                                                    "warnings": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
-                                                    },
                                                     "name": {
                                                         "type": "string"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
+                                                    "warnings",
                                                     "href",
-                                                    "status",
                                                     "slug",
                                                     "uuid",
-                                                    "warnings",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -16420,9 +16432,9 @@
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
-                                                                        "search",
                                                                         "read",
                                                                         "edit",
+                                                                        "search",
                                                                         "compile",
                                                                         "stage"
                                                                     ]
@@ -16509,23 +16521,23 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
-                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "status",
                                                     "slug",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -16538,8 +16550,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16551,8 +16563,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
                                                             "success",
+                                                            "error",
                                                             "rejected",
                                                             "timeout"
                                                         ]
@@ -16565,10 +16577,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -16588,36 +16596,40 @@
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
                                                                         "tableName",
-                                                                        "label",
-                                                                        "name"
+                                                                        "name",
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
                                                             },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "dimension",
                                                                     "metric",
+                                                                    "dimension",
                                                                     null
                                                                 ],
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -16625,8 +16637,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -25381,7 +25393,7 @@
             },
             "url.URL": {
                 "type": "string",
-                "description": "The URL interface represents an object providing static methods used for creating object URLs.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/URL)\n`URL` class is a global reference for `import { URL } from 'url'`\nhttps://nodejs.org/api/url.html#the-whatwg-url-api"
+                "description": "The **`URL`** interface is used to parse, construct, normalize, and encode URL.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/URL)\n`URL` class is a global reference for `import { URL } from 'url'`\nhttps://nodejs.org/api/url.html#the-whatwg-url-api"
             },
             "OauthAuth": {
                 "properties": {
@@ -31757,22 +31769,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -41663,7 +41675,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3260.2",
+        "version": "0.3270.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -182,6 +182,8 @@ describe('defineTool', () => {
             .sort();
 
         expect(structuredMcpToolNames).toEqual([
+            'find_explores',
+            'find_fields',
             'get_query_result',
             'list_skills',
             'read_skill',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -96,11 +96,13 @@ import {
     toolFindDashboardsOutputSchema,
 } from './toolFindDashboardsArgs';
 import {
+    mcpFindExploresStructuredOutputSchema,
     TOOL_FIND_EXPLORES_DESCRIPTION,
     toolFindExploresArgsSchemaV3,
     toolFindExploresOutputSchema,
 } from './toolFindExploresArgs';
 import {
+    mcpFindFieldsStructuredOutputSchema,
     TOOL_FIND_FIELDS_DESCRIPTION,
     toolFindFieldsArgsSchema,
     toolFindFieldsOutputSchema,
@@ -323,7 +325,10 @@ export const findExploresToolDefinition = defineTool({
     availability: ['agent', 'mcp'],
     inputSchema: toolFindExploresArgsSchemaV3,
     agent: { outputSchema: toolFindExploresOutputSchema },
-    mcp: { annotations: readOnlyAnnotations },
+    mcp: {
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: mcpFindExploresStructuredOutputSchema,
+    },
 });
 
 export const findFieldsToolDefinition = defineTool({
@@ -333,7 +338,10 @@ export const findFieldsToolDefinition = defineTool({
     availability: ['agent', 'mcp'],
     inputSchema: toolFindFieldsArgsSchema,
     agent: { outputSchema: toolFindFieldsOutputSchema },
-    mcp: { annotations: readOnlyAnnotations },
+    mcp: {
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: mcpFindFieldsStructuredOutputSchema,
+    },
 });
 
 export const searchSemanticLayerToolDefinition = defineTool({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -96,13 +96,13 @@ import {
     toolFindDashboardsOutputSchema,
 } from './toolFindDashboardsArgs';
 import {
-    mcpFindExploresStructuredOutputSchema,
+    findExploresResultSchema,
     TOOL_FIND_EXPLORES_DESCRIPTION,
     toolFindExploresArgsSchemaV3,
     toolFindExploresOutputSchema,
 } from './toolFindExploresArgs';
 import {
-    mcpFindFieldsStructuredOutputSchema,
+    findFieldsResultSchema,
     TOOL_FIND_FIELDS_DESCRIPTION,
     toolFindFieldsArgsSchema,
     toolFindFieldsOutputSchema,
@@ -327,7 +327,7 @@ export const findExploresToolDefinition = defineTool({
     agent: { outputSchema: toolFindExploresOutputSchema },
     mcp: {
         annotations: readOnlyAnnotations,
-        structuredContentSchema: mcpFindExploresStructuredOutputSchema,
+        structuredContentSchema: findExploresResultSchema,
     },
 });
 
@@ -340,7 +340,7 @@ export const findFieldsToolDefinition = defineTool({
     agent: { outputSchema: toolFindFieldsOutputSchema },
     mcp: {
         annotations: readOnlyAnnotations,
-        structuredContentSchema: mcpFindFieldsStructuredOutputSchema,
+        structuredContentSchema: findFieldsResultSchema,
     },
 });
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -89,7 +89,7 @@ export const findExploresRankingMetadataSchema = z.object({
         .optional(),
 });
 
-export const mcpFindExploresRequiredFilterSchema = z.object({
+export const findExploresRequiredFilterSchema = z.object({
     fieldId: z.string(),
     fieldRef: z.string(),
     tableName: z.string(),
@@ -99,7 +99,7 @@ export const mcpFindExploresRequiredFilterSchema = z.object({
     required: z.boolean(),
 });
 
-export const mcpFindExploresRelevantVerifiedAnswerSchema = z.object({
+export const findExploresRelevantVerifiedAnswerSchema = z.object({
     artifactVersionUuid: z.string(),
     chartConfig: z.record(z.unknown()),
     artifactType: z.enum(['chart', 'dashboard']),
@@ -109,7 +109,7 @@ export const mcpFindExploresRelevantVerifiedAnswerSchema = z.object({
     similarity: z.number(),
 });
 
-export const mcpFindExploresStructuredOutputSchema = z.object({
+export const findExploresResultSchema = z.object({
     searchQuery: z.string(),
     description: z.string(),
     searchResults: z.object({
@@ -119,7 +119,7 @@ export const mcpFindExploresStructuredOutputSchema = z.object({
             z.object({
                 name: z.string(),
                 label: z.string(),
-                searchRank: z.string(),
+                searchRank: z.number().nullable(),
                 description: z.string().nullable(),
                 aiHints: z.array(z.string()),
                 joinedTables: z.object({
@@ -127,7 +127,7 @@ export const mcpFindExploresStructuredOutputSchema = z.object({
                     note: z.string().nullable(),
                     tables: z.array(z.string()),
                 }),
-                requiredFilters: z.array(mcpFindExploresRequiredFilterSchema),
+                requiredFilters: z.array(findExploresRequiredFilterSchema),
             }),
         ),
     }),
@@ -140,14 +140,14 @@ export const mcpFindExploresStructuredOutputSchema = z.object({
                 label: z.string(),
                 exploreName: z.string(),
                 fieldType: z.string(),
-                searchRank: z.string(),
+                searchRank: z.number().nullable(),
                 usageInCharts: z.number(),
                 usageInVerifiedCharts: z.number(),
             }),
         ),
     }),
     relevantVerifiedAnswers: z
-        .array(mcpFindExploresRelevantVerifiedAnswerSchema)
+        .array(findExploresRelevantVerifiedAnswerSchema)
         .optional(),
 });
 
@@ -169,9 +169,7 @@ export type ToolFindExploresArgsV3 = z.infer<
 >;
 export type ToolFindExploresArgs = z.infer<typeof toolFindExploresArgsSchemaV3>;
 export type ToolFindExploresArgsTransformed = ToolFindExploresArgs;
-export type McpFindExploresStructuredOutput = z.infer<
-    typeof mcpFindExploresStructuredOutputSchema
->;
+export type FindExploresResult = z.infer<typeof findExploresResultSchema>;
 export type ToolFindExploresOutput = z.infer<
     typeof toolFindExploresOutputSchema
 >;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -89,6 +89,68 @@ export const findExploresRankingMetadataSchema = z.object({
         .optional(),
 });
 
+export const mcpFindExploresRequiredFilterSchema = z.object({
+    fieldId: z.string(),
+    fieldRef: z.string(),
+    tableName: z.string(),
+    operator: z.string(),
+    values: z.array(z.unknown()).optional(),
+    settings: z.unknown().optional(),
+    required: z.boolean(),
+});
+
+export const mcpFindExploresRelevantVerifiedAnswerSchema = z.object({
+    artifactVersionUuid: z.string(),
+    chartConfig: z.record(z.unknown()),
+    artifactType: z.enum(['chart', 'dashboard']),
+    verifiedQuestion: z.string().nullable(),
+    title: z.string().nullable(),
+    description: z.string().nullable(),
+    similarity: z.number(),
+});
+
+export const mcpFindExploresStructuredOutputSchema = z.object({
+    searchQuery: z.string(),
+    description: z.string(),
+    searchResults: z.object({
+        count: z.number(),
+        note: z.string(),
+        results: z.array(
+            z.object({
+                name: z.string(),
+                label: z.string(),
+                searchRank: z.string(),
+                description: z.string().nullable(),
+                aiHints: z.array(z.string()),
+                joinedTables: z.object({
+                    count: z.number(),
+                    note: z.string().nullable(),
+                    tables: z.array(z.string()),
+                }),
+                requiredFilters: z.array(mcpFindExploresRequiredFilterSchema),
+            }),
+        ),
+    }),
+    topMatchingFields: z.object({
+        count: z.number(),
+        note: z.string(),
+        fields: z.array(
+            z.object({
+                name: z.string(),
+                label: z.string(),
+                exploreName: z.string(),
+                fieldType: z.string(),
+                searchRank: z.string(),
+                usageInCharts: z.number(),
+                usageInVerifiedCharts: z.number(),
+            }),
+        ),
+    }),
+    relevantVerifiedAnswers: z
+        .array(mcpFindExploresRelevantVerifiedAnswerSchema)
+        .optional(),
+});
+
 export const toolFindExploresOutputSchema = z.object({
     result: z.string(),
     metadata: baseOutputMetadataSchema.extend({
@@ -107,6 +169,9 @@ export type ToolFindExploresArgsV3 = z.infer<
 >;
 export type ToolFindExploresArgs = z.infer<typeof toolFindExploresArgsSchemaV3>;
 export type ToolFindExploresArgsTransformed = ToolFindExploresArgs;
+export type McpFindExploresStructuredOutput = z.infer<
+    typeof mcpFindExploresStructuredOutputSchema
+>;
 export type ToolFindExploresOutput = z.infer<
     typeof toolFindExploresOutputSchema
 >;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
@@ -57,6 +57,39 @@ export const findFieldsRankingMetadataSchema = z.object({
     ),
 });
 
+export const mcpFindFieldsStructuredOutputSchema = z.object({
+    searchResults: z.array(
+        z.object({
+            searchQuery: z.string(),
+            page: z.number().nullable(),
+            pageSize: z.number().nullable(),
+            totalPageCount: z.number().nullable(),
+            totalResults: z.number().nullable(),
+            fields: z.array(
+                z.object({
+                    type: z.string(),
+                    baseTable: z.string(),
+                    name: z.string(),
+                    fieldId: z.string(),
+                    fieldType: z.string(),
+                    fieldFilterType: z.string(),
+                    searchRank: z.number().nullable().optional(),
+                    chartUsage: z.number().nullable().optional(),
+                    usageInVerifiedCharts: z.number(),
+                    isFromJoinedTable: z.boolean(),
+                    caseSensitiveFilters: z.boolean().nullable(),
+                    note: z.string().nullable(),
+                    label: z.string(),
+                    aiHints: z.array(z.string()),
+                    description: z.string().nullable(),
+                    categories: z.array(z.string()),
+                    emoji: z.string().nullable(),
+                }),
+            ),
+        }),
+    ),
+});
+
 export const toolFindFieldsOutputSchema = z.object({
     result: z.string(),
     metadata: baseOutputMetadataSchema.extend({
@@ -66,4 +99,7 @@ export const toolFindFieldsOutputSchema = z.object({
 
 export type ToolFindFieldsArgs = z.infer<typeof toolFindFieldsArgsSchema>;
 export type ToolFindFieldsArgsTransformed = ToolFindFieldsArgs;
+export type McpFindFieldsStructuredOutput = z.infer<
+    typeof mcpFindFieldsStructuredOutputSchema
+>;
 export type ToolFindFieldsOutput = z.infer<typeof toolFindFieldsOutputSchema>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
@@ -33,7 +33,9 @@ export const toolFindFieldsArgsSchemaTransformed = toolFindFieldsArgsSchema;
 export const findFieldsRankingMetadataSchema = z.object({
     searchQueries: z.array(
         z.object({
+            status: z.enum(['success', 'error']).optional(),
             label: z.string(),
+            error: z.string().optional(),
             results: z.array(
                 z.object({
                     name: z.string(),
@@ -57,36 +59,48 @@ export const findFieldsRankingMetadataSchema = z.object({
     ),
 });
 
-export const mcpFindFieldsStructuredOutputSchema = z.object({
-    searchResults: z.array(
+const findFieldsSearchSuccessSchema = z.object({
+    status: z.literal('success'),
+    searchQuery: z.string(),
+    page: z.number().nullable(),
+    pageSize: z.number().nullable(),
+    totalPageCount: z.number().nullable(),
+    totalResults: z.number().nullable(),
+    fields: z.array(
         z.object({
-            searchQuery: z.string(),
-            page: z.number().nullable(),
-            pageSize: z.number().nullable(),
-            totalPageCount: z.number().nullable(),
-            totalResults: z.number().nullable(),
-            fields: z.array(
-                z.object({
-                    type: z.string(),
-                    baseTable: z.string(),
-                    name: z.string(),
-                    fieldId: z.string(),
-                    fieldType: z.string(),
-                    fieldFilterType: z.string(),
-                    searchRank: z.number().nullable().optional(),
-                    chartUsage: z.number().nullable().optional(),
-                    usageInVerifiedCharts: z.number(),
-                    isFromJoinedTable: z.boolean(),
-                    caseSensitiveFilters: z.boolean().nullable(),
-                    note: z.string().nullable(),
-                    label: z.string(),
-                    aiHints: z.array(z.string()),
-                    description: z.string().nullable(),
-                    categories: z.array(z.string()),
-                    emoji: z.string().nullable(),
-                }),
-            ),
+            type: z.string(),
+            baseTable: z.string(),
+            name: z.string(),
+            fieldId: z.string(),
+            fieldType: z.string(),
+            fieldFilterType: z.string(),
+            searchRank: z.number().nullable().optional(),
+            chartUsage: z.number().nullable().optional(),
+            usageInVerifiedCharts: z.number(),
+            isFromJoinedTable: z.boolean(),
+            caseSensitiveFilters: z.boolean().nullable(),
+            note: z.string().nullable(),
+            label: z.string(),
+            aiHints: z.array(z.string()),
+            description: z.string().nullable(),
+            categories: z.array(z.string()),
+            emoji: z.string().nullable(),
         }),
+    ),
+});
+
+const findFieldsSearchErrorSchema = z.object({
+    status: z.literal('error'),
+    searchQuery: z.string(),
+    error: z.string(),
+});
+
+export const findFieldsResultSchema = z.object({
+    searchResults: z.array(
+        z.discriminatedUnion('status', [
+            findFieldsSearchSuccessSchema,
+            findFieldsSearchErrorSchema,
+        ]),
     ),
 });
 
@@ -99,7 +113,5 @@ export const toolFindFieldsOutputSchema = z.object({
 
 export type ToolFindFieldsArgs = z.infer<typeof toolFindFieldsArgsSchema>;
 export type ToolFindFieldsArgsTransformed = ToolFindFieldsArgs;
-export type McpFindFieldsStructuredOutput = z.infer<
-    typeof mcpFindFieldsStructuredOutputSchema
->;
+export type FindFieldsResult = z.infer<typeof findFieldsResultSchema>;
 export type ToolFindFieldsOutput = z.infer<typeof toolFindFieldsOutputSchema>;

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -284,7 +284,226 @@
                 "type": "object"
             },
             "name": "find_explores",
-            "outputSchema": null,
+            "outputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "relevantVerifiedAnswers": {
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "artifactType": {
+                                    "enum": ["chart", "dashboard"],
+                                    "type": "string"
+                                },
+                                "artifactVersionUuid": {
+                                    "type": "string"
+                                },
+                                "chartConfig": {
+                                    "additionalProperties": {},
+                                    "type": "object"
+                                },
+                                "description": {
+                                    "type": ["string", "null"]
+                                },
+                                "similarity": {
+                                    "type": "number"
+                                },
+                                "title": {
+                                    "type": ["string", "null"]
+                                },
+                                "verifiedQuestion": {
+                                    "type": ["string", "null"]
+                                }
+                            },
+                            "required": [
+                                "artifactVersionUuid",
+                                "chartConfig",
+                                "artifactType",
+                                "verifiedQuestion",
+                                "title",
+                                "description",
+                                "similarity"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "searchQuery": {
+                        "type": "string"
+                    },
+                    "searchResults": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "count": {
+                                "type": "number"
+                            },
+                            "note": {
+                                "type": "string"
+                            },
+                            "results": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "aiHints": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "description": {
+                                            "type": ["string", "null"]
+                                        },
+                                        "joinedTables": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "count": {
+                                                    "type": "number"
+                                                },
+                                                "note": {
+                                                    "type": ["string", "null"]
+                                                },
+                                                "tables": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "count",
+                                                "note",
+                                                "tables"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "label": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "requiredFilters": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "fieldId": {
+                                                        "type": "string"
+                                                    },
+                                                    "fieldRef": {
+                                                        "type": "string"
+                                                    },
+                                                    "operator": {
+                                                        "type": "string"
+                                                    },
+                                                    "required": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "settings": {},
+                                                    "tableName": {
+                                                        "type": "string"
+                                                    },
+                                                    "values": {
+                                                        "items": {},
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "fieldId",
+                                                    "fieldRef",
+                                                    "tableName",
+                                                    "operator",
+                                                    "required"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "searchRank": {
+                                            "type": ["number", "null"]
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "label",
+                                        "searchRank",
+                                        "description",
+                                        "aiHints",
+                                        "joinedTables",
+                                        "requiredFilters"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["count", "note", "results"],
+                        "type": "object"
+                    },
+                    "topMatchingFields": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "count": {
+                                "type": "number"
+                            },
+                            "fields": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "exploreName": {
+                                            "type": "string"
+                                        },
+                                        "fieldType": {
+                                            "type": "string"
+                                        },
+                                        "label": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "searchRank": {
+                                            "type": ["number", "null"]
+                                        },
+                                        "usageInCharts": {
+                                            "type": "number"
+                                        },
+                                        "usageInVerifiedCharts": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "label",
+                                        "exploreName",
+                                        "fieldType",
+                                        "searchRank",
+                                        "usageInCharts",
+                                        "usageInVerifiedCharts"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "note": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["count", "note", "fields"],
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "searchQuery",
+                    "description",
+                    "searchResults",
+                    "topMatchingFields"
+                ],
+                "type": "object"
+            },
             "title": "Find explores"
         },
         {
@@ -326,7 +545,177 @@
                 "type": "object"
             },
             "name": "find_fields",
-            "outputSchema": null,
+            "outputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "searchResults": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "fields": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "aiHints": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "baseTable": {
+                                                        "type": "string"
+                                                    },
+                                                    "caseSensitiveFilters": {
+                                                        "type": [
+                                                            "boolean",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "categories": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "chartUsage": {
+                                                        "type": [
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "description": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "emoji": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "fieldFilterType": {
+                                                        "type": "string"
+                                                    },
+                                                    "fieldId": {
+                                                        "type": "string"
+                                                    },
+                                                    "fieldType": {
+                                                        "type": "string"
+                                                    },
+                                                    "isFromJoinedTable": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "note": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "searchRank": {
+                                                        "type": [
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "type": {
+                                                        "type": "string"
+                                                    },
+                                                    "usageInVerifiedCharts": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "baseTable",
+                                                    "name",
+                                                    "fieldId",
+                                                    "fieldType",
+                                                    "fieldFilterType",
+                                                    "usageInVerifiedCharts",
+                                                    "isFromJoinedTable",
+                                                    "caseSensitiveFilters",
+                                                    "note",
+                                                    "label",
+                                                    "aiHints",
+                                                    "description",
+                                                    "categories",
+                                                    "emoji"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "page": {
+                                            "type": ["number", "null"]
+                                        },
+                                        "pageSize": {
+                                            "type": ["number", "null"]
+                                        },
+                                        "searchQuery": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "const": "success",
+                                            "type": "string"
+                                        },
+                                        "totalPageCount": {
+                                            "type": ["number", "null"]
+                                        },
+                                        "totalResults": {
+                                            "type": ["number", "null"]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "searchQuery",
+                                        "page",
+                                        "pageSize",
+                                        "totalPageCount",
+                                        "totalResults",
+                                        "fields"
+                                    ],
+                                    "type": "object"
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "searchQuery": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "const": "error",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "searchQuery",
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["searchResults"],
+                "type": "object"
+            },
             "title": "Find fields"
         },
         {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingDisplay.tsx
@@ -53,70 +53,81 @@ export const RankingDisplay: React.FC<{
                             <Text fw={500} size="xs" c="dark" mb="xs">
                                 Search: "{query.label}"
                             </Text>
-                            {query.pagination && (
-                                <Text size="xs" c="dimmed" mb="xs">
-                                    Page {query.pagination.page} of{' '}
-                                    {query.pagination.totalPageCount} (
-                                    {query.pagination.totalResults} total
-                                    results)
+                            {query.status === 'error' ? (
+                                <Text size="xs" c="red" mb="xs">
+                                    {query.error}
                                 </Text>
+                            ) : (
+                                <>
+                                    {query.pagination && (
+                                        <Text size="xs" c="dimmed" mb="xs">
+                                            Page {query.pagination.page} of{' '}
+                                            {query.pagination.totalPageCount} (
+                                            {query.pagination.totalResults}{' '}
+                                            total results)
+                                        </Text>
+                                    )}
+                                    <RankingTable<FieldResult>
+                                        columns={[
+                                            {
+                                                header: 'Field',
+                                                render: (field) => (
+                                                    <Box>
+                                                        <TableCellText>
+                                                            {field.label}
+                                                        </TableCellText>
+                                                        <TableCellText dimmed>
+                                                            {field.name}
+                                                        </TableCellText>
+                                                    </Box>
+                                                ),
+                                            },
+                                            {
+                                                header: 'Table',
+                                                render: (field) => (
+                                                    <TableCellText>
+                                                        {field.tableName}
+                                                    </TableCellText>
+                                                ),
+                                            },
+                                            {
+                                                header: 'Type',
+                                                render: (field) => (
+                                                    <TableCellText>
+                                                        {field.fieldType}
+                                                    </TableCellText>
+                                                ),
+                                            },
+                                            {
+                                                header: 'Rank',
+                                                render: (field) => (
+                                                    <TableCellText>
+                                                        {field.searchRank !==
+                                                            null &&
+                                                        field.searchRank !==
+                                                            undefined
+                                                            ? field.searchRank.toFixed(
+                                                                  3,
+                                                              )
+                                                            : 'N/A'}
+                                                    </TableCellText>
+                                                ),
+                                            },
+                                            {
+                                                header: 'Usage',
+                                                render: (field) => (
+                                                    <TableCellText>
+                                                        {field.chartUsage ??
+                                                            'N/A'}
+                                                    </TableCellText>
+                                                ),
+                                            },
+                                        ]}
+                                        data={query.results}
+                                        maxHeight={300}
+                                    />
+                                </>
                             )}
-                            <RankingTable<FieldResult>
-                                columns={[
-                                    {
-                                        header: 'Field',
-                                        render: (field) => (
-                                            <Box>
-                                                <TableCellText>
-                                                    {field.label}
-                                                </TableCellText>
-                                                <TableCellText dimmed>
-                                                    {field.name}
-                                                </TableCellText>
-                                            </Box>
-                                        ),
-                                    },
-                                    {
-                                        header: 'Table',
-                                        render: (field) => (
-                                            <TableCellText>
-                                                {field.tableName}
-                                            </TableCellText>
-                                        ),
-                                    },
-                                    {
-                                        header: 'Type',
-                                        render: (field) => (
-                                            <TableCellText>
-                                                {field.fieldType}
-                                            </TableCellText>
-                                        ),
-                                    },
-                                    {
-                                        header: 'Rank',
-                                        render: (field) => (
-                                            <TableCellText>
-                                                {field.searchRank !== null &&
-                                                field.searchRank !== undefined
-                                                    ? field.searchRank.toFixed(
-                                                          3,
-                                                      )
-                                                    : 'N/A'}
-                                            </TableCellText>
-                                        ),
-                                    },
-                                    {
-                                        header: 'Usage',
-                                        render: (field) => (
-                                            <TableCellText>
-                                                {field.chartUsage ?? 'N/A'}
-                                            </TableCellText>
-                                        ),
-                                    },
-                                ]}
-                                data={query.results}
-                                maxHeight={300}
-                            />
                         </Box>
                     ))}
                 </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Adds typed MCP structured content for the discover-fields subagent search tools that are also exposed over MCP.

- `find_explores` advertises an MCP output schema and returns its catalog search payload as `structuredContent`.
- `find_fields` advertises an MCP output schema and returns field search results as `structuredContent`.
- Shared builders keep the text response and structured payload aligned across agent and MCP usage.
