### PR TITLE
ci: carry the release-safety upgrade floor forward across releases (PROD-8359)

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -78,6 +78,11 @@ module.exports = {
                     'packages/warehouses/package.json',
                     'packages/query-sdk/package.json',
                     'packages/frontend/sdk/package.json',
+                    // PROD-8359: when the marker generator auto-records this
+                    // release's expand/contract upgrade floor, the change to this
+                    // committed file ships in the release commit so future releases
+                    // carry the floor forward. Unchanged (the common case) → no-op.
+                    'release-safety.overrides.json',
                 ],
                 message:
                     'chore(release): ${nextRelease.version} \n\n${nextRelease.notes}',

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -10,6 +10,7 @@ import {
     detectMigrations,
     GitChange,
     MARKER_SCHEMA_VERSION,
+    ownExpandContractFloor,
 } from './gen-release-safety';
 
 let passed = 0;
@@ -600,6 +601,107 @@ test('all phases compose: capabilities ordered migrations, sql-lint, ai-review, 
     assert.strictEqual(m.api.rest.breaking, true);
     assert.strictEqual(m.api.mcp.checked, true);
     assert.strictEqual(m.upgrade.requiredStop, true);
+});
+
+// --- carriedFloor (forward-carried high-water mark) --------------------------
+
+test('carriedFloor sets the floor on a release with no own floor + claims "upgrade"', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        carriedFloor: { minPreviousVersion: '0.3260.0', sourceVersion: '0.3265.0', kind: 'minPrevious' },
+    });
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3260.0');
+    assert.strictEqual(m.upgrade.requiredStop, false);
+    assert.ok(m.capabilities.includes('upgrade'));
+    assert.ok(/0\.3265\.0/.test(m.upgrade.note ?? ''));
+});
+
+test('carriedFloor RAISES a lower human-declared floor (an in-between hazard wins)', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        upgrade: { consulted: true, minPreviousVersion: '0.3200.0', requiredStop: false, note: 'declared' },
+        carriedFloor: { minPreviousVersion: '0.3260.0', sourceVersion: '0.3265.0', kind: 'minPrevious' },
+    });
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3260.0'); // raised, not 0.3200.0
+    assert.ok(/0\.3265\.0/.test(m.upgrade.note ?? ''));
+    assert.ok(/declared/.test(m.upgrade.note ?? '')); // prior note preserved
+});
+
+test('carriedFloor does NOT lower a higher existing floor', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        upgrade: { consulted: true, minPreviousVersion: '0.3290.0', requiredStop: false, note: 'declared' },
+        carriedFloor: { minPreviousVersion: '0.3260.0', sourceVersion: '0.3265.0', kind: 'minPrevious' },
+    });
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3290.0'); // unchanged
+    assert.strictEqual(m.upgrade.note, 'declared'); // note untouched
+});
+
+test('a required-stop carriedFloor yields a required-stop note; own requiredStop preserved', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        upgrade: { consulted: true, minPreviousVersion: null, requiredStop: true, note: 'this release is also a stop' },
+        carriedFloor: { minPreviousVersion: '0.3280.0', sourceVersion: '0.3280.0', kind: 'requiredStop' },
+    });
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3280.0');
+    assert.strictEqual(m.upgrade.requiredStop, true); // own stop preserved
+    assert.ok(/required stop/i.test(m.upgrade.note ?? ''));
+});
+
+// --- ownExpandContractFloor (persisted-floor source of truth) ----------------
+
+test('ownExpandContractFloor returns the traced expand floor when present', () => {
+    const f = ownExpandContractFloor({
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: true, findings: ['drop-column'] },
+        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'cleared' },
+        expandContractFloor: '0.3240.0',
+        previousVersion: '0.3260.2',
+    });
+    assert.strictEqual(f, '0.3240.0');
+});
+
+test('ownExpandContractFloor falls back to previousVersion with no traced floor', () => {
+    const f = ownExpandContractFloor({
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: true, findings: ['drop-column'] },
+        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'cleared' },
+        previousVersion: '0.3260.2',
+    });
+    assert.strictEqual(f, '0.3260.2');
+});
+
+test('ownExpandContractFloor is null unless linter-flagged AND AI-cleared AND migration present', () => {
+    const cleared = { rollingUpdateSafe: true as const, recommendedStrategy: 'RollingUpdate' as const, summary: '' };
+    const breaking = { ran: true, breaking: true, findings: ['x'] };
+    // linter clean → null
+    assert.strictEqual(ownExpandContractFloor({ migrations: migPresent, sqlLint: { ran: true, breaking: false, findings: [] }, aiReview: cleared, previousVersion: '0.3260.2' }), null);
+    // AI not "safe" → null
+    assert.strictEqual(ownExpandContractFloor({ migrations: migPresent, sqlLint: breaking, aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: '' }, previousVersion: '0.3260.2' }), null);
+    // no migration → null
+    assert.strictEqual(ownExpandContractFloor({ migrations: noMig, sqlLint: breaking, aiReview: cleared, previousVersion: '0.3260.2' }), null);
+    // first release (no previousVersion, no traced floor) → null
+    assert.strictEqual(ownExpandContractFloor({ migrations: migPresent, sqlLint: breaking, aiReview: cleared, previousVersion: null }), null);
+});
+
+test('NO DRIFT: ownExpandContractFloor equals the floor buildMarker advertises', () => {
+    // Same inputs, no human override and no carried floor → the persisted floor
+    // (ownExpandContractFloor) must equal what the marker shows, or operators get a
+    // floor in the committed file that disagrees with the published marker.
+    const input = {
+        ...base,
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: true, findings: ['drop-column'] },
+        aiReview: { rollingUpdateSafe: true as const, recommendedStrategy: 'RollingUpdate' as const, summary: 'cleared' },
+        expandContractFloor: '0.3240.0',
+    };
+    const m = buildMarker(input);
+    assert.strictEqual(ownExpandContractFloor(input), m.upgrade.minPreviousVersion);
+    assert.strictEqual(ownExpandContractFloor(input), '0.3240.0');
 });
 
 // --- report ------------------------------------------------------------------

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -17,12 +17,15 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { aiRollingUpdateReview } from './ai-migration-review';
 import { lintMigrations, renderFindings, SqlLintFinding } from './sql-migration-lint';
-import { findExpandFloor } from './expand-version';
+import { compareVersions, findExpandFloor } from './expand-version';
 import { diffRestApi } from './rest-api-diff';
 import { diffMcpTools } from './mcp-tools-diff';
 import {
+    CarriedFloor,
+    carriedUpgradeFloor,
     DEFAULT_OVERRIDES_PATH,
     loadUpgradeOverrides,
+    recordDerivedFloor,
     resolveUpgrade,
     UpgradeResolution,
 } from './upgrade-overrides';
@@ -178,6 +181,15 @@ export interface BuildMarkerInput {
      * committed overrides file was present). null leaves the honest stub.
      */
     upgrade?: UpgradeResolution | null;
+    /**
+     * Optional forward-carried upgrade floor (high-water mark) computed from the
+     * committed overrides across ALL releases <= this one. Only ever RAISES
+     * upgrade.minPreviousVersion (never lowers — the safe direction), so a single
+     * marker is sufficient for a version-skip: an operator reading only this marker
+     * still cannot be told "safe from anywhere" when an in-between release dropped
+     * something their old pods use. null/absent leaves the per-release floor as-is.
+     */
+    carriedFloor?: CarriedFloor | null;
 }
 
 export interface AiReviewSummary {
@@ -192,6 +204,39 @@ export interface SqlLintSummary {
     breaking: boolean;
     /** Pre-rendered finding strings for the marker note. */
     findings: string[];
+}
+
+/**
+ * PURE. The upgrade floor THIS release contributes on its own: non-null ONLY when
+ * the AI cleared a linter-flagged destructive change as the safe "contract" step
+ * of an expand/contract (it verified the previous release no longer references the
+ * dropped object). Returns the git-traced expand version when available (more
+ * permissive, still provably safe), else the conservative previousVersion.
+ *
+ * Single source of truth shared by `buildMarker` (sets the live floor on this
+ * release's marker) and the IO shell (persists it into the committed overrides so
+ * FUTURE releases carry it forward — they cannot re-derive it without re-running
+ * the AI). Keeping one function means the persisted value can never drift from the
+ * value the marker advertises.
+ */
+export function ownExpandContractFloor(input: {
+    migrations: MigrationsResult | null;
+    sqlLint?: SqlLintSummary | null;
+    aiReview?: AiReviewSummary | null;
+    expandContractFloor?: string | null;
+    previousVersion: string | null;
+}): string | null {
+    const present: TriState = input.migrations
+        ? input.migrations.present
+        : 'unknown';
+    const linterFlagged = Boolean(
+        input.sqlLint?.ran && input.sqlLint.breaking && present === true,
+    );
+    const cleared = Boolean(
+        linterFlagged && input.aiReview && input.aiReview.rollingUpdateSafe === true,
+    );
+    if (!cleared) return null;
+    return input.expandContractFloor || input.previousVersion || null;
 }
 
 /**
@@ -287,12 +332,17 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     // only ever make the marker MORE accurate, never downgrade a deterministic
     // break to "unknown". It never applies on a first release or on a release with
     // nothing flagged (no migration AND no API break).
-    // True when the AI cleared a linter-flagged destructive change as the safe
-    // "contract" step of an expand/contract — the verdict it reached by verifying
-    // the PREVIOUS release (previousVersion) no longer uses the object.
-    const aiClearedExpandContract = Boolean(
-        linterFlagged && aiReview && aiReview.rollingUpdateSafe === true,
-    );
+    // The floor THIS release contributes on its own — non-null only when the AI
+    // cleared a linter-flagged destructive change as the safe "contract" step of an
+    // expand/contract (verified the PREVIOUS release no longer uses the object).
+    // Computed via the shared helper so the IO shell persists the EXACT same value.
+    const ownFloor = ownExpandContractFloor({
+        migrations,
+        sqlLint,
+        aiReview,
+        expandContractFloor: input.expandContractFloor,
+        previousVersion,
+    });
     if (aiReview && (present === true || nonMigrationHazard)) {
         capabilities.push('ai-review');
         if (aiReview.rollingUpdateSafe !== 'unknown') {
@@ -351,11 +401,12 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     // safe value (the release we actually checked); the author can lower it via the
     // overrides file if the "expand" shipped earlier. A human-authored
     // minPreviousVersion (from the overrides file) always wins.
-    if (aiClearedExpandContract && upgrade.minPreviousVersion === null && (input.expandContractFloor || previousVersion)) {
-        // Prefer the git-traced expand version (earliest release the app stopped
-        // using the object — provably safe and more permissive); fall back to the
-        // conservative previousVersion (the single release the AI verified).
-        const floor = input.expandContractFloor || previousVersion!;
+    if (ownFloor && upgrade.minPreviousVersion === null) {
+        // ownFloor already prefers the git-traced expand version (earliest release
+        // the app stopped using the object — provably safe and more permissive) and
+        // falls back to the conservative previousVersion (the single release the AI
+        // verified). A human-authored minPreviousVersion (set above) always wins.
+        const floor = ownFloor;
         const traced = Boolean(input.expandContractFloor);
         upgrade = {
             minPreviousVersion: floor,
@@ -365,6 +416,36 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
                 : `Auto-derived: the AI verified the change is safe via expand/contract from ${floor}. ` +
                   `Upgrading from an earlier release is NOT verified — set a lower minPreviousVersion in ` +
                   `release-safety.overrides.json if the app stopped using the object before then.`,
+        };
+        upgradeKnown = true;
+    }
+
+    // Forward-carry the high-water-mark floor across releases. A hazardous change
+    // declared in ANY release at or before this one — a minPreviousVersion floor,
+    // or a required stop — constrains how far back a DIRECT upgrade to this release
+    // may start. Take the most restrictive (highest) floor so a single marker is
+    // safe for a version-skip: an operator reading only this marker can't be told
+    // "safe from anywhere" when an in-between release dropped something their old
+    // pods still use. This only ever RAISES the floor (never lowers it): the
+    // per-release floor above can be undercut by an in-between hazard, never the
+    // reverse — so it can over-constrain (annoying) but never falsely free a skip.
+    const carried = input.carriedFloor;
+    if (
+        carried?.minPreviousVersion &&
+        (upgrade.minPreviousVersion === null ||
+            compareVersions(carried.minPreviousVersion, upgrade.minPreviousVersion) >
+                0)
+    ) {
+        const floor = carried.minPreviousVersion;
+        const src = carried.sourceVersion;
+        const carriedNote =
+            carried.kind === 'requiredStop'
+                ? `Release ${src} is a required stop — upgrade from ${floor} or later; an older version cannot skip directly past it.`
+                : `An earlier release${src ? ` (${src})` : ''} requires upgrading from ${floor} or later — a change on the path is not safe to skip past from an older version.`;
+        upgrade = {
+            minPreviousVersion: floor,
+            requiredStop: upgrade.requiredStop,
+            note: upgrade.note ? `${carriedNote} ${upgrade.note}` : carriedNote,
         };
         upgradeKnown = true;
     }
@@ -606,6 +687,10 @@ async function main(): Promise<void> {
     // never silently drop a maintainer's declared required-stop.
     const overrides = loadUpgradeOverrides(args.overrides);
     const upgrade = resolveUpgrade(overrides, args.version);
+    // Forward-carried floor: the high-water mark of every floor / required stop
+    // declared in any release at or before this one, so the marker is self-
+    // sufficient for a version-skip (see buildMarker's carriedFloor fold).
+    const carriedFloor = carriedUpgradeFloor(overrides, args.version);
 
     const marker = buildMarker({
         version: args.version,
@@ -618,7 +703,31 @@ async function main(): Promise<void> {
         restApi,
         mcpApi,
         upgrade,
+        carriedFloor,
     });
+
+    // Persist THIS release's own auto-derived expand/contract floor into the
+    // committed overrides so EVERY future release carries it forward automatically
+    // (carriedUpgradeFloor) — no maintainer action, and no need to re-run the AI on
+    // historical releases. Same kill-switch as the asset: while dark we never touch
+    // the repo. Write-if-absent, so a hand-authored floor always wins. The file is
+    // committed by @semantic-release/git (see release.config.js); an unchanged file
+    // (no new floor, or already recorded) is a no-op in that commit.
+    const ownFloor = ownExpandContractFloor({
+        migrations,
+        sqlLint,
+        aiReview,
+        expandContractFloor,
+        previousVersion: args.previousVersion,
+    });
+    if (markerEnabled && ownFloor) {
+        const wrote = recordDerivedFloor(args.overrides, args.version, ownFloor);
+        console.warn(
+            wrote
+                ? `[release-safety] recorded upgrade floor in ${args.overrides}: ${args.version} -> minPreviousVersion ${ownFloor}`
+                : `[release-safety] upgrade floor for ${args.version} already declared in ${args.overrides}; left as-is`,
+        );
+    }
 
     const json = `${JSON.stringify(marker, null, 2)}\n`;
     // Always print the marker (CI logs + the PR preview workflow read this); only

--- a/scripts/upgrade-overrides.test.ts
+++ b/scripts/upgrade-overrides.test.ts
@@ -6,7 +6,16 @@
  * checks). The file IO (loadUpgradeOverrides) is exercised by the CLI.
  */
 import * as assert from 'assert';
-import { resolveUpgrade, validateOverrides } from './upgrade-overrides';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    carriedUpgradeFloor,
+    loadUpgradeOverrides,
+    recordDerivedFloor,
+    resolveUpgrade,
+    validateOverrides,
+} from './upgrade-overrides';
 
 let passed = 0;
 const failures: string[] = [];
@@ -61,6 +70,79 @@ test('empty overrides object => stub values but consulted true', () => {
     assert.strictEqual(r.minPreviousVersion, null);
 });
 
+// --- carriedUpgradeFloor (forward-carried high-water mark) --------------------
+
+test('null overrides => no carried floor', () => {
+    assert.deepStrictEqual(carriedUpgradeFloor(null, '0.3300.0'), {
+        minPreviousVersion: null,
+        sourceVersion: null,
+        kind: null,
+    });
+});
+
+test('empty overrides => no carried floor', () => {
+    assert.strictEqual(carriedUpgradeFloor({}, '0.3300.0').minPreviousVersion, null);
+});
+
+test('default floor applies to any release', () => {
+    const f = carriedUpgradeFloor({ default: { minPreviousVersion: '0.3000.0' } }, '0.3300.0');
+    assert.strictEqual(f.minPreviousVersion, '0.3000.0');
+    assert.strictEqual(f.kind, 'default');
+});
+
+test('THE version-skip case: a floor declared at an EARLIER release is carried forward', () => {
+    // 0.3265.0 dropped a column (safe from 0.3260.0 onward). Target 0.3300.0 is
+    // itself clean, but jumping to it from before 0.3260.0 still crosses the drop.
+    const f = carriedUpgradeFloor(
+        { versions: { '0.3265.0': { minPreviousVersion: '0.3260.0' } } },
+        '0.3300.0',
+    );
+    assert.strictEqual(f.minPreviousVersion, '0.3260.0');
+    assert.strictEqual(f.sourceVersion, '0.3265.0');
+    assert.strictEqual(f.kind, 'minPrevious');
+});
+
+test('a floor declared at a LATER release does not apply to an earlier target', () => {
+    const f = carriedUpgradeFloor(
+        { versions: { '0.3400.0': { minPreviousVersion: '0.3390.0' } } },
+        '0.3300.0',
+    );
+    assert.strictEqual(f.minPreviousVersion, null);
+});
+
+test('a required stop at an earlier release is itself a floor (= that stop)', () => {
+    const f = carriedUpgradeFloor(
+        { versions: { '0.3280.0': { requiredStop: true } } },
+        '0.3300.0',
+    );
+    assert.strictEqual(f.minPreviousVersion, '0.3280.0');
+    assert.strictEqual(f.sourceVersion, '0.3280.0');
+    assert.strictEqual(f.kind, 'requiredStop');
+});
+
+test("a release's OWN required stop does not floor itself", () => {
+    const f = carriedUpgradeFloor(
+        { versions: { '0.3300.0': { requiredStop: true } } },
+        '0.3300.0',
+    );
+    assert.strictEqual(f.minPreviousVersion, null);
+});
+
+test('the highest (most restrictive) floor wins across mixed sources', () => {
+    const f = carriedUpgradeFloor(
+        {
+            default: { minPreviousVersion: '0.3000.0' },
+            versions: {
+                '0.3265.0': { minPreviousVersion: '0.3260.0' },
+                '0.3280.0': { requiredStop: true }, // floor 0.3280.0 — the highest
+            },
+        },
+        '0.3300.0',
+    );
+    assert.strictEqual(f.minPreviousVersion, '0.3280.0');
+    assert.strictEqual(f.kind, 'requiredStop');
+});
+
 // --- validateOverrides (fail loud) -------------------------------------------
 
 const throws = (fn: () => void, re: RegExp): void => assert.throws(fn, re);
@@ -84,6 +166,64 @@ test('rejects a wrong-typed minPreviousVersion', () =>
     throws(() => validateOverrides({ default: { minPreviousVersion: 3 } }), /minPreviousVersion must be a string or null/));
 test('rejects a non-object versions map', () =>
     throws(() => validateOverrides({ versions: [] }), /versions must be an object/));
+
+// --- recordDerivedFloor (IO: persist a floor for future releases) ------------
+
+let tmpSeq = 0;
+const withTmpOverrides = (initial: string | null, fn: (p: string) => void): void => {
+    tmpSeq += 1;
+    const p = path.join(os.tmpdir(), `rs-overrides-${process.pid}-${tmpSeq}.json`);
+    try {
+        if (initial !== null) fs.writeFileSync(p, initial);
+        fn(p);
+    } finally {
+        if (fs.existsSync(p)) fs.unlinkSync(p);
+    }
+};
+
+test('recordDerivedFloor writes a new version floor; preserves $schema, default, siblings', () => {
+    withTmpOverrides(
+        JSON.stringify({
+            $schema: './scripts/release-safety-overrides.schema.json',
+            default: { minPreviousVersion: null, requiredStop: false, note: null },
+            versions: { '0.3265.0': { minPreviousVersion: '0.3260.0' } },
+        }),
+        (p) => {
+            const wrote = recordDerivedFloor(p, '0.3300.0', '0.3290.0');
+            assert.strictEqual(wrote, true);
+            const reloaded = loadUpgradeOverrides(p)!;
+            assert.strictEqual(reloaded.versions?.['0.3300.0']?.minPreviousVersion, '0.3290.0');
+            // sibling + default + $schema survive
+            assert.strictEqual(reloaded.versions?.['0.3265.0']?.minPreviousVersion, '0.3260.0');
+            assert.strictEqual(reloaded.default?.requiredStop, false);
+            assert.ok((reloaded as { $schema?: string }).$schema);
+            // and the carried floor now sees the recorded entry
+            assert.strictEqual(carriedUpgradeFloor(reloaded, '0.3400.0').minPreviousVersion, '0.3290.0');
+        },
+    );
+});
+
+test('recordDerivedFloor is write-if-absent: never clobbers a declared floor', () => {
+    withTmpOverrides(
+        JSON.stringify({ versions: { '0.3300.0': { minPreviousVersion: '0.3200.0', note: 'human' } } }),
+        (p) => {
+            const wrote = recordDerivedFloor(p, '0.3300.0', '0.3290.0');
+            assert.strictEqual(wrote, false);
+            const reloaded = loadUpgradeOverrides(p)!;
+            assert.strictEqual(reloaded.versions?.['0.3300.0']?.minPreviousVersion, '0.3200.0'); // unchanged
+            assert.strictEqual(reloaded.versions?.['0.3300.0']?.note, 'human');
+        },
+    );
+});
+
+test('recordDerivedFloor creates a valid file when none exists', () => {
+    withTmpOverrides(null, (p) => {
+        const wrote = recordDerivedFloor(p, '0.3300.0', '0.3290.0');
+        assert.strictEqual(wrote, true);
+        const reloaded = loadUpgradeOverrides(p)!;
+        assert.strictEqual(reloaded.versions?.['0.3300.0']?.minPreviousVersion, '0.3290.0');
+    });
+});
 
 if (failures.length > 0) {
     console.error(`\n❌ ${failures.length} failed, ${passed} passed:\n`);

--- a/scripts/upgrade-overrides.ts
+++ b/scripts/upgrade-overrides.ts
@@ -8,11 +8,17 @@
  * facts about the upgrade path (e.g. "operators on < X must stop at this release
  * first"), modelled on GitLab's `config/upgrade_path.yml` required-stops artifact.
  *
- * The file is a version-keyed map plus a default block. The generator looks up
+ * The file is a version-keyed map plus a default block. `resolveUpgrade` looks up
  * the EXACT release version being cut; a version-specific entry's fields win over
- * the default (most-specific declaration wins — "HEAD wins"). An entry is inert
- * for every release except the one it names, so committing a required stop can't
- * leak onto later releases.
+ * the default (most-specific declaration wins — "HEAD wins"). For THAT lookup an
+ * entry is inert for every release except the one it names.
+ *
+ * `carriedUpgradeFloor` is the deliberate exception: for the upgrade FLOOR
+ * (minPreviousVersion) only, it forward-carries a high-water mark across releases
+ * — a hazardous change declared at release X (a floor, or a required stop) keeps
+ * constraining every release >= X. This is what makes a single marker safe for a
+ * version-skip: an operator reading only the target release's marker still learns
+ * they cannot jump directly past an in-between hazard from too old a version.
  *
  * FAIL-SAFE ASYMMETRY (deliberate, the opposite of the detector phases): an
  * ABSENT file means the mechanism wasn't used — leave the honest stub and don't
@@ -23,6 +29,8 @@
  * CLI:  npx tsx scripts/upgrade-overrides.ts --version 0.3261.0 [--overrides release-safety.overrides.json]
  */
 import * as fs from 'fs';
+import * as nodePath from 'path';
+import { compareVersions } from './expand-version';
 
 export interface UpgradeBlock {
     /** Oldest previous version that may upgrade directly to this release; null = no floor. */
@@ -68,6 +76,79 @@ export function resolveUpgrade(
         ...specific,
         consulted: true,
     };
+}
+
+/** What set the binding floor — for an operator-facing note. */
+export type CarriedFloorKind = 'minPrevious' | 'requiredStop' | 'default' | null;
+
+export interface CarriedFloor {
+    /**
+     * The most restrictive (highest) minimum-source version implied by THIS
+     * release and every earlier one's declared floors / required stops. An
+     * operator on an older version than this cannot upgrade DIRECTLY to the target
+     * — a hazardous change on the path is not safe to skip past. null = no floor.
+     */
+    minPreviousVersion: string | null;
+    /** The release whose declaration established the binding floor. */
+    sourceVersion: string | null;
+    kind: CarriedFloorKind;
+}
+
+const NO_FLOOR: CarriedFloor = {
+    minPreviousVersion: null,
+    sourceVersion: null,
+    kind: null,
+};
+
+/**
+ * PURE. The forward-carried upgrade floor (high-water mark) for `version`.
+ *
+ * Where `resolveUpgrade` reads only this version's own block, this scans the whole
+ * committed history and returns the MOST RESTRICTIVE floor any release at or before
+ * `version` imposes:
+ *   - `default.minPreviousVersion` — a blanket floor on every release.
+ *   - `versions[v].minPreviousVersion` for every `v <= version` — a hazard declared
+ *     at `v` means crossing `v` from before that floor is unsafe, so the floor binds
+ *     every release at or after `v` (a later target doesn't make the in-between
+ *     hazard disappear).
+ *   - `v` for every `v < version` with `versions[v].requiredStop` — operators must
+ *     land on a required stop before going further, so the stop is itself a floor.
+ *     (`v === version` is excluded: a release's own required stop does not floor it.)
+ *
+ * Returns the binding floor, the release that set it, and which kind it was, so the
+ * caller can both raise minPreviousVersion and explain WHY. A null `overrides`
+ * (file absent) yields no floor.
+ */
+export function carriedUpgradeFloor(
+    overrides: UpgradeOverridesFile | null,
+    version: string,
+): CarriedFloor {
+    if (!overrides) return NO_FLOOR;
+    let best: CarriedFloor = NO_FLOOR;
+    const consider = (
+        candidate: string | null | undefined,
+        sourceVersion: string | null,
+        kind: CarriedFloorKind,
+    ): void => {
+        if (!candidate) return;
+        if (
+            best.minPreviousVersion === null ||
+            compareVersions(candidate, best.minPreviousVersion) > 0
+        ) {
+            best = { minPreviousVersion: candidate, sourceVersion, kind };
+        }
+    };
+
+    consider(overrides.default?.minPreviousVersion ?? null, null, 'default');
+    for (const [v, block] of Object.entries(overrides.versions ?? {})) {
+        if (compareVersions(v, version) <= 0) {
+            consider(block.minPreviousVersion ?? null, v, 'minPrevious');
+        }
+        if (compareVersions(v, version) < 0 && block.requiredStop === true) {
+            consider(v, v, 'requiredStop');
+        }
+    }
+    return best;
 }
 
 /**
@@ -139,6 +220,58 @@ export function loadUpgradeOverrides(path: string): UpgradeOverridesFile | null 
         throw new Error(`${path} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
     }
     return validateOverrides(parsed);
+}
+
+/** IO. Write the overrides object back atomically (temp file + rename) so a crash
+ *  never leaves a partial/corrupt file that would fail the NEXT release's load. */
+function writeOverridesAtomic(overridesPath: string, data: UpgradeOverridesFile): void {
+    const dir = nodePath.dirname(nodePath.resolve(overridesPath));
+    const tmp = nodePath.join(dir, `.release-safety-overrides.${process.pid}.tmp`);
+    fs.writeFileSync(tmp, `${JSON.stringify(data, null, 4)}\n`);
+    fs.renameSync(tmp, overridesPath);
+}
+
+/**
+ * IO. Persist THIS release's own auto-derived upgrade floor into the committed
+ * overrides file, keyed by the release version, so FUTURE releases carry it
+ * forward via `carriedUpgradeFloor` — they cannot re-derive it (that needs the
+ * AI verdict, which isn't replayed). The complement to the forward-carry read:
+ * one writes the floor at the hazard release, the other reads it on every later
+ * release.
+ *
+ * WRITE-IF-ABSENT — never clobbers a `versions[version].minPreviousVersion` that
+ * is already set (a maintainer's hand-authored floor, or a prior run of this same
+ * release): human/HEAD precedence is preserved exactly as `resolveUpgrade` has it.
+ * A missing file is created. The result is RE-VALIDATED before the write so a
+ * release can never poison the file for the next one. Returns true iff it wrote.
+ */
+export function recordDerivedFloor(
+    overridesPath: string,
+    version: string,
+    floor: string,
+): boolean {
+    const current = loadUpgradeOverrides(overridesPath) ?? {};
+    const versions = current.versions ?? {};
+    const existing = versions[version] ?? {};
+    // Already declared (human or a previous run) → leave it untouched.
+    if (existing.minPreviousVersion) return false;
+    const updated: UpgradeOverridesFile = {
+        ...current,
+        versions: {
+            ...versions,
+            [version]: {
+                ...existing,
+                minPreviousVersion: floor,
+                note:
+                    existing.note ??
+                    `Auto-recorded at release ${version}: a destructive migration here is safe to roll past only when upgrading from ${floor} or later.`,
+            },
+        },
+    };
+    // Belt-and-suspenders: never write a shape that would fail the next load.
+    validateOverrides(updated);
+    writeOverridesAtomic(overridesPath, updated);
+    return true;
 }
 
 // ---- CLI --------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Builds on the shipped PROD-8359 release-safety marker. Today the marker's `upgrade.minPreviousVersion` floor is only ever set on the **single** release that declared it — a human override, or an expand/contract drop the AI cleared. That leaves a version-skip blind spot:

> A self-hosted operator on an old version upgrades **directly** to a much later release. They read only the target marker, see no floor, and roll a destructive migration from an in-between release under `RollingUpdate`. The old pods keep serving against the already-migrated schema and crash mid-rollout.

This makes a **single marker self-sufficient for version-skips**: the floor of any hazardous release at or before the target is carried forward, so reading just the target marker tells an operator the oldest version they may upgrade directly from.

## How

- **`carriedUpgradeFloor()`** — forward-carried high-water mark from the committed overrides: the most restrictive floor any release `<= target` imposes (declared `minPreviousVersion` floors **+** required stops, which are themselves floors). `buildMarker` folds it in and **only ever RAISES** the floor — never lowers it. So a bug here can over-constrain an upgrade (annoying) but can never falsely free a dangerous skip (the fail-closed direction this codebase uses everywhere).

- **`recordDerivedFloor()`** — persists *this* release's own AI-cleared expand/contract floor back into `release-safety.overrides.json` (write-if-absent so a hand-authored floor always wins; atomic temp+rename; re-validated before write so a release can never poison the next one's load). `release.config.js` adds the file to `@semantic-release/git` assets so the change ships in the release commit. Future releases then carry it forward **automatically** — they can't re-derive it without re-running the AI. Gated by the same `RELEASE_SAFETY_MARKER_ENABLED` kill-switch, so dark = repo untouched.

- **`ownExpandContractFloor()`** — single source of truth for the derived floor, shared by the marker and the persistence write, with a drift-guard test asserting the persisted value can never disagree with what the marker advertises.

## Net effect (zero human action)

A release that drops a column via expand/contract now both shows the floor on its own marker **and** records it in the committed overrides; every later release's marker carries it forward. An operator reading any later marker sees the correct `minPreviousVersion`.

Only AI-cleared expand/contract drops record a floor — a genuinely-breaking migration gets `rollingUpdateSafe: false` + `Recreate` (skip-safe from any version), so there's nothing to record.

## Testing

- `npx tsx scripts/upgrade-overrides.test.ts` — 22 pass (+ carried-floor cases, write-if-absent IO, `$schema`/default/sibling preservation)
- `npx tsx scripts/gen-release-safety.test.ts` — 51 pass (+ version-skip carry, raise-not-lower, required-stop note, drift guard)
- `tsc --strict` clean on the touched files

No runtime/app code touched — blast radius is the release pipeline only. All existing marker tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
