### PR TITLE
feat(apps): minimal data app viz library picker (GLITCH-552)

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -47,7 +47,9 @@ import type {
     ApiGenerateAppResponse,
     ApiGetAppCodeResponse,
     ApiGetAppResponse,
+    ApiGetDataAppVizResponse,
     ApiGetUserAgentPreferencesResponse,
+    ApiListDataAppVizsResponse,
     ApiManagedAgentActionResponse,
     ApiManagedAgentRunResponse,
     ApiManagedAgentRunsListResponse,
@@ -1160,6 +1162,8 @@ type ApiResults =
     | ApiGenerateAppResponse['results']
     | ApiGetAppCodeResponse['results']
     | ApiGetAppResponse['results']
+    | ApiListDataAppVizsResponse['results']
+    | ApiGetDataAppVizResponse['results']
     | ApiMyAppsResponse['results']
     | ApiPromoteAppResponse['results']
     | ApiPromoteAppDiffResponse['results']

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
@@ -1,0 +1,86 @@
+import { type DataAppViz } from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { type ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useDataAppVisualizations } from '../hooks/useDataAppVisualizations';
+import DataAppVizLibraryPicker from './DataAppVizLibraryPicker';
+
+vi.mock('../hooks/useDataAppVisualizations', () => ({
+    useDataAppVisualizations: vi.fn(),
+}));
+
+const mockedUseDataAppVisualizations = vi.mocked(useDataAppVisualizations);
+
+const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
+    dataAppVizUuid: 'data-app-viz-1',
+    name: 'Radial gauge',
+    description: '',
+    projectUuid: 'project-1',
+    spaceUuid: null,
+    schema: {
+        fields: [{ name: 'v', label: 'V', type: 'metric', required: true }],
+        configOptions: [],
+    },
+    createdAt: new Date('2026-06-30'),
+    createdByUserUuid: 'user-1',
+    ...overrides,
+});
+
+const setData = (data: DataAppViz[]) => {
+    mockedUseDataAppVisualizations.mockReturnValue({
+        data: { pages: [{ data }], pageParams: [1] },
+        isInitialLoading: false,
+        error: null,
+        hasNextPage: false,
+        fetchNextPage: vi.fn(),
+        isFetchingNextPage: false,
+    } as unknown as ReturnType<typeof useDataAppVisualizations>);
+};
+
+const render = (onSelect: (id: string) => void): ReactElement =>
+    renderWithProviders(
+        <DataAppVizLibraryPicker
+            projectUuid="project-1"
+            selectedDataAppVizUuid={null}
+            onSelect={onSelect}
+        />,
+    ) as unknown as ReactElement;
+
+describe('DataAppVizLibraryPicker', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('lists the vizs returned by the endpoint', () => {
+        setData([
+            makeDataAppViz({ dataAppVizUuid: 'a', name: 'Radial gauge' }),
+            makeDataAppViz({ dataAppVizUuid: 'b', name: 'Bar race' }),
+        ]);
+        render(vi.fn());
+
+        expect(screen.getByText('Radial gauge')).toBeDefined();
+        expect(screen.getByText('Bar race')).toBeDefined();
+    });
+
+    it('returns the selected viz uuid on click', () => {
+        setData([
+            makeDataAppViz({ dataAppVizUuid: 'picked', name: 'Pick me' }),
+        ]);
+        const onSelect = vi.fn();
+        render(onSelect);
+
+        fireEvent.click(screen.getByText('Pick me'));
+
+        expect(onSelect).toHaveBeenCalledWith('picked');
+    });
+
+    it('shows an empty state when there are no bindable vizs', () => {
+        setData([]);
+        render(vi.fn());
+
+        expect(
+            screen.getByText(/No data app visualizations yet/),
+        ).toBeDefined();
+    });
+});

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
@@ -1,0 +1,95 @@
+import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
+import { Button, Center, Loader, NavLink, Stack, Text } from '@mantine-8/core';
+import { IconPuzzle } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useDataAppVisualizations } from '../hooks/useDataAppVisualizations';
+
+type Props = {
+    projectUuid: string;
+    selectedDataAppVizUuid: string | null;
+    onSelect: (dataAppVizUuid: string) => void;
+};
+
+const fieldSummary = (dataAppViz: DataAppViz): string => {
+    const count = dataAppViz.schema?.fields.length ?? 0;
+    return `${count} field${count === 1 ? '' : 's'}`;
+};
+
+// Library picker: lists the project's saved data app vizs; selecting one calls
+// `onSelect` with its uuid.
+const DataAppVizLibraryPicker: FC<Props> = ({
+    projectUuid,
+    selectedDataAppVizUuid,
+    onSelect,
+}) => {
+    const {
+        data,
+        isInitialLoading,
+        error,
+        hasNextPage,
+        fetchNextPage,
+        isFetchingNextPage,
+    } = useDataAppVisualizations(projectUuid);
+
+    if (isInitialLoading) {
+        return (
+            <Center p="md">
+                <Loader size="sm" />
+            </Center>
+        );
+    }
+
+    if (error) {
+        console.error('Failed to load data app visualizations:', error);
+        return (
+            <Text c="red" size="sm" p="md">
+                Failed to load data app visualizations. Please try again.
+            </Text>
+        );
+    }
+
+    const dataAppVizs = data?.pages.flatMap((page) => page.data) ?? [];
+
+    if (dataAppVizs.length === 0) {
+        return (
+            <Text c="dimmed" size="sm" p="md">
+                No data app visualizations yet. Generate one to reuse it here.
+            </Text>
+        );
+    }
+
+    return (
+        <Stack gap={0}>
+            {dataAppVizs.map((dataAppViz) => (
+                <NavLink
+                    key={dataAppViz.dataAppVizUuid}
+                    active={
+                        dataAppViz.dataAppVizUuid === selectedDataAppVizUuid
+                    }
+                    label={getAppDisplayName(
+                        dataAppViz.name,
+                        dataAppViz.dataAppVizUuid,
+                    )}
+                    description={
+                        dataAppViz.description || fieldSummary(dataAppViz)
+                    }
+                    leftSection={<MantineIcon icon={IconPuzzle} />}
+                    onClick={() => onSelect(dataAppViz.dataAppVizUuid)}
+                />
+            ))}
+            {hasNextPage && (
+                <Button
+                    variant="subtle"
+                    size="xs"
+                    loading={isFetchingNextPage}
+                    onClick={() => void fetchNextPage()}
+                >
+                    Load more
+                </Button>
+            )}
+        </Stack>
+    );
+};
+
+export default DataAppVizLibraryPicker;

--- a/packages/frontend/src/features/apps/hooks/useDataAppVisualizations.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVisualizations.ts
@@ -1,0 +1,45 @@
+import {
+    type ApiError,
+    type ApiListDataAppVizsResponse,
+} from '@lightdash/common';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+type DataAppVizsPage = ApiListDataAppVizsResponse['results'];
+
+const getDataAppVisualizations = async (
+    projectUuid: string,
+    page: number,
+    pageSize: number,
+): Promise<DataAppVizsPage> => {
+    const params = new URLSearchParams({
+        page: String(page),
+        pageSize: String(pageSize),
+    });
+    return lightdashApi<DataAppVizsPage>({
+        method: 'GET',
+        url: `/ee/projects/${projectUuid}/apps/visualizations?${params.toString()}`,
+        body: undefined,
+    });
+};
+
+const FETCH_SIZE = 25;
+
+// Lists the project's saved data app vizs (paginated) for the library picker.
+export const useDataAppVisualizations = (projectUuid: string | undefined) =>
+    useInfiniteQuery<DataAppVizsPage, ApiError>({
+        queryKey: ['data-app-vizs', projectUuid, FETCH_SIZE],
+        queryFn: ({ pageParam = 1 }) =>
+            getDataAppVisualizations(
+                projectUuid!,
+                pageParam as number,
+                FETCH_SIZE,
+            ),
+        getNextPageParam: (lastPage, pages) => {
+            const totalPages = lastPage.pagination?.totalPageCount ?? 0;
+            return pages.length < totalPages ? pages.length + 1 : undefined;
+        },
+        enabled: !!projectUuid,
+        keepPreviousData: true,
+        refetchOnWindowFocus: false,
+    });


### PR DESCRIPTION
Minimal library picker: a paginated list of the project's saved data app vizs (those that have generated a schema), reused wherever a viz needs to be picked. Backed by an infinite query over `GET /apps/visualizations` with a "Load more" control.

Closes: GLITCH-552
