### PR TITLE
feat(data-apps): data lineage — link rendered values to their queries [GLITCH-532]

### DIFF
--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -57,6 +57,13 @@ type Props = {
      *  sits during inspect mode (the toolbar button before any click; the
      *  prompt editor after each click — TipTap yanks focus back on insert). */
     onInspectorCancelled?: () => void;
+    /** When true, clicks inside the iframe are intercepted to reveal the query. */
+    lineageEnabled?: boolean;
+    onLineageAvailabilityChange?: (available: boolean) => void;
+    onLineageSelected?: (event: { queryUuid: string }) => void;
+    /** queryUuid whose rendered elements should be outlined (null clears). */
+    lineageHighlightQueryUuid?: string | null;
+    onLineageCancelled?: () => void;
     /** Dashboard filters to merge into every metric-query the iframe runs.
      *  Set by `DashboardDataAppTile`; left undefined by `AppGenerate` where
      *  there's no dashboard context. */
@@ -110,6 +117,11 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onInspectorAvailabilityChange,
             onScreenshotAvailabilityChange,
             onInspectorCancelled,
+            lineageEnabled,
+            onLineageAvailabilityChange,
+            onLineageSelected,
+            lineageHighlightQueryUuid,
+            onLineageCancelled,
             dashboardFilters,
             invalidateCache,
             onIframeLoad,
@@ -127,20 +139,31 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
         const handleScreenshotAnnounce = useCallback(() => {
             onScreenshotAvailabilityChange?.(true);
         }, [onScreenshotAvailabilityChange]);
-        const { handleIframeLoad, enableInspector, disableInspector } =
-            useAppSdkBridge(
-                iframeRef,
-                expectedPreviewOrigin,
-                projectUuid,
-                appUuid,
-                onQueryEvent,
-                onElementSelected,
-                handleInspectorAnnounce,
-                handleScreenshotAnnounce,
-                dashboardFilters,
-                invalidateCache,
-                capabilities,
-            );
+        const handleLineageAnnounce = useCallback(() => {
+            onLineageAvailabilityChange?.(true);
+        }, [onLineageAvailabilityChange]);
+        const {
+            handleIframeLoad,
+            enableInspector,
+            disableInspector,
+            enableLineage,
+            disableLineage,
+            highlightLineage,
+        } = useAppSdkBridge(
+            iframeRef,
+            expectedPreviewOrigin,
+            projectUuid,
+            appUuid,
+            onQueryEvent,
+            onElementSelected,
+            handleInspectorAnnounce,
+            handleScreenshotAnnounce,
+            dashboardFilters,
+            invalidateCache,
+            capabilities,
+            handleLineageAnnounce,
+            onLineageSelected,
+        );
         const { captureScreenshot } = useIframeScreenshot(iframeRef);
 
         useImperativeHandle(ref, () => ({ captureScreenshot }), [
@@ -158,10 +181,12 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
         useEffect(() => {
             onInspectorAvailabilityChange?.(false);
             onScreenshotAvailabilityChange?.(false);
+            onLineageAvailabilityChange?.(false);
         }, [
             identityKey,
             onInspectorAvailabilityChange,
             onScreenshotAvailabilityChange,
+            onLineageAvailabilityChange,
         ]);
 
         // Toggling the prop while the iframe is alive — push the change through.
@@ -170,26 +195,43 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             else disableInspector();
         }, [inspectorEnabled, enableInspector, disableInspector]);
 
+        useEffect(() => {
+            if (lineageEnabled) enableLineage();
+            else disableLineage();
+        }, [lineageEnabled, enableLineage, disableLineage]);
+
+        useEffect(() => {
+            highlightLineage(lineageHighlightQueryUuid ?? null);
+        }, [lineageHighlightQueryUuid, highlightLineage]);
+
         // Esc-to-cancel. Lives on the parent's window because focus is on the
         // parent (the toolbar button before any click; the editor afterwards) —
         // the iframe never holds focus during inspect mode, so an iframe-side
         // keydown listener would never fire.
         useEffect(() => {
-            if (!inspectorEnabled) return;
+            if (!inspectorEnabled && !lineageEnabled) return;
             const onKey = (e: KeyboardEvent) => {
                 if (e.key === 'Escape') {
-                    onInspectorCancelled?.();
+                    if (inspectorEnabled) onInspectorCancelled?.();
+                    if (lineageEnabled) onLineageCancelled?.();
                 }
             };
             window.addEventListener('keydown', onKey);
             return () => window.removeEventListener('keydown', onKey);
-        }, [inspectorEnabled, onInspectorCancelled]);
+        }, [
+            inspectorEnabled,
+            lineageEnabled,
+            onInspectorCancelled,
+            onLineageCancelled,
+        ]);
 
         // The iframe reloads on every new app version. The useEffect above won't
         // re-fire if `inspectorEnabled` was already true, so re-sync on load.
         const handleLoad = () => {
             handleIframeLoad();
             if (inspectorEnabled) enableInspector();
+            if (lineageEnabled) enableLineage();
+            highlightLineage(lineageHighlightQueryUuid ?? null);
             onIframeLoad?.();
         };
 

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -29,7 +29,6 @@ import {
     IconClick,
     IconDatabase,
     IconDatabasePlus,
-    IconDatabaseSearch,
     IconLayoutDashboard,
     IconPhoto,
     IconPlugConnected,
@@ -143,35 +142,6 @@ export const InspectButton: FC<{
             aria-label="Toggle element inspector"
         >
             <MantineIcon icon={IconClick} size={16} />
-        </ActionIcon>
-    </Tooltip>
-);
-
-/**
- * Toggle button that activates the iframe-side data-lineage picker. While
- * enabled, clicking a value in the preview reveals the query behind it in the
- * Queries panel. Mutually exclusive with the element inspector.
- */
-export const InspectDataButton: FC<{
-    enabled: boolean;
-    onToggle: () => void;
-    disabled?: boolean;
-}> = ({ enabled, onToggle, disabled }) => (
-    <Tooltip
-        label={enabled ? 'Inspect data: on' : 'Inspect data'}
-        withArrow
-        position="top"
-    >
-        <ActionIcon
-            variant={enabled ? 'filled' : 'default'}
-            color={enabled ? 'violet' : undefined}
-            size="lg"
-            radius="md"
-            onClick={onToggle}
-            disabled={disabled}
-            aria-label="Toggle data lineage inspector"
-        >
-            <MantineIcon icon={IconDatabaseSearch} size={16} />
         </ActionIcon>
     </Tooltip>
 );

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -29,6 +29,7 @@ import {
     IconClick,
     IconDatabase,
     IconDatabasePlus,
+    IconDatabaseSearch,
     IconLayoutDashboard,
     IconPhoto,
     IconPlugConnected,
@@ -142,6 +143,35 @@ export const InspectButton: FC<{
             aria-label="Toggle element inspector"
         >
             <MantineIcon icon={IconClick} size={16} />
+        </ActionIcon>
+    </Tooltip>
+);
+
+/**
+ * Toggle button that activates the iframe-side data-lineage picker. While
+ * enabled, clicking a value in the preview reveals the query behind it in the
+ * Queries panel. Mutually exclusive with the element inspector.
+ */
+export const InspectDataButton: FC<{
+    enabled: boolean;
+    onToggle: () => void;
+    disabled?: boolean;
+}> = ({ enabled, onToggle, disabled }) => (
+    <Tooltip
+        label={enabled ? 'Inspect data: on' : 'Inspect data'}
+        withArrow
+        position="top"
+    >
+        <ActionIcon
+            variant={enabled ? 'filled' : 'default'}
+            color={enabled ? 'violet' : undefined}
+            size="lg"
+            radius="md"
+            onClick={onToggle}
+            disabled={disabled}
+            aria-label="Toggle data lineage inspector"
+        >
+            <MantineIcon icon={IconDatabaseSearch} size={16} />
         </ActionIcon>
     </Tooltip>
 );

--- a/packages/frontend/src/features/apps/QueryInspector.module.css
+++ b/packages/frontend/src/features/apps/QueryInspector.module.css
@@ -86,6 +86,19 @@
     }
 }
 
+.queryRowFocused {
+    animation: queryRowFlash 1.2s ease-out;
+}
+
+@keyframes queryRowFlash {
+    0% {
+        background-color: rgba(124, 58, 237, 0.18);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
 .queryHeader {
     padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
     cursor: pointer;

--- a/packages/frontend/src/features/apps/QueryInspector.test.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.test.tsx
@@ -1,6 +1,6 @@
 // QueryInspector.test.tsx
 import { MantineProvider } from '@mantine-8/core';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import QueryInspector from './QueryInspector';
 
 const baseQuery = {
@@ -49,9 +49,51 @@ describe('QueryInspector lineage hooks', () => {
         expect(onHoverQuery).toHaveBeenCalledWith(null);
     });
 
-    it('expands the focused query so its UUID is visible', () => {
-        Element.prototype.scrollIntoView = vi.fn();
-        renderInspector({ focusedQueryUuid: 'q-1' });
-        expect(screen.getByText('q-1')).toBeInTheDocument();
+    describe('focus reveal', () => {
+        // jsdom does not implement scrollIntoView; install a vi.fn() on the
+        // prototype for the duration of each test and clean it up afterwards
+        // so it does not bleed into other suites.
+        let scrollIntoViewMock: ReturnType<typeof vi.fn>;
+
+        beforeEach(() => {
+            scrollIntoViewMock = vi.fn();
+            Object.defineProperty(Element.prototype, 'scrollIntoView', {
+                configurable: true,
+                writable: true,
+                value: scrollIntoViewMock,
+            });
+        });
+
+        afterEach(() => {
+            delete (Element.prototype as Partial<Element>).scrollIntoView;
+        });
+
+        it('scrolls the focused row into view with smooth behavior', () => {
+            renderInspector({
+                focusedQueryUuid: 'q-1',
+                defaultCollapsed: false,
+            });
+            expect(scrollIntoViewMock).toHaveBeenCalledWith({
+                behavior: 'smooth',
+                block: 'nearest',
+            });
+        });
+
+        it('does NOT scroll when focusedQueryUuid does not match any row', () => {
+            renderInspector({
+                focusedQueryUuid: 'does-not-exist',
+                defaultCollapsed: false,
+            });
+            expect(scrollIntoViewMock).not.toHaveBeenCalled();
+        });
+
+        it('applies the focused CSS class to the matching row', () => {
+            renderInspector({
+                focusedQueryUuid: 'q-1',
+                defaultCollapsed: false,
+            });
+            const row = document.querySelector('[data-query-uuid="q-1"]')!;
+            expect(row.className).toMatch(/queryRowFocused/);
+        });
     });
 });

--- a/packages/frontend/src/features/apps/QueryInspector.test.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.test.tsx
@@ -1,6 +1,6 @@
 // QueryInspector.test.tsx
 import { MantineProvider } from '@mantine-8/core';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import QueryInspector from './QueryInspector';
 
 const baseQuery = {
@@ -94,6 +94,16 @@ describe('QueryInspector lineage hooks', () => {
             });
             const row = document.querySelector('[data-query-uuid="q-1"]')!;
             expect(row.className).toMatch(/queryRowFocused/);
+        });
+
+        it('auto-uncollapses the panel when a matching focusedQueryUuid arrives', async () => {
+            // Panel starts collapsed (defaultCollapsed defaults to true).
+            // The effect in QueryInspector should call setCollapsed(false)
+            // because 'q-1' matches a query in the list, making the row visible.
+            renderInspector({ focusedQueryUuid: 'q-1' });
+            await waitFor(() =>
+                expect(screen.getByText('Revenue')).toBeVisible(),
+            );
         });
     });
 });

--- a/packages/frontend/src/features/apps/QueryInspector.test.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.test.tsx
@@ -106,4 +106,30 @@ describe('QueryInspector lineage hooks', () => {
             );
         });
     });
+
+    describe('inspect data toggle', () => {
+        it('calls onToggleLineage when the header toggle is clicked', () => {
+            const onToggleLineage = vi.fn();
+            renderInspector({
+                onToggleLineage,
+                lineageAvailable: true,
+                defaultCollapsed: false,
+            });
+            fireEvent.click(
+                screen.getByLabelText('Toggle data lineage inspector'),
+            );
+            expect(onToggleLineage).toHaveBeenCalledTimes(1);
+        });
+
+        it('disables the toggle when lineage is unavailable', () => {
+            renderInspector({
+                onToggleLineage: vi.fn(),
+                lineageAvailable: false,
+                defaultCollapsed: false,
+            });
+            expect(
+                screen.getByLabelText('Toggle data lineage inspector'),
+            ).toBeDisabled();
+        });
+    });
 });

--- a/packages/frontend/src/features/apps/QueryInspector.test.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.test.tsx
@@ -1,0 +1,57 @@
+// QueryInspector.test.tsx
+import { MantineProvider } from '@mantine-8/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import QueryInspector from './QueryInspector';
+
+const baseQuery = {
+    id: '1',
+    timestamp: 0,
+    label: 'Revenue',
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: ['orders_revenue'],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    limit: 20,
+    queryUuid: 'q-1',
+    status: 'ready' as const,
+    rowCount: 3,
+    durationMs: 20,
+    error: null,
+    rawMetricQuery: null,
+};
+
+const renderInspector = (
+    props: Partial<React.ComponentProps<typeof QueryInspector>>,
+) =>
+    render(
+        <MantineProvider>
+            <QueryInspector
+                queries={[baseQuery]}
+                projectUuid="p-1"
+                onClear={() => {}}
+                onDismiss={() => {}}
+                {...props}
+            />
+        </MantineProvider>,
+    );
+
+describe('QueryInspector lineage hooks', () => {
+    it('calls onHoverQuery with the queryUuid on hover and null on leave', () => {
+        const onHoverQuery = vi.fn();
+        renderInspector({ onHoverQuery });
+        const row = document.querySelector('[data-query-uuid="q-1"]')!;
+        fireEvent.mouseEnter(row);
+        expect(onHoverQuery).toHaveBeenCalledWith('q-1');
+        fireEvent.mouseLeave(row);
+        expect(onHoverQuery).toHaveBeenCalledWith(null);
+    });
+
+    it('expands the focused query so its UUID is visible', () => {
+        Element.prototype.scrollIntoView = vi.fn();
+        renderInspector({ focusedQueryUuid: 'q-1' });
+        expect(screen.getByText('q-1')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -18,6 +18,7 @@ import {
     IconChevronRight,
     IconCopy,
     IconDatabase,
+    IconDatabaseSearch,
     IconExternalLink,
     IconTrash,
     IconX,
@@ -56,6 +57,11 @@ type Props = {
      *  until queries arrive; the preview passes `false` so once opened from
      *  the menu the panel remains visible. */
     hideWhenEmpty?: boolean;
+    /** Data-lineage ("Inspect data") toggle rendered in the panel header.
+     *  When `onToggleLineage` is omitted, the toggle is hidden. */
+    lineageEnabled?: boolean;
+    lineageAvailable?: boolean;
+    onToggleLineage?: () => void;
     /** Called with the queryUuid when a row is hovered, and null on leave.
      *  The parent forwards this to the iframe to outline matching elements. */
     onHoverQuery?: (queryUuid: string | null) => void;
@@ -384,6 +390,9 @@ const QueryInspector: FC<Props> = ({
     hideWhenEmpty = true,
     onHoverQuery,
     focusedQueryUuid,
+    lineageEnabled,
+    lineageAvailable,
+    onToggleLineage,
 }) => {
     const [collapsed, setCollapsed] = useState(defaultCollapsed);
     const [height, setHeight] = useState(DEFAULT_HEIGHT);
@@ -476,6 +485,36 @@ const QueryInspector: FC<Props> = ({
                 <Box ml="auto" />
                 {!collapsed && (
                     <>
+                        {onToggleLineage && (
+                            <Tooltip
+                                label={
+                                    lineageEnabled
+                                        ? 'Inspect data: on'
+                                        : 'Inspect data'
+                                }
+                                withArrow
+                                position="top"
+                            >
+                                <ActionIcon
+                                    variant={
+                                        lineageEnabled ? 'filled' : 'subtle'
+                                    }
+                                    color={lineageEnabled ? 'violet' : 'gray'}
+                                    size="xs"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onToggleLineage();
+                                    }}
+                                    disabled={!lineageAvailable}
+                                    aria-label="Toggle data lineage inspector"
+                                >
+                                    <MantineIcon
+                                        icon={IconDatabaseSearch}
+                                        size={12}
+                                    />
+                                </ActionIcon>
+                            </Tooltip>
+                        )}
                         <Tooltip label="Clear queries" withArrow position="top">
                             <ActionIcon
                                 variant="subtle"

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -436,6 +436,17 @@ const QueryInspector: FC<Props> = ({
         [onClear],
     );
 
+    // Auto-uncollapse the panel when a matching focused query arrives so
+    // the focused row is not hidden inside a closed collapse region.
+    useEffect(() => {
+        if (
+            focusedQueryUuid != null &&
+            queries.some((q) => q.queryUuid === focusedQueryUuid)
+        ) {
+            setCollapsed(false);
+        }
+    }, [focusedQueryUuid, queries]);
+
     // Hide the panel entirely only when there's nothing to show *and* the
     // user hasn't engaged with it. If they've expanded it (e.g. cleared the
     // log to wait for fresh queries), keep it mounted with an empty state so

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -22,7 +22,7 @@ import {
     IconTrash,
     IconX,
 } from '@tabler/icons-react';
-import { useCallback, useRef, useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import type { QueryEvent } from './hooks/useAppSdkBridge';
@@ -56,6 +56,12 @@ type Props = {
      *  until queries arrive; the preview passes `false` so once opened from
      *  the menu the panel remains visible. */
     hideWhenEmpty?: boolean;
+    /** Called with the queryUuid when a row is hovered, and null on leave.
+     *  The parent forwards this to the iframe to outline matching elements. */
+    onHoverQuery?: (queryUuid: string | null) => void;
+    /** When set, the matching row auto-expands, scrolls into view, and flashes.
+     *  Driven by element→query lineage selection from the parent. */
+    focusedQueryUuid?: string | null;
 };
 
 const statusColor = (status: TrackedQuery['status']): string => {
@@ -109,15 +115,34 @@ const buildExploreUrl = (
     return `${pathname}?${search}`;
 };
 
-const QueryRow: FC<{ query: TrackedQuery; projectUuid: string }> = ({
-    query,
-    projectUuid,
-}) => {
+const QueryRow: FC<{
+    query: TrackedQuery;
+    projectUuid: string;
+    onHover?: (queryUuid: string | null) => void;
+    focused?: boolean;
+}> = ({ query, projectUuid, onHover, focused }) => {
     const [expanded, setExpanded] = useState(false);
     const [jsonExpanded, setJsonExpanded] = useState(false);
+    const rowRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (focused) {
+            setExpanded(true);
+            rowRef.current?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest',
+            });
+        }
+    }, [focused]);
 
     return (
-        <Box className={classes.queryRow}>
+        <Box
+            ref={rowRef}
+            className={`${classes.queryRow}${focused ? ` ${classes.queryRowFocused}` : ''}`}
+            data-query-uuid={query.queryUuid ?? undefined}
+            onMouseEnter={() => query.queryUuid && onHover?.(query.queryUuid)}
+            onMouseLeave={() => onHover?.(null)}
+        >
             <Group
                 gap="xs"
                 wrap="nowrap"
@@ -357,6 +382,8 @@ const QueryInspector: FC<Props> = ({
     defaultCollapsed = true,
     onDismiss,
     hideWhenEmpty = true,
+    onHoverQuery,
+    focusedQueryUuid,
 }) => {
     const [collapsed, setCollapsed] = useState(defaultCollapsed);
     const [height, setHeight] = useState(DEFAULT_HEIGHT);
@@ -509,6 +536,11 @@ const QueryInspector: FC<Props> = ({
                                     key={q.queryUuid ?? q.id}
                                     query={q}
                                     projectUuid={projectUuid}
+                                    onHover={onHoverQuery}
+                                    focused={
+                                        focusedQueryUuid != null &&
+                                        q.queryUuid === focusedQueryUuid
+                                    }
                                 />
                             ))
                         )}

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -567,6 +567,37 @@ describe('external-fetch branch', () => {
         );
     });
 
+    it('routes lightdash:lineage:selected to onLineageSelected with the queryUuid', () => {
+        const onLineageSelected = vi.fn();
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge(
+                iframeRef,
+                window.location.origin,
+                PROJECT_UUID,
+                APP_UUID,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                onLineageSelected,
+            ),
+        );
+
+        dispatchFetchMessage({
+            type: 'lightdash:lineage:selected',
+            queryUuid: 'q-9',
+        });
+
+        expect(onLineageSelected).toHaveBeenCalledWith({ queryUuid: 'q-9' });
+    });
+
     it('rejects external-fetch messages from a spoofed sender (wrong source AND wrong origin)', async () => {
         // Security invariant: the bridge guard checks BOTH event.source
         // (must match iframeRef.current.contentWindow) AND event.origin

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -399,6 +399,77 @@ describe('useAppSdkBridge', () => {
     });
 });
 
+describe('lineage message routing', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it('routes lightdash:lineage:selected to onLineageSelected with the queryUuid', () => {
+        const onLineageSelected = vi.fn();
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge(
+                iframeRef,
+                window.location.origin,
+                PROJECT_UUID,
+                APP_UUID,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                onLineageSelected,
+            ),
+        );
+
+        dispatchFetchMessage({
+            type: 'lightdash:lineage:selected',
+            queryUuid: 'q-9',
+        });
+
+        expect(onLineageSelected).toHaveBeenCalledWith({ queryUuid: 'q-9' });
+    });
+
+    it('routes lightdash:lineage:available to onLineageAvailable', () => {
+        const onLineageAvailable = vi.fn();
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge(
+                iframeRef,
+                window.location.origin,
+                PROJECT_UUID,
+                APP_UUID,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                onLineageAvailable,
+            ),
+        );
+
+        dispatchFetchMessage({
+            type: 'lightdash:lineage:available',
+        });
+
+        expect(onLineageAvailable).toHaveBeenCalled();
+    });
+});
+
 describe('external-fetch branch', () => {
     beforeEach(() => {
         vi.stubGlobal('fetch', vi.fn());
@@ -565,37 +636,6 @@ describe('external-fetch branch', () => {
                 )?.['result'],
             ).toBeDefined(),
         );
-    });
-
-    it('routes lightdash:lineage:selected to onLineageSelected with the queryUuid', () => {
-        const onLineageSelected = vi.fn();
-        const iframeRef = {
-            current: { contentWindow: window } as unknown as HTMLIFrameElement,
-        } as RefObject<HTMLIFrameElement | null>;
-        renderHook(() =>
-            useAppSdkBridge(
-                iframeRef,
-                window.location.origin,
-                PROJECT_UUID,
-                APP_UUID,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                onLineageSelected,
-            ),
-        );
-
-        dispatchFetchMessage({
-            type: 'lightdash:lineage:selected',
-            queryUuid: 'q-9',
-        });
-
-        expect(onLineageSelected).toHaveBeenCalledWith({ queryUuid: 'q-9' });
     });
 
     it('rejects external-fetch messages from a spoofed sender (wrong source AND wrong origin)', async () => {

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -186,6 +186,8 @@ export function useAppSdkBridge(
      * will receive an error response for those requests.
      */
     capabilities?: { gsheetExport?: boolean },
+    onLineageAvailable?: () => void,
+    onLineageSelected?: (event: { queryUuid: string }) => void,
 ) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -239,6 +241,20 @@ export function useAppSdkBridge(
                 const label = typeof data.label === 'string' ? data.label : '';
                 if (label && onElementSelected) {
                     onElementSelected({ label });
+                }
+                return;
+            }
+
+            if (data?.type === 'lightdash:lineage:available') {
+                onLineageAvailable?.();
+                return;
+            }
+
+            if (data?.type === 'lightdash:lineage:selected') {
+                const queryUuid =
+                    typeof data.queryUuid === 'string' ? data.queryUuid : '';
+                if (queryUuid && onLineageSelected) {
+                    onLineageSelected({ queryUuid });
                 }
                 return;
             }
@@ -665,6 +681,8 @@ export function useAppSdkBridge(
             embedToken,
             embedProjectUuid,
             capabilities,
+            onLineageAvailable,
+            onLineageSelected,
             health.data,
             user.data,
         ],
@@ -701,9 +719,36 @@ export function useAppSdkBridge(
         );
     }, [iframeRef]);
 
+    const enableLineage = useCallback(() => {
+        iframeRef.current?.contentWindow?.postMessage(
+            { type: 'lightdash:lineage:enable' },
+            '*',
+        );
+    }, [iframeRef]);
+
+    const disableLineage = useCallback(() => {
+        iframeRef.current?.contentWindow?.postMessage(
+            { type: 'lightdash:lineage:disable' },
+            '*',
+        );
+    }, [iframeRef]);
+
+    const highlightLineage = useCallback(
+        (queryUuid: string | null) => {
+            iframeRef.current?.contentWindow?.postMessage(
+                { type: 'lightdash:lineage:highlight', queryUuid },
+                '*',
+            );
+        },
+        [iframeRef],
+    );
+
     return {
         handleIframeLoad,
         enableInspector,
         disableInspector,
+        enableLineage,
+        disableLineage,
+        highlightLineage,
     };
 }

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -76,6 +76,7 @@ import AppPromptEditor, {
 import {
     AttachButton,
     InspectButton,
+    InspectDataButton,
     ModelPicker,
     ScreenshotButton,
     SelectedDashboardSection,
@@ -191,6 +192,11 @@ type AppPreviewProps = {
     onInspectorAvailabilityChange?: (available: boolean) => void;
     onScreenshotAvailabilityChange?: (available: boolean) => void;
     onInspectorCancelled?: () => void;
+    lineageEnabled?: boolean;
+    onLineageAvailabilityChange?: (available: boolean) => void;
+    onLineageSelected?: (event: { queryUuid: string }) => void;
+    lineageHighlightQueryUuid?: string | null;
+    onLineageCancelled?: () => void;
 };
 
 const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
@@ -207,6 +213,11 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
             onInspectorAvailabilityChange,
             onScreenshotAvailabilityChange,
             onInspectorCancelled,
+            lineageEnabled,
+            onLineageAvailabilityChange,
+            onLineageSelected,
+            lineageHighlightQueryUuid,
+            onLineageCancelled,
         },
         ref,
     ) => {
@@ -258,6 +269,11 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 onInspectorAvailabilityChange={onInspectorAvailabilityChange}
                 onScreenshotAvailabilityChange={onScreenshotAvailabilityChange}
                 onInspectorCancelled={onInspectorCancelled}
+                lineageEnabled={lineageEnabled}
+                onLineageAvailabilityChange={onLineageAvailabilityChange}
+                onLineageSelected={onLineageSelected}
+                lineageHighlightQueryUuid={lineageHighlightQueryUuid}
+                onLineageCancelled={onLineageCancelled}
                 capabilities={{ gsheetExport: true }}
             />
         );
@@ -493,6 +509,14 @@ const AppGenerate: FC = () => {
     // Screenshot button stays hidden — they keep working as before.
     const [screenshotAvailable, setScreenshotAvailable] = useState(false);
     const [isCapturingScreenshot, setIsCapturingScreenshot] = useState(false);
+    const [lineageEnabled, setLineageEnabled] = useState(false);
+    const [lineageAvailable, setLineageAvailable] = useState(false);
+    const [hoveredQueryUuid, setHoveredQueryUuid] = useState<string | null>(
+        null,
+    );
+    const [focusedQueryUuid, setFocusedQueryUuid] = useState<string | null>(
+        null,
+    );
     const previewRef = useRef<AppIframePreviewHandle>(null);
     const {
         queries: trackedQueries,
@@ -522,6 +546,17 @@ const AppGenerate: FC = () => {
     // every render of this page.
     const handleInspectorCancelled = useCallback(() => {
         setInspectorEnabled(false);
+    }, []);
+    const handleLineageSelected = useCallback(
+        (event: { queryUuid: string }) => {
+            setQueriesPanelHidden(false);
+            setFocusedQueryUuid(event.queryUuid);
+        },
+        [],
+    );
+
+    const handleLineageCancelled = useCallback(() => {
+        setLineageEnabled(false);
     }, []);
     const [localMessages, setLocalMessages] = useState<ChatMessage[]>([]);
     // Pre-build clarification round: captured submission args that we need
@@ -604,6 +639,10 @@ const AppGenerate: FC = () => {
         setInspectorAvailable(false);
         setScreenshotAvailable(false);
         setIsCapturingScreenshot(false);
+        setLineageEnabled(false);
+        setLineageAvailable(false);
+        setHoveredQueryUuid(null);
+        setFocusedQueryUuid(null);
         setSelectedTemplate(null);
         setThemeChipOverride(null);
         setPendingClarification(null);
@@ -2679,12 +2718,31 @@ const AppGenerate: FC = () => {
                                             />
                                             <InspectButton
                                                 enabled={inspectorEnabled}
-                                                onToggle={() =>
-                                                    setInspectorEnabled(
-                                                        (v) => !v,
-                                                    )
-                                                }
+                                                onToggle={() => {
+                                                    setInspectorEnabled((v) => {
+                                                        const next = !v;
+                                                        if (next)
+                                                            setLineageEnabled(
+                                                                false,
+                                                            );
+                                                        return next;
+                                                    });
+                                                }}
                                                 disabled={!inspectorAvailable}
+                                            />
+                                            <InspectDataButton
+                                                enabled={lineageEnabled}
+                                                onToggle={() => {
+                                                    setLineageEnabled((v) => {
+                                                        const next = !v;
+                                                        if (next)
+                                                            setInspectorEnabled(
+                                                                false,
+                                                            );
+                                                        return next;
+                                                    });
+                                                }}
+                                                disabled={!lineageAvailable}
                                             />
                                             <ModelPicker
                                                 value={selectedModel}
@@ -2905,6 +2963,19 @@ const AppGenerate: FC = () => {
                                         onInspectorCancelled={
                                             handleInspectorCancelled
                                         }
+                                        lineageEnabled={lineageEnabled}
+                                        onLineageAvailabilityChange={
+                                            setLineageAvailable
+                                        }
+                                        onLineageSelected={
+                                            handleLineageSelected
+                                        }
+                                        lineageHighlightQueryUuid={
+                                            hoveredQueryUuid
+                                        }
+                                        onLineageCancelled={
+                                            handleLineageCancelled
+                                        }
                                     />
                                 ) : (
                                     <Box className={classes.previewEmpty}>
@@ -2924,6 +2995,8 @@ const AppGenerate: FC = () => {
                                         onDismiss={() =>
                                             setQueriesPanelHidden(true)
                                         }
+                                        onHoverQuery={setHoveredQueryUuid}
+                                        focusedQueryUuid={focusedQueryUuid}
                                     />
                                 )}
                             </Box>

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -76,7 +76,6 @@ import AppPromptEditor, {
 import {
     AttachButton,
     InspectButton,
-    InspectDataButton,
     ModelPicker,
     ScreenshotButton,
     SelectedDashboardSection,
@@ -557,6 +556,14 @@ const AppGenerate: FC = () => {
 
     const handleLineageCancelled = useCallback(() => {
         setLineageEnabled(false);
+    }, []);
+
+    const handleToggleLineage = useCallback(() => {
+        setLineageEnabled((v) => {
+            const next = !v;
+            if (next) setInspectorEnabled(false);
+            return next;
+        });
     }, []);
     const [localMessages, setLocalMessages] = useState<ChatMessage[]>([]);
     // Pre-build clarification round: captured submission args that we need
@@ -2730,20 +2737,6 @@ const AppGenerate: FC = () => {
                                                 }}
                                                 disabled={!inspectorAvailable}
                                             />
-                                            <InspectDataButton
-                                                enabled={lineageEnabled}
-                                                onToggle={() => {
-                                                    setLineageEnabled((v) => {
-                                                        const next = !v;
-                                                        if (next)
-                                                            setInspectorEnabled(
-                                                                false,
-                                                            );
-                                                        return next;
-                                                    });
-                                                }}
-                                                disabled={!lineageAvailable}
-                                            />
                                             <ModelPicker
                                                 value={selectedModel}
                                                 onChange={handleModelChange}
@@ -2997,6 +2990,9 @@ const AppGenerate: FC = () => {
                                         }
                                         onHoverQuery={setHoveredQueryUuid}
                                         focusedQueryUuid={focusedQueryUuid}
+                                        lineageEnabled={lineageEnabled}
+                                        lineageAvailable={lineageAvailable}
+                                        onToggleLineage={handleToggleLineage}
                                     />
                                 )}
                             </Box>

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -65,6 +65,17 @@ export default function AppPreviewTest() {
 
     const [queriesPanelHidden, setQueriesPanelHidden] = useState(true);
 
+    // Data-lineage ("Inspect data"): click a value to reveal the query behind
+    // it; hover a query row to highlight where it renders.
+    const [lineageEnabled, setLineageEnabled] = useState(false);
+    const [lineageAvailable, setLineageAvailable] = useState(false);
+    const [hoveredQueryUuid, setHoveredQueryUuid] = useState<string | null>(
+        null,
+    );
+    const [focusedQueryUuid, setFocusedQueryUuid] = useState<string | null>(
+        null,
+    );
+
     // Query tracking from the preview iframe. The panel is opt-in (hidden by
     // default in preview because most viewers aren't technical), but we wire
     // up the SDK bridge callback unconditionally so queries that run before
@@ -82,6 +93,22 @@ export default function AppPreviewTest() {
         setInvalidateCache(true);
         clearQueries();
     }, [clearQueries]);
+
+    const handleToggleLineage = useCallback(
+        () => setLineageEnabled((v) => !v),
+        [],
+    );
+    const handleLineageSelected = useCallback(
+        (event: { queryUuid: string }) => {
+            setQueriesPanelHidden(false);
+            setFocusedQueryUuid(event.queryUuid);
+        },
+        [],
+    );
+    const handleLineageCancelled = useCallback(
+        () => setLineageEnabled(false),
+        [],
+    );
 
     const previewOrigin = usePreviewOrigin();
 
@@ -237,6 +264,11 @@ export default function AppPreviewTest() {
                     invalidateCache={invalidateCache}
                     onQueryEvent={handleQueryEvent}
                     capabilities={{ gsheetExport: true }}
+                    lineageEnabled={lineageEnabled}
+                    onLineageAvailabilityChange={setLineageAvailable}
+                    onLineageSelected={handleLineageSelected}
+                    lineageHighlightQueryUuid={hoveredQueryUuid}
+                    onLineageCancelled={handleLineageCancelled}
                 />
                 {!queriesPanelHidden && (
                     <QueryInspector
@@ -246,6 +278,11 @@ export default function AppPreviewTest() {
                         defaultCollapsed={false}
                         hideWhenEmpty={false}
                         onDismiss={() => setQueriesPanelHidden(true)}
+                        onHoverQuery={setHoveredQueryUuid}
+                        focusedQueryUuid={focusedQueryUuid}
+                        lineageEnabled={lineageEnabled}
+                        lineageAvailable={lineageAvailable}
+                        onToggleLineage={handleToggleLineage}
                     />
                 )}
             </Box>

--- a/packages/query-sdk/src/client.ts
+++ b/packages/query-sdk/src/client.ts
@@ -7,6 +7,7 @@
 
 import { createApiTransport } from './apiTransport';
 import { mountInspector } from './inspector';
+import { mountLineage } from './lineage';
 import { createPostMessageTransport } from './postMessageTransport';
 import { QueryBuilder } from './query';
 import type {
@@ -106,6 +107,7 @@ export function createClient(): LightdashClient {
         if (params.get('transport') === 'postMessage') {
             const projectUuid = params.get('projectUuid') ?? '';
             mountInspector(window.parent);
+            mountLineage(window.parent);
             return new LightdashClient(
                 { apiKey: '', baseUrl: '', projectUuid },
                 createPostMessageTransport({ targetWindow: window.parent, projectUuid }),

--- a/packages/query-sdk/src/lineage.test.ts
+++ b/packages/query-sdk/src/lineage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { resolveLineageTarget, applyHighlight, clearHighlight } from './lineage';
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('resolveLineageTarget', () => {
+    it('returns the queryUuid from the nearest stamped ancestor', () => {
+        document.body.innerHTML =
+            '<div data-ld-query="q-1"><span id="cell">$1.2M</span></div>';
+        const cell = document.getElementById('cell');
+        expect(resolveLineageTarget(cell)).toBe('q-1');
+    });
+
+    it('returns null when no stamped ancestor exists', () => {
+        document.body.innerHTML = '<div><span id="cell">x</span></div>';
+        expect(resolveLineageTarget(document.getElementById('cell'))).toBeNull();
+    });
+
+    it('returns null for a null element', () => {
+        expect(resolveLineageTarget(null)).toBeNull();
+    });
+});
+
+describe('applyHighlight / clearHighlight', () => {
+    it('outlines all elements matching the queryUuid and clears them', () => {
+        document.body.innerHTML =
+            '<div data-ld-query="q-1" id="a"></div>' +
+            '<div data-ld-query="q-1" id="b"></div>' +
+            '<div data-ld-query="q-2" id="c"></div>';
+        applyHighlight('q-1');
+        expect(document.getElementById('a')!.style.outline).not.toBe('');
+        expect(document.getElementById('b')!.style.outline).not.toBe('');
+        expect(document.getElementById('c')!.style.outline).toBe('');
+        clearHighlight();
+        expect(document.getElementById('a')!.style.outline).toBe('');
+    });
+
+    it('clearing happens automatically when applying a new/null target', () => {
+        document.body.innerHTML = '<div data-ld-query="q-1" id="a"></div>';
+        applyHighlight('q-1');
+        applyHighlight(null);
+        expect(document.getElementById('a')!.style.outline).toBe('');
+    });
+});

--- a/packages/query-sdk/src/lineage.ts
+++ b/packages/query-sdk/src/lineage.ts
@@ -1,0 +1,125 @@
+/**
+ * Data-lineage runtime that lives inside the sandboxed iframe, alongside the
+ * element inspector. Unlike the inspector (which maps a clicked element to its
+ * source location for AI edits and draws a crosshair overlay), this maps a
+ * clicked element to the *query* that produced it (via the build-/render-time
+ * `data-ld-query` stamp) and can highlight where a given query renders.
+ *
+ * Protocol (parent <-> iframe), all over postMessage:
+ *   iframe -> parent : lightdash:lineage:available           (on mount)
+ *   parent -> iframe : lightdash:lineage:enable | :disable    (click-select mode)
+ *   iframe -> parent : lightdash:lineage:selected {queryUuid} (on click, while enabled)
+ *   parent -> iframe : lightdash:lineage:highlight {queryUuid|null}  (hover, any time)
+ */
+
+type LineageEnableMessage = { type: 'lightdash:lineage:enable' };
+type LineageDisableMessage = { type: 'lightdash:lineage:disable' };
+type LineageHighlightMessage = {
+    type: 'lightdash:lineage:highlight';
+    queryUuid: string | null;
+};
+
+export type LineageSelectedMessage = {
+    type: 'lightdash:lineage:selected';
+    queryUuid: string;
+};
+
+export type LineageAvailableMessage = {
+    type: 'lightdash:lineage:available';
+};
+
+const HIGHLIGHT_OUTLINE = '2px solid #7c3aed';
+const HIGHLIGHT_OFFSET = '2px';
+
+/** queryUuid of the nearest stamped ancestor of `el`, or null. */
+export function resolveLineageTarget(el: Element | null): string | null {
+    const stamped = el?.closest?.('[data-ld-query]') ?? null;
+    return stamped?.getAttribute('data-ld-query') ?? null;
+}
+
+let highlighted: HTMLElement[] = [];
+
+export function clearHighlight(): void {
+    for (const el of highlighted) {
+        el.style.outline = '';
+        el.style.outlineOffset = '';
+    }
+    highlighted = [];
+}
+
+export function applyHighlight(queryUuid: string | null): void {
+    clearHighlight();
+    if (!queryUuid) return;
+    const nodes = document.querySelectorAll<HTMLElement>(
+        `[data-ld-query="${queryUuid}"]`,
+    );
+    nodes.forEach((el) => {
+        el.style.outline = HIGHLIGHT_OUTLINE;
+        el.style.outlineOffset = HIGHLIGHT_OFFSET;
+        highlighted.push(el);
+    });
+}
+
+let enabled = false;
+let parentWindow: Window | null = null;
+let clickListenerAttached = false;
+let messageListenerAttached = false;
+
+function onClick(e: MouseEvent) {
+    if (!enabled) return;
+    const queryUuid = resolveLineageTarget(e.target as Element | null);
+    if (!queryUuid) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (typeof e.stopImmediatePropagation === 'function') {
+        e.stopImmediatePropagation();
+    }
+    parentWindow?.postMessage(
+        {
+            type: 'lightdash:lineage:selected',
+            queryUuid,
+        } satisfies LineageSelectedMessage,
+        '*',
+    );
+}
+
+/**
+ * Mounts the lineage runtime. Idempotent. Mirrors `mountInspector`.
+ */
+export function mountLineage(parent: Window): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return;
+    }
+    parentWindow = parent;
+    if (!clickListenerAttached) {
+        clickListenerAttached = true;
+        // Capture phase so we see the click before the app's own handlers and
+        // can suppress them while inspect-data mode is on.
+        window.addEventListener('click', onClick, true);
+    }
+
+    parent.postMessage(
+        { type: 'lightdash:lineage:available' } satisfies LineageAvailableMessage,
+        '*',
+    );
+
+    if (messageListenerAttached) return;
+    messageListenerAttached = true;
+    window.addEventListener('message', (event: MessageEvent) => {
+        const data = event.data as
+            | LineageEnableMessage
+            | LineageDisableMessage
+            | LineageHighlightMessage
+            | { type?: unknown }
+            | undefined;
+        if (!data || typeof data.type !== 'string') return;
+        if (data.type === 'lightdash:lineage:enable') {
+            enabled = true;
+        } else if (data.type === 'lightdash:lineage:disable') {
+            enabled = false;
+        } else if (data.type === 'lightdash:lineage:highlight') {
+            const q = (data as LineageHighlightMessage).queryUuid;
+            applyHighlight(typeof q === 'string' ? q : null);
+        }
+    });
+}

--- a/packages/query-sdk/src/useLightdash.test.ts
+++ b/packages/query-sdk/src/useLightdash.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { buildLineageProps } from './useLightdash';
+
+describe('buildLineageProps', () => {
+    it('returns the data-ld-query attribute once a queryUuid is known', () => {
+        expect(buildLineageProps('abc-123')).toEqual({ 'data-ld-query': 'abc-123' });
+    });
+
+    it('returns an empty (spread-safe) object before the query resolves', () => {
+        expect(buildLineageProps(null)).toEqual({});
+    });
+});

--- a/packages/query-sdk/src/useLightdash.ts
+++ b/packages/query-sdk/src/useLightdash.ts
@@ -27,6 +27,16 @@ import type {
     UnderlyingDataResult,
 } from './types';
 
+export type LineageProps = { 'data-ld-query'?: string };
+
+/**
+ * Props an app spreads onto the root element of a query-bound block so the
+ * Lightdash parent can trace a clicked element back to its query.
+ * Empty (spread-safe) until the query has a queryUuid.
+ */
+export const buildLineageProps = (queryUuid: string | null): LineageProps =>
+    queryUuid ? { 'data-ld-query': queryUuid } : {};
+
 const noopFormat: FormatFunction = (_row, _fieldId) => '';
 
 type UseLightdashResult = {
@@ -46,6 +56,8 @@ type UseLightdashResult = {
     refetch: () => void;
     /** Async query UUID for the source query, once loaded. */
     queryUuid: string | null;
+    /** Spread onto the root element of this query's UI block to enable data lineage. */
+    lineage: LineageProps;
     /** Fetch raw rows behind an aggregated metric value from this query result. */
     getUnderlyingData: (
         options: UnderlyingDataOptions,
@@ -95,6 +107,8 @@ export function useLightdash(query: QueryBuilder): UseLightdashResult {
     const refetch = useCallback(() => {
         setFetchCount((c) => c + 1);
     }, []);
+
+    const lineage = useMemo(() => buildLineageProps(queryUuid), [queryUuid]);
 
     useEffect(() => {
         let cancelled = false;
@@ -189,6 +203,7 @@ export function useLightdash(query: QueryBuilder): UseLightdashResult {
         error,
         refetch,
         queryUuid,
+        lineage,
         getUnderlyingData,
         downloadUnderlyingData,
         downloadResults,

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -333,6 +333,11 @@ query('orders').label('KPI Summary').metrics(['total_revenue', 'order_count']).l
 
 The query inspector shows for each query: the label, status, row count, duration, explore name, dimensions, and metrics. If present, it also shows table calculations and additional metrics. Write clear labels so users can match each inspector entry to the component it powers.
 
+**Spread `lineage` on each query block** — `useLightdash` returns a `lineage`
+prop bag; spread it onto the root element of the card/table/chart that renders
+that query (e.g. `<Card {...lineage}>`). This lets users click a value to see
+which query produced it. One spread per query block is enough.
+
 ### Table calculations
 
 Table calculations are computed columns evaluated after the warehouse query returns. They can reference dimensions and metrics using `${table.field}` syntax in their SQL expression.


### PR DESCRIPTION
## What & why

Data Apps render AI-generated charts in a sandboxed iframe, but there was no way to see which query produced a given value. This adds a **data-lineage inspector** so users can validate what powers what:

- **Click a value → its query.** Toggle **Inspect data** (in the Queries-panel header), click any rendered value, and the Queries panel reveals + scrolls to + flashes the query behind it — including the existing **Open in Explore**.
- **Hover a query → its elements.** Hover a row in the Queries panel and every element rendered from that query is outlined in the app. Works across duplicated charts — it highlights all of them.

## How it works

One container-grain DOM stamp, threaded over the existing parent ↔ iframe `postMessage` bridge:

- `useLightdash` returns a spread-safe `lineage` prop bag; generated apps spread it on each query block (`<Card {...lineage}>`), stamping `data-ld-query=<queryUuid>` (taught in the data-app skill).
- A new iframe-side runtime (`lineage.ts`, mounted next to the element inspector) announces availability, posts the clicked query up, and outlines matching nodes on demand. No crosshair/overlay — capture-phase click is used only to avoid colliding with the app's own click handlers.
- `useAppSdkBridge` routes the new messages; `AppIframePreview` drives the toggle/highlight; `QueryInspector` hosts the header toggle, the row-hover, and the reveal/scroll/flash. Wired into both the builder and the standalone preview page.

The element-edit inspector and the data-lineage inspector are **mutually exclusive** (one click-owner at a time). **No backend changes.**

## Scope

Container-grain only. Deferred follow-ups (out of this PR): field-grain stamps, an anchored popover, and a "reference this query in the prompt" pill so the agent can edit a specific query.

## Testing

- `@lightdash/query-sdk` — unit tests for the `lineage` prop bag and the iframe-runtime helpers.
- frontend — `useAppSdkBridge` lineage routing; `QueryInspector` hover / focus-reveal / toggle.
- Manual — click→reveal, hover→highlight (incl. duplicated charts), Open in Explore, and mutual exclusivity on a generated app.

Closes: GLITCH-532
Relates: PROD-7837
Relates: #23363
