### PR TITLE
feat(charts): render saved data app viz charts (GLITCH-555)

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -32,37 +32,37 @@ Build a print-optimized report:
 - Prefer narrative copy with charts as supporting evidence, not a dense dashboard grid.`;
 
 const DATA_APP_VIZ_INSTRUCTIONS = `[Data app viz]
-You are building a reusable **data app viz**, NOT a multi-panel app, and NOT a normal data app. A data app viz is data-agnostic: the HOST owns the query and pushes the already-fetched rows + a field mapping into your iframe. You are ONLY the renderer. Both numbered deliverables below are MANDATORY.
+You are building ONE reusable chart component. You do NOT fetch data or run queries: Lightdash runs the query, then gives you the result rows plus a mapping from your field names to the columns in those rows. The same component is reused across many different queries, so never hardcode column names — just render whatever data you are handed.
 
-1. Render a SINGLE visualization (one chart) filling the available space. No dashboard, navigation, multiple panels, or page chrome.
+Three requirements, all mandatory:
 
-2. Do NOT run queries yourself (don't use the SDK's query hooks or \`client\`) and do NOT hardcode field/column names — you are ONLY the renderer. Receive the host's data through the SDK's viz-context hook — the scaffold already wires delivery, so NEVER add your own \`window.addEventListener('message', …)\`; just call \`useVizContext()\`:
+1. Build ONE chart visualization component whose job is to make the mapped data easy to read at a glance. Build the chart type the user asked for; only if they didn't specify one, pick what best fits the fields (bars to compare categories, a line for a trend over time, etc.). Either way, get the fundamentals right: clear axes and labels, readable spacing, and a tooltip on hover. This is a single reusable visualization, not an app: no dashboard, navigation, multiple panels, filters, or page chrome. Recharts, echarts, D3, or plain SVG all work.
+   Fill the viewport: give your root element \`height: 100vh\` (or \`position: fixed; inset: 0\`), NOT \`height: 100%\` — that collapses to a 0-height invisible box unless every ancestor also sets a height. This gives auto-sizing charts like recharts \`<ResponsiveContainer>\` a real height to measure. Confirm the chart actually renders and isn't a blank box.
+
+2. Get your data from the \`useVizContext()\` hook — do not add a message listener or fetch anything yourself:
 
    import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk';
 
    function Chart() {
      const { fieldMapping, rows, ready } = useVizContext();
-     // fieldMapping: { [yourFieldName]: queryFieldId }
-     // rows: host-fetched result rows, re-pushed on every query/mapping change.
-     if (!ready) return <Placeholder />; // no context has arrived yet
-     // ...map rows to your chart's shape (see below)
-   }
-
-   Resolve each declared field's query field id via \`fieldMapping[fieldName]\`, then read that field's cell from each row with the helpers — \`getFormatted(row, fieldId)\` for the display string, \`getRaw(row, fieldId)\` for the numeric/raw value:
-     const catField = fieldMapping['category'];
+     if (!ready) return <Placeholder />;            // data hasn't arrived yet
+     const catField = fieldMapping['category'];     // your field name -> column id
      const valField = fieldMapping['value'];
      const data = rows.map((row) => ({
-       label: getFormatted(row, catField),
-       value: Number(getRaw(row, valField) ?? 0),
+       label: getFormatted(row, catField),          // display text, e.g. "Completed"
+       value: Number(getRaw(row, valField) ?? 0),   // raw number
      }));
-   Render an empty/placeholder state while \`!ready\`, or when a field is unbound / rows are empty. Recharts, echarts, or plain SVG/HTML are all fine.
+     // ...render \`data\`
+   }
 
-3. Declare the field schema for your renderer — the typed inputs it reads from \`fieldMapping\`. It is collected as the run's structured output (do NOT write a file); the host uses it to build the field mapping UI, so the viz is unusable without it. For each field:
-   - \`name\` = the machine key your renderer reads from \`fieldMapping\` (unique, non-empty, no spaces) — must match the keys you used in step 2.
-   - \`label\` = human label shown in the field mapping UI.
-   - \`type\` = \`dimension\` (categorical/grouping), \`metric\` (numeric measure), or \`series\` (a dimension used to split/colour).
-   - \`required\` = false only when the viz can render without that field.
-   Declare exactly the fields your renderer reads — no more, no less. Example: a field "category" (type dimension, required) plus a field "value" (type metric, required).`;
+   Show a clearly visible placeholder (readable, good contrast — never near-white on white) while \`!ready\`, when a field is unmapped, or when there are no rows.
+
+3. Declare the fields your component reads. This is collected as structured output (do NOT write a file); Lightdash uses it to build the field-mapping UI, so the component is unusable without it. For each field:
+   - \`name\`: the key you read from \`fieldMapping\` (unique, no spaces) — must match what you used above.
+   - \`label\`: human label shown in the mapping UI.
+   - \`type\`: \`dimension\` (category/grouping), \`metric\` (number), or \`series\` (a dimension used to split/colour).
+   - \`required\`: false only if the chart still renders without it.
+   Declare exactly what you read — no more, no less. e.g. "category" (dimension, required) + "value" (metric, required).`;
 
 export const getTemplateInstructions = (
     template: DataAppTemplate,

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -36,7 +36,7 @@ You are building a reusable **data app viz**, NOT a multi-panel app, and NOT a n
 
 1. Render a SINGLE visualization (one chart) filling the available space. No dashboard, navigation, multiple panels, or page chrome.
 
-2. Do NOT run queries yourself (don't use the SDK's query hooks or \`client\`) and do NOT hardcode field/column names — you are ONLY the renderer. Receive the host's data through the SDK's viz-context hook (no raw \`window.addEventListener\`):
+2. Do NOT run queries yourself (don't use the SDK's query hooks or \`client\`) and do NOT hardcode field/column names — you are ONLY the renderer. Receive the host's data through the SDK's viz-context hook — the scaffold already wires delivery, so NEVER add your own \`window.addEventListener('message', …)\`; just call \`useVizContext()\`:
 
    import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk';
 

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -39,6 +39,12 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         hasSignaledScreenshotReady.current = true;
     }, [onScreenshotReady]);
 
+    // Fetch every page so the renderer gets all rows — surfaces that don't
+    // auto-fetch (dashboard tiles) would otherwise push a partial result.
+    useEffect(() => {
+        resultsData?.setFetchAll(true);
+    }, [resultsData]);
+
     const config = isDataAppVizVisualizationConfig(visualizationConfig)
         ? visualizationConfig.chartConfig.validConfig
         : undefined;

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -80,7 +80,12 @@ export type {
 } from './exportToSheets';
 
 // Data app viz render context (host-pushed rows + field mapping)
-export { useVizContext, getFormatted, getRaw } from './vizContext';
+export {
+    VizContextProvider,
+    useVizContext,
+    getFormatted,
+    getRaw,
+} from './vizContext';
 export type {
     VizContext,
     VizContextCell,

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -5,12 +5,23 @@
  * into the iframe. This module is the SDK primitive generated vizs use to
  * receive that context, so they never hand-roll a `window.addEventListener`.
  *
- * Handshake: the renderer can mount after the host's first push, so on mount
- * the hook posts a `viz-context-request` to the parent, which replies with the
- * current context. The host also re-pushes on every change. No timers.
+ * Delivery is a handshake: the receiver posts `viz-context-request` once its
+ * listener is mounted, and the host replies with the current context (and
+ * re-pushes on every change). `VizContextProvider` owns that handshake at the
+ * scaffold level — mounted above `<App/>`, its effect runs *after* the app's
+ * own effects (React fires child effects before parent effects), so the
+ * request is guaranteed to be sent after any listener the app registered. The
+ * host's reply therefore can't be missed. No timers, no races.
  */
 
-import { useEffect, useState } from 'react';
+import {
+    createContext,
+    createElement,
+    useContext,
+    useEffect,
+    useState,
+    type ReactNode,
+} from 'react';
 
 /** A single cell of a Lightdash result row: `{ value: { raw, formatted } }`. */
 export type VizContextCell = {
@@ -66,19 +77,28 @@ export type VizContext = {
     ready: boolean;
 };
 
+type VizContextState = {
+    fieldMapping: Record<string, string>;
+    rows: VizContextRow[];
+} | null;
+
+// Distinguishes "no provider mounted" from "provider present, no context yet".
+const NO_PROVIDER = Symbol('viz-context/no-provider');
+
+const VizContextContext = createContext<VizContextState | typeof NO_PROVIDER>(
+    NO_PROVIDER,
+);
+
 /**
- * Subscribe to the host's render context. Re-renders whenever the host pushes
- * (on load, on mapping change, on query change). Resolve a declared field to
- * its bound cell with `fieldMapping[name]` then `getFormatted`/`getRaw`.
+ * Registers the `message` listener and posts the `viz-context-request`
+ * handshake. `enabled` is false when a provider already owns the subscription,
+ * so `useVizContext` can obey the rules of hooks without a redundant listener.
  */
-export function useVizContext(): VizContext {
-    const [context, setContext] = useState<{
-        fieldMapping: Record<string, string>;
-        rows: VizContextRow[];
-    } | null>(null);
+function useVizContextSubscription(enabled: boolean): VizContextState {
+    const [context, setContext] = useState<VizContextState>(null);
 
     useEffect(() => {
-        if (typeof window === 'undefined') return undefined;
+        if (!enabled || typeof window === 'undefined') return undefined;
 
         const handleMessage = (event: MessageEvent) => {
             const data = event.data as DataAppVizContextMessage | undefined;
@@ -91,15 +111,53 @@ export function useVizContext(): VizContext {
 
         window.addEventListener('message', handleMessage);
 
-        // Ask the host to push the current context — the renderer may have
-        // mounted after the host's first push.
+        // Ask the host to push the current context. Sent from a mount effect —
+        // when this runs inside VizContextProvider (above <App/>), it fires
+        // after the app's own effects, so any listener the app set up is
+        // already live by the time the host replies.
         const request: VizContextRequestMessage = {
             type: VIZ_CONTEXT_REQUEST_MESSAGE,
         };
         window.parent?.postMessage(request, '*');
 
         return () => window.removeEventListener('message', handleMessage);
-    }, []);
+    }, [enabled]);
+
+    return context;
+}
+
+/**
+ * Owns the single listener + handshake for a data app viz. Mount it in the
+ * scaffold, wrapping `<App/>`, so generated renderers receive the host's
+ * context through `useVizContext()` without hand-rolling a message listener.
+ */
+export function VizContextProvider({ children }: { children: ReactNode }) {
+    const context = useVizContextSubscription(true);
+    return createElement(
+        VizContextContext.Provider,
+        { value: context },
+        children,
+    );
+}
+
+/**
+ * Subscribe to the host's render context. Reads from `VizContextProvider` when
+ * one is mounted (the scaffold default); otherwise self-subscribes so the hook
+ * still works standalone. Re-renders whenever the host pushes (on load, on
+ * mapping change, on query change). Resolve a declared field to its bound cell
+ * with `fieldMapping[name]` then `getFormatted`/`getRaw`.
+ */
+export function useVizContext(): VizContext {
+    const fromProvider = useContext(VizContextContext);
+    const hasProvider = fromProvider !== NO_PROVIDER;
+
+    // Always call the subscription hook (rules of hooks); it stays inert when a
+    // provider is present so we don't register a second listener or handshake.
+    const selfSubscribed = useVizContextSubscription(!hasProvider);
+
+    const context = hasProvider
+        ? (fromProvider as VizContextState)
+        : selfSubscribed;
 
     return {
         fieldMapping: context?.fieldMapping ?? {},

--- a/sandboxes/data-apps/template/src/main.jsx
+++ b/sandboxes/data-apps/template/src/main.jsx
@@ -3,7 +3,11 @@ import '@/lib/globalErrorHandler';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createClient, LightdashProvider } from '@lightdash/query-sdk';
+import {
+    createClient,
+    LightdashProvider,
+    VizContextProvider,
+} from '@lightdash/query-sdk';
 import { FilterProvider } from '@/lib/filters';
 import { ErrorBoundary } from '@/lib/ErrorBoundary';
 import App from './App';
@@ -30,7 +34,9 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <LightdashProvider client={lightdash}>
                 <FilterProvider>
                     <ErrorBoundary>
-                        <App />
+                        <VizContextProvider>
+                            <App />
+                        </VizContextProvider>
                     </ErrorBoundary>
                 </FilterProvider>
             </LightdashProvider>


### PR DESCRIPTION
Saves a data app viz as a normal saved chart (`chart_type = data_app_viz`, `chartConfig = { dataAppVizUuid, fieldMapping }`) so it renders for free in chart view and dashboard tiles, driven by each surface's own query. Re-pushes the render context on a short schedule so the iframe re-renders reliably.

Closes: GLITCH-555
