### PR TITLE
feat(charts): data app viz chart-config variant (GLITCH-551)

### DIFF
--- a/packages/backend/src/database/migrations/20260624120004_add_data_app_viz_chart_type.ts
+++ b/packages/backend/src/database/migrations/20260624120004_add_data_app_viz_chart_type.ts
@@ -1,0 +1,12 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex('chart_types').insert({ chart_type: 'data_app_viz' });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex('saved_queries_versions')
+        .where('chart_type', 'data_app_viz')
+        .delete();
+    await knex('chart_types').delete().where('chart_type', 'data_app_viz');
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2712,6 +2712,7 @@ const models: TsoaRoute.Models = {
             'gauge',
             'map',
             'sankey',
+            'data_app_viz',
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -6365,6 +6366,40 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartType.DATA_APP_VIZ': {
+        dataType: 'refEnum',
+        enums: ['data_app_viz'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppVizFieldMapping: {
+        dataType: 'refAlias',
+        type: { ref: 'Record_string.string_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppVizChart: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                fieldMapping: { ref: 'DataAppVizFieldMapping', required: true },
+                dataAppVizUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppVizChartConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: { ref: 'DataAppVizChart' },
+                type: { ref: 'ChartType.DATA_APP_VIZ', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ChartType.MAP': {
         dataType: 'refEnum',
         enums: ['map'],
@@ -6576,6 +6611,7 @@ const models: TsoaRoute.Models = {
                 { ref: 'TableChartConfig' },
                 { ref: 'TreemapChartConfig' },
                 { ref: 'GaugeChartConfig' },
+                { ref: 'DataAppVizChartConfig' },
                 { ref: 'MapChartConfig' },
                 { ref: 'SankeyChartConfig' },
             ],
@@ -27631,6 +27667,7 @@ const models: TsoaRoute.Models = {
             'custom',
             'map',
             'sankey',
+            'data_app_viz',
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2784,7 +2784,8 @@
                     "treemap",
                     "gauge",
                     "map",
-                    "sankey"
+                    "sankey",
+                    "data_app_viz"
                 ],
                 "type": "string"
             },
@@ -7258,6 +7259,41 @@
                 "required": ["type"],
                 "type": "object"
             },
+            "ChartType.DATA_APP_VIZ": {
+                "enum": ["data_app_viz"],
+                "type": "string"
+            },
+            "DataAppVizFieldMapping": {
+                "$ref": "#/components/schemas/Record_string.string_",
+                "description": "Maps a data app viz's field name → the host query field id bound to it."
+            },
+            "DataAppVizChart": {
+                "properties": {
+                    "fieldMapping": {
+                        "$ref": "#/components/schemas/DataAppVizFieldMapping"
+                    },
+                    "dataAppVizUuid": {
+                        "type": "string",
+                        "description": "The reusable data app viz this chart renders with (by reference)."
+                    }
+                },
+                "required": ["fieldMapping", "dataAppVizUuid"],
+                "type": "object"
+            },
+            "DataAppVizChartConfig": {
+                "properties": {
+                    "config": {
+                        "$ref": "#/components/schemas/DataAppVizChart",
+                        "description": "Reference to a data app viz plus its field mapping."
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ChartType.DATA_APP_VIZ",
+                        "description": "Type of chart visualization"
+                    }
+                },
+                "required": ["type"],
+                "type": "object"
+            },
             "ChartType.MAP": {
                 "enum": ["map"],
                 "type": "string"
@@ -7575,6 +7611,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/GaugeChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DataAppVizChartConfig"
                     },
                     {
                         "$ref": "#/components/schemas/MapChartConfig"
@@ -27991,7 +28030,8 @@
                     "gauge",
                     "custom",
                     "map",
-                    "sankey"
+                    "sankey",
+                    "data_app_viz"
                 ],
                 "type": "string"
             },

--- a/packages/backend/src/services/RenameService/rename.ts
+++ b/packages/backend/src/services/RenameService/rename.ts
@@ -29,6 +29,7 @@ import {
     SchedulerAndTargets,
     TableCalculationTemplateType,
     type ConditionalFormattingConfig,
+    type DataAppVizChartConfig,
     type SankeyChartConfig,
 } from '@lightdash/common';
 
@@ -503,6 +504,27 @@ export const renameChartConfigType = (
                     ),
                     metricFieldId: replaceOptionalId(
                         sankeyConfig.config?.metricFieldId,
+                    ),
+                },
+            };
+        }
+
+        case ChartType.DATA_APP_VIZ: {
+            const dataAppVizConfig = chartConfig as DataAppVizChartConfig;
+            if (!dataAppVizConfig.config) return dataAppVizConfig;
+            // Field mapping keys are the viz's internal field names; the values
+            // are query field ids, so only the values get renamed.
+            return {
+                ...dataAppVizConfig,
+                config: {
+                    ...dataAppVizConfig.config,
+                    fieldMapping: Object.fromEntries(
+                        Object.entries(
+                            dataAppVizConfig.config.fieldMapping,
+                        ).map(([field, fieldId]) => [
+                            field,
+                            replaceId(fieldId),
+                        ]),
                     ),
                 },
             };

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -527,6 +527,7 @@ export function derivePivotConfigurationFromChart(
         case ChartType.BIG_NUMBER:
         case ChartType.MAP:
         case ChartType.SANKEY:
+        case ChartType.DATA_APP_VIZ:
             newConfig = undefined;
             break;
         default:

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -401,6 +401,9 @@
                     "$ref": "#/$defs/GaugeChartConfig"
                 },
                 {
+                    "$ref": "#/$defs/DataAppVizChartConfig"
+                },
+                {
                     "$ref": "#/$defs/MapChartConfig"
                 },
                 {
@@ -418,6 +421,10 @@
         },
         "ChartType.CUSTOM": {
             "enum": ["custom"],
+            "type": "string"
+        },
+        "ChartType.DATA_APP_VIZ": {
+            "enum": ["data_app_viz"],
             "type": "string"
         },
         "ChartType.FUNNEL": {
@@ -1044,6 +1051,37 @@
             },
             "required": ["type"],
             "type": "object"
+        },
+        "DataAppVizChart": {
+            "properties": {
+                "dataAppVizUuid": {
+                    "description": "The reusable data app viz this chart renders with (by reference).",
+                    "type": "string"
+                },
+                "fieldMapping": {
+                    "$ref": "#/$defs/DataAppVizFieldMapping"
+                }
+            },
+            "required": ["fieldMapping", "dataAppVizUuid"],
+            "type": "object"
+        },
+        "DataAppVizChartConfig": {
+            "properties": {
+                "config": {
+                    "$ref": "#/$defs/DataAppVizChart",
+                    "description": "Reference to a data app viz plus its field mapping."
+                },
+                "type": {
+                    "$ref": "#/$defs/ChartType.DATA_APP_VIZ",
+                    "description": "Type of chart visualization"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "DataAppVizFieldMapping": {
+            "$ref": "#/$defs/Record_string.string_",
+            "description": "Maps a data app viz's field name → the host query field id bound to it."
         },
         "DimensionOverrides": {
             "additionalProperties": {
@@ -3420,6 +3458,20 @@
                         },
                         "type": {
                             "const": "gauge",
+                            "description": "Type of chart visualization"
+                        }
+                    },
+                    "required": ["type"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "config": {
+                            "$ref": "#/$defs/DataAppVizChart",
+                            "description": "Reference to a data app viz plus its field mapping."
+                        },
+                        "type": {
+                            "const": "data_app_viz",
                             "description": "Type of chart visualization"
                         }
                     },

--- a/packages/common/src/types/savedCharts.test.ts
+++ b/packages/common/src/types/savedCharts.test.ts
@@ -1,9 +1,15 @@
 import {
     CartesianSeriesType,
+    ChartKind,
     ChartType,
+    getChartKind,
+    getChartType,
+    isDataAppVizChart,
+    isTableChartConfig,
     removePivotedSeriesValuesFromChartConfig,
     type CartesianChartConfig,
     type ChartConfig,
+    type DataAppVizChartConfig,
     type Series,
 } from './savedCharts';
 
@@ -143,5 +149,34 @@ describe('removePivotedSeriesValuesFromChartConfig', () => {
         expect(removePivotedSeriesValuesFromChartConfig(emptySeries)).toBe(
             emptySeries,
         );
+    });
+});
+
+describe('ChartType.DATA_APP_VIZ variant', () => {
+    const dataAppVizConfig: DataAppVizChartConfig = {
+        type: ChartType.DATA_APP_VIZ,
+        config: {
+            dataAppVizUuid: 'data-app-viz-1',
+            fieldMapping: { category: 'orders_status', value: 'orders_count' },
+        },
+    };
+
+    it('round-trips through getChartKind / getChartType without loss', () => {
+        const kind = getChartKind(
+            dataAppVizConfig.type,
+            dataAppVizConfig.config,
+        );
+        expect(kind).toBe(ChartKind.DATA_APP_VIZ);
+        expect(getChartType(kind)).toBe(ChartType.DATA_APP_VIZ);
+    });
+
+    it('isDataAppVizChart identifies the config and rejects others', () => {
+        expect(isDataAppVizChart(dataAppVizConfig.config)).toBe(true);
+        expect(isDataAppVizChart({ spec: {} })).toBe(false);
+        expect(isDataAppVizChart(undefined)).toBe(false);
+    });
+
+    it('is not misclassified as a table config', () => {
+        expect(isTableChartConfig(dataAppVizConfig.config)).toBe(false);
     });
 });

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -31,6 +31,7 @@ export enum ChartKind {
     GAUGE = 'gauge',
     MAP = 'map',
     SANKEY = 'sankey',
+    DATA_APP_VIZ = 'data_app_viz',
 }
 
 export enum ChartType {
@@ -44,6 +45,7 @@ export enum ChartType {
     CUSTOM = 'custom',
     MAP = 'map',
     SANKEY = 'sankey',
+    DATA_APP_VIZ = 'data_app_viz',
 }
 
 export enum ComparisonFormatTypes {
@@ -776,6 +778,15 @@ export type CustomVis = {
     spec?: Record<string, unknown>;
 };
 
+/** Maps a data app viz's field name → the host query field id bound to it. */
+export type DataAppVizFieldMapping = Record<string, string>;
+
+export type DataAppVizChart = {
+    /** The reusable data app viz this chart renders with (by reference). */
+    dataAppVizUuid: string;
+    fieldMapping: DataAppVizFieldMapping;
+};
+
 export type CartesianChart = {
     /** Layout configuration for the chart axes and orientation */
     layout: CartesianChartLayout;
@@ -810,6 +821,13 @@ export type CustomVisConfig = {
     type: ChartType.CUSTOM;
     /** Chart-type-specific configuration */
     config?: CustomVis;
+};
+
+export type DataAppVizChartConfig = {
+    /** Type of chart visualization */
+    type: ChartType.DATA_APP_VIZ;
+    /** Reference to a data app viz plus its field mapping. */
+    config?: DataAppVizChart;
 };
 
 export type PieChartConfig = {
@@ -870,6 +888,7 @@ export type ChartConfig =
     | TableChartConfig
     | TreemapChartConfig
     | GaugeChartConfig
+    | DataAppVizChartConfig
     | MapChartConfig
     | SankeyChartConfig;
 
@@ -1025,13 +1044,20 @@ export const isCartesianChartConfig = (
 ): value is CartesianChart =>
     !!value && 'layout' in value && 'eChartsConfig' in value;
 
+export const isDataAppVizChart = (
+    value: ChartConfig['config'],
+): value is DataAppVizChart =>
+    !!value && 'dataAppVizUuid' in value && 'fieldMapping' in value;
+
 export const isBigNumberConfig = (
     value: ChartConfig['config'],
-): value is BigNumber => !!value && !isCartesianChartConfig(value);
+): value is BigNumber =>
+    !!value && !isCartesianChartConfig(value) && !isDataAppVizChart(value);
 
 export const isTableChartConfig = (
     value: ChartConfig['config'],
-): value is TableChart => !!value && !isCartesianChartConfig(value);
+): value is TableChart =>
+    !!value && !isCartesianChartConfig(value) && !isDataAppVizChart(value);
 
 export const isPieChartConfig = (
     value: ChartConfig['config'],
@@ -1184,6 +1210,8 @@ export const getChartType = (chartKind: ChartKind | undefined): ChartType => {
             return ChartType.GAUGE;
         case ChartKind.SANKEY:
             return ChartType.SANKEY;
+        case ChartKind.DATA_APP_VIZ:
+            return ChartType.DATA_APP_VIZ;
         default:
             return ChartType.CARTESIAN;
     }
@@ -1244,6 +1272,8 @@ export const getChartKind = (
             return ChartKind.MAP;
         case ChartType.SANKEY:
             return ChartKind.SANKEY;
+        case ChartType.DATA_APP_VIZ:
+            return ChartKind.DATA_APP_VIZ;
         default:
             return assertUnreachable(
                 chartType,

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -1,0 +1,35 @@
+import { Stack, Text } from '@mantine-8/core';
+import { IconPuzzle } from '@tabler/icons-react';
+import { useEffect, useRef, type FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
+import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
+
+type Props = {
+    onScreenshotReady?: () => void;
+    onScreenshotError?: () => void;
+};
+
+const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
+    const { visualizationConfig } = useVisualizationContext();
+    const hasSignaledScreenshotReady = useRef(false);
+
+    useEffect(() => {
+        if (hasSignaledScreenshotReady.current) return;
+        onScreenshotReady?.();
+        hasSignaledScreenshotReady.current = true;
+    }, [onScreenshotReady]);
+
+    if (!isDataAppVizVisualizationConfig(visualizationConfig)) return null;
+
+    return (
+        <Stack align="center" justify="center" gap="xs" h="100%" w="100%">
+            <MantineIcon icon={IconPuzzle} size="xl" color="ldGray.5" />
+            <Text c="dimmed" size="sm" ta="center">
+                The data app viz renderer isn't wired up yet.
+            </Text>
+        </Stack>
+    );
+};
+
+export default DataAppVizRenderer;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -62,6 +62,12 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
                 );
             case ChartType.SANKEY:
                 return SankeyConfigTabs;
+            case ChartType.DATA_APP_VIZ:
+                return () => (
+                    <Text p="sm" color="dimmed" size="sm">
+                        No configuration options yet.
+                    </Text>
+                );
             default:
                 return assertUnreachable(
                     chartType,

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -19,6 +19,7 @@ import {
     IconGauge,
     IconGitMerge,
     IconMap,
+    IconPuzzle,
     IconSquareNumber1,
     IconTable,
 } from '@tabler/icons-react';
@@ -195,6 +196,11 @@ const VisualizationCardOptions: FC = memo(() => {
                 return {
                     text: 'Sankey',
                     icon: <MantineIcon icon={IconGitMerge} color="ldGray" />,
+                };
+            case ChartType.DATA_APP_VIZ:
+                return {
+                    text: 'Data app visualization',
+                    icon: <MantineIcon icon={IconPuzzle} color="ldGray" />,
                 };
             default: {
                 return assertUnreachable(

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationDataAppVizConfig.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationDataAppVizConfig.tsx
@@ -1,0 +1,17 @@
+import { ChartType } from '@lightdash/common';
+import { type FC } from 'react';
+import { type VisualizationDataAppVizConfigProps } from './types';
+
+const VisualizationDataAppVizConfig: FC<VisualizationDataAppVizConfigProps> = ({
+    initialChartConfig,
+    children,
+}) => {
+    return children({
+        visualizationConfig: {
+            chartType: ChartType.DATA_APP_VIZ,
+            chartConfig: { validConfig: initialChartConfig },
+        },
+    });
+};
+
+export default VisualizationDataAppVizConfig;

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -51,6 +51,7 @@ import VisualizationConfigSankey from './VisualizationConfigSankey';
 import VisualizationTableConfig from './VisualizationConfigTable';
 import VisualizationTreemapConfig from './VisualizationConfigTreemap';
 import VisualizationCustomConfig from './VisualizationCustomConfig';
+import VisualizationDataAppVizConfig from './VisualizationDataAppVizConfig';
 
 export type VisualizationProviderProps = {
     minimal?: boolean;
@@ -565,6 +566,23 @@ const VisualizationProvider: FC<
                         </Context.Provider>
                     )}
                 </VisualizationConfigSankey>
+            );
+        case ChartType.DATA_APP_VIZ:
+            return (
+                <VisualizationDataAppVizConfig
+                    itemsMap={itemsMap}
+                    resultsData={lastValidResultsData}
+                    initialChartConfig={chartConfig.config}
+                    onChartConfigChange={handleChartConfigChange}
+                >
+                    {({ visualizationConfig }) => (
+                        <Context.Provider
+                            value={{ ...value, visualizationConfig }}
+                        >
+                            {children}
+                        </Context.Provider>
+                    )}
+                </VisualizationDataAppVizConfig>
             );
         default:
             return assertUnreachable(chartConfig, 'Unknown chart type');

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from '../common/EmptyState';
 import MantineIcon from '../common/MantineIcon';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import CustomVisualization from '../CustomVisualization';
+import DataAppVizRenderer from '../DataAppVizRenderer';
 import FunnelChart from '../FunnelChart';
 import SimpleChart from '../SimpleChart';
 import SimpleGauge from '../SimpleGauge';
@@ -264,6 +265,14 @@ const LightdashVisualization = memo(
                         <SimpleSankey
                             isInDashboard={!!isDashboard}
                             $shouldExpand
+                            onScreenshotReady={onScreenshotReady}
+                            onScreenshotError={onScreenshotError}
+                        />
+                    );
+                    break;
+                case ChartType.DATA_APP_VIZ:
+                    chartContent = (
+                        <DataAppVizRenderer
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
                         />

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -1,5 +1,6 @@
 import {
     ChartType,
+    type DataAppVizChart,
     type CustomDimension,
     type DashboardFilters,
     type DateZoom,
@@ -199,6 +200,26 @@ export type VisualizationCustomConfigProps =
         itemsMap?: ItemsMap | undefined;
     };
 
+// Data app viz
+
+export type VisualizationConfigDataAppViz = {
+    chartType: ChartType.DATA_APP_VIZ;
+    chartConfig: {
+        validConfig: DataAppVizChart | undefined;
+    };
+};
+
+export const isDataAppVizVisualizationConfig = (
+    visualizationConfig: VisualizationConfig | undefined,
+): visualizationConfig is VisualizationConfigDataAppViz => {
+    return visualizationConfig?.chartType === ChartType.DATA_APP_VIZ;
+};
+
+export type VisualizationDataAppVizConfigProps =
+    VisualizationConfigCommon<VisualizationConfigDataAppViz> & {
+        itemsMap?: ItemsMap | undefined;
+    };
+
 // Gauge
 
 export type VisualizationConfigGauge = {
@@ -279,4 +300,5 @@ export type VisualizationConfig =
     | VisualizationConfigGauge
     | VisualizationConfigMap
     | VisualizationCustomConfigType
-    | VisualizationConfigSankeyType;
+    | VisualizationConfigSankeyType
+    | VisualizationConfigDataAppViz;

--- a/packages/frontend/src/components/common/ResourceIcon/utils.ts
+++ b/packages/frontend/src/components/common/ResourceIcon/utils.ts
@@ -12,6 +12,7 @@ import {
     IconGauge,
     IconGitMerge,
     IconMap,
+    IconPuzzle,
     IconSquareNumber1,
     IconTable,
 } from '@tabler/icons-react';
@@ -49,6 +50,8 @@ export const getChartIcon = (chartKind: ChartKind | undefined) => {
             return IconMap;
         case ChartKind.SANKEY:
             return IconGitMerge;
+        case ChartKind.DATA_APP_VIZ:
+            return IconPuzzle;
         default:
             return IconChartBar;
     }

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -49,6 +49,8 @@ export const getResourceTypeName = (item: ResourceViewItem) => {
                     return 'Map';
                 case ChartKind.SANKEY:
                     return 'Sankey';
+                case ChartKind.DATA_APP_VIZ:
+                    return 'Data app visualization';
                 default:
                     return 'Chart';
             }

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -5,6 +5,7 @@ import {
     type CartesianChartConfig,
     type ChartConfig,
     type ChartType,
+    type DataAppVizChartConfig,
     type CreateSavedChartVersion,
     type CustomDimension,
     type CustomFormat,
@@ -106,6 +107,7 @@ export type ConfigCacheMap = {
     [ChartType.MAP]: MapChartConfigCache;
     [ChartType.CUSTOM]: ChartConfigCache<CustomVisConfig['config']>;
     [ChartType.SANKEY]: ChartConfigCache<SankeyChartConfig['config']>;
+    [ChartType.DATA_APP_VIZ]: ChartConfigCache<DataAppVizChartConfig['config']>;
 };
 
 export type Action =

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -16,6 +16,7 @@ const DEFAULTS = {
     [ChartType.MAP]: () => ({}),
     [ChartType.CUSTOM]: () => ({}),
     [ChartType.SANKEY]: () => ({}),
+    [ChartType.DATA_APP_VIZ]: () => ({}),
 };
 
 // simple clone; reducer guarantees we’re not handing in drafts


### PR DESCRIPTION
Adds the `ChartType.DATA_APP_VIZ` chart-config variant so a saved chart can reference a data app viz by id plus a field mapping: `{ dataAppVizUuid, fieldMapping }`.

- `DataAppVizChart` / `DataAppVizChartConfig` in the `ChartConfig` union; `getChartKind` / `getChartType` + pivot cases.
- `chart_types` migration adds `data_app_viz`.
- Rename-service field-mapping value remap; frontend chart-type wiring + placeholder renderer.

Closes: GLITCH-551
