### PR TITLE
fix(ai): time out searchFieldValues + cap agent results so slow lookups don't hang the turn

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -393,6 +393,43 @@ describe('AiAgentToolsService', () => {
         },
     });
 
+    it('searches agent field values with a capped limit and passes the query through', async () => {
+        const searchFieldUniqueValues = vi
+            .fn()
+            .mockResolvedValue({ results: ['shipped', 'pending'] });
+        const service = makeService({
+            explores: {
+                orders: makeExplore({
+                    name: 'orders',
+                    dimensions: {
+                        status: {
+                            name: 'status',
+                            table: 'orders',
+                            type: 'string',
+                        },
+                    },
+                }),
+            },
+            searchFieldUniqueValues,
+        });
+        const runtime = service.createRuntime(makeRuntimeContext());
+
+        const results = await runtime.searchFieldValues({
+            table: 'orders',
+            fieldId: 'orders_status',
+            query: 'shi',
+        });
+
+        expect(results).toEqual(['shipped', 'pending']);
+        expect(searchFieldUniqueValues).toHaveBeenCalledTimes(1);
+        const callArgs = searchFieldUniqueValues.mock.calls[0];
+        // 5th positional arg is the search term, 6th is the limit. The agent
+        // caps results to 50 (parity with the app's filter autocomplete) rather
+        // than the previous 100.
+        expect(callArgs[4]).toBe('shi');
+        expect(callArgs[5]).toBe(50);
+    });
+
     it('does not search MCP field values when the field is outside the scoped explore', async () => {
         const searchFieldUniqueValues = vi.fn();
         const service = makeService({

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -111,6 +111,12 @@ const CONTENT_AS_CODE_TYPE_LABELS = {
     chart: 'Chart',
 } as const satisfies Record<ContentAsCodeType, string>;
 
+// Max distinct field values returned to the agent per search. Kept in line with
+// the app's filter autocomplete (`MAX_AUTOCOMPLETE_RESULTS = 50`): the agent
+// only needs a representative sample to build filters, and a smaller cap means
+// less to sort/transfer warehouse-side and fewer tokens for the model to read.
+const AI_FIELD_VALUE_SEARCH_LIMIT = 50;
+
 export type AiAgentToolsSource = 'ai_agent' | 'mcp';
 
 export type AiAgentToolsRuntimeContext = {
@@ -1734,7 +1740,7 @@ export class AiAgentToolsService extends BaseService {
                         args.table,
                         args.fieldId,
                         args.query,
-                        100,
+                        AI_FIELD_VALUE_SEARCH_LIMIT,
                         andFilters,
                         false,
                         undefined,

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -4290,7 +4290,7 @@ Usage Tips:
 - Specify the table and field you want to search values for
 - Query parameter: use it to narrow down the search to matching values
 - Optionally add filters to further restrict the results
-- Results are returned as a list of unique field values (limited to 100)
+- Results are returned as a list of unique field values (limited to 50). Use the query parameter to find values beyond this cap.
 ",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -6190,7 +6190,7 @@ Usage Tips:
 - Specify the table and field you want to search values for
 - Query parameter: use it to narrow down the search to matching values
 - Optionally add filters to further restrict the results
-- Results are returned as a list of unique field values (limited to 100)
+- Results are returned as a list of unique field values (limited to 50). Use the query parameter to find values beyond this cap.
 ",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/backend/src/ee/services/ai/tools/searchFieldValues.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/searchFieldValues.test.ts
@@ -1,0 +1,92 @@
+import type { SearchFieldValuesFn } from '../types/aiAgentDependencies';
+import {
+    getSearchFieldValues,
+    SEARCH_FIELD_VALUES_TIMEOUT_MS,
+} from './searchFieldValues';
+
+type ExecuteResult = { result: string; metadata: { status: string } };
+
+const baseArgs = {
+    table: 'orders',
+    fieldId: 'orders_status',
+    query: 'shipped',
+    filters: null,
+};
+
+const execute = async (
+    searchFieldValues: SearchFieldValuesFn,
+    args: Record<string, unknown> = baseArgs,
+): Promise<ExecuteResult> => {
+    const tool = getSearchFieldValues({ searchFieldValues });
+    const result = await tool.execute!(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        args as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+    );
+    return result as ExecuteResult;
+};
+
+describe('searchFieldValues tool', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('returns a success result for a normal query', async () => {
+        const searchFieldValues = vi
+            .fn<SearchFieldValuesFn>()
+            .mockResolvedValue(['shipped', 'pending']);
+
+        const result = await execute(searchFieldValues);
+
+        expect(result.metadata).toEqual({ status: 'success' });
+        expect(result.result).toContain('shipped');
+        expect(searchFieldValues).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes an empty/null query through to the dependency (does not reject it)', async () => {
+        // A blank query is a legitimate "list all distinct values" request and
+        // must keep working — it is not failed fast.
+        const searchFieldValues = vi
+            .fn<SearchFieldValuesFn>()
+            .mockResolvedValue(['shipped', 'pending', 'cancelled']);
+
+        const result = await execute(searchFieldValues, {
+            ...baseArgs,
+            query: null,
+        });
+
+        expect(result.metadata).toEqual({ status: 'success' });
+        expect(searchFieldValues).toHaveBeenCalledTimes(1);
+        // The schema coerces a null query to an empty string.
+        expect(searchFieldValues).toHaveBeenCalledWith(
+            expect.objectContaining({ query: '' }),
+        );
+    });
+
+    it('returns an error within the timeout when the search never resolves', async () => {
+        vi.useFakeTimers();
+
+        // A dependency that never settles — the bug being guarded against.
+        const searchFieldValues = vi
+            .fn<SearchFieldValuesFn>()
+            .mockImplementation(() => new Promise<string[]>(() => {}));
+
+        const tool = getSearchFieldValues({ searchFieldValues });
+        const resultPromise = tool.execute!(
+            baseArgs,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            {} as any,
+        ) as Promise<ExecuteResult>;
+
+        // Advance past the timeout budget so the race rejects.
+        await vi.advanceTimersByTimeAsync(SEARCH_FIELD_VALUES_TIMEOUT_MS + 1);
+
+        const result = await resultPromise;
+
+        expect(result.metadata).toEqual({ status: 'error' });
+        expect(result.result).toContain('timed out');
+        expect(searchFieldValues).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/searchFieldValues.ts
+++ b/packages/backend/src/ee/services/ai/tools/searchFieldValues.ts
@@ -1,5 +1,6 @@
 import {
     searchFieldValuesToolDefinition,
+    TimeoutError,
     toolSearchFieldValuesArgsSchemaTransformed,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -14,6 +15,34 @@ type Dependencies = {
 
 const toolDefinition = searchFieldValuesToolDefinition.for('agent');
 
+// Upper bound for a single field-values search. On high-cardinality fields the
+// warehouse search can take minutes; chained slow calls bleed past the
+// stream/connection timeout and surface to the user as a network error while
+// the backend keeps working. Fail fast with a usable error instead.
+export const SEARCH_FIELD_VALUES_TIMEOUT_MS = 15_000;
+
+// Races a promise against a timeout. NOTE: this only stops *waiting* on the
+// underlying call — a warehouse query started by `searchFieldValues` keeps
+// running server-side. That is acceptable here: the goal is to unblock the
+// agent turn, not to cancel the query.
+const withTimeout = <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+    let timer: NodeJS.Timeout;
+    return Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+            timer = setTimeout(
+                () =>
+                    reject(
+                        new TimeoutError(
+                            `Search for field values timed out after ${timeoutMs}ms. Retry with a more specific (non-empty) query to narrow the results, or add filters.`,
+                        ),
+                    ),
+                timeoutMs,
+            );
+        }),
+    ]).finally(() => clearTimeout(timer));
+};
+
 export const getSearchFieldValues = ({ searchFieldValues }: Dependencies) =>
     tool({
         ...toolDefinition,
@@ -22,7 +51,10 @@ export const getSearchFieldValues = ({ searchFieldValues }: Dependencies) =>
                 const args =
                     toolSearchFieldValuesArgsSchemaTransformed.parse(toolArgs);
 
-                const results = await searchFieldValues(args);
+                const results = await withTimeout(
+                    searchFieldValues(args),
+                    SEARCH_FIELD_VALUES_TIMEOUT_MS,
+                );
 
                 return {
                     result: serializeData(results, 'json'),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
@@ -13,7 +13,7 @@ Usage Tips:
 - Specify the table and field you want to search values for
 - Query parameter: use it to narrow down the search to matching values
 - Optionally add filters to further restrict the results
-- Results are returned as a list of unique field values (limited to 100)
+- Results are returned as a list of unique field values (limited to 50). Use the query parameter to find values beyond this cap.
 `;
 
 export const toolSearchFieldValuesArgsSchema = createToolSchema()


### PR DESCRIPTION
## Summary

Two changes to the AI agent's `searchFieldValues` tool, prompted by live evidence of value lookups taking ~47s–3.5min (and one ~135s lookup on a *low*-cardinality dimension):

1. **Safety net — 15s timeout** so a slow/never-settling search can no longer hang the agent turn or bleed past the stream/connection timeout into a user-facing network error.
2. **Perf — cap agent results at 50** (down from 100), matching the app's own filter autocomplete (`MAX_AUTOCOMPLETE_RESULTS = 50`).

## Investigation (what's actually slow)

I traced the tool's `SearchFieldValuesFn` dependency:
`AiAgentToolsService.searchFieldValues` → `ProjectService.searchFieldUniqueValues` → `getFieldValuesMetricQuery` (`fieldValuesQueryBuilder.ts`).

Findings:
- **The AI tool does NOT bypass a cached/optimized path — it uses the *exact same* method the app's filter autocomplete uses** (`projectRouter` `POST /field/:fieldId/search` → `searchFieldUniqueValues`).
- That path already does the things you'd reach for first:
  - **pushes the search term down** into the warehouse query as an `INCLUDE`/ILIKE filter (`getFieldValuesMetricQuery` builds it), plus a `NOT_NULL` filter;
  - applies a **LIMIT** and an `ORDER BY` on the dimension;
  - reads/writes an **S3 "autocomplete" cache** keyed by the compiled query.
- **Cache caveat:** in Cloud the cache is enabled by default (`AUTOCOMPLETE_CACHE_ENABLED: "true"` in the Helm defaults), but the key includes the compiled query (search term) and user, so the agent's varied / empty-enumeration / first-time lookups **miss** the cache and land a cold query. (In OSS the cache is off unless `AUTOCOMPLETE_CACHE_ENABLED=true`.)
- **Root cause of the slowness:** the cold query runs the *explore's underlying SQL* (which can be an expensive multi-join report model) and `GROUP BY`s the column for distinct values. The ILIKE/LIMIT narrow the **output** but not that **scan**, so even a low-cardinality dimension is slow when its explore SQL is expensive.

**Conclusion:** the "reuse the cached path" and "push the search term down" options were already implemented. The remaining cost is the explore-SQL scan, which can't be fixed by a small query rewrite without correctness/warehouse-specific risk (see Follow-ups). So this PR ships the timeout safety net plus the one safe, app-consistent win (tighter limit), and documents the larger options rather than building them.

## Changes

- `packages/backend/src/ee/services/ai/tools/searchFieldValues.ts` — wrap the dependency call in a **15s timeout** (`Promise.race` + `TimeoutError`, mirroring the scheduler's existing `SchedulerJobTimeout.ts` pattern; no reusable helper existed). On timeout, return a `status: 'error'` result telling the model to retry with a more specific (non-empty) query. A null/empty query stays valid (lists all values) and is not special-cased.
- `packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts` — new `AI_FIELD_VALUE_SEARCH_LIMIT = 50` constant; the agent now requests 50 distinct values instead of 100 (parity with the app's `MAX_AUTOCOMPLETE_RESULTS`). Less to sort/transfer warehouse-side and fewer tokens for the model.
- `packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts` — update the tool description ("limited to 50") + agent/MCP contract snapshots accordingly.

## Limitation

The timeout only stops *waiting* on the call — the warehouse query started by `searchFieldValues` keeps running server-side. Cancelling it is out of scope here; the goal is to unblock the agent turn.

## Follow-ups (proposed, not in this PR)

- **Precompute / materialize distinct values** for AI-eligible dimensions (or a dedicated low-cardinality value cache not keyed per search term), so enumerations don't re-scan the explore SQL. This is the real fix for the cold-query cost but is a larger build.
- Consider a **search-term-agnostic cache** for the empty-query "list all values" case, which is the agent's most common and most expensive pattern.

## Tests (vitest)

- `searchFieldValues.test.ts` (new): normal query → `success`; null/empty query → still passed through to the dependency (not rejected) → `success`; a never-resolving dependency → `status: 'error'` within the timeout (fake timers), no hang.
- `AiAgentToolsService.test.ts`: added a case asserting the agent path passes the search term through and caps the limit at **50**.

### Commands run (all pass)
- `pnpm -F backend exec vitest run src/ee/services/ai/tools/searchFieldValues.test.ts src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts` — 25 passed
- `pnpm -F backend exec vitest run -u src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts` — snapshots updated, 3299 passed / 1 skipped
- `pnpm -F backend run linter <touched backend files>` — clean
- `pnpm -F backend typecheck:fast` — clean
- `pnpm -F common` typecheck (`tsc --project tsconfig.json --noEmit`) — clean

No customer/production data anywhere — synthetic names only (`orders`, `status`, `shipped`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
