### PR TITLE
feat(ai-agents): add Claude Sonnet 5 model

### DIFF
--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -105,6 +105,18 @@ export const MODEL_PRESETS: {
     ],
     anthropic: [
         {
+            name: 'claude-sonnet-5',
+            provider: 'anthropic',
+            modelId: 'claude-sonnet-5',
+            displayName: 'Claude Sonnet 5',
+            description: 'Newest Sonnet model balancing speed and intelligence',
+            contextWindowTokens: 200000,
+            supportsReasoning: true,
+            reasoningStyle: 'adaptive',
+            callOptions: {},
+            providerOptions: undefined,
+        },
+        {
             name: 'claude-opus-4-7',
             provider: 'anthropic',
             modelId: 'claude-opus-4-7',


### PR DESCRIPTION
Adds `claude-sonnet-5` as a selectable Anthropic model for AI agents.

The new preset follows the adaptive-thinking pattern used by the newest Claude models (`reasoningStyle: 'adaptive'`, no `temperature` in `callOptions`), matching the `claude-opus-4-7` entry. Model options endpoints, the frontend selector, and env-var filtering all read from `MODEL_PRESETS`, so no other changes are needed for the model to appear.

Scoped to the first-party Anthropic provider only — no Bedrock entry, since that requires a versioned `anthropic.claude-sonnet-5-…-v1:0` model ID that isn't yet known.