### PR TITLE
feat(apps): data app viz entity + typed field schema (GLITCH-549)

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -2,6 +2,7 @@ import {
     type AppVersionResources,
     type AppVersionStatus,
     type DataAppTemplate,
+    type DataAppVizSchema,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 
@@ -84,6 +85,8 @@ export type DbAppVersion = {
     status_message: string | null;
     status_updated_at: Date | null;
     resources: AppVersionResources | null;
+    // Declared schema for data-app-viz versions; null otherwise.
+    viz_schema: DataAppVizSchema | null;
     created_at: Date;
     created_by_user_uuid: string;
 };
@@ -94,11 +97,17 @@ export type AppVersionsTable = Knex.CompositeTableType<
         DbAppVersion,
         'app_id' | 'version' | 'prompt' | 'status' | 'created_by_user_uuid'
     > &
-        Partial<Pick<DbAppVersion, 'app_version_id' | 'resources'>>,
+        Partial<
+            Pick<DbAppVersion, 'app_version_id' | 'resources' | 'viz_schema'>
+        >,
     Partial<
         Pick<
             DbAppVersion,
-            'status' | 'error' | 'status_message' | 'status_updated_at'
+            | 'status'
+            | 'error'
+            | 'status_message'
+            | 'status_updated_at'
+            | 'viz_schema'
         >
     >
 >;

--- a/packages/backend/src/database/migrations/20260624120003_add_field_schema_to_app_versions.ts
+++ b/packages/backend/src/database/migrations/20260624120003_add_field_schema_to_app_versions.ts
@@ -1,0 +1,15 @@
+import { type Knex } from 'knex';
+
+// A data app viz declares a typed schema (its data-binding fields + config
+// options). Stored per-version so each generated version carries its own.
+export const up = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable('app_versions', (table) => {
+        table.jsonb('viz_schema').nullable();
+    });
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable('app_versions', (table) => {
+        table.dropColumn('viz_schema');
+    });
+};

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -16,7 +16,9 @@ import {
     type ApiGenerateAppResponse,
     type ApiGetAppCodeResponse,
     type ApiGetAppResponse,
+    type ApiGetDataAppVizResponse,
     type ApiImportAppCodeResponse,
+    type ApiListDataAppVizsResponse,
     type ApiMyAppsResponse,
     type ApiPreviewTokenResponse,
     type ApiPromoteAppDiffResponse,
@@ -114,6 +116,59 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results,
+        };
+    }
+
+    /**
+     * @summary List project data app visualizations
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/visualizations')
+    @OperationId('listDataAppVisualizations')
+    async listDataAppVisualizations(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Query() page?: number,
+        @Query() pageSize?: number,
+    ): Promise<ApiListDataAppVizsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results =
+            await this.getAppGenerateService().listDataAppVisualizations(
+                toSessionUser(req.account),
+                projectUuid,
+                page && pageSize ? { page, pageSize } : undefined,
+            );
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * @summary Get a data app visualization
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/visualizations/{dataAppVizUuid}')
+    @OperationId('getDataAppVisualization')
+    async getDataAppVisualization(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() dataAppVizUuid: string,
+    ): Promise<ApiGetDataAppVizResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const result =
+            await this.getAppGenerateService().getDataAppVisualization(
+                toSessionUser(req.account),
+                projectUuid,
+                dataAppVizUuid,
+            );
+        return {
+            status: 'ok',
+            results: result,
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -1,0 +1,145 @@
+// Stub the e2b/ai SDKs so the tests never reach a real sandbox or model client.
+import {
+    DATA_APP_VIZ_TEMPLATE,
+    NotFoundError,
+    type DataAppVizSchema,
+} from '@lightdash/common';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+
+const USER = { userUuid: 'user-1' } as never;
+
+const vizSchema: DataAppVizSchema = {
+    fields: [
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension',
+            required: true,
+        },
+        { name: 'value', label: 'Value', type: 'metric', required: true },
+    ],
+    configOptions: [],
+};
+
+const makeDataAppVizRow = (overrides: Record<string, unknown> = {}) => ({
+    app_id: 'data-app-viz-1',
+    name: 'Radial gauge',
+    description: 'A radial gauge renderer',
+    project_uuid: 'project-1',
+    space_uuid: null,
+    sandbox_id: null,
+    template: DATA_APP_VIZ_TEMPLATE,
+    viz_schema: vizSchema,
+    design_uuid: null,
+    upstream_app_uuid: null,
+    created_at: new Date('2026-06-30'),
+    created_by_user_uuid: 'user-1',
+    deleted_at: null,
+    deleted_by_user_uuid: null,
+    views_count: 0,
+    search_vector: '',
+    organization_uuid: 'org-1',
+    ...overrides,
+});
+
+function buildService(appModel: unknown) {
+    const service = new AppGenerateService({
+        lightdashConfig: {} as never,
+        analytics: {} as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        appModel: appModel as never,
+        featureFlagModel: {
+            get: vi.fn().mockResolvedValue({ enabled: true }),
+        } as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {
+            getSummary: vi
+                .fn()
+                .mockResolvedValue({ organizationUuid: 'org-1' }),
+        } as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {} as never,
+        spacePermissionService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: {} as never,
+    });
+    // Bypass real CASL — the mapping/flow is what these tests cover.
+    (
+        service as unknown as { createAuditedAbility: () => unknown }
+    ).createAuditedAbility = () => ({ cannot: () => false });
+    return service;
+}
+
+describe('AppGenerateService data app vizs', () => {
+    it('maps a page of rows to by-reference DataAppVizs (no code copied)', async () => {
+        const pagination = {
+            page: 1,
+            pageSize: 25,
+            totalPageCount: 1,
+            totalResults: 1,
+        };
+        const appModel = {
+            listDataAppVisualizations: vi
+                .fn()
+                .mockResolvedValue({ data: [makeDataAppVizRow()], pagination }),
+        };
+        const service = buildService(appModel);
+
+        const result = await service.listDataAppVisualizations(
+            USER,
+            'project-1',
+            { page: 1, pageSize: 25 },
+        );
+
+        expect(appModel.listDataAppVisualizations).toHaveBeenCalledWith(
+            'project-1',
+            { page: 1, pageSize: 25 },
+        );
+        expect(result).toEqual({
+            data: [
+                {
+                    dataAppVizUuid: 'data-app-viz-1',
+                    name: 'Radial gauge',
+                    description: 'A radial gauge renderer',
+                    projectUuid: 'project-1',
+                    spaceUuid: null,
+                    schema: vizSchema,
+                    createdAt: new Date('2026-06-30'),
+                    createdByUserUuid: 'user-1',
+                },
+            ],
+            pagination,
+        });
+    });
+
+    it('404s getDataAppVisualization for an id that is not a data app viz', async () => {
+        const appModel = {
+            findVisualizationApp: vi.fn().mockResolvedValue(undefined),
+        };
+        const service = buildService(appModel);
+
+        await expect(
+            service.getDataAppVisualization(
+                USER,
+                'project-1',
+                'not-a-data-app-viz',
+            ),
+        ).rejects.toThrow(NotFoundError);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -44,11 +44,15 @@ import {
     type DataAppClaudeModel,
     type DataAppCode,
     type DataAppTemplate,
+    type DataAppViz,
+    type DataAppVizSchema,
     type EmbedProjectApp,
     type Explore,
     type ExternalConnectionMethod,
     type ExternalConnectionSample,
     type ImportAppCodeRequestBody,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
     type LightdashProjectParameter,
     type PromoteAppAction,
     type PromoteAppDiff,
@@ -5393,6 +5397,70 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         }
         const apps = await this.appModel.listAppsByProject(projectUuid);
         return apps.map((app) => ({ appUuid: app.app_id, name: app.name }));
+    }
+
+    private static mapDataAppViz(
+        app: DbApp & { viz_schema: DataAppVizSchema | null },
+    ): DataAppViz {
+        return {
+            dataAppVizUuid: app.app_id,
+            name: app.name,
+            description: app.description,
+            projectUuid: app.project_uuid,
+            spaceUuid: app.space_uuid,
+            schema: app.viz_schema,
+            createdAt: app.created_at,
+            createdByUserUuid: app.created_by_user_uuid,
+        };
+    }
+
+    async listDataAppVisualizations(
+        user: SessionUser,
+        projectUuid: string,
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<DataAppViz[]>> {
+        await this.assertDataAppsEnabled(user);
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('DataApp', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError('Insufficient permissions');
+        }
+        const { data, pagination } =
+            await this.appModel.listDataAppVisualizations(
+                projectUuid,
+                paginateArgs,
+            );
+        return { data: data.map(AppGenerateService.mapDataAppViz), pagination };
+    }
+
+    async getDataAppVisualization(
+        user: SessionUser,
+        projectUuid: string,
+        dataAppVizUuid: string,
+    ): Promise<DataAppViz> {
+        await this.assertDataAppsEnabled(user);
+        const dataAppViz = await this.appModel.findVisualizationApp(
+            dataAppVizUuid,
+            projectUuid,
+        );
+        if (!dataAppViz) {
+            throw new NotFoundError(
+                `Data app visualization not found: ${dataAppVizUuid}`,
+            );
+        }
+        await this.assertCanViewApp(user, {
+            project_uuid: dataAppViz.project_uuid,
+            space_uuid: dataAppViz.space_uuid,
+            organization_uuid: dataAppViz.organization_uuid,
+            created_by_user_uuid: dataAppViz.created_by_user_uuid,
+        });
+        return AppGenerateService.mapDataAppViz(dataAppViz);
     }
 
     async listMyApps(

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -43,6 +43,10 @@ export const getTemplateInstructions = (
             return PDF_REPORT_INSTRUCTIONS;
         case 'custom':
             return null;
+        case 'data_app_viz':
+            // The viz starter injects its own prompt + schema request separately,
+            // not a generic starter-instruction block.
+            return null;
         default:
             return assertUnreachable(
                 template,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9237,6 +9237,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['dashboard'] },
                 { dataType: 'enum', enums: ['slideshow'] },
                 { dataType: 'enum', enums: ['pdf'] },
+                { dataType: 'enum', enums: ['data_app_viz'] },
             ],
             validators: {},
         },
@@ -9375,6 +9376,291 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_EmbedProjectApp-Array_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppVizFieldType: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['dimension'] },
+                { dataType: 'enum', enums: ['metric'] },
+                { dataType: 'enum', enums: ['series'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppVizField: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                required: { dataType: 'boolean', required: true },
+                type: { ref: 'DataAppVizFieldType', required: true },
+                label: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppVizConfigOption: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        default: { dataType: 'boolean', required: true },
+                        group: { dataType: 'string' },
+                        label: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['boolean'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        default: { dataType: 'string', required: true },
+                        choices: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    label: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                    value: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                },
+                            },
+                            required: true,
+                        },
+                        group: { dataType: 'string' },
+                        label: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['select'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        max: { dataType: 'double' },
+                        min: { dataType: 'double' },
+                        default: { dataType: 'double', required: true },
+                        group: { dataType: 'string' },
+                        label: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['number'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        default: { dataType: 'string', required: true },
+                        group: { dataType: 'string' },
+                        label: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['text'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        default: { dataType: 'string', required: true },
+                        group: { dataType: 'string' },
+                        label: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['color'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        default: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                        group: { dataType: 'string' },
+                        label: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['palette'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppVizSchema: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                configOptions: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'DataAppVizConfigOption',
+                    },
+                    required: true,
+                },
+                fields: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DataAppVizField' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppViz: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                createdByUserUuid: { dataType: 'string', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schema: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DataAppVizSchema' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                spaceUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                projectUuid: { dataType: 'string', required: true },
+                description: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                dataAppVizUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    KnexPaginateArgs: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                page: { dataType: 'double', required: true },
+                pageSize: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'KnexPaginatedData_DataAppViz-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pagination: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'KnexPaginateArgs' },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                totalResults: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                totalPageCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+                data: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DataAppViz' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_KnexPaginatedData_DataAppViz-Array__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'KnexPaginatedData_DataAppViz-Array_',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiListDataAppVizsResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_KnexPaginatedData_DataAppViz-Array__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_DataAppViz_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'DataAppViz', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetDataAppVizResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_DataAppViz_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__questions-string-Array__': {
         dataType: 'refAlias',
         type: {
@@ -9451,6 +9737,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['dashboard'] },
                 { dataType: 'enum', enums: ['slideshow'] },
                 { dataType: 'enum', enums: ['pdf'] },
+                { dataType: 'enum', enums: ['data_app_viz'] },
             ],
             validators: {},
         },
@@ -10756,18 +11043,6 @@ const models: TsoaRoute.Models = {
                 description: { dataType: 'string', required: true },
                 name: { dataType: 'string', required: true },
                 appUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    KnexPaginateArgs: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                page: { dataType: 'double', required: true },
-                pageSize: { dataType: 'double', required: true },
             },
             validators: {},
         },
@@ -46485,6 +46760,136 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listProjectApps',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_listDataAppVisualizations: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        page: { in: 'query', name: 'page', dataType: 'double' },
+        pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/apps/visualizations',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.listDataAppVisualizations,
+        ),
+
+        async function AppGenerateController_listDataAppVisualizations(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_listDataAppVisualizations,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listDataAppVisualizations',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_getDataAppVisualization: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        dataAppVizUuid: {
+            in: 'path',
+            name: 'dataAppVizUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/apps/visualizations/:dataAppVizUuid',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.getDataAppVisualization,
+        ),
+
+        async function AppGenerateController_getDataAppVisualization(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_getDataAppVisualization,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getDataAppVisualization',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10552,7 +10552,13 @@
             },
             "DataAppTemplate": {
                 "type": "string",
-                "enum": ["custom", "dashboard", "slideshow", "pdf"]
+                "enum": [
+                    "custom",
+                    "dashboard",
+                    "slideshow",
+                    "pdf",
+                    "data_app_viz"
+                ]
             },
             "AppChartReference": {
                 "properties": {
@@ -10695,6 +10701,349 @@
             "ApiEmbedProjectAppsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_EmbedProjectApp-Array_"
             },
+            "DataAppVizFieldType": {
+                "type": "string",
+                "enum": ["dimension", "metric", "series"]
+            },
+            "DataAppVizField": {
+                "properties": {
+                    "required": {
+                        "type": "boolean"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/DataAppVizFieldType"
+                    },
+                    "label": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["required", "type", "label", "name"],
+                "type": "object"
+            },
+            "DataAppVizConfigOption": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "default": {
+                                "type": "boolean"
+                            },
+                            "group": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["boolean"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["default", "label", "name", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "default": {
+                                "type": "string"
+                            },
+                            "choices": {
+                                "items": {
+                                    "properties": {
+                                        "label": {
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["label", "value"],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "group": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["select"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "default",
+                            "choices",
+                            "label",
+                            "name",
+                            "type"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "max": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "min": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "default": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "group": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["number"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["default", "label", "name", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "default": {
+                                "type": "string"
+                            },
+                            "group": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["text"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["default", "label", "name", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "default": {
+                                "type": "string"
+                            },
+                            "group": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["color"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["default", "label", "name", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "default": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "group": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["palette"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["default", "label", "name", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "DataAppVizSchema": {
+                "properties": {
+                    "configOptions": {
+                        "items": {
+                            "$ref": "#/components/schemas/DataAppVizConfigOption"
+                        },
+                        "type": "array"
+                    },
+                    "fields": {
+                        "items": {
+                            "$ref": "#/components/schemas/DataAppVizField"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["configOptions", "fields"],
+                "type": "object",
+                "description": "The full declaration a data app viz emits: data-binding fields + config form."
+            },
+            "DataAppViz": {
+                "properties": {
+                    "createdByUserUuid": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schema": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DataAppVizSchema"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "spaceUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "dataAppVizUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "createdByUserUuid",
+                    "createdAt",
+                    "schema",
+                    "spaceUuid",
+                    "projectUuid",
+                    "description",
+                    "name",
+                    "dataAppVizUuid"
+                ],
+                "type": "object"
+            },
+            "KnexPaginateArgs": {
+                "properties": {
+                    "page": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "pageSize": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["page", "pageSize"],
+                "type": "object"
+            },
+            "KnexPaginatedData_DataAppViz-Array_": {
+                "properties": {
+                    "pagination": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/KnexPaginateArgs"
+                            },
+                            {
+                                "properties": {
+                                    "totalResults": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "totalPageCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    }
+                                },
+                                "required": ["totalResults", "totalPageCount"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "data": {
+                        "items": {
+                            "$ref": "#/components/schemas/DataAppViz"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["data"],
+                "type": "object"
+            },
+            "ApiSuccess_KnexPaginatedData_DataAppViz-Array__": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/KnexPaginatedData_DataAppViz-Array_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiListDataAppVizsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_DataAppViz-Array__"
+            },
+            "ApiSuccess_DataAppViz_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/DataAppViz"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiGetDataAppVizResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_DataAppViz_"
+            },
             "ApiSuccess__questions-string-Array__": {
                 "properties": {
                     "results": {
@@ -10773,7 +11122,7 @@
             },
             "Exclude_DataAppTemplate.custom_": {
                 "type": "string",
-                "enum": ["dashboard", "slideshow", "pdf"],
+                "enum": ["dashboard", "slideshow", "pdf", "data_app_viz"],
                 "description": "Exclude from T those types that are assignable to U"
             },
             "AppVersionStatus": {
@@ -12232,20 +12581,6 @@
                     "name",
                     "appUuid"
                 ],
-                "type": "object"
-            },
-            "KnexPaginateArgs": {
-                "properties": {
-                    "page": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "pageSize": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["page", "pageSize"],
                 "type": "object"
             },
             "ApiSuccess__data-ApiAppSummary-Array--pagination_63_-KnexPaginateArgs-and-_totalPageCount-number--totalResults-number___": {
@@ -41982,7 +42317,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3274.1",
+        "version": "0.3277.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1,7 +1,9 @@
 import {
+    DATA_APP_VIZ_TEMPLATE,
     NotFoundError,
     ProjectType,
     type AppVersionResources,
+    type DataAppVizSchema,
     type KnexPaginateArgs,
     type KnexPaginatedData,
 } from '@lightdash/common';
@@ -532,6 +534,102 @@ export class AppModel {
             .where({ project_uuid: projectUuid })
             .whereNull('deleted_at')
             .select('*');
+    }
+
+    // Derived table of each app's latest ready version number, for joining the
+    // latest ready version's schema onto a data app viz.
+    private latestReadyVersions() {
+        return this.database(AppVersionsTableName)
+            .select('app_id')
+            .max({ version: 'version' })
+            .where('status', 'ready')
+            .groupBy('app_id')
+            .as('lrv');
+    }
+
+    private joinLatestReadyVersion(
+        query: Knex.QueryBuilder,
+    ): Knex.QueryBuilder {
+        return query
+            .leftJoin(
+                this.latestReadyVersions(),
+                `${AppsTableName}.app_id`,
+                'lrv.app_id',
+            )
+            .leftJoin(AppVersionsTableName, function joinVersion() {
+                this.on(
+                    `${AppsTableName}.app_id`,
+                    `${AppVersionsTableName}.app_id`,
+                ).andOn('lrv.version', `${AppVersionsTableName}.version`);
+            });
+    }
+
+    /**
+     * A page of the project's bindable data app vizs — only those whose latest
+     * ready version has generated a schema, so pagination counts are exact.
+     */
+    async listDataAppVisualizations(
+        projectUuid: string,
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<
+        KnexPaginatedData<(DbApp & { viz_schema: DataAppVizSchema })[]>
+    > {
+        const query = this.joinLatestReadyVersion(this.database(AppsTableName))
+            .where({
+                [`${AppsTableName}.project_uuid`]: projectUuid,
+                [`${AppsTableName}.template`]: DATA_APP_VIZ_TEMPLATE,
+            })
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .whereNotNull(`${AppVersionsTableName}.viz_schema`)
+            .select<(DbApp & { viz_schema: DataAppVizSchema })[]>(
+                `${AppsTableName}.*`,
+                `${AppVersionsTableName}.viz_schema`,
+            )
+            .orderBy(`${AppsTableName}.created_at`, 'desc');
+        return KnexPaginate.paginate(query, paginateArgs);
+    }
+
+    /**
+     * Fetch a single data app viz by id, with its organization uuid (for the
+     * view permission check) and latest schema. Undefined when the id is not a
+     * data app viz in this project.
+     */
+    async findVisualizationApp(
+        dataAppVizUuid: string,
+        projectUuid: string,
+    ): Promise<
+        | (DbApp & {
+              organization_uuid: string;
+              viz_schema: DataAppVizSchema | null;
+          })
+        | undefined
+    > {
+        return this.joinLatestReadyVersion(this.database(AppsTableName))
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${AppsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${AppsTableName}.app_id`, dataAppVizUuid)
+            .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
+            .andWhere(`${AppsTableName}.template`, DATA_APP_VIZ_TEMPLATE)
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .select<
+                (DbApp & {
+                    organization_uuid: string;
+                    viz_schema: DataAppVizSchema | null;
+                })[]
+            >(
+                `${AppsTableName}.*`,
+                `${OrganizationTableName}.organization_uuid`,
+                `${AppVersionsTableName}.viz_schema`,
+            )
+            .first();
     }
 
     /**

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -10,6 +10,8 @@ export type DataAppManifest = {
     version: number;
     name: string;
     description: string;
+    // The app's stored template flavor (includes data_app_viz); null for
+    // "Custom" or apps predating template persistence.
     template: Exclude<DataAppTemplate, 'custom'> | null;
     downloadedAt: string; // ISO
 };

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -1,0 +1,190 @@
+import {
+    dataAppVizSchema,
+    getEffectiveOptionValues,
+    type DataAppVizConfigOption,
+} from './types';
+
+const validFields = {
+    fields: [
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension',
+            required: true,
+        },
+        { name: 'value', label: 'Value', type: 'metric', required: true },
+        { name: 'series', label: 'Series', type: 'series', required: false },
+    ],
+};
+
+describe('dataAppVizSchema', () => {
+    it('accepts a well-formed fields declaration (configOptions defaults to [])', () => {
+        const r = dataAppVizSchema.safeParse(validFields);
+        expect(r.success).toBe(true);
+        if (r.success) expect(r.data.configOptions).toEqual([]);
+    });
+
+    it('accepts an empty field list', () => {
+        expect(dataAppVizSchema.safeParse({ fields: [] }).success).toBe(true);
+    });
+
+    it('rejects non-object / nullish values', () => {
+        expect(dataAppVizSchema.safeParse(null).success).toBe(false);
+        expect(dataAppVizSchema.safeParse(undefined).success).toBe(false);
+        expect(dataAppVizSchema.safeParse('fields').success).toBe(false);
+    });
+
+    it('rejects a missing or non-array fields property', () => {
+        expect(dataAppVizSchema.safeParse({}).success).toBe(false);
+        expect(dataAppVizSchema.safeParse({ fields: {} }).success).toBe(false);
+    });
+
+    it('rejects a field with a type outside the vocabulary', () => {
+        expect(
+            dataAppVizSchema.safeParse({
+                fields: [
+                    { name: 'x', label: 'X', type: 'pivot', required: true },
+                ],
+            }).success,
+        ).toBe(false);
+    });
+
+    it('rejects a field missing required properties or with an empty name', () => {
+        expect(
+            dataAppVizSchema.safeParse({
+                fields: [{ name: 'x', type: 'dimension' }],
+            }).success,
+        ).toBe(false);
+        expect(
+            dataAppVizSchema.safeParse({
+                fields: [
+                    {
+                        name: '',
+                        label: 'Empty',
+                        type: 'metric',
+                        required: true,
+                    },
+                ],
+            }).success,
+        ).toBe(false);
+    });
+
+    it('rejects duplicate field names (mapping is keyed by name)', () => {
+        expect(
+            dataAppVizSchema.safeParse({
+                fields: [
+                    { name: 'v', label: 'A', type: 'metric', required: true },
+                    { name: 'v', label: 'B', type: 'metric', required: false },
+                ],
+            }).success,
+        ).toBe(false);
+    });
+
+    it('accepts each config option type', () => {
+        const r = dataAppVizSchema.safeParse({
+            fields: [],
+            configOptions: [
+                {
+                    name: 'showLegend',
+                    label: 'Legend',
+                    type: 'boolean',
+                    default: true,
+                },
+                {
+                    name: 'orient',
+                    label: 'Orientation',
+                    type: 'select',
+                    default: 'h',
+                    choices: [
+                        { value: 'h', label: 'Horizontal' },
+                        { value: 'v', label: 'Vertical' },
+                    ],
+                },
+                {
+                    name: 'pad',
+                    label: 'Padding',
+                    type: 'number',
+                    default: 8,
+                    min: 0,
+                },
+                { name: 'title', label: 'Title', type: 'text', default: '' },
+                {
+                    name: 'accent',
+                    label: 'Accent',
+                    type: 'color',
+                    default: '#7262ff',
+                },
+                {
+                    name: 'palette',
+                    label: 'Palette',
+                    type: 'palette',
+                    default: ['#111', '#222'],
+                },
+            ],
+        });
+        expect(r.success).toBe(true);
+    });
+
+    it('rejects a boolean option with a non-boolean default', () => {
+        expect(
+            dataAppVizSchema.safeParse({
+                fields: [],
+                configOptions: [
+                    { name: 'x', label: 'X', type: 'boolean', default: 'nope' },
+                ],
+            }).success,
+        ).toBe(false);
+    });
+
+    it('rejects a select option with no choices', () => {
+        expect(
+            dataAppVizSchema.safeParse({
+                fields: [],
+                configOptions: [
+                    {
+                        name: 'x',
+                        label: 'X',
+                        type: 'select',
+                        default: 'a',
+                        choices: [],
+                    },
+                ],
+            }).success,
+        ).toBe(false);
+    });
+
+    it('rejects duplicate option names', () => {
+        expect(
+            dataAppVizSchema.safeParse({
+                fields: [],
+                configOptions: [
+                    { name: 'x', label: 'X', type: 'boolean', default: true },
+                    { name: 'x', label: 'X2', type: 'text', default: '' },
+                ],
+            }).success,
+        ).toBe(false);
+    });
+});
+
+describe('getEffectiveOptionValues', () => {
+    const opts: DataAppVizConfigOption[] = [
+        { name: 'a', label: 'A', type: 'boolean', default: true },
+        { name: 'b', label: 'B', type: 'number', default: 8, min: 0 },
+    ];
+
+    it('falls back to each option default when unset, keeps set values', () => {
+        expect(getEffectiveOptionValues(opts, { b: 12 })).toEqual({
+            a: true,
+            b: 12,
+        });
+    });
+
+    it('ignores stale values for options that no longer exist', () => {
+        expect(
+            getEffectiveOptionValues(
+                [{ name: 'a', label: 'A', type: 'boolean', default: false }],
+                { gone: 5, a: true },
+            ),
+        ).toEqual({ a: true });
+    });
+});

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1,5 +1,10 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { type ApiSuccess, type ApiSuccessEmpty } from '../../types/api/success';
-import { type KnexPaginateArgs } from '../../types/knex-paginate';
+import {
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+} from '../../types/knex-paginate';
 import { type MetricQuery } from '../../types/metricQuery';
 
 /**
@@ -47,11 +52,15 @@ export type ApiAppImageUploadResponse = ApiSuccess<{
     imageId: string;
 }>;
 
+/** Starter template for a single-tile renderer that emits a typed viz schema. */
+export const DATA_APP_VIZ_TEMPLATE = 'data_app_viz' as const;
+
 export const DATA_APP_TEMPLATES = [
     'dashboard',
     'slideshow',
     'pdf',
     'custom',
+    DATA_APP_VIZ_TEMPLATE,
 ] as const;
 export type DataAppTemplate = (typeof DATA_APP_TEMPLATES)[number];
 
@@ -260,7 +269,7 @@ export type ApiGetAppResponse = ApiSuccess<{
     createdByUserUuid: string;
     spaceUuid: string | null;
     spaceName: string | null;
-    // null when the user picked "Custom" or for apps that pre-date template persistence
+    // The stored template flavor; null for "Custom" or apps predating template persistence.
     template: Exclude<DataAppTemplate, 'custom'> | null;
     pinnedListUuid: string | null;
     pinnedListOrder: number | null;
@@ -378,3 +387,195 @@ export type ApiMyAppsResponse = ApiSuccess<{
         totalResults: number;
     };
 }>;
+
+// Data app viz declaration: explicit TS types (for the OpenAPI spec) plus a zod
+// schema (runtime validation of the generated declaration), kept in sync by the
+// compile-time assertion below.
+
+// Binds a host query column: dimension (grouping), metric (measure), series (splits/colours).
+export type DataAppVizFieldType = 'dimension' | 'metric' | 'series';
+export type DataAppVizField = {
+    name: string;
+    label: string;
+    type: DataAppVizFieldType;
+    required: boolean;
+};
+
+export type DataAppVizConfigOptionType =
+    | 'boolean'
+    | 'select'
+    | 'number'
+    | 'text'
+    | 'color'
+    | 'palette';
+
+// A whole-viz config option rendered as a form control; `group` is an optional tab label.
+export type DataAppVizConfigOption =
+    | {
+          type: 'boolean';
+          name: string;
+          label: string;
+          group?: string;
+          default: boolean;
+      }
+    | {
+          type: 'select';
+          name: string;
+          label: string;
+          group?: string;
+          choices: { value: string; label: string }[];
+          default: string;
+      }
+    | {
+          type: 'number';
+          name: string;
+          label: string;
+          group?: string;
+          default: number;
+          min?: number;
+          max?: number;
+      }
+    | {
+          type: 'text';
+          name: string;
+          label: string;
+          group?: string;
+          default: string;
+      }
+    | {
+          type: 'color';
+          name: string;
+          label: string;
+          group?: string;
+          default: string;
+      }
+    | {
+          type: 'palette';
+          name: string;
+          label: string;
+          group?: string;
+          default: string[];
+      };
+
+/** A persisted config value; its shape is set by the option's declared `type`. */
+export type DataAppVizOptionValue = boolean | number | string | string[];
+
+/** The full declaration a data app viz emits: data-binding fields + config form. */
+export type DataAppVizSchema = {
+    fields: DataAppVizField[];
+    configOptions: DataAppVizConfigOption[];
+};
+
+const uniqueNames = <T extends { name: string }>(arr: T[]): boolean =>
+    new Set(arr.map((a) => a.name)).size === arr.length;
+
+const optionBase = {
+    name: z.string().min(1),
+    label: z.string(),
+    group: z.string().optional(),
+};
+
+// Runtime validator for the untrusted generated declaration. Also the source
+// for the JSON Schema embedded in the generation prompt.
+export const dataAppVizSchema = z.object({
+    fields: z
+        .array(
+            z.object({
+                name: z.string().min(1),
+                label: z.string(),
+                type: z.enum(['dimension', 'metric', 'series']),
+                required: z.boolean(),
+            }),
+        )
+        .refine(uniqueNames, 'duplicate field name'),
+    configOptions: z
+        .array(
+            z.discriminatedUnion('type', [
+                z.object({
+                    ...optionBase,
+                    type: z.literal('boolean'),
+                    default: z.boolean(),
+                }),
+                z.object({
+                    ...optionBase,
+                    type: z.literal('select'),
+                    choices: z
+                        .array(
+                            z.object({ value: z.string(), label: z.string() }),
+                        )
+                        .min(1),
+                    default: z.string(),
+                }),
+                z.object({
+                    ...optionBase,
+                    type: z.literal('number'),
+                    default: z.number(),
+                    min: z.number().optional(),
+                    max: z.number().optional(),
+                }),
+                z.object({
+                    ...optionBase,
+                    type: z.literal('text'),
+                    default: z.string(),
+                }),
+                z.object({
+                    ...optionBase,
+                    type: z.literal('color'),
+                    default: z.string(),
+                }),
+                z.object({
+                    ...optionBase,
+                    type: z.literal('palette'),
+                    default: z.array(z.string()),
+                }),
+            ]),
+        )
+        .default([])
+        .refine(uniqueNames, 'duplicate option name'),
+});
+
+// Compile-time guard: the zod schema's output type must match the explicit
+// type exposed through the API. If either side drifts, this line fails to type.
+type AssertMutuallyAssignable<A, B> = [A] extends [B]
+    ? [B] extends [A]
+        ? true
+        : never
+    : never;
+const dataAppVizSchemaMatchesApiType: AssertMutuallyAssignable<
+    z.infer<typeof dataAppVizSchema>,
+    DataAppVizSchema
+> = true;
+void dataAppVizSchemaMatchesApiType;
+
+// JSON Schema form of `dataAppVizSchema` for the generator CLI's `--json-schema`
+// flag. Refinements (e.g. unique names) don't survive the conversion and stay
+// enforced by the runtime `safeParse`.
+export const dataAppVizJsonSchema = zodToJsonSchema(dataAppVizSchema);
+
+/** Effective option values = stored value ?? declared default (derive, never seed). */
+export const getEffectiveOptionValues = (
+    configOptions: DataAppVizConfigOption[],
+    optionValues: Record<string, DataAppVizOptionValue>,
+): Record<string, DataAppVizOptionValue> =>
+    Object.fromEntries(
+        configOptions.map((o) => [o.name, optionValues[o.name] ?? o.default]),
+    );
+
+// A reusable, by-reference data app viz: a single-tile data app that declares a
+// schema. Consumers store the `dataAppVizUuid` plus their own mapping, never a
+// copy. `schema` is null until a version generates one.
+export type DataAppViz = {
+    dataAppVizUuid: string;
+    name: string;
+    description: string;
+    projectUuid: string;
+    spaceUuid: string | null;
+    schema: DataAppVizSchema | null;
+    createdAt: Date;
+    createdByUserUuid: string;
+};
+
+export type ApiListDataAppVizsResponse = ApiSuccess<
+    KnexPaginatedData<DataAppViz[]>
+>;
+export type ApiGetDataAppVizResponse = ApiSuccess<DataAppViz>;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -934,7 +934,9 @@ const AppGenerate: FC = () => {
         ? selectedTemplate
         : appPersistedTemplate;
     const displayTemplate: DataAppTemplate | null =
-        candidateTemplate && candidateTemplate !== 'custom'
+        candidateTemplate &&
+        candidateTemplate !== 'custom' &&
+        candidateTemplate !== 'data_app_viz'
             ? candidateTemplate
             : null;
     // New-app empty screen: arch + composer, centered, no preview/split yet.


### PR DESCRIPTION
Introduces the **data app viz** entity: a reusable, by-reference single-tile renderer built on the data-apps infra, declaring a typed **schema** per version.

- `apps.template = 'data_app_viz'` flavor + `DataAppViz` type in common.
- The declared schema is `{ fields, configOptions }`: `fields` are the data-binding inputs (dimension / metric / series); `configOptions` are typed display options (boolean / select / number / text / color / palette), the groundwork for a generated config form (see GLITCH-563 — generation still emits fields-only for now, so `configOptions` defaults to `[]`).
- Validated with a zod schema (`dataAppVizSchema` + `safeParse`). The API-facing types are explicit (so tsoa can resolve them into the OpenAPI spec), with a compile-time guard keeping them in sync with the zod schema.
- `app_versions.viz_schema` (JSONB) stores the declared schema per version.
- `AppModel.listDataAppVisualizations` (paginated via `KnexPaginate`) / `findVisualizationApp` join the latest-ready version's schema.
- `GET /apps/visualizations` (paginated — feeds the library picker) and `GET /apps/visualizations/{uuid}` (the selected viz's schema for the field-mapping panel), both gated by `EnableDataApps`.

Closes: GLITCH-549
Relates: GLITCH-563
