### PR TITLE
fix(ai): stop truncating field descriptions in getMetadata tool

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
@@ -1,0 +1,110 @@
+import {
+    DimensionType,
+    FieldType,
+    SupportedDbtAdapter,
+    type Explore,
+} from '@lightdash/common';
+import { getGetMetadata } from './getMetadata';
+
+// A description that enumerates valid filter values, longer than the old 240
+// cap. This is the exact pattern that used to be silently cut off, leaving the
+// agent unable to see (and therefore filter on) the later values.
+const longDescription = `Allowed values: ${Array.from(
+    { length: 40 },
+    (_, i) => `'value_${i}'`,
+).join(', ')}.`;
+
+const makeExplore = (overrides: {
+    baseTableDescription?: string;
+    fieldDescription?: string;
+}): Explore => ({
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'sales',
+    label: 'Sales',
+    tags: [],
+    spotlight: { visibility: 'show', categories: [] },
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'test_db',
+            schema: 'public',
+            sqlTable: 'orders',
+            sqlWhere: undefined,
+            uncompiledSqlWhere: undefined,
+            description: overrides.baseTableDescription,
+            dimensions: {
+                status: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'status',
+                    label: 'Status',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.status',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.status',
+                    tablesReferences: ['orders'],
+                    description: overrides.fieldDescription,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+    },
+});
+
+type ExecuteResult = { result: string; metadata: { status: string } };
+
+const execute = async (
+    explore: Explore,
+    requests: Parameters<
+        NonNullable<ReturnType<typeof getGetMetadata>['execute']>
+    >[0]['requests'],
+): Promise<ExecuteResult> => {
+    const tool = getGetMetadata({ availableExplores: [explore] });
+    const result = await tool.execute!(
+        { requests },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+    );
+    return result as ExecuteResult;
+};
+
+describe('getMetadata description truncation', () => {
+    it('returns a long field description in full (above the old 240 cap)', async () => {
+        expect(longDescription.length).toBeGreaterThan(240);
+
+        const explore = makeExplore({ fieldDescription: longDescription });
+        const result = await execute(explore, [
+            {
+                type: 'field',
+                fields: [{ exploreId: 'sales', fieldId: 'orders_status' }],
+            },
+        ]);
+
+        expect(result.metadata).toEqual({ status: 'success' });
+        // The full enumerated list must be present — including the last value,
+        // which the old 240-char cap dropped.
+        expect(result.result).toContain(`description: ${longDescription}`);
+        expect(result.result).toContain("'value_39'");
+    });
+
+    it('keeps the explore-level summary terse (caps the base table description)', async () => {
+        const explore = makeExplore({ baseTableDescription: longDescription });
+        const result = await execute(explore, [
+            { type: 'explore', exploreIds: ['sales'] },
+        ]);
+
+        expect(result.metadata).toEqual({ status: 'success' });
+        const descriptionLine = result.result
+            .split('\n')
+            .find((line) => line.includes('description:'));
+        expect(descriptionLine).toBeDefined();
+        // Explore summaries stay compact: the description is capped at 240 chars.
+        expect(descriptionLine).not.toContain("'value_39'");
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.ts
@@ -21,6 +21,11 @@ const flatHint = (hint?: string | string[]): string =>
 const collapse = (text: string, max = 240): string =>
     text.replace(/\s+/g, ' ').trim().slice(0, max);
 
+// Field descriptions carry critical info (allowed values, units, semantics), so
+// they get a generous cap — a tight one silently truncates them and misleads the
+// agent. Safe here: this tool only renders the few fields explicitly requested.
+const FIELD_DESCRIPTION_MAX = 2000;
+
 const renderExplore = (explore: Explore): string => {
     const baseTable = explore.tables[explore.baseTable];
     const dimensionCount = Object.values(baseTable?.dimensions ?? {}).filter(
@@ -90,10 +95,12 @@ const renderField = (
         lines.push(`  case-sensitive filters: ${field.caseSensitive ?? true}`);
     }
     if (field.description) {
-        lines.push(`  description: ${collapse(field.description)}`);
+        lines.push(
+            `  description: ${collapse(field.description, FIELD_DESCRIPTION_MAX)}`,
+        );
     }
     const hint = flatHint(field.aiHint);
-    if (hint) lines.push(`  hint: ${collapse(hint)}`);
+    if (hint) lines.push(`  hint: ${collapse(hint, FIELD_DESCRIPTION_MAX)}`);
     return lines.join('\n');
 };
 


### PR DESCRIPTION
## Problem

The AI agent's `getMetadata` tool hard-truncated field descriptions to **240 characters**. When a field's description enumerates its valid filter values — a common pattern, e.g. a `metric_type` / `status` dimension whose description reads `Allowed values: 'alpha', 'beta', 'gamma', ... 'omega'` — the 240-char cap silently cut the list off partway through. The agent then never saw the later values and picked the wrong one when building a query, producing a wrong answer **with no error**.

## Why getMetadata is the right place to fix it

`getMetadata` is a **targeted deep-read tool**: it only renders the handful of fields/explores the agent explicitly asked about (typically after `grepFields`). It does no DB or warehouse access and has no flood risk, so a tight cap on the descriptions it returns is the wrong tradeoff — those descriptions are exactly where the critical information lives (allowed values, units, semantics).

## The fix

- Give field descriptions (and field hints) a generous `FIELD_DESCRIPTION_MAX = 2000` cap instead of the default 240.
- Keep the explore-level summary (`renderExplore`) at the default 240-char cap so listing many explores stays compact.

`grepFields` is **intentionally left** at its tight 140/160-char caps: it is the discovery/ranking tool that can return up to 40 fields per pattern, so terse output is correct there. This change does not touch it.

## Test coverage

Adds `getMetadata.test.ts`:
- A long field description (longer than the old 240 cap, including a final enumerated value) is returned **in full** from a field deep-read.
- The explore-level base-table description stays **capped** (terse summary).

## Commands run

- `pnpm -F backend exec vitest run src/ee/services/ai/tools/getMetadata.test.ts` — 2 passed
- `pnpm -F backend typecheck:fast` — passed
- `pnpm -F backend lint` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)