### PR TITLE
feat(apps): generate data app vizs + field schema (GLITCH-550)

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -1,0 +1,171 @@
+// Stub the e2b/ai SDKs before importing AppGenerateService so the tests never
+// reach the real sandbox or model client.
+import {
+    DATA_APP_VIZ_TEMPLATE,
+    type DataAppVizSchema,
+} from '@lightdash/common';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+
+const USER = { userUuid: 'user-1', organizationUuid: 'org-1' } as never;
+
+function buildService(
+    overrides: {
+        appModel?: Record<string, unknown>;
+        schedulerClient?: Record<string, unknown>;
+    } = {},
+) {
+    const appModel = overrides.appModel ?? {
+        createWithVersion: vi.fn().mockResolvedValue(undefined),
+    };
+    const schedulerClient = overrides.schedulerClient ?? {
+        appGeneratePipeline: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new AppGenerateService({
+        lightdashConfig: {} as never,
+        analytics: { track: vi.fn() } as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        appModel: appModel as never,
+        featureFlagModel: {
+            get: vi.fn().mockResolvedValue({ enabled: true }),
+        } as never,
+        organizationDesignModel: {
+            getDefault: vi.fn().mockResolvedValue(null),
+        } as never,
+        pinnedListModel: {} as never,
+        projectModel: {
+            getSummary: vi
+                .fn()
+                .mockResolvedValue({ organizationUuid: 'org-1' }),
+        } as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        schedulerClient: schedulerClient as never,
+        savedChartService: {} as never,
+        spacePermissionService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: {} as never,
+    });
+    // Bypass real CASL — the mapping/flow is what these tests cover.
+    (
+        service as unknown as { createAuditedAbility: () => unknown }
+    ).createAuditedAbility = () => ({ cannot: () => false });
+    return { service, appModel, schedulerClient };
+}
+
+describe('AppGenerateService.generateApp with the data app viz template', () => {
+    it('persists the viz template so the pipeline builds a data app viz', async () => {
+        const { service, appModel, schedulerClient } = buildService();
+
+        const result = await service.generateApp(
+            USER,
+            'project-1',
+            'a radial gauge',
+            [], // imageIds
+            undefined, // preGeneratedAppUuid
+            undefined, // charts
+            undefined, // dashboard
+            DATA_APP_VIZ_TEMPLATE,
+        );
+
+        expect(result).toEqual({
+            appUuid: expect.any(String),
+            version: 1,
+        });
+
+        const createCall = (
+            appModel.createWithVersion as ReturnType<typeof vi.fn>
+        ).mock.calls[0];
+        expect(createCall[0]).toMatchObject({
+            app_id: result.appUuid,
+            project_uuid: 'project-1',
+            created_by_user_uuid: 'user-1',
+            template: DATA_APP_VIZ_TEMPLATE,
+            space_uuid: null,
+        });
+        expect(createCall[2]).toBe('pending');
+
+        // The pipeline switches on the app's stored template to build a data
+        // app viz — no separate endpoint or flag needed.
+        const enqueueCall = (
+            schedulerClient.appGeneratePipeline as ReturnType<typeof vi.fn>
+        ).mock.calls[0][0];
+        expect(enqueueCall).toMatchObject({
+            appUuid: result.appUuid,
+            version: 1,
+            projectUuid: 'project-1',
+            isIteration: false,
+            template: DATA_APP_VIZ_TEMPLATE,
+        });
+    });
+});
+
+describe('AppGenerateService.parseSchema', () => {
+    const validSchema: DataAppVizSchema = {
+        fields: [
+            {
+                name: 'category',
+                label: 'Category',
+                type: 'dimension',
+                required: true,
+            },
+            { name: 'value', label: 'Value', type: 'metric', required: true },
+        ],
+        configOptions: [],
+    };
+
+    it('validates a well-formed schema', () => {
+        expect(AppGenerateService.parseSchema(validSchema)).toEqual(
+            validSchema,
+        );
+    });
+
+    it('defaults configOptions to [] when omitted', () => {
+        expect(
+            AppGenerateService.parseSchema({ fields: validSchema.fields }),
+        ).toEqual(validSchema);
+    });
+
+    it('returns null for a non-object value', () => {
+        expect(AppGenerateService.parseSchema('nope')).toBeNull();
+        expect(AppGenerateService.parseSchema(null)).toBeNull();
+    });
+
+    it('returns null for a structurally invalid schema', () => {
+        expect(
+            AppGenerateService.parseSchema({
+                fields: [
+                    { name: 'x', label: 'X', type: 'nope', required: true },
+                ],
+            }),
+        ).toBeNull();
+    });
+
+    it('returns null for duplicate field names', () => {
+        expect(
+            AppGenerateService.parseSchema({
+                fields: [
+                    {
+                        name: 'a',
+                        label: 'A',
+                        type: 'dimension',
+                        required: true,
+                    },
+                    { name: 'a', label: 'A2', type: 'metric', required: false },
+                ],
+            }),
+        ).toBeNull();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -15,6 +15,9 @@ import {
     assertEmbeddedAuth,
     assertUnreachable,
     DATA_APP_CLAUDE_MODELS,
+    DATA_APP_VIZ_TEMPLATE,
+    dataAppVizJsonSchema,
+    dataAppVizSchema,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
     FeatureFlags,
     ForbiddenError,
@@ -1550,6 +1553,7 @@ export class AppGenerateService extends BaseService {
         bucket: string,
         chartReferences: ChartReference[] | undefined,
         template: DataAppTemplate | undefined,
+        isDataAppViz: boolean,
     ): Promise<{
         durationMs: number;
         tableCount: number;
@@ -1625,9 +1629,16 @@ export class AppGenerateService extends BaseService {
             }
         }
 
-        // Prepend starter-template instructions, when one was selected on creation
-        if (template) {
-            const templateInstructions = getTemplateInstructions(template);
+        // Viz instructions come from the app's stored template (reliable on
+        // iterate/retry, where payload.template is absent); starter-template
+        // instructions seed only the initial generate. Both resolve through the
+        // same exhaustive switch.
+        const instructionsTemplate = isDataAppViz
+            ? DATA_APP_VIZ_TEMPLATE
+            : template;
+        if (instructionsTemplate) {
+            const templateInstructions =
+                getTemplateInstructions(instructionsTemplate);
             if (templateInstructions) {
                 finalPrompt = `${templateInstructions}\n\n${finalPrompt}`;
             }
@@ -1897,15 +1908,41 @@ export class AppGenerateService extends BaseService {
         continueSession: boolean,
         claudeCodeEnv: Record<string, string>,
         claudeModel: DataAppClaudeModel,
+        // JSON Schema string for `--json-schema` structured output. When set,
+        // the CLI validates the run's final output against it (retrying on
+        // failure) and emits the parsed object on the result event. `null`
+        // for runs that don't collect a structured schema (metadata, builds).
+        structuredOutputSchema: string | null,
     ): Promise<{
         durationMs: number;
         responseText: string | null;
+        structuredOutput: unknown;
         toolCallCount: number;
         usage: ClaudeGenerationUsage | null;
         timeToFirstTokenMs: number | null;
         turnDurationsMs: number[];
     }> {
         const start = performance.now();
+
+        if (structuredOutputSchema) {
+            // A resumed sandbox may still hold a root-owned
+            // /tmp/output-schema.json from the previous run's Claude execution,
+            // which would make the write below fail with a permission error.
+            // Remove it first (same pattern as the other /tmp scratch files).
+            await sandbox.commands.run(
+                'rm -f /tmp/output-schema.json 2>/dev/null; true',
+                { timeoutMs: 10_000 },
+            );
+            await sandbox.files.write(
+                '/tmp/output-schema.json',
+                structuredOutputSchema,
+            );
+        }
+        // `"$(cat …)"` splices the schema in as a single literal arg — robust
+        // to the JSON's own quotes/braces, and a no-op when unset.
+        const jsonSchemaFlag = structuredOutputSchema
+            ? '--json-schema "$(cat /tmp/output-schema.json)" '
+            : '';
 
         // When the sandbox was resumed from a previous iteration, use
         // --continue so Claude has the full conversation history of what
@@ -1922,6 +1959,7 @@ export class AppGenerateService extends BaseService {
         ): Promise<{
             durationMs: number;
             responseText: string | null;
+            structuredOutput: unknown;
             toolCallCount: number;
             usage: ClaudeGenerationUsage | null;
             timeToFirstTokenMs: number | null;
@@ -1931,6 +1969,7 @@ export class AppGenerateService extends BaseService {
                 continueSession || forceContinue ? '--continue -p' : '-p';
             const processor = new ClaudeStreamProcessor();
             let responseText: string | null = null;
+            let structuredOutput: unknown = null;
             let sessionEstablished = false;
 
             const result = await sandbox.commands
@@ -1939,7 +1978,7 @@ export class AppGenerateService extends BaseService {
                         `--model ${claudeModel} ` +
                         `--verbose --output-format stream-json --include-partial-messages ` +
                         `--allowedTools "Read(//app/**),Read(//tmp/dbt-repo/**),Read(//tmp/images/**),Read(//tmp/metric-queries/**),Read(//tmp/external-data/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Glob(//tmp/metric-queries/**),Glob(//tmp/external-data/**),Grep(//app/**),Grep(//tmp/dbt-repo/**),Grep(//tmp/external-data/**)" ` +
-                        `--append-system-prompt-file ${AppGenerateService.EFFECTIVE_SKILL_PATH}`,
+                        `${jsonSchemaFlag}--append-system-prompt-file ${AppGenerateService.EFFECTIVE_SKILL_PATH}`,
                     {
                         cwd: '/app',
                         timeoutMs: 55 * 60 * 1000,
@@ -1987,6 +2026,8 @@ export class AppGenerateService extends BaseService {
                                         if (event.text) {
                                             responseText = event.text;
                                         }
+                                        structuredOutput =
+                                            event.structuredOutput;
                                         break;
                                     default:
                                         assertUnreachable(
@@ -2038,6 +2079,7 @@ export class AppGenerateService extends BaseService {
                 return {
                     durationMs,
                     responseText,
+                    structuredOutput,
                     toolCallCount,
                     usage,
                     timeToFirstTokenMs,
@@ -2160,6 +2202,7 @@ export class AppGenerateService extends BaseService {
             true, // --continue: Claude remembers what it just built
             claudeCodeEnv,
             claudeModel,
+            null, // metadata run collects no structured schema
         );
 
         const durationMs = AppGenerateService.elapsed(start);
@@ -2375,6 +2418,7 @@ export class AppGenerateService extends BaseService {
                 true, // --continue: keep conversation context from generation
                 claudeCodeEnv,
                 claudeModel,
+                null, // build-fix run collects no structured schema
             );
             fixGenerationMs += generation.durationMs;
             fixUsage = addClaudeUsage(fixUsage, generation.usage);
@@ -2811,6 +2855,12 @@ export class AppGenerateService extends BaseService {
         chartReferences: ChartReference[] | undefined,
     ): Promise<void> {
         const { appUuid, version, projectUuid, prompt, template } = payload;
+        // Drives the data-app-viz prompt instructions + schema collection.
+        // Derived from the app's own template (the source of truth) rather than
+        // a payload flag, so it is correct on every path — initial generate,
+        // iteration, and retry — not just the ones that remembered to set it.
+        const pipelineApp = await this.appModel.getApp(appUuid, projectUuid);
+        const isDataAppViz = pipelineApp.template === DATA_APP_VIZ_TEMPLATE;
         // Resolve the model once per pipeline run. Jobs enqueued before the
         // picker shipped (or any future caller that omits the field) fall back
         // to the default so we never run with `--model undefined`.
@@ -2880,6 +2930,7 @@ export class AppGenerateService extends BaseService {
                     bucket,
                     chartReferences,
                     template,
+                    isDataAppViz,
                 );
                 durations.catalogMs = catalogResult.durationMs;
                 catalogStats = {
@@ -2915,6 +2966,10 @@ export class AppGenerateService extends BaseService {
 
         // --- Stage: generating ---
         let responseText: string | null = null;
+        // The data app viz schema, collected as the generation run's
+        // `--json-schema` structured output (null for non-viz apps or when the
+        // generating stage is skipped on a resumed build).
+        let vizStructuredOutput: unknown = null;
         if (shouldRun('generating')) {
             try {
                 const advanced = await this.advanceStage(
@@ -2938,9 +2993,13 @@ export class AppGenerateService extends BaseService {
                     continueSession,
                     claudeCodeEnv,
                     claudeModel,
+                    // Data app vizs collect a validated schema as the run's
+                    // structured output; other apps don't declare one.
+                    isDataAppViz ? JSON.stringify(dataAppVizJsonSchema) : null,
                 );
                 durations.generateMs = generation.durationMs;
                 responseText = generation.responseText;
+                vizStructuredOutput = generation.structuredOutput;
                 toolCallCount = generation.toolCallCount;
                 generationUsage = addClaudeUsage(
                     generationUsage,
@@ -3132,6 +3191,12 @@ export class AppGenerateService extends BaseService {
                 }
                 return;
             }
+        }
+
+        // Data app viz: persist the schema the generator declared as the run's
+        // structured output.
+        if (isDataAppViz) {
+            await this.persistSchema(vizStructuredOutput, appUuid, version);
         }
 
         try {
@@ -5420,6 +5485,41 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         }
         const apps = await this.appModel.listAppsByProject(projectUuid);
         return apps.map((app) => ({ appUuid: app.app_id, name: app.name }));
+    }
+
+    // Validate the generator's declared schema. Pure (no IO); null when the
+    // value doesn't match the contract. Never throws.
+    static parseSchema(value: unknown): DataAppVizSchema | null {
+        const result = dataAppVizSchema.safeParse(value);
+        return result.success ? result.data : null;
+    }
+
+    // Persist the schema the generator emitted as the run's `--json-schema`
+    // structured output. Best-effort: a missing (null) or invalid structured
+    // output leaves viz_schema untouched without failing an otherwise-good
+    // build — a data app viz with no schema is simply absent from the picker.
+    private async persistSchema(
+        structuredOutput: unknown,
+        appUuid: string,
+        version: number,
+    ): Promise<void> {
+        if (structuredOutput === null || structuredOutput === undefined) {
+            this.logger.warn(
+                `App ${appUuid}: no structured schema from the generation run; leaving viz_schema null`,
+            );
+            return;
+        }
+        const schema = AppGenerateService.parseSchema(structuredOutput);
+        if (!schema) {
+            this.logger.warn(
+                `App ${appUuid}: structured schema failed validation; leaving viz_schema null`,
+            );
+            return;
+        }
+        await this.appModel.setSchema(appUuid, version, schema);
+        this.logger.info(
+            `App ${appUuid} v${version}: persisted schema (${schema.fields.length} field(s), ${schema.configOptions.length} option(s))`,
+        );
     }
 
     private static mapDataAppViz(

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
@@ -33,7 +33,11 @@ describe('ClaudeStreamProcessor result parsing', () => {
         const events = processor.feedChunk(resultLine());
 
         expect(events).toEqual([
-            { kind: 'result', text: 'Done building the dashboard.' },
+            {
+                kind: 'result',
+                text: 'Done building the dashboard.',
+                structuredOutput: null,
+            },
         ]);
         expect(processor.lastUsage).toEqual({
             inputTokens: 1_000,
@@ -52,8 +56,36 @@ describe('ClaudeStreamProcessor result parsing', () => {
             line({ type: 'result', subtype: 'success' }),
         );
 
-        expect(events).toEqual([{ kind: 'result', text: '' }]);
+        expect(events).toEqual([
+            { kind: 'result', text: '', structuredOutput: null },
+        ]);
         expect(processor.lastUsage).toEqual(ZERO_CLAUDE_USAGE);
+    });
+
+    test('captures structured_output when the run used --json-schema', () => {
+        const processor = new ClaudeStreamProcessor();
+        const schema = {
+            fields: [
+                {
+                    name: 'category',
+                    label: 'Category',
+                    type: 'dimension',
+                    required: true,
+                },
+            ],
+            configOptions: [],
+        };
+        const events = processor.feedChunk(
+            resultLine({ structured_output: schema }),
+        );
+
+        expect(events).toEqual([
+            {
+                kind: 'result',
+                text: 'Done building the dashboard.',
+                structuredOutput: schema,
+            },
+        ]);
     });
 
     test('ignores non-JSON and non-result lines, leaving usage null', () => {

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
@@ -61,7 +61,7 @@ export type ClaudeStreamEvent =
     | { kind: 'thinking_started'; turn: number }
     | { kind: 'thinking_snippet'; snippet: string }
     | { kind: 'tool_use'; index: number; description: string }
-    | { kind: 'result'; text: string };
+    | { kind: 'result'; text: string; structuredOutput: unknown };
 
 const STATUS_THROTTLE_MS = 3000;
 const SNIPPET_SENTENCES = 1;
@@ -210,9 +210,13 @@ function asFiniteNumber(value: unknown): number {
  * the `result` event is emitted once per run and always carries usage, but
  * we parse defensively in case a field is absent on older CLI versions.
  */
-function parseResult(
-    line: string,
-): { text: string | null; usage: ClaudeGenerationUsage } | undefined {
+function parseResult(line: string):
+    | {
+          text: string | null;
+          usage: ClaudeGenerationUsage;
+          structuredOutput: unknown;
+      }
+    | undefined {
     let event: Record<string, unknown>;
     try {
         event = JSON.parse(line);
@@ -223,6 +227,10 @@ function parseResult(
     const usage = (event.usage ?? {}) as Record<string, unknown>;
     return {
         text: typeof event.result === 'string' ? event.result : null,
+        // Populated only when the run was invoked with `--json-schema`; the CLI
+        // validates the final output against that schema and emits the parsed
+        // object here. `null`/absent otherwise.
+        structuredOutput: event.structured_output ?? null,
         usage: {
             inputTokens: asFiniteNumber(usage.input_tokens),
             outputTokens: asFiniteNumber(usage.output_tokens),
@@ -391,7 +399,11 @@ export class ClaudeStreamProcessor {
                 this.lastTurnStartAt = null;
             }
             this.lastUsageValue = result.usage;
-            events.push({ kind: 'result', text: result.text ?? '' });
+            events.push({
+                kind: 'result',
+                text: result.text ?? '',
+                structuredOutput: result.structuredOutput,
+            });
         }
     }
 }

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -31,6 +31,41 @@ Build a print-optimized report:
 - \`window.print()\` can be a secondary Print action, but do not rely on it for the Download PDF button.
 - Prefer narrative copy with charts as supporting evidence, not a dense dashboard grid.`;
 
+const DATA_APP_VIZ_INSTRUCTIONS = `[Data app viz]
+You are building a reusable **data app viz**, NOT a multi-panel app, and NOT a normal data app. A data app viz is data-agnostic: the HOST owns the query and pushes the already-fetched rows + a field mapping into your iframe. You are ONLY the renderer. Both numbered deliverables below are MANDATORY.
+
+1. Render a SINGLE visualization (one chart) filling the available space. No dashboard, navigation, multiple panels, or page chrome.
+
+2. Do NOT use the normal Lightdash app SDK / \`client\` to run queries, and do NOT hardcode field/column names. Receive your data over the postMessage bridge — the host sends exactly one message type you must listen for:
+
+   window.addEventListener('message', (event) => {
+     const data = event.data;
+     if (!data || data.type !== 'lightdash:sdk:data-app-viz-context') return;
+     const { fieldMapping, rows } = data;
+     // fieldMapping: { [yourFieldName]: queryFieldId }
+     // rows: Lightdash result rows. Each row is keyed by field id; each cell
+     //       is { value: { raw, formatted } }.
+     //   display string:  row[fieldId].value.formatted
+     //   numeric value:   row[fieldId].value.raw
+     // Re-render every time this fires (host re-sends on query/mapping change).
+   });
+
+   Resolve each declared field's query field id via \`fieldMapping[fieldName]\`, then read that field's cell from each row. Example for fields "category" (dimension) + "value" (metric):
+     const catField = fieldMapping['category'];
+     const valField = fieldMapping['value'];
+     const data = rows.map((r) => ({
+       label: r[catField]?.value?.formatted ?? '',
+       value: Number(r[valField]?.value?.raw ?? 0),
+     }));
+   Render an empty/placeholder state before the first message arrives or when a field is unbound / rows are empty. Recharts, echarts, or plain SVG/HTML are all fine.
+
+3. Declare the field schema for your renderer — the typed inputs it reads from \`fieldMapping\`. It is collected as the run's structured output (do NOT write a file); the host uses it to build the field mapping UI, so the viz is unusable without it. For each field:
+   - \`name\` = the machine key your renderer reads from \`fieldMapping\` (unique, non-empty, no spaces) — must match the keys you used in step 2.
+   - \`label\` = human label shown in the field mapping UI.
+   - \`type\` = \`dimension\` (categorical/grouping), \`metric\` (numeric measure), or \`series\` (a dimension used to split/colour).
+   - \`required\` = false only when the viz can render without that field.
+   Declare exactly the fields your renderer reads — no more, no less. Example: a field "category" (type dimension, required) plus a field "value" (type metric, required).`;
+
 export const getTemplateInstructions = (
     template: DataAppTemplate,
 ): string | null => {
@@ -44,9 +79,7 @@ export const getTemplateInstructions = (
         case 'custom':
             return null;
         case 'data_app_viz':
-            // The viz starter injects its own prompt + schema request separately,
-            // not a generic starter-instruction block.
-            return null;
+            return DATA_APP_VIZ_INSTRUCTIONS;
         default:
             return assertUnreachable(
                 template,

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -632,6 +632,21 @@ export class AppModel {
             .first();
     }
 
+    // Persist the schema generated for a data app viz on its version row.
+    async setSchema(
+        appId: string,
+        version: number,
+        schema: DataAppVizSchema,
+    ): Promise<void> {
+        await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version })
+            .update({
+                viz_schema: JSON.stringify(
+                    schema,
+                ) as unknown as DataAppVizSchema,
+            });
+    }
+
     /**
      * Repoint a preview project's data-app dashboard tiles from the source
      * (upstream) apps they were copied with onto the preview's own duplicated

--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -1,7 +1,7 @@
 .fan {
     position: relative;
     width: 100%;
-    max-width: 720px;
+    max-width: 920px;
     height: 260px;
     margin: 0 auto;
 }
@@ -37,28 +37,34 @@
 }
 
 .card[data-pos='0'] {
-    --x: -258px;
-    --y: 44px;
+    --x: -332px;
+    --y: 56px;
     --rot: -15deg;
     z-index: 1;
 }
 .card[data-pos='1'] {
-    --x: -88px;
-    --y: 2px;
-    --rot: -5deg;
+    --x: -166px;
+    --y: 16px;
+    --rot: -8deg;
     z-index: 2;
 }
 .card[data-pos='2'] {
-    --x: 88px;
-    --y: 2px;
-    --rot: 5deg;
+    --x: 0px;
+    --y: 0px;
+    --rot: 0deg;
     z-index: 3;
 }
 .card[data-pos='3'] {
-    --x: 258px;
-    --y: 44px;
-    --rot: 15deg;
+    --x: 166px;
+    --y: 16px;
+    --rot: 8deg;
     z-index: 4;
+}
+.card[data-pos='4'] {
+    --x: 332px;
+    --y: 56px;
+    --rot: 15deg;
+    z-index: 5;
 }
 
 .card:hover,
@@ -122,7 +128,7 @@
 }
 
 /* Narrow widths can't hold the arch — stack the cards vertically. */
-@media (max-width: 760px) {
+@media (max-width: 880px) {
     .fan {
         height: auto;
         display: flex;

--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -37,34 +37,28 @@
 }
 
 .card[data-pos='0'] {
-    --x: -332px;
-    --y: 56px;
-    --rot: -15deg;
+    --x: -249px;
+    --y: 32px;
+    --rot: -12deg;
     z-index: 1;
 }
 .card[data-pos='1'] {
-    --x: -166px;
-    --y: 16px;
-    --rot: -8deg;
+    --x: -83px;
+    --y: 4px;
+    --rot: -4deg;
     z-index: 2;
 }
 .card[data-pos='2'] {
-    --x: 0px;
-    --y: 0px;
-    --rot: 0deg;
+    --x: 83px;
+    --y: 4px;
+    --rot: 4deg;
     z-index: 3;
 }
 .card[data-pos='3'] {
-    --x: 166px;
-    --y: 16px;
-    --rot: 8deg;
+    --x: 249px;
+    --y: 32px;
+    --rot: 12deg;
     z-index: 4;
-}
-.card[data-pos='4'] {
-    --x: 332px;
-    --y: 56px;
-    --rot: 15deg;
-    z-index: 5;
 }
 
 .card:hover,

--- a/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import AppTemplatePicker from './AppTemplatePicker';
 
 const setup = (
-    selected: 'dashboard' | 'slideshow' | 'pdf' | 'custom' | null,
+    selected: 'dashboard' | 'slideshow' | 'pdf' | 'data_app_viz' | null,
     onSelectedChange = vi.fn(),
 ) => {
     render(
@@ -31,7 +31,7 @@ describe('AppTemplatePicker', () => {
             screen.getByRole('button', { name: /PDF Report/i }),
         ).toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: /From scratch/i }),
+            screen.getByRole('button', { name: /Data app visualization/i }),
         ).toBeInTheDocument();
         expect(
             screen.queryByRole('button', { name: /Let's go/i }),

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -4,6 +4,7 @@ import {
     IconLayoutDashboard,
     IconPencil,
     IconPresentation,
+    IconPuzzle,
     type Icon as TablerIcon,
 } from '@tabler/icons-react';
 
@@ -34,6 +35,13 @@ export const TEMPLATES: TemplateDefinition[] = [
         description:
             'A print-friendly document with sections and supporting charts.',
         icon: IconFileText,
+    },
+    {
+        id: 'data_app_viz',
+        title: 'Data app visualization',
+        description:
+            'A reusable single-tile chart you can apply to any query like a chart type.',
+        icon: IconPuzzle,
     },
     {
         id: 'custom',

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -2,7 +2,6 @@ import { type DataAppTemplate } from '@lightdash/common';
 import {
     IconFileText,
     IconLayoutDashboard,
-    IconPencil,
     IconPresentation,
     IconPuzzle,
     type Icon as TablerIcon,
@@ -42,12 +41,6 @@ export const TEMPLATES: TemplateDefinition[] = [
         description:
             'A reusable single-tile chart you can apply to any query like a chart type.',
         icon: IconPuzzle,
-    },
-    {
-        id: 'custom',
-        title: 'From scratch',
-        description: 'Start from scratch and describe whatever you want.',
-        icon: IconPencil,
     },
 ];
 

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -935,9 +935,7 @@ const AppGenerate: FC = () => {
         ? selectedTemplate
         : appPersistedTemplate;
     const displayTemplate: DataAppTemplate | null =
-        candidateTemplate &&
-        candidateTemplate !== 'custom' &&
-        candidateTemplate !== 'data_app_viz'
+        candidateTemplate && candidateTemplate !== 'custom'
             ? candidateTemplate
             : null;
     // New-app empty screen: arch + composer, centered, no preview/split yet.
@@ -1530,6 +1528,12 @@ const AppGenerate: FC = () => {
             setIsSubmitting(true);
         }
 
+        // Starter template selected in the picker, if any. `data_app_viz` is a
+        // template like the others — it flows through the same clarify + build
+        // path; the pipeline keys the viz behaviour off the app's stored template.
+        const starterTemplate: DataAppTemplate | undefined =
+            selectedTemplate ?? undefined;
+
         try {
             // Send structured chart refs (uuid + per-chart sample-data opt-in).
             // The backend resolves these server-side so the client never sees
@@ -1680,7 +1684,7 @@ const AppGenerate: FC = () => {
                     const { questions } = await clarifyMutateAsync({
                         projectUuid: projectUuid!,
                         prompt: trimmed,
-                        template: selectedTemplate ?? undefined,
+                        template: starterTemplate,
                         charts,
                         dashboard,
                         imageIds,
@@ -1689,7 +1693,7 @@ const AppGenerate: FC = () => {
                         setPendingClarification({
                             questions,
                             prompt: trimmed,
-                            template: selectedTemplate ?? undefined,
+                            template: starterTemplate,
                             imageIds,
                             appUuid: newAppUuid,
                             charts,
@@ -1738,7 +1742,7 @@ const AppGenerate: FC = () => {
                     {
                         projectUuid,
                         prompt: trimmed,
-                        template: selectedTemplate ?? undefined,
+                        template: starterTemplate,
                         imageIds,
                         appUuid: newAppUuid,
                         charts,


### PR DESCRIPTION
Generates a data app viz end-to-end: a single-tile renderer that emits its renderer code together with its declared schema.

- `generateDataAppVisualization` service + `POST /apps/visualizations/generate`; injects the data-app-viz prompt instructions.
- The renderer writes `lightdash.schema.json`; `extractAndPersistSchema` reads it, validates it with zod (`safeParse`), and persists `viz_schema` on the built version.
- "Data app visualization" card on `/apps/generate`.

Closes: GLITCH-550
