### PR TITLE
feat(apps): push data app viz field mapping via SDK bridge (GLITCH-553)

### DIFF
--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -595,3 +595,21 @@ export type ApiListDataAppVizsResponse = ApiSuccess<
     KnexPaginatedData<DataAppViz[]>
 >;
 export type ApiGetDataAppVizResponse = ApiSuccess<DataAppViz>;
+
+// postMessage type the host uses to push render context into the sandboxed
+// iframe over the existing app SDK bridge (no new transport).
+export const APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE =
+    'lightdash:sdk:data-app-viz-context';
+
+// postMessage type the iframe posts on mount (via the SDK's useVizContext) to
+// ask the host to push the current context — the renderer may mount after the
+// host's first push, so this handshake replaces blind timed re-sends.
+export const APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE =
+    'lightdash:sdk:viz-context-request';
+
+// Host-owned render context pushed into a data app viz: field name → bound query
+// field id, plus the host-fetched result rows the renderer reads.
+export type DataAppVizContext = {
+    fieldMapping: Record<string, string>;
+    rows: Record<string, unknown>[];
+};

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1,4 +1,9 @@
-import { LightdashAppUuidHeader } from '@lightdash/common';
+import {
+    APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+    APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
+    LightdashAppUuidHeader,
+    type DataAppVizContext,
+} from '@lightdash/common';
 import { renderHook } from '@testing-library/react';
 import { type RefObject } from 'react';
 import {
@@ -819,5 +824,91 @@ describe('external-fetch branch', () => {
                 (r) => r['type'] === 'lightdash:sdk:external-fetch-response',
             ),
         ).toBeUndefined();
+    });
+});
+
+describe('data-app-viz-context push', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const dataAppVizContext: DataAppVizContext = {
+        fieldMapping: { category: 'orders_status', value: 'orders_count' },
+        rows: [
+            {
+                orders_status: {
+                    value: { raw: 'completed', formatted: 'Completed' },
+                },
+                orders_count: { value: { raw: 42, formatted: '42' } },
+            },
+        ],
+    };
+
+    function renderWithDataAppVizContext(ctx: DataAppVizContext | undefined) {
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        return renderHook(() =>
+            useAppSdkBridge({
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                dataAppVizContext: ctx,
+            }),
+        );
+    }
+
+    it('pushes the render context to the iframe when set', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        renderWithDataAppVizContext(dataAppVizContext);
+        expect(postSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+                fieldMapping: dataAppVizContext.fieldMapping,
+                rows: dataAppVizContext.rows,
+            }),
+            '*',
+        );
+    });
+
+    it('re-pushes the context in response to the iframe handshake request', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        renderWithDataAppVizContext(dataAppVizContext);
+        // Isolate the handshake push from the on-mount push.
+        postSpy.mockClear();
+        dispatchFetchMessage({ type: APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE });
+        expect(postSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+                fieldMapping: dataAppVizContext.fieldMapping,
+                rows: dataAppVizContext.rows,
+            }),
+            '*',
+        );
+    });
+
+    it('does not push a render context for ordinary apps (no context)', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        renderWithDataAppVizContext(undefined);
+        expect(postSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+            }),
+            '*',
+        );
+    });
+
+    it('ignores a handshake request for ordinary apps (no context)', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        renderWithDataAppVizContext(undefined);
+        postSpy.mockClear();
+        dispatchFetchMessage({ type: APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE });
+        expect(postSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+            }),
+            '*',
+        );
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,6 +1,9 @@
 import {
+    APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+    APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     JWT_HEADER_NAME,
     LightdashAppUuidHeader,
+    type DataAppVizContext,
     type DashboardFilters,
 } from '@lightdash/common';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
@@ -231,6 +234,9 @@ export type UseAppSdkBridgeParams = {
      * and a terminal `ready`/`error` event when it settles.
      */
     onExternalRequestEvent?: (event: ExternalRequestEvent) => void;
+    // When set, the host pushes this render context into the iframe over the
+    // existing bridge — on load and on every change. Only set for data app vizs.
+    dataAppVizContext?: DataAppVizContext;
 };
 
 export function useAppSdkBridge({
@@ -248,6 +254,7 @@ export function useAppSdkBridge({
     onLineageAvailable,
     onLineageSelected,
     onExternalRequestEvent,
+    dataAppVizContext,
 }: UseAppSdkBridgeParams) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -270,6 +277,21 @@ export function useAppSdkBridge({
     // in-flight set never drains and the screenshot indicator never
     // mounts).
     const queryUuidToPostIdRef = useRef<Map<string, string>>(new Map());
+
+    // Push the render context into the iframe. Sent in response to the iframe's
+    // `viz-context-request` handshake (the renderer mounts after its bundle
+    // loads, so a single push on `load` can arrive before its listener exists)
+    // and re-sent whenever the context changes. No-op for non-viz apps.
+    const pushDataAppVizContext = useCallback(() => {
+        if (!dataAppVizContext) return;
+        iframeRef.current?.contentWindow?.postMessage(
+            {
+                type: APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+                ...dataAppVizContext,
+            },
+            '*',
+        );
+    }, [iframeRef, dataAppVizContext]);
 
     const handleMessage = useCallback(
         async (event: MessageEvent) => {
@@ -294,6 +316,14 @@ export function useAppSdkBridge({
 
             if (data?.type === 'lightdash:sdk:screenshot-available') {
                 onScreenshotAvailable?.();
+                return;
+            }
+
+            // Handshake: the iframe's viz renderer asks for the current context
+            // once its listener is mounted. Reply with a push (no-op if this
+            // isn't a data app viz).
+            if (data?.type === APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE) {
+                pushDataAppVizContext();
                 return;
             }
 
@@ -818,6 +848,7 @@ export function useAppSdkBridge({
             onLineageAvailable,
             onLineageSelected,
             onExternalRequestEvent,
+            pushDataAppVizContext,
             health.data,
             user.data,
         ],
@@ -839,6 +870,14 @@ export function useAppSdkBridge({
             '*',
         );
     }, [iframeRef]);
+
+    // Re-push the render context whenever the host's field mapping or rows
+    // change, so an already-loaded iframe re-renders live. The initial delivery
+    // is driven by the iframe's `viz-context-request` handshake, so no push on
+    // `load` is needed here.
+    useEffect(() => {
+        pushDataAppVizContext();
+    }, [pushDataAppVizContext]);
 
     const enableInspector = useCallback(() => {
         iframeRef.current?.contentWindow?.postMessage(

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -78,3 +78,13 @@ export type {
     ExportToSheetsOptions,
     ExportToSheetsResult,
 } from './exportToSheets';
+
+// Data app viz render context (host-pushed rows + field mapping)
+export { useVizContext, getFormatted, getRaw } from './vizContext';
+export type {
+    VizContext,
+    VizContextCell,
+    VizContextRow,
+    DataAppVizContextMessage,
+    VizContextRequestMessage,
+} from './vizContext';

--- a/packages/query-sdk/src/vizContext.test.ts
+++ b/packages/query-sdk/src/vizContext.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { getFormatted, getRaw, type VizContextRow } from './vizContext';
+
+const row: VizContextRow = {
+    orders_status: { value: { raw: 'completed', formatted: 'Completed' } },
+    orders_count: { value: { raw: 42, formatted: '42' } },
+    empty_field: undefined,
+};
+
+describe('getFormatted', () => {
+    it('returns the formatted display string for a bound field', () => {
+        expect(getFormatted(row, 'orders_status')).toBe('Completed');
+        expect(getFormatted(row, 'orders_count')).toBe('42');
+    });
+
+    it('returns an empty string for a missing row, field, or cell', () => {
+        expect(getFormatted(undefined, 'orders_count')).toBe('');
+        expect(getFormatted(row, undefined)).toBe('');
+        expect(getFormatted(row, 'not_a_field')).toBe('');
+        expect(getFormatted(row, 'empty_field')).toBe('');
+    });
+});
+
+describe('getRaw', () => {
+    it('returns the raw value for a bound field', () => {
+        expect(getRaw(row, 'orders_status')).toBe('completed');
+        expect(getRaw(row, 'orders_count')).toBe(42);
+    });
+
+    it('returns null for a missing row, field, or cell', () => {
+        expect(getRaw(undefined, 'orders_count')).toBeNull();
+        expect(getRaw(row, undefined)).toBeNull();
+        expect(getRaw(row, 'not_a_field')).toBeNull();
+        expect(getRaw(row, 'empty_field')).toBeNull();
+    });
+});

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -1,0 +1,109 @@
+/**
+ * Data app viz render context — the iframe-side counterpart to the host's
+ * `useAppSdkBridge` push. A data app viz is a data-agnostic renderer: the host
+ * owns the query, fetches the rows, and pushes them (plus a field mapping)
+ * into the iframe. This module is the SDK primitive generated vizs use to
+ * receive that context, so they never hand-roll a `window.addEventListener`.
+ *
+ * Handshake: the renderer can mount after the host's first push, so on mount
+ * the hook posts a `viz-context-request` to the parent, which replies with the
+ * current context. The host also re-pushes on every change. No timers.
+ */
+
+import { useEffect, useState } from 'react';
+
+/** A single cell of a Lightdash result row: `{ value: { raw, formatted } }`. */
+export type VizContextCell = {
+    value?: { raw?: unknown; formatted?: string };
+};
+
+/** A result row keyed by query field id. */
+export type VizContextRow = Record<string, VizContextCell | undefined>;
+
+/**
+ * Pushed by the host into the iframe. `fieldMapping` maps each field name the
+ * renderer declared to the query field id it resolves to; `rows` are the
+ * host-fetched result rows keyed by field id.
+ */
+export type DataAppVizContextMessage = {
+    type: 'lightdash:sdk:data-app-viz-context';
+    fieldMapping: Record<string, string>;
+    rows: VizContextRow[];
+};
+
+/** Posted by the iframe on mount so the host pushes the current context. */
+export type VizContextRequestMessage = {
+    type: 'lightdash:sdk:viz-context-request';
+};
+
+const DATA_APP_VIZ_CONTEXT_MESSAGE = 'lightdash:sdk:data-app-viz-context';
+const VIZ_CONTEXT_REQUEST_MESSAGE = 'lightdash:sdk:viz-context-request';
+
+/** Display string for a field's cell in a row, e.g. `"$1,234"`. Empty when unset. */
+export const getFormatted = (
+    row: VizContextRow | undefined,
+    fieldId: string | undefined,
+): string => {
+    if (!row || !fieldId) return '';
+    return String(row[fieldId]?.value?.formatted ?? '');
+};
+
+/** Raw value for a field's cell in a row (number/string/etc.), or null when unset. */
+export const getRaw = (
+    row: VizContextRow | undefined,
+    fieldId: string | undefined,
+): unknown => {
+    if (!row || !fieldId) return null;
+    return row[fieldId]?.value?.raw ?? null;
+};
+
+export type VizContext = {
+    /** field name → query field id, as bound in the host field mapping UI. */
+    fieldMapping: Record<string, string>;
+    /** Host-fetched result rows, keyed by query field id. */
+    rows: VizContextRow[];
+    /** False until the first context arrives — render a placeholder while false. */
+    ready: boolean;
+};
+
+/**
+ * Subscribe to the host's render context. Re-renders whenever the host pushes
+ * (on load, on mapping change, on query change). Resolve a declared field to
+ * its bound cell with `fieldMapping[name]` then `getFormatted`/`getRaw`.
+ */
+export function useVizContext(): VizContext {
+    const [context, setContext] = useState<{
+        fieldMapping: Record<string, string>;
+        rows: VizContextRow[];
+    } | null>(null);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+
+        const handleMessage = (event: MessageEvent) => {
+            const data = event.data as DataAppVizContextMessage | undefined;
+            if (!data || data.type !== DATA_APP_VIZ_CONTEXT_MESSAGE) return;
+            setContext({
+                fieldMapping: data.fieldMapping ?? {},
+                rows: Array.isArray(data.rows) ? data.rows : [],
+            });
+        };
+
+        window.addEventListener('message', handleMessage);
+
+        // Ask the host to push the current context — the renderer may have
+        // mounted after the host's first push.
+        const request: VizContextRequestMessage = {
+            type: VIZ_CONTEXT_REQUEST_MESSAGE,
+        };
+        window.parent?.postMessage(request, '*');
+
+        return () => window.removeEventListener('message', handleMessage);
+    }, []);
+
+    return {
+        fieldMapping: context?.fieldMapping ?? {},
+        rows: context?.rows ?? [],
+        ready: context !== null,
+    };
+}


### PR DESCRIPTION
Pushes the host-owned render context (field mapping + host-fetched rows) into the data-app-viz iframe, and gives generated vizs a first-class SDK primitive to consume it instead of hand-rolling a `postMessage` listener.

### Contract (`@lightdash/common`)

- `DataAppVizContext` is `{ fieldMapping, rows }` — the field-name → query-field-id map plus the host-fetched result rows the renderer reads.

### Transport (host ↔ iframe)

- The host pushes the context over the existing app SDK bridge (`useAppSdkBridge`) — no new transport.
- Delivery is a **handshake**, not blind timed re-sends: the iframe posts `lightdash:sdk:viz-context-request` once its listener mounts, and the host replies with a push (and re-pushes on every mapping/rows change). This avoids the race where the renderer's bundle loads after the host's first push.

### SDK primitive (`@lightdash/query-sdk`)

- New `useVizContext()` hook returns `{ fieldMapping, rows, ready }` and owns the listener + handshake.
- `getFormatted(row, fieldId)` / `getRaw(row, fieldId)` helpers centralize the result-cell access convention (`.value.formatted` / `.value.raw`) so generated apps don't re-derive it.

Generated vizs now `import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk'` (see the prompt change in the stacked PR) instead of matching a magic message string by hand.

Closes: GLITCH-553
