### PR TITLE
feat(apps): render data app vizs live and as saved charts (GLITCH-554, GLITCH-555)

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -36,28 +36,26 @@ You are building a reusable **data app viz**, NOT a multi-panel app, and NOT a n
 
 1. Render a SINGLE visualization (one chart) filling the available space. No dashboard, navigation, multiple panels, or page chrome.
 
-2. Do NOT use the normal Lightdash app SDK / \`client\` to run queries, and do NOT hardcode field/column names. Receive your data over the postMessage bridge — the host sends exactly one message type you must listen for:
+2. Do NOT run queries yourself (don't use the SDK's query hooks or \`client\`) and do NOT hardcode field/column names — you are ONLY the renderer. Receive the host's data through the SDK's viz-context hook (no raw \`window.addEventListener\`):
 
-   window.addEventListener('message', (event) => {
-     const data = event.data;
-     if (!data || data.type !== 'lightdash:sdk:data-app-viz-context') return;
-     const { fieldMapping, rows } = data;
+   import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk';
+
+   function Chart() {
+     const { fieldMapping, rows, ready } = useVizContext();
      // fieldMapping: { [yourFieldName]: queryFieldId }
-     // rows: Lightdash result rows. Each row is keyed by field id; each cell
-     //       is { value: { raw, formatted } }.
-     //   display string:  row[fieldId].value.formatted
-     //   numeric value:   row[fieldId].value.raw
-     // Re-render every time this fires (host re-sends on query/mapping change).
-   });
+     // rows: host-fetched result rows, re-pushed on every query/mapping change.
+     if (!ready) return <Placeholder />; // no context has arrived yet
+     // ...map rows to your chart's shape (see below)
+   }
 
-   Resolve each declared field's query field id via \`fieldMapping[fieldName]\`, then read that field's cell from each row. Example for fields "category" (dimension) + "value" (metric):
+   Resolve each declared field's query field id via \`fieldMapping[fieldName]\`, then read that field's cell from each row with the helpers — \`getFormatted(row, fieldId)\` for the display string, \`getRaw(row, fieldId)\` for the numeric/raw value:
      const catField = fieldMapping['category'];
      const valField = fieldMapping['value'];
-     const data = rows.map((r) => ({
-       label: r[catField]?.value?.formatted ?? '',
-       value: Number(r[valField]?.value?.raw ?? 0),
+     const data = rows.map((row) => ({
+       label: getFormatted(row, catField),
+       value: Number(getRaw(row, valField) ?? 0),
      }));
-   Render an empty/placeholder state before the first message arrives or when a field is unbound / rows are empty. Recharts, echarts, or plain SVG/HTML are all fine.
+   Render an empty/placeholder state while \`!ready\`, or when a field is unbound / rows are empty. Recharts, echarts, or plain SVG/HTML are all fine.
 
 3. Declare the field schema for your renderer — the typed inputs it reads from \`fieldMapping\`. It is collected as the run's structured output (do NOT write a file); the host uses it to build the field mapping UI, so the viz is unusable without it. For each field:
    - \`name\` = the machine key your renderer reads from \`fieldMapping\` (unique, non-empty, no spaces) — must match the keys you used in step 2.

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -32,37 +32,37 @@ Build a print-optimized report:
 - Prefer narrative copy with charts as supporting evidence, not a dense dashboard grid.`;
 
 const DATA_APP_VIZ_INSTRUCTIONS = `[Data app viz]
-You are building a reusable **data app viz**, NOT a multi-panel app, and NOT a normal data app. A data app viz is data-agnostic: the HOST owns the query and pushes the already-fetched rows + a field mapping into your iframe. You are ONLY the renderer. Both numbered deliverables below are MANDATORY.
+You are building ONE reusable chart component. You do NOT fetch data or run queries: Lightdash runs the query, then gives you the result rows plus a mapping from your field names to the columns in those rows. The same component is reused across many different queries, so never hardcode column names — just render whatever data you are handed.
 
-1. Render a SINGLE visualization (one chart) filling the available space. No dashboard, navigation, multiple panels, or page chrome.
+Three requirements, all mandatory:
 
-2. Do NOT run queries yourself (don't use the SDK's query hooks or \`client\`) and do NOT hardcode field/column names — you are ONLY the renderer. Receive the host's data through the SDK's viz-context hook — the scaffold already wires delivery, so NEVER add your own \`window.addEventListener('message', …)\`; just call \`useVizContext()\`:
+1. Build ONE chart visualization component whose job is to make the mapped data easy to read at a glance. Build the chart type the user asked for; only if they didn't specify one, pick what best fits the fields (bars to compare categories, a line for a trend over time, etc.). Either way, get the fundamentals right: clear axes and labels, readable spacing, and a tooltip on hover. This is a single reusable visualization, not an app: no dashboard, navigation, multiple panels, filters, or page chrome. Recharts, echarts, D3, or plain SVG all work.
+   Fill the viewport: give your root element \`height: 100vh\` (or \`position: fixed; inset: 0\`), NOT \`height: 100%\` — that collapses to a 0-height invisible box unless every ancestor also sets a height. This gives auto-sizing charts like recharts \`<ResponsiveContainer>\` a real height to measure. Confirm the chart actually renders and isn't a blank box.
+
+2. Get your data from the \`useVizContext()\` hook — do not add a message listener or fetch anything yourself:
 
    import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk';
 
    function Chart() {
      const { fieldMapping, rows, ready } = useVizContext();
-     // fieldMapping: { [yourFieldName]: queryFieldId }
-     // rows: host-fetched result rows, re-pushed on every query/mapping change.
-     if (!ready) return <Placeholder />; // no context has arrived yet
-     // ...map rows to your chart's shape (see below)
-   }
-
-   Resolve each declared field's query field id via \`fieldMapping[fieldName]\`, then read that field's cell from each row with the helpers — \`getFormatted(row, fieldId)\` for the display string, \`getRaw(row, fieldId)\` for the numeric/raw value:
-     const catField = fieldMapping['category'];
+     if (!ready) return <Placeholder />;            // data hasn't arrived yet
+     const catField = fieldMapping['category'];     // your field name -> column id
      const valField = fieldMapping['value'];
      const data = rows.map((row) => ({
-       label: getFormatted(row, catField),
-       value: Number(getRaw(row, valField) ?? 0),
+       label: getFormatted(row, catField),          // display text, e.g. "Completed"
+       value: Number(getRaw(row, valField) ?? 0),   // raw number
      }));
-   Render an empty/placeholder state while \`!ready\`, or when a field is unbound / rows are empty. Recharts, echarts, or plain SVG/HTML are all fine.
+     // ...render \`data\`
+   }
 
-3. Declare the field schema for your renderer — the typed inputs it reads from \`fieldMapping\`. It is collected as the run's structured output (do NOT write a file); the host uses it to build the field mapping UI, so the viz is unusable without it. For each field:
-   - \`name\` = the machine key your renderer reads from \`fieldMapping\` (unique, non-empty, no spaces) — must match the keys you used in step 2.
-   - \`label\` = human label shown in the field mapping UI.
-   - \`type\` = \`dimension\` (categorical/grouping), \`metric\` (numeric measure), or \`series\` (a dimension used to split/colour).
-   - \`required\` = false only when the viz can render without that field.
-   Declare exactly the fields your renderer reads — no more, no less. Example: a field "category" (type dimension, required) plus a field "value" (type metric, required).`;
+   Show a clearly visible placeholder (readable, good contrast — never near-white on white) while \`!ready\`, when a field is unmapped, or when there are no rows.
+
+3. Declare the fields your component reads. This is collected as structured output (do NOT write a file); Lightdash uses it to build the field-mapping UI, so the component is unusable without it. For each field:
+   - \`name\`: the key you read from \`fieldMapping\` (unique, no spaces) — must match what you used above.
+   - \`label\`: human label shown in the mapping UI.
+   - \`type\`: \`dimension\` (category/grouping), \`metric\` (number), or \`series\` (a dimension used to split/colour).
+   - \`required\`: false only if the chart still renders without it.
+   Declare exactly what you read — no more, no less. e.g. "category" (dimension, required) + "value" (metric, required).`;
 
 export const getTemplateInstructions = (
     template: DataAppTemplate,

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -36,7 +36,7 @@ You are building a reusable **data app viz**, NOT a multi-panel app, and NOT a n
 
 1. Render a SINGLE visualization (one chart) filling the available space. No dashboard, navigation, multiple panels, or page chrome.
 
-2. Do NOT run queries yourself (don't use the SDK's query hooks or \`client\`) and do NOT hardcode field/column names — you are ONLY the renderer. Receive the host's data through the SDK's viz-context hook (no raw \`window.addEventListener\`):
+2. Do NOT run queries yourself (don't use the SDK's query hooks or \`client\`) and do NOT hardcode field/column names — you are ONLY the renderer. Receive the host's data through the SDK's viz-context hook — the scaffold already wires delivery, so NEVER add your own \`window.addEventListener('message', …)\`; just call \`useVizContext()\`:
 
    import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk';
 

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -39,6 +39,12 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         hasSignaledScreenshotReady.current = true;
     }, [onScreenshotReady]);
 
+    // Fetch every page so the renderer gets all rows — surfaces that don't
+    // auto-fetch (dashboard tiles) would otherwise push a partial result.
+    useEffect(() => {
+        resultsData?.setFetchAll(true);
+    }, [resultsData]);
+
     const config = isDataAppVizVisualizationConfig(visualizationConfig)
         ? visualizationConfig.chartConfig.validConfig
         : undefined;

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -1,6 +1,12 @@
+import { type DataAppVizContext } from '@lightdash/common';
 import { Stack, Text } from '@mantine-8/core';
 import { IconPuzzle } from '@tabler/icons-react';
-import { useEffect, useRef, type FC } from 'react';
+import { useEffect, useMemo, useRef, type FC } from 'react';
+import { useParams } from 'react-router';
+import AppIframePreview from '../../features/apps/AppIframePreview';
+import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
+import { useGetApp } from '../../features/apps/hooks/useGetApp';
+import { usePreviewOrigin } from '../../features/apps/previewOrigin';
 import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -10,25 +16,84 @@ type Props = {
     onScreenshotError?: () => void;
 };
 
+const DataAppVizPlaceholder: FC<{ message: string }> = ({ message }) => (
+    <Stack align="center" justify="center" gap="xs" h="100%" w="100%">
+        <MantineIcon icon={IconPuzzle} size="xl" color="ldGray.5" />
+        <Text c="dimmed" size="sm" ta="center">
+            {message}
+        </Text>
+    </Stack>
+);
+
 const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
-    const { visualizationConfig } = useVisualizationContext();
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { visualizationConfig, resultsData } = useVisualizationContext();
+    const previewOrigin = usePreviewOrigin();
     const hasSignaledScreenshotReady = useRef(false);
 
+    // Signal screenshot readiness on mount so dashboard capture isn't blocked
+    // waiting on the sandboxed iframe (which runs its own async query).
     useEffect(() => {
         if (hasSignaledScreenshotReady.current) return;
         onScreenshotReady?.();
         hasSignaledScreenshotReady.current = true;
     }, [onScreenshotReady]);
 
-    if (!isDataAppVizVisualizationConfig(visualizationConfig)) return null;
+    const config = isDataAppVizVisualizationConfig(visualizationConfig)
+        ? visualizationConfig.chartConfig.validConfig
+        : undefined;
+    const dataAppVizUuid = config?.dataAppVizUuid ?? '';
+    const fieldMapping = config?.fieldMapping;
+    const rows = resultsData?.rows;
+
+    // Hooks run unconditionally; the queries are `enabled`-gated on their args.
+    const { data: appData } = useGetApp(
+        projectUuid,
+        dataAppVizUuid || undefined,
+    );
+
+    // Latest READY version of the chosen data app viz drives the preview.
+    const readyVersion = useMemo(() => {
+        const versions = appData?.pages.flatMap((page) => page.versions) ?? [];
+        const ready = versions.filter((v) => v.status === 'ready');
+        if (ready.length === 0) return undefined;
+        return ready.reduce((max, v) => Math.max(max, v.version), 0);
+    }, [appData]);
+
+    const { data: token } = useAppPreviewToken(
+        projectUuid,
+        dataAppVizUuid || undefined,
+        readyVersion,
+    );
+
+    const dataAppVizContext = useMemo<DataAppVizContext | undefined>(() => {
+        if (!rows) return undefined;
+        return { fieldMapping: fieldMapping ?? {}, rows };
+    }, [fieldMapping, rows]);
+
+    if (!projectUuid || !dataAppVizUuid) {
+        return (
+            <DataAppVizPlaceholder message="Pick a data app visualization to render." />
+        );
+    }
+
+    if (readyVersion === undefined || !token) {
+        return (
+            <DataAppVizPlaceholder message="Data app visualization is still generating…" />
+        );
+    }
+
+    const previewUrl = `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${readyVersion}/t/${token}/?r=0#transport=postMessage&projectUuid=${projectUuid}`;
 
     return (
-        <Stack align="center" justify="center" gap="xs" h="100%" w="100%">
-            <MantineIcon icon={IconPuzzle} size="xl" color="ldGray.5" />
-            <Text c="dimmed" size="sm" ta="center">
-                The data app viz renderer isn't wired up yet.
-            </Text>
-        </Stack>
+        <AppIframePreview
+            src={previewUrl}
+            expectedPreviewOrigin={previewOrigin}
+            projectUuid={projectUuid}
+            appUuid={dataAppVizUuid}
+            identityKey={dataAppVizUuid}
+            dataAppVizContext={dataAppVizContext}
+        />
     );
 };
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -13,6 +13,7 @@ import { lazy, Suspense, useMemo, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { ConfigTabs as BigNumberConfigTabs } from '../../VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs';
 import { ConfigTabs as ChartConfigTabs } from '../../VisualizationConfigs/ChartConfigPanel/ConfigTabs';
+import { ConfigTabs as DataAppVizConfigTabs } from '../../VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs';
 import { ConfigTabs as FunnelChartConfigTabs } from '../../VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs';
 import { ConfigTabs as GaugeConfigTabs } from '../../VisualizationConfigs/GaugeConfig/GaugeConfigTabs';
 import { ConfigTabs as MapConfigTabs } from '../../VisualizationConfigs/MapConfig';
@@ -63,11 +64,7 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
             case ChartType.SANKEY:
                 return SankeyConfigTabs;
             case ChartType.DATA_APP_VIZ:
-                return () => (
-                    <Text p="sm" color="dimmed" size="sm">
-                        No configuration options yet.
-                    </Text>
-                );
+                return DataAppVizConfigTabs;
             default:
                 return assertUnreachable(
                     chartType,

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     CartesianSeriesType,
     ChartType,
+    FeatureFlags,
     isSeriesWithMixedChartTypes,
 } from '@lightdash/common';
 import { Button, Menu } from '@mantine-8/core';
@@ -24,10 +25,12 @@ import {
     IconTable,
 } from '@tabler/icons-react';
 import { memo, useMemo, type FC, type ReactNode } from 'react';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 import {
     isBigNumberVisualizationConfig,
     isCartesianVisualizationConfig,
+    isDataAppVizVisualizationConfig,
     isCustomVisualizationConfig,
     isFunnelVisualizationConfig,
     isGaugeVisualizationConfig,
@@ -49,6 +52,9 @@ const VisualizationCardOptions: FC = memo(() => {
         resultsData,
         pivotDimensions,
     } = useVisualizationContext();
+    const dataAppsEnabled =
+        useServerFeatureFlag(FeatureFlags.EnableDataApps).data?.enabled ===
+        true;
     const disabled = isLoading || !resultsData || resultsData.rows.length <= 0;
 
     const cartesianConfig = useMemo(() => {
@@ -510,6 +516,25 @@ const VisualizationCardOptions: FC = memo(() => {
                 >
                     Custom
                 </Menu.Item>
+
+                {dataAppsEnabled && (
+                    <Menu.Item
+                        disabled={disabled}
+                        color={
+                            isDataAppVizVisualizationConfig(visualizationConfig)
+                                ? 'blue'
+                                : undefined
+                        }
+                        leftSection={<MantineIcon icon={IconPuzzle} />}
+                        onClick={() => {
+                            setStacking(undefined);
+                            setCartesianType(undefined);
+                            setChartType(ChartType.DATA_APP_VIZ);
+                        }}
+                    >
+                        Data app visualization
+                    </Menu.Item>
+                )}
             </Menu.Dropdown>
         </Menu>
     );

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -30,8 +30,8 @@ import MantineIcon from '../../common/MantineIcon';
 import {
     isBigNumberVisualizationConfig,
     isCartesianVisualizationConfig,
-    isDataAppVizVisualizationConfig,
     isCustomVisualizationConfig,
+    isDataAppVizVisualizationConfig,
     isFunnelVisualizationConfig,
     isGaugeVisualizationConfig,
     isMapVisualizationConfig,

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationDataAppVizConfig.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationDataAppVizConfig.tsx
@@ -1,15 +1,29 @@
-import { ChartType } from '@lightdash/common';
-import { type FC } from 'react';
+import { ChartType, type DataAppVizChart } from '@lightdash/common';
+import { useCallback, type FC } from 'react';
+import useDataAppVizVisualizationConfig from '../../hooks/useDataAppVizVisualizationConfig';
 import { type VisualizationDataAppVizConfigProps } from './types';
 
 const VisualizationDataAppVizConfig: FC<VisualizationDataAppVizConfigProps> = ({
     initialChartConfig,
+    onChartConfigChange,
     children,
 }) => {
+    const handleConfigChange = useCallback(
+        (config: DataAppVizChart) => {
+            onChartConfigChange?.({ type: ChartType.DATA_APP_VIZ, config });
+        },
+        [onChartConfigChange],
+    );
+
+    const dataAppVizConfig = useDataAppVizVisualizationConfig(
+        initialChartConfig,
+        handleConfigChange,
+    );
+
     return children({
         visualizationConfig: {
             chartType: ChartType.DATA_APP_VIZ,
-            chartConfig: { validConfig: initialChartConfig },
+            chartConfig: dataAppVizConfig,
         },
     });
 };

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -1,6 +1,5 @@
 import {
     ChartType,
-    type DataAppVizChart,
     type CustomDimension,
     type DashboardFilters,
     type DateZoom,
@@ -19,6 +18,7 @@ import type useCartesianChartConfig from '../../hooks/cartesianChartConfig/useCa
 import { type CartesianTypeOptions } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import type useTableConfig from '../../hooks/tableVisualization/useTableConfig';
 import type useBigNumberConfig from '../../hooks/useBigNumberConfig';
+import type useDataAppVizVisualizationConfig from '../../hooks/useDataAppVizVisualizationConfig';
 import type useCustomVisualizationConfig from '../../hooks/useCustomVisualizationConfig';
 import type useFunnelChartConfig from '../../hooks/useFunnelChartConfig';
 import type useGaugeChartConfig from '../../hooks/useGaugeChartConfig';
@@ -204,9 +204,7 @@ export type VisualizationCustomConfigProps =
 
 export type VisualizationConfigDataAppViz = {
     chartType: ChartType.DATA_APP_VIZ;
-    chartConfig: {
-        validConfig: DataAppVizChart | undefined;
-    };
+    chartConfig: ReturnType<typeof useDataAppVizVisualizationConfig>;
 };
 
 export const isDataAppVizVisualizationConfig = (

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -18,8 +18,8 @@ import type useCartesianChartConfig from '../../hooks/cartesianChartConfig/useCa
 import { type CartesianTypeOptions } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import type useTableConfig from '../../hooks/tableVisualization/useTableConfig';
 import type useBigNumberConfig from '../../hooks/useBigNumberConfig';
-import type useDataAppVizVisualizationConfig from '../../hooks/useDataAppVizVisualizationConfig';
 import type useCustomVisualizationConfig from '../../hooks/useCustomVisualizationConfig';
+import type useDataAppVizVisualizationConfig from '../../hooks/useDataAppVizVisualizationConfig';
 import type useFunnelChartConfig from '../../hooks/useFunnelChartConfig';
 import type useGaugeChartConfig from '../../hooks/useGaugeChartConfig';
 import type usePieChartConfig from '../../hooks/usePieChartConfig';

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -1,0 +1,123 @@
+import {
+    getItemId,
+    isCustomDimension,
+    isDimension,
+    isMetric,
+    isTableCalculation,
+    type DataAppVizField,
+    type Item,
+} from '@lightdash/common';
+import {
+    MantineProvider,
+    Stack,
+    Text,
+    useMantineColorScheme,
+} from '@mantine/core';
+import { memo, useMemo, type FC } from 'react';
+import { useParams } from 'react-router';
+import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';
+import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
+import FieldSelect from '../../common/FieldSelect';
+import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import { Config } from '../common/Config';
+import { getVizConfigThemeOverride } from '../mantineTheme';
+
+const isDimensionItem = (item: Item): boolean =>
+    isDimension(item) || isCustomDimension(item);
+
+const isMetricItem = (item: Item): boolean =>
+    isMetric(item) || isTableCalculation(item);
+
+export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { visualizationConfig, itemsMap } = useVisualizationContext();
+
+    const isDataAppViz = isDataAppVizVisualizationConfig(visualizationConfig);
+    const dataAppVizUuid = isDataAppViz
+        ? visualizationConfig.chartConfig.dataAppVizUuid
+        : '';
+
+    const { data: dataAppViz } = useDataAppVisualization(
+        projectUuid,
+        dataAppVizUuid || undefined,
+    );
+
+    const allItems = useMemo(() => Object.values(itemsMap ?? {}), [itemsMap]);
+    const dimensions = useMemo(
+        () => allItems.filter(isDimensionItem),
+        [allItems],
+    );
+    const metrics = useMemo(() => allItems.filter(isMetricItem), [allItems]);
+
+    const fieldItems = (field: DataAppVizField): Item[] =>
+        field.type === 'metric' ? metrics : dimensions;
+
+    if (!isDataAppViz) return null;
+
+    const { setDataAppVizUuid, setField, fieldMapping } =
+        visualizationConfig.chartConfig;
+    const fields = dataAppViz?.schema?.fields ?? [];
+
+    return (
+        <MantineProvider inherit theme={themeOverride}>
+            <Stack>
+                <Config>
+                    <Config.Section>
+                        <Config.Heading>Data app visualization</Config.Heading>
+                        <DataAppVizLibraryPicker
+                            projectUuid={projectUuid ?? ''}
+                            selectedDataAppVizUuid={dataAppVizUuid || null}
+                            onSelect={setDataAppVizUuid}
+                        />
+                    </Config.Section>
+                </Config>
+
+                {dataAppVizUuid && fields.length === 0 && (
+                    <Text c="dimmed" size="sm">
+                        This visualization has no fields to map.
+                    </Text>
+                )}
+
+                {fields.map((field) => {
+                    const items = fieldItems(field);
+                    const selectedId = fieldMapping[field.name];
+                    const selectedItem = selectedId
+                        ? items.find((i) => getItemId(i) === selectedId)
+                        : undefined;
+                    return (
+                        <Config key={field.name}>
+                            <Config.Section>
+                                <Config.Heading>
+                                    {field.label}
+                                    {field.required ? ' *' : ''}
+                                </Config.Heading>
+                                <FieldSelect
+                                    placeholder={`Select ${field.label.toLowerCase()}`}
+                                    disabled={items.length === 0}
+                                    item={selectedItem}
+                                    items={items}
+                                    onChange={(newField) =>
+                                        setField(
+                                            field.name,
+                                            newField
+                                                ? getItemId(newField)
+                                                : null,
+                                        )
+                                    }
+                                    clearable={!field.required}
+                                    hasGrouping
+                                />
+                            </Config.Section>
+                        </Config>
+                    );
+                })}
+            </Stack>
+        </MantineProvider>
+    );
+});

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -1,4 +1,7 @@
-import { type DashboardFilters } from '@lightdash/common';
+import {
+    type DataAppVizContext,
+    type DashboardFilters,
+} from '@lightdash/common';
 import {
     forwardRef,
     useCallback,
@@ -85,6 +88,9 @@ type Props = {
      *  serve untrusted viewers (embed/JWT) must omit each capability flag.
      *  `gsheetExport`: enables `exportToSheets()` from the iframe SDK. */
     capabilities?: { gsheetExport?: boolean };
+    // Render context for data app vizs: the field mapping + host rows, pushed
+    // into the iframe over the SDK bridge. Undefined for ordinary data apps.
+    dataAppVizContext?: DataAppVizContext;
 };
 
 /**
@@ -132,6 +138,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             invalidateCache,
             onIframeLoad,
             capabilities,
+            dataAppVizContext,
         },
         ref,
     ) => {
@@ -170,6 +177,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onLineageAvailable: handleLineageAnnounce,
             onLineageSelected,
             onExternalRequestEvent,
+            dataAppVizContext,
         });
         const { captureScreenshot } = useIframeScreenshot(iframeRef);
 

--- a/packages/frontend/src/features/apps/hooks/useDataAppVisualization.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVisualization.ts
@@ -1,0 +1,25 @@
+import { type ApiError, type DataAppViz } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const getDataAppVisualization = async (
+    projectUuid: string,
+    dataAppVizUuid: string,
+): Promise<DataAppViz> =>
+    lightdashApi<DataAppViz>({
+        method: 'GET',
+        url: `/ee/projects/${projectUuid}/apps/visualizations/${dataAppVizUuid}`,
+        body: undefined,
+    });
+
+// Fetches a single saved data app viz (incl. its field schema) by id — used by
+// the config panel to render one FieldSelect per declared field.
+export const useDataAppVisualization = (
+    projectUuid: string | undefined,
+    dataAppVizUuid: string | undefined,
+) =>
+    useQuery<DataAppViz, ApiError>({
+        queryKey: ['data-app-viz', projectUuid, dataAppVizUuid],
+        queryFn: () => getDataAppVisualization(projectUuid!, dataAppVizUuid!),
+        enabled: !!projectUuid && !!dataAppVizUuid,
+    });

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -1,0 +1,62 @@
+import { type DataAppVizChart } from '@lightdash/common';
+import { useCallback, useState } from 'react';
+
+export interface DataAppVizVisualizationConfigAndData {
+    validConfig: DataAppVizChart;
+    dataAppVizUuid: string;
+    fieldMapping: Record<string, string>;
+    setDataAppVizUuid: (dataAppVizUuid: string) => void;
+    setField: (fieldName: string, fieldId: string | null) => void;
+}
+
+// Local state for a data-app-viz chart (selected viz + field mapping); setters
+// push each change up via `onConfigChange`. Mirrors useCustomVisualizationConfig.
+const useDataAppVizVisualizationConfig = (
+    initialChartConfig: DataAppVizChart | undefined,
+    onConfigChange?: (config: DataAppVizChart) => void,
+): DataAppVizVisualizationConfigAndData => {
+    const [dataAppVizUuid, setDataAppVizUuidState] = useState<string>(
+        initialChartConfig?.dataAppVizUuid ?? '',
+    );
+    const [fieldMapping, setFieldMappingState] = useState<
+        Record<string, string>
+    >(initialChartConfig?.fieldMapping ?? {});
+
+    const setDataAppVizUuid = useCallback(
+        (newDataAppVizUuid: string) => {
+            // Fields are viz-specific, so switching viz drops the old mapping
+            // rather than carrying over now-meaningless field names.
+            setDataAppVizUuidState(newDataAppVizUuid);
+            setFieldMappingState({});
+            onConfigChange?.({
+                dataAppVizUuid: newDataAppVizUuid,
+                fieldMapping: {},
+            });
+        },
+        [onConfigChange],
+    );
+
+    const setField = useCallback(
+        (fieldName: string, fieldId: string | null) => {
+            const nextMapping = { ...fieldMapping };
+            if (fieldId === null) {
+                delete nextMapping[fieldName];
+            } else {
+                nextMapping[fieldName] = fieldId;
+            }
+            setFieldMappingState(nextMapping);
+            onConfigChange?.({ dataAppVizUuid, fieldMapping: nextMapping });
+        },
+        [dataAppVizUuid, fieldMapping, onConfigChange],
+    );
+
+    return {
+        validConfig: { dataAppVizUuid, fieldMapping },
+        dataAppVizUuid,
+        fieldMapping,
+        setDataAppVizUuid,
+        setField,
+    };
+};
+
+export default useDataAppVizVisualizationConfig;

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -80,7 +80,12 @@ export type {
 } from './exportToSheets';
 
 // Data app viz render context (host-pushed rows + field mapping)
-export { useVizContext, getFormatted, getRaw } from './vizContext';
+export {
+    VizContextProvider,
+    useVizContext,
+    getFormatted,
+    getRaw,
+} from './vizContext';
 export type {
     VizContext,
     VizContextCell,

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -5,12 +5,23 @@
  * into the iframe. This module is the SDK primitive generated vizs use to
  * receive that context, so they never hand-roll a `window.addEventListener`.
  *
- * Handshake: the renderer can mount after the host's first push, so on mount
- * the hook posts a `viz-context-request` to the parent, which replies with the
- * current context. The host also re-pushes on every change. No timers.
+ * Delivery is a handshake: the receiver posts `viz-context-request` once its
+ * listener is mounted, and the host replies with the current context (and
+ * re-pushes on every change). `VizContextProvider` owns that handshake at the
+ * scaffold level — mounted above `<App/>`, its effect runs *after* the app's
+ * own effects (React fires child effects before parent effects), so the
+ * request is guaranteed to be sent after any listener the app registered. The
+ * host's reply therefore can't be missed. No timers, no races.
  */
 
-import { useEffect, useState } from 'react';
+import {
+    createContext,
+    createElement,
+    useContext,
+    useEffect,
+    useState,
+    type ReactNode,
+} from 'react';
 
 /** A single cell of a Lightdash result row: `{ value: { raw, formatted } }`. */
 export type VizContextCell = {
@@ -66,19 +77,28 @@ export type VizContext = {
     ready: boolean;
 };
 
+type VizContextState = {
+    fieldMapping: Record<string, string>;
+    rows: VizContextRow[];
+} | null;
+
+// Distinguishes "no provider mounted" from "provider present, no context yet".
+const NO_PROVIDER = Symbol('viz-context/no-provider');
+
+const VizContextContext = createContext<VizContextState | typeof NO_PROVIDER>(
+    NO_PROVIDER,
+);
+
 /**
- * Subscribe to the host's render context. Re-renders whenever the host pushes
- * (on load, on mapping change, on query change). Resolve a declared field to
- * its bound cell with `fieldMapping[name]` then `getFormatted`/`getRaw`.
+ * Registers the `message` listener and posts the `viz-context-request`
+ * handshake. `enabled` is false when a provider already owns the subscription,
+ * so `useVizContext` can obey the rules of hooks without a redundant listener.
  */
-export function useVizContext(): VizContext {
-    const [context, setContext] = useState<{
-        fieldMapping: Record<string, string>;
-        rows: VizContextRow[];
-    } | null>(null);
+function useVizContextSubscription(enabled: boolean): VizContextState {
+    const [context, setContext] = useState<VizContextState>(null);
 
     useEffect(() => {
-        if (typeof window === 'undefined') return undefined;
+        if (!enabled || typeof window === 'undefined') return undefined;
 
         const handleMessage = (event: MessageEvent) => {
             const data = event.data as DataAppVizContextMessage | undefined;
@@ -91,15 +111,53 @@ export function useVizContext(): VizContext {
 
         window.addEventListener('message', handleMessage);
 
-        // Ask the host to push the current context — the renderer may have
-        // mounted after the host's first push.
+        // Ask the host to push the current context. Sent from a mount effect —
+        // when this runs inside VizContextProvider (above <App/>), it fires
+        // after the app's own effects, so any listener the app set up is
+        // already live by the time the host replies.
         const request: VizContextRequestMessage = {
             type: VIZ_CONTEXT_REQUEST_MESSAGE,
         };
         window.parent?.postMessage(request, '*');
 
         return () => window.removeEventListener('message', handleMessage);
-    }, []);
+    }, [enabled]);
+
+    return context;
+}
+
+/**
+ * Owns the single listener + handshake for a data app viz. Mount it in the
+ * scaffold, wrapping `<App/>`, so generated renderers receive the host's
+ * context through `useVizContext()` without hand-rolling a message listener.
+ */
+export function VizContextProvider({ children }: { children: ReactNode }) {
+    const context = useVizContextSubscription(true);
+    return createElement(
+        VizContextContext.Provider,
+        { value: context },
+        children,
+    );
+}
+
+/**
+ * Subscribe to the host's render context. Reads from `VizContextProvider` when
+ * one is mounted (the scaffold default); otherwise self-subscribes so the hook
+ * still works standalone. Re-renders whenever the host pushes (on load, on
+ * mapping change, on query change). Resolve a declared field to its bound cell
+ * with `fieldMapping[name]` then `getFormatted`/`getRaw`.
+ */
+export function useVizContext(): VizContext {
+    const fromProvider = useContext(VizContextContext);
+    const hasProvider = fromProvider !== NO_PROVIDER;
+
+    // Always call the subscription hook (rules of hooks); it stays inert when a
+    // provider is present so we don't register a second listener or handshake.
+    const selfSubscribed = useVizContextSubscription(!hasProvider);
+
+    const context = hasProvider
+        ? (fromProvider as VizContextState)
+        : selfSubscribed;
 
     return {
         fieldMapping: context?.fieldMapping ?? {},

--- a/sandboxes/data-apps/template/src/main.jsx
+++ b/sandboxes/data-apps/template/src/main.jsx
@@ -3,7 +3,11 @@ import '@/lib/globalErrorHandler';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createClient, LightdashProvider } from '@lightdash/query-sdk';
+import {
+    createClient,
+    LightdashProvider,
+    VizContextProvider,
+} from '@lightdash/query-sdk';
 import { FilterProvider } from '@/lib/filters';
 import { ErrorBoundary } from '@/lib/ErrorBoundary';
 import App from './App';
@@ -30,7 +34,9 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <LightdashProvider client={lightdash}>
                 <FilterProvider>
                     <ErrorBoundary>
-                        <App />
+                        <VizContextProvider>
+                            <App />
+                        </VizContextProvider>
                     </ErrorBoundary>
                 </FilterProvider>
             </LightdashProvider>


### PR DESCRIPTION
Renders data app vizs both live in the Explorer and as persisted saved charts, closing the render loop for the data-app-viz chart type.

## Explorer (live)
Pick a data app viz (the chart-type entry is gated behind `EnableDataApps`), map query fields to its declared fields, and render it live against the current query results through the SDK bridge.

## Saved charts + dashboards
Saves a data app viz as a normal saved chart (`chart_type = data_app_viz`, `chartConfig = { dataAppVizUuid, fieldMapping }`) so it renders for free in chart view and dashboard tiles, each driven by its own surface's query.

## Reliable render context
The iframe adopts the render context via a mount-time handshake owned by scaffold code the model can't break: a `VizContextProvider` in `@lightdash/query-sdk` owns the message listener and posts a `viz-context-request` on mount. Because the provider is a direct ancestor of `App`, its mount effect fires after the app's own effects, so the request is always sent after any listener is registered and the host's reply can't be missed. No timers.

Closes: GLITCH-554
Closes: GLITCH-555