### PR TITLE
feat(ai-writeback): target the right dbt source when a project has several

### DIFF
--- a/packages/backend/src/ee/controllers/AiWritebackController.ts
+++ b/packages/backend/src/ee/controllers/AiWritebackController.ts
@@ -41,9 +41,11 @@ import { AiWritebackService } from '../services/AiWritebackService/AiWritebackSe
 import { PreviewDeploySetupService } from '../services/PreviewDeploySetupService/PreviewDeploySetupService';
 
 // The target repo (owner/repo) and dbt sub-folder are resolved server-side from
-// the project's dbt connection, so the body only carries the prompt.
+// the chosen dbt source. `dbtSourceUuid` selects it when the project has more
+// than one; omit it to target the primary or let the run infer/ask.
 const aiWritebackBodySchema = z.object({
     prompt: z.string().trim().min(1, 'prompt is required'),
+    dbtSourceUuid: z.string().trim().uuid().optional(),
 });
 
 const mergePullRequestBodySchema = z.object({
@@ -88,12 +90,13 @@ export class AiWritebackController extends BaseController {
                 parsed.error.errors[0]?.message ?? 'Invalid request parameters',
             );
         }
-        const { prompt } = parsed.data;
+        const { prompt, dbtSourceUuid } = parsed.data;
         this.setStatus(200);
         const result = await this.getAiWritebackService().run({
             user: toSessionUser(req.account),
             projectUuid,
             prompt,
+            dbtSourceUuid,
             source: 'api',
         });
         return {

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -118,6 +118,14 @@ export type DbAiWritebackThread = {
      */
     sandbox_uuid: string | null;
     pull_request_uuid: string | null;
+    /**
+     * The dbt source this thread (and its single PR) is bound to: a
+     * `project_dbt_sources` row uuid for an additional source, or null for the
+     * project's primary dbt connection. Every resumed turn re-resolves to this
+     * source so the thread keeps editing the same repo. FK is ON DELETE SET
+     * NULL — deleting the source degrades a resume back to the primary.
+     */
+    project_dbt_source_uuid: string | null;
     created_at: Date;
 };
 
@@ -126,7 +134,8 @@ export type AiWritebackThreadTable = Knex.CompositeTableType<
     Pick<
         DbAiWritebackThread,
         'ai_thread_uuid' | 'sandbox_uuid' | 'pull_request_uuid'
-    >,
+    > &
+        Partial<Pick<DbAiWritebackThread, 'project_dbt_source_uuid'>>,
     Pick<DbAiWritebackThread, 'sandbox_uuid' | 'pull_request_uuid'>
 >;
 

--- a/packages/backend/src/ee/database/migrations/20260630170000_add_dbt_source_to_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260630170000_add_dbt_source_to_ai_writeback_thread.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+const AiWritebackThreadTableName = 'ai_writeback_thread';
+const ProjectDbtSourcesTableName = 'project_dbt_sources';
+const ColumnName = 'project_dbt_source_uuid';
+
+// Bind a writeback thread to the dbt source it targets so every resumed turn
+// edits the same repo (one thread, one PR). Null means the project's primary
+// dbt connection; a row uuid means an additional source. ON DELETE SET NULL so
+// deleting a source degrades a resume back to the primary rather than orphaning
+// the thread.
+export async function up(knex: Knex): Promise<void> {
+    const hasColumn = await knex.schema.hasColumn(
+        AiWritebackThreadTableName,
+        ColumnName,
+    );
+    if (!hasColumn) {
+        await knex.schema.alterTable(AiWritebackThreadTableName, (table) => {
+            table
+                .uuid(ColumnName)
+                .nullable()
+                .references('project_dbt_source_uuid')
+                .inTable(ProjectDbtSourcesTableName)
+                .onDelete('SET NULL');
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    const hasColumn = await knex.schema.hasColumn(
+        AiWritebackThreadTableName,
+        ColumnName,
+    );
+    if (hasColumn) {
+        await knex.schema.alterTable(AiWritebackThreadTableName, (table) => {
+            table.dropColumn(ColumnName);
+        });
+    }
+}

--- a/packages/backend/src/ee/database/migrations/20260630170000_add_dbt_source_to_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260630170000_add_dbt_source_to_ai_writeback_thread.ts
@@ -26,14 +26,8 @@ export async function up(knex: Knex): Promise<void> {
     }
 }
 
-export async function down(knex: Knex): Promise<void> {
-    const hasColumn = await knex.schema.hasColumn(
-        AiWritebackThreadTableName,
-        ColumnName,
-    );
-    if (hasColumn) {
-        await knex.schema.alterTable(AiWritebackThreadTableName, (table) => {
-            table.dropColumn(ColumnName);
-        });
-    }
+export async function down(_knex: Knex): Promise<void> {
+    // Intentionally a no-op. Dropping a column is a destructive operation that
+    // can lose data (the thread→source bindings) and break a running old pod
+    // mid-rollback, so per the migration rules the column is left in place.
 }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -128,6 +128,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig: context.lightdashConfig,
                     analytics: context.lightdashAnalytics,
                     projectModel: models.getProjectModel(),
+                    projectDbtSourcesModel: models.getProjectDbtSourcesModel(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     githubAppInstallationsModel:
                         models.getGithubAppInstallationsModel(),

--- a/packages/backend/src/ee/models/AiWritebackThreadModel.ts
+++ b/packages/backend/src/ee/models/AiWritebackThreadModel.ts
@@ -58,6 +58,9 @@ export class AiWritebackThreadModel {
         aiThreadUuid: string;
         sandboxUuid: string;
         pullRequestUuid: string;
+        // The dbt source this thread targets — null for the project's primary
+        // dbt connection. Binds the thread to one repo across resumes.
+        projectDbtSourceUuid: string | null;
     }): Promise<DbAiWritebackThread> {
         const [row] = await this.database<AiWritebackThreadTable>(
             AiWritebackThreadTableName,
@@ -66,6 +69,7 @@ export class AiWritebackThreadModel {
                 ai_thread_uuid: data.aiThreadUuid,
                 sandbox_uuid: data.sandboxUuid,
                 pull_request_uuid: data.pullRequestUuid,
+                project_dbt_source_uuid: data.projectDbtSourceUuid,
             })
             .returning('*');
         return row;

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -6,6 +6,7 @@ import {
     FeatureFlags,
     ForbiddenError,
     getLatestSupportDbtVersion,
+    ParameterError,
     PullRequestProvider,
     RequestMethod,
     SupportedDbtVersions,
@@ -87,6 +88,11 @@ const buildService = (overrides: Record<string, AnyType> = {}) =>
         lightdashConfig: { gitlab: {} } as AnyType,
         analytics: { track: vi.fn() } as AnyType,
         projectModel: { get: vi.fn() } as AnyType,
+        // Default: no additional dbt sources, so the single-source (primary)
+        // path is taken unless a test overrides this.
+        projectDbtSourcesModel: {
+            getSources: vi.fn().mockResolvedValue([]),
+        } as AnyType,
         featureFlagModel: { get: vi.fn() } as AnyType,
         githubAppInstallationsModel: {} as AnyType,
         githubAppService: {
@@ -340,12 +346,22 @@ describe('AiWritebackService.prepareTurn', () => {
         warehouseConnection: { type: WarehouseTypes.POSTGRES },
     });
 
-    const prepareTurn = (service: AiWritebackService, user: SessionUser) =>
-        (service as AnyType).prepareTurn({
+    // prepareTurn now returns a discriminated union ({ kind: 'run', turn } |
+    // { kind: 'select', ... }); unwrap the turn so these single-source tests keep
+    // asserting on the turn context directly. Rejections still propagate.
+    const prepareTurn = async (
+        service: AiWritebackService,
+        user: SessionUser,
+    ) => {
+        const prepared = await (service as AnyType).prepareTurn({
             user,
             projectUuid: 'p1',
+            prompt: 'add a revenue metric',
             aiThreadUuid: undefined,
+            dbtSourceUuid: undefined,
         });
+        return prepared.kind === 'run' ? prepared.turn : prepared;
+    };
 
     it('rejects when the AI writeback feature flag is disabled', async () => {
         const service = buildService({
@@ -471,6 +487,203 @@ describe('AiWritebackService.prepareTurn', () => {
                 hostDomain: 'gitlab.acme.com',
             },
         });
+    });
+});
+
+describe('AiWritebackService dbt source targeting', () => {
+    const PRIMARY_CONNECTION = {
+        type: DbtProjectType.GITHUB,
+        authorization_method: 'installation_id',
+        repository: 'acme/analytics',
+        branch: 'main',
+        project_sub_path: '/',
+    };
+    const project = (): AnyType => ({
+        projectUuid: 'p1',
+        dbtConnection: PRIMARY_CONNECTION,
+    });
+    // An additional (non-primary) GitHub dbt source pointing at a different repo.
+    const marketingSource = (): AnyType => ({
+        projectDbtSourceUuid: 'src-marketing',
+        projectUuid: 'p1',
+        name: 'Marketing dbt',
+        isPrimary: false,
+        precedence: 1,
+        dbtConnection: {
+            type: DbtProjectType.GITHUB,
+            authorization_method: 'installation_id',
+            repository: 'acme/marketing',
+            branch: 'main',
+            project_sub_path: '/',
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const serviceWithSources = (sources: AnyType[]) =>
+        buildService({
+            projectDbtSourcesModel: {
+                getSources: vi.fn().mockResolvedValue(sources),
+            } as AnyType,
+        });
+
+    const resolve = (
+        service: AiWritebackService,
+        args: {
+            prompt?: string;
+            dbtSourceUuid?: string;
+            existingRow?: AnyType;
+        },
+    ) =>
+        (service as AnyType).resolveDbtTarget({
+            projectUuid: 'p1',
+            project: project(),
+            prompt: args.prompt ?? '',
+            dbtSourceUuid: args.dbtSourceUuid,
+            existingRow: args.existingRow ?? null,
+        });
+
+    it('targets the primary connection when the project has no additional sources', async () => {
+        const result = await resolve(serviceWithSources([]), {
+            prompt: 'add a revenue metric',
+        });
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: null, isPrimary: true, optionUuid: 'p1' },
+        });
+    });
+
+    it('honours an explicit additional dbtSourceUuid', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            dbtSourceUuid: 'src-marketing',
+        });
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: {
+                sourceUuid: 'src-marketing',
+                isPrimary: false,
+                connection: { repository: 'acme/marketing' },
+            },
+        });
+    });
+
+    it('treats the project uuid as an explicit choice of the primary source', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            dbtSourceUuid: 'p1',
+        });
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: null, isPrimary: true },
+        });
+    });
+
+    it('rejects an explicit dbtSourceUuid that is not a target', async () => {
+        await expect(
+            resolve(serviceWithSources([marketingSource()]), {
+                dbtSourceUuid: 'does-not-exist',
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('infers the source from the prompt when exactly one matches', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            prompt: 'add a spend metric to the marketing models',
+        });
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: 'src-marketing' },
+        });
+    });
+
+    it('asks the caller to choose when the prompt names no source', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            prompt: 'add a new metric',
+        });
+        expect(result.kind).toBe('select');
+        expect(result.options).toHaveLength(2);
+        expect(result.options).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    projectDbtSourceUuid: 'p1',
+                    isPrimary: true,
+                }),
+                expect.objectContaining({
+                    projectDbtSourceUuid: 'src-marketing',
+                    repository: 'acme/marketing',
+                }),
+            ]),
+        );
+    });
+
+    it('keeps a resumed thread bound to its original source, ignoring the prompt', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            // The prompt names the primary repo, but the thread is bound to the
+            // additional source — binding wins so the resumed sandbox stays put.
+            prompt: 'change something in analytics',
+            existingRow: { project_dbt_source_uuid: 'src-marketing' },
+        });
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: 'src-marketing' },
+        });
+    });
+
+    it('falls back to the primary when a resumed thread`s bound source was deleted', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            existingRow: { project_dbt_source_uuid: 'deleted-source' },
+        });
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: null, isPrimary: true },
+        });
+    });
+
+    it('run() returns a selection request without starting a sandbox', async () => {
+        const service = buildService({
+            featureFlagModel: {
+                get: vi.fn().mockResolvedValue({ enabled: true }),
+            } as AnyType,
+            projectModel: {
+                get: vi.fn().mockResolvedValue({
+                    projectUuid: 'p1',
+                    organizationUuid: ORG,
+                    name: 'Analytics',
+                    dbtConnection: PRIMARY_CONNECTION,
+                    warehouseConnection: null,
+                    dbtVersion: SupportedDbtVersions.V1_9,
+                }),
+            } as AnyType,
+            projectDbtSourcesModel: {
+                getSources: vi.fn().mockResolvedValue([marketingSource()]),
+            } as AnyType,
+            aiWritebackThreadModel: {
+                findByAiThreadUuid: vi.fn().mockResolvedValue(null),
+            } as AnyType,
+        });
+        const { build, can } = new AbilityBuilder<MemberAbility>(Ability);
+        can('manage', 'SourceCode', { organizationUuid: ORG });
+        const user = {
+            userUuid: 'u1',
+            organizationUuid: ORG,
+            organizationName: 'Acme',
+            organizationCreatedAt: new Date(),
+            role: 'admin',
+            ability: build(),
+        } as AnyType;
+
+        const result = await service.run({
+            user,
+            projectUuid: 'p1',
+            prompt: 'add a new metric',
+            source: 'api',
+        });
+
+        expect(result.needsDbtSourceSelection).toBe(true);
+        expect(result.prUrl).toBeNull();
+        expect(result.dbtSourceUuid).toBeNull();
+        expect(result.dbtSourceOptions).toHaveLength(2);
+        // No sandbox manager is ever constructed on the selection path.
+        expect(createSandboxManager).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -596,6 +596,59 @@ describe('AiWritebackService dbt source targeting', () => {
         });
     });
 
+    it('prefers the most specific source when names share a prefix', async () => {
+        // Primary `jaffle` is a substring of the additional `jaffle-2`, so naive
+        // substring matching would flag both and ask. The longest-match rule
+        // resolves "jaffle-2" to jaffle-2 and bare "jaffle" to the primary.
+        const jaffle2 = {
+            projectDbtSourceUuid: 'src-j2',
+            projectUuid: 'p1',
+            name: 'jaffle-2',
+            isPrimary: false,
+            precedence: 1,
+            dbtConnection: {
+                type: DbtProjectType.GITHUB,
+                authorization_method: 'installation_id',
+                repository: 'charliedowler/jaffle-2',
+                branch: 'main',
+                project_sub_path: '/dbt',
+            },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+        const service = serviceWithSources([jaffle2]);
+        const primaryJaffle = {
+            projectUuid: 'p1',
+            dbtConnection: {
+                type: DbtProjectType.GITHUB,
+                authorization_method: 'installation_id',
+                repository: 'charliedowler/jaffle',
+                branch: 'main',
+                project_sub_path: '/dbt',
+            },
+        };
+        const resolvePrompt = (prompt: string) =>
+            (service as AnyType).resolveDbtTarget({
+                projectUuid: 'p1',
+                project: primaryJaffle,
+                prompt,
+                dbtSourceUuid: undefined,
+                existingRow: null,
+            });
+        await expect(
+            resolvePrompt('In jaffle-2, add a total_revenue metric to orders'),
+        ).resolves.toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: 'src-j2' },
+        });
+        await expect(
+            resolvePrompt('add a metric in the jaffle repo'),
+        ).resolves.toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: null, isPrimary: true },
+        });
+    });
+
     it('asks the caller to choose when the prompt names no source', async () => {
         const result = await resolve(serviceWithSources([marketingSource()]), {
             prompt: 'add a new metric',

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -37,6 +37,7 @@ import {
     PR_TITLE_CLOSE,
     PR_TITLE_OPEN,
 } from './constants';
+import { WritebackGitNotConnectedError } from './errors';
 
 // Stub e2b and the GitHub/octokit client so the run() tests drive fakes and the
 // unit tests below never reach the real SDKs.
@@ -636,6 +637,42 @@ describe('AiWritebackService dbt source targeting', () => {
             kind: 'resolved',
             candidate: { sourceUuid: null, isPrimary: true },
         });
+    });
+
+    it('drops a non-git primary but still targets git-backed additional sources', async () => {
+        const service = serviceWithSources([marketingSource()]);
+        const result = await (service as AnyType).resolveDbtTarget({
+            projectUuid: 'p1',
+            // Local (non-git) primary — cannot be a writeback target.
+            project: {
+                projectUuid: 'p1',
+                dbtConnection: { type: DbtProjectType.DBT },
+            },
+            prompt: 'add a metric',
+            dbtSourceUuid: undefined,
+            existingRow: null,
+        });
+        // Only the git-backed additional source remains, so it's the sole target.
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: 'src-marketing', isPrimary: false },
+        });
+    });
+
+    it('rejects when no git-backed source exists at all', async () => {
+        const service = serviceWithSources([]);
+        await expect(
+            (service as AnyType).resolveDbtTarget({
+                projectUuid: 'p1',
+                project: {
+                    projectUuid: 'p1',
+                    dbtConnection: { type: DbtProjectType.DBT },
+                },
+                prompt: 'add a metric',
+                dbtSourceUuid: undefined,
+                existingRow: null,
+            }),
+        ).rejects.toThrow(WritebackGitNotConnectedError);
     });
 
     it('run() returns a selection request without starting a sandbox', async () => {

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -692,6 +692,28 @@ describe('AiWritebackService dbt source targeting', () => {
         });
     });
 
+    it('falls back to the first git source (not by stale array order) when the bound source is deleted and the primary is non-git', async () => {
+        // Graphite-flagged scenario: with a non-git primary the primary is not a
+        // candidate, so `candidates[0]` is the first *additional* source, not the
+        // primary. When the bound source has been deleted there is no primary to
+        // return; degrade deterministically to the first git-backed source.
+        const service = serviceWithSources([marketingSource()]);
+        const result = await (service as AnyType).resolveDbtTarget({
+            projectUuid: 'p1',
+            project: {
+                projectUuid: 'p1',
+                dbtConnection: { type: DbtProjectType.DBT },
+            },
+            prompt: 'change something',
+            dbtSourceUuid: undefined,
+            existingRow: { project_dbt_source_uuid: 'deleted-src' },
+        });
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: 'src-marketing', isPrimary: false },
+        });
+    });
+
     it('drops a non-git primary but still targets git-backed additional sources', async () => {
         const service = serviceWithSources([marketingSource()]);
         const result = await (service as AnyType).resolveDbtTarget({

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1824,11 +1824,25 @@ export class AiWritebackService extends BaseService {
             return { kind: 'resolved', candidate: candidates[0] };
         }
 
-        const matches = candidates.filter((c) =>
-            AiWritebackService.promptTargetsDbtSource(prompt, c),
-        );
-        if (matches.length === 1) {
-            return { kind: 'resolved', candidate: matches[0] };
+        // Score each candidate by how specifically the prompt names it (the
+        // length of the longest identifier of it found in the prompt), then take
+        // the single best. Scoring by length — not just "matched at all" — is
+        // what disambiguates prefix-related names: a prompt saying "jaffle-2"
+        // matches both `jaffle` and `jaffle-2` as substrings, but `jaffle-2` is
+        // the more specific (longer) match and wins. A tie for the top score
+        // (e.g. the prompt names two sources) stays ambiguous and asks.
+        const scored = candidates
+            .map((candidate) => ({
+                candidate,
+                score: AiWritebackService.dbtSourceMatchScore(prompt, candidate),
+            }))
+            .filter((s) => s.score > 0);
+        if (scored.length > 0) {
+            const topScore = Math.max(...scored.map((s) => s.score));
+            const top = scored.filter((s) => s.score === topScore);
+            if (top.length === 1) {
+                return { kind: 'resolved', candidate: top[0].candidate };
+            }
         }
 
         return {
@@ -1875,15 +1889,17 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * Whether the prompt plausibly names this dbt source — used only to choose
-     * between several. Matches the repo (`owner/repo` or repo name) or a
-     * non-generic source name as a case-insensitive substring. Deliberately
-     * conservative: 0 or >1 matches across candidates fall through to asking.
+     * How specifically the prompt names this dbt source: the length of the
+     * longest identifier of it (full `owner/repo`, the repo name, or a
+     * non-generic source name) that appears in the prompt, or 0 if none do.
+     * Returning a length — rather than a boolean — lets the caller prefer the
+     * most specific match, so prefix-related names (`jaffle` vs `jaffle-2`)
+     * disambiguate to the longer one instead of colliding.
      */
-    private static promptTargetsDbtSource(
+    private static dbtSourceMatchScore(
         prompt: string,
         candidate: DbtTargetCandidate,
-    ): boolean {
+    ): number {
         const haystack = prompt.toLowerCase();
         const { repository } = AiWritebackService.dbtSourceGitIdentity(
             candidate.connection,
@@ -1900,9 +1916,9 @@ export class AiWritebackService extends BaseService {
         if (!candidate.isPrimary && candidate.name.trim().length >= 3) {
             needles.push(candidate.name.toLowerCase());
         }
-        return needles.some(
-            (needle) => needle.length >= 3 && haystack.includes(needle),
-        );
+        return needles
+            .filter((needle) => needle.length >= 3 && haystack.includes(needle))
+            .reduce((best, needle) => Math.max(best, needle.length), 0);
     }
 
     /**

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1714,24 +1714,29 @@ export class AiWritebackService extends BaseService {
 
     /**
      * Build the candidate dbt sources a writeback run can target: the project's
-     * primary dbt connection (always present, precedence 0) plus any additional
-     * `project_dbt_sources` that are git-backed (the only ones writeback can
-     * open a PR against). A project with no additional sources yields just the
-     * primary — the unchanged single-source path.
+     * primary dbt connection (precedence 0) plus any additional
+     * `project_dbt_sources`, keeping only the git-backed ones — GitHub/GitLab
+     * are the only sources writeback can open a PR against. A non-git primary
+     * (e.g. a local `dbt` or dbt-cloud project) is therefore dropped, but its
+     * git-backed additional sources are still targetable. A project with no
+     * additional sources yields just the primary — the single-source path.
      */
     private async listDbtTargetCandidates(
         projectUuid: string,
         project: { projectUuid: string; dbtConnection: DbtProjectConfig },
     ): Promise<DbtTargetCandidate[]> {
-        const primary: DbtTargetCandidate = {
-            sourceUuid: null,
-            // The primary's client-facing id is the project uuid — the same id
-            // the project's dbt-sources list synthesises for it.
-            optionUuid: project.projectUuid,
-            name: 'Project dbt connection',
-            isPrimary: true,
-            connection: project.dbtConnection,
-        };
+        const primary: DbtTargetCandidate | null =
+            AiWritebackService.isWritebackTargetable(project.dbtConnection.type)
+                ? {
+                      sourceUuid: null,
+                      // The primary's client-facing id is the project uuid — the
+                      // same id the project's dbt-sources list synthesises for it.
+                      optionUuid: project.projectUuid,
+                      name: 'Project dbt connection',
+                      isPrimary: true,
+                      connection: project.dbtConnection,
+                  }
+                : null;
         const additional =
             await this.projectDbtSourcesModel.getSources(projectUuid);
         const extra = additional.flatMap<DbtTargetCandidate>((dbtSource) =>
@@ -1750,7 +1755,7 @@ export class AiWritebackService extends BaseService {
                   ]
                 : [],
         );
-        return [primary, ...extra];
+        return primary ? [primary, ...extra] : extra;
     }
 
     /**
@@ -1782,6 +1787,16 @@ export class AiWritebackService extends BaseService {
             projectUuid,
             project,
         );
+
+        // No git-backed source anywhere (non-git primary, no git additional
+        // sources) — there's nothing to open a PR against. Mirror the connection
+        // gate getGitProvider enforced when the primary was the only target.
+        if (candidates.length === 0) {
+            throw new WritebackGitNotConnectedError(
+                null,
+                `AI writeback requires a GitHub or GitLab dbt source, but this project ("${project.dbtConnection.type}") has none`,
+            );
+        }
 
         if (existingRow) {
             const bound = candidates.find(

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1802,10 +1802,16 @@ export class AiWritebackService extends BaseService {
             const bound = candidates.find(
                 (c) => c.sourceUuid === existingRow.project_dbt_source_uuid,
             );
-            // The bound source is the primary (null), or was deleted after the
-            // thread started (FK SET NULL) — fall back to the primary, which is
-            // always candidates[0].
-            return { kind: 'resolved', candidate: bound ?? candidates[0] };
+            if (bound) {
+                return { kind: 'resolved', candidate: bound };
+            }
+            // The bound source is null (the primary) or was deleted after the
+            // thread started (FK SET NULL). Prefer the primary — but it is only a
+            // candidate when git-backed, so `candidates[0]` is NOT always the
+            // primary. Look it up explicitly, and when the primary is non-git
+            // (absent) fall back to the first git-backed source.
+            const primary = candidates.find((c) => c.isPrimary);
+            return { kind: 'resolved', candidate: primary ?? candidates[0] };
         }
 
         if (dbtSourceUuid) {
@@ -1814,7 +1820,7 @@ export class AiWritebackService extends BaseService {
             );
             if (!chosen) {
                 throw new ParameterError(
-                    `dbt source ${dbtSourceUuid} is not a writeback target for this project`,
+                    'The specified dbt source is not a valid writeback target for this project',
                 );
             }
             return { kind: 'resolved', candidate: chosen };
@@ -1834,7 +1840,10 @@ export class AiWritebackService extends BaseService {
         const scored = candidates
             .map((candidate) => ({
                 candidate,
-                score: AiWritebackService.dbtSourceMatchScore(prompt, candidate),
+                score: AiWritebackService.dbtSourceMatchScore(
+                    prompt,
+                    candidate,
+                ),
             }))
             .filter((s) => s.score > 0);
         if (scored.length > 0) {

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -14,8 +14,10 @@ import {
     RequestMethod,
     SupportedDbtVersions,
     WarehouseTypes,
+    type AiWritebackDbtSourceOption,
     type AiWritebackRunResult,
     type AiWritebackStep,
+    type DbtProjectConfig,
     type GitRepo,
     type MergePullRequestResult,
     type PullRequestWritebackAction,
@@ -37,6 +39,7 @@ import type { LightdashConfig } from '../../../config/parseConfig';
 import type { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import type { GitlabAppInstallationsModel } from '../../../models/GitlabAppInstallations/GitlabAppInstallationsModel';
+import type { ProjectDbtSourcesModel } from '../../../models/ProjectDbtSourcesModel';
 import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import type { PullRequestsModel } from '../../../models/PullRequestsModel';
 import type PrometheusMetrics from '../../../prometheus/PrometheusMetrics';
@@ -146,10 +149,35 @@ const getPrAction = (
     return applied.prCreated ? 'opened' : 'updated';
 };
 
+/**
+ * Outcome of `prepareTurn`: either a turn ready to run, or — when the project
+ * has several dbt sources and the prompt didn't name one — a request for the
+ * caller to choose which source to target.
+ */
+type PreparedTurn =
+    | { kind: 'run'; turn: TurnContext }
+    | {
+          kind: 'select';
+          projectName: string;
+          options: AiWritebackDbtSourceOption[];
+      };
+
+/** A dbt source a writeback run can target, with its decrypted connection. */
+type DbtTargetCandidate = {
+    /** `project_dbt_sources` row uuid for an additional source; null for primary. */
+    sourceUuid: string | null;
+    /** Client-facing id: the project uuid for primary, the row uuid otherwise. */
+    optionUuid: string;
+    name: string;
+    isPrimary: boolean;
+    connection: DbtProjectConfig;
+};
+
 type AiWritebackServiceDeps = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
     projectModel: ProjectModel;
+    projectDbtSourcesModel: ProjectDbtSourcesModel;
     featureFlagModel: FeatureFlagModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
     githubAppService: GithubAppService;
@@ -242,6 +270,8 @@ export class AiWritebackService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly projectDbtSourcesModel: ProjectDbtSourcesModel;
+
     private readonly featureFlagModel: FeatureFlagModel;
 
     private readonly aiWritebackThreadModel: AiWritebackThreadModel;
@@ -269,6 +299,7 @@ export class AiWritebackService extends BaseService {
         lightdashConfig,
         analytics,
         projectModel,
+        projectDbtSourcesModel,
         featureFlagModel,
         githubAppInstallationsModel,
         githubAppService,
@@ -284,6 +315,7 @@ export class AiWritebackService extends BaseService {
         this.lightdashConfig = lightdashConfig;
         this.analytics = analytics;
         this.projectModel = projectModel;
+        this.projectDbtSourcesModel = projectDbtSourcesModel;
         this.featureFlagModel = featureFlagModel;
         this.aiWritebackThreadModel = aiWritebackThreadModel;
         this.sandboxRegistryModel = sandboxRegistryModel;
@@ -1216,6 +1248,7 @@ export class AiWritebackService extends BaseService {
             prUrl,
             aiThreadUuid,
             source,
+            dbtSourceUuid,
             onProgress,
         } = args;
         const runStartedAt = performance.now();
@@ -1247,12 +1280,32 @@ export class AiWritebackService extends BaseService {
             reportProgress(text);
         };
 
-        const turn = await this.prepareTurn({
+        const prepared = await this.prepareTurn({
             user,
             projectUuid,
+            prompt,
             aiThreadUuid,
             source,
+            dbtSourceUuid,
         });
+
+        // The project has more than one dbt source and the prompt didn't pin a
+        // single one down. Ask the caller to choose before spending a sandbox —
+        // no clone, no PR. The caller re-runs with the chosen `dbtSourceUuid`.
+        if (prepared.kind === 'select') {
+            this.logger.info('AI writeback needs a dbt source selection', {
+                event: 'ai_writeback.run.needs_selection',
+                source,
+                projectUuid,
+                aiThreadUuid: aiThreadUuid ?? null,
+                optionCount: prepared.options.length,
+            });
+            return AiWritebackService.buildDbtSourceSelectionResult(
+                prepared.projectName,
+                prepared.options,
+            );
+        }
+        const { turn } = prepared;
 
         this.logger.info('AI writeback run started', {
             event: 'ai_writeback.run.started',
@@ -1424,6 +1477,7 @@ export class AiWritebackService extends BaseService {
                     projectName: turn.projectName,
                     repository,
                     steps: stepLog,
+                    dbtSourceUuid: turn.projectDbtSourceUuid,
                 };
             }
 
@@ -1481,6 +1535,7 @@ export class AiWritebackService extends BaseService {
                 projectName: turn.projectName,
                 repository,
                 steps: stepLog,
+                dbtSourceUuid: turn.projectDbtSourceUuid,
             };
         } catch (error) {
             this.logger.error('AI writeback run failed', {
@@ -1525,20 +1580,26 @@ export class AiWritebackService extends BaseService {
 
     /**
      * Pre-flight: enforce source-specific rollout gates, the
-     * `manage:SourceCode` permission, and resolve everything from the request
-     * that doesn't require a sandbox.
+     * `manage:SourceCode` permission, decide which dbt source the run targets,
+     * and resolve everything from the request that doesn't require a sandbox.
+     * Returns `kind: 'select'` instead when the project has several dbt sources
+     * and the prompt doesn't pin one down — the caller asks the user to choose.
      */
     private async prepareTurn({
         user,
         projectUuid,
+        prompt,
         aiThreadUuid,
         source,
+        dbtSourceUuid,
     }: {
         user: SessionUser;
         projectUuid: string;
+        prompt: string;
         aiThreadUuid: string | undefined;
         source: AiWritebackSource;
-    }): Promise<TurnContext> {
+        dbtSourceUuid: string | undefined;
+    }): Promise<PreparedTurn> {
         await this.assertEnabled(user, source);
 
         const project = await this.projectModel.get(projectUuid);
@@ -1561,10 +1622,6 @@ export class AiWritebackService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
 
-        // Resolve the git host once; the rest of the run stays host-agnostic.
-        const provider = this.getGitProvider(project.dbtConnection.type);
-        const gitConnection = provider.resolveConnection(project.dbtConnection);
-
         // Resume only when both the caller supplied a thread uuid AND we
         // have a stored sandbox for it. Otherwise we start fresh.
         const storedRow = aiThreadUuid
@@ -1583,6 +1640,30 @@ export class AiWritebackService extends BaseService {
             storedRow && storedRow.sandbox_uuid !== null
                 ? { ...storedRow, sandbox_uuid: storedRow.sandbox_uuid }
                 : null;
+
+        // Decide which dbt source to target before resolving the git host: a
+        // resumed thread stays bound to its source, otherwise we honour an
+        // explicit choice, infer from the prompt, or ask the caller to pick.
+        const target = await this.resolveDbtTarget({
+            projectUuid,
+            project,
+            prompt,
+            dbtSourceUuid,
+            existingRow,
+        });
+        if (target.kind === 'select') {
+            return {
+                kind: 'select',
+                projectName: project.name,
+                options: target.options,
+            };
+        }
+        const { candidate } = target;
+
+        // Resolve the git host from the chosen source; the rest stays
+        // host-agnostic.
+        const provider = this.getGitProvider(candidate.connection.type);
+        const gitConnection = provider.resolveConnection(candidate.connection);
 
         // A thread is bound to its first PR. If that PR has since been merged or
         // closed (from the chat card or directly on the host), editing it again
@@ -1616,14 +1697,231 @@ export class AiWritebackService extends BaseService {
         const dbtVersion = resolveSandboxDbtVersion(project.dbtVersion);
 
         return {
-            organizationUuid: user.organizationUuid,
-            projectName: project.name,
-            provider,
-            gitConnection,
-            existingRow,
-            isResume: existingRow !== null,
-            warehouseType,
-            dbtVersion,
+            kind: 'run',
+            turn: {
+                organizationUuid: user.organizationUuid,
+                projectName: project.name,
+                provider,
+                gitConnection,
+                projectDbtSourceUuid: candidate.sourceUuid,
+                existingRow,
+                isResume: existingRow !== null,
+                warehouseType,
+                dbtVersion,
+            },
+        };
+    }
+
+    /**
+     * Build the candidate dbt sources a writeback run can target: the project's
+     * primary dbt connection (always present, precedence 0) plus any additional
+     * `project_dbt_sources` that are git-backed (the only ones writeback can
+     * open a PR against). A project with no additional sources yields just the
+     * primary — the unchanged single-source path.
+     */
+    private async listDbtTargetCandidates(
+        projectUuid: string,
+        project: { projectUuid: string; dbtConnection: DbtProjectConfig },
+    ): Promise<DbtTargetCandidate[]> {
+        const primary: DbtTargetCandidate = {
+            sourceUuid: null,
+            // The primary's client-facing id is the project uuid — the same id
+            // the project's dbt-sources list synthesises for it.
+            optionUuid: project.projectUuid,
+            name: 'Project dbt connection',
+            isPrimary: true,
+            connection: project.dbtConnection,
+        };
+        const additional =
+            await this.projectDbtSourcesModel.getSources(projectUuid);
+        const extra = additional.flatMap<DbtTargetCandidate>((dbtSource) =>
+            dbtSource.dbtConnection &&
+            AiWritebackService.isWritebackTargetable(
+                dbtSource.dbtConnection.type,
+            )
+                ? [
+                      {
+                          sourceUuid: dbtSource.projectDbtSourceUuid,
+                          optionUuid: dbtSource.projectDbtSourceUuid,
+                          name: dbtSource.name,
+                          isPrimary: false,
+                          connection: dbtSource.dbtConnection,
+                      },
+                  ]
+                : [],
+        );
+        return [primary, ...extra];
+    }
+
+    /**
+     * Decide which dbt source a turn targets. Precedence:
+     * 1. a resumed thread stays bound to its original source (never re-infer, or
+     *    a follow-up could retarget the sandbox's already-cloned repo);
+     * 2. an explicit `dbtSourceUuid` (a UI picker, or an agent re-call);
+     * 3. the only source, when the project has one — unchanged behaviour;
+     * 4. the source the prompt names, when exactly one matches;
+     * otherwise return the candidates for the caller to choose from.
+     */
+    private async resolveDbtTarget({
+        projectUuid,
+        project,
+        prompt,
+        dbtSourceUuid,
+        existingRow,
+    }: {
+        projectUuid: string;
+        project: { projectUuid: string; dbtConnection: DbtProjectConfig };
+        prompt: string;
+        dbtSourceUuid: string | undefined;
+        existingRow: ResumableWritebackThread | null;
+    }): Promise<
+        | { kind: 'resolved'; candidate: DbtTargetCandidate }
+        | { kind: 'select'; options: AiWritebackDbtSourceOption[] }
+    > {
+        const candidates = await this.listDbtTargetCandidates(
+            projectUuid,
+            project,
+        );
+
+        if (existingRow) {
+            const bound = candidates.find(
+                (c) => c.sourceUuid === existingRow.project_dbt_source_uuid,
+            );
+            // The bound source is the primary (null), or was deleted after the
+            // thread started (FK SET NULL) — fall back to the primary, which is
+            // always candidates[0].
+            return { kind: 'resolved', candidate: bound ?? candidates[0] };
+        }
+
+        if (dbtSourceUuid) {
+            const chosen = candidates.find(
+                (c) => c.optionUuid === dbtSourceUuid,
+            );
+            if (!chosen) {
+                throw new ParameterError(
+                    `dbt source ${dbtSourceUuid} is not a writeback target for this project`,
+                );
+            }
+            return { kind: 'resolved', candidate: chosen };
+        }
+
+        if (candidates.length === 1) {
+            return { kind: 'resolved', candidate: candidates[0] };
+        }
+
+        const matches = candidates.filter((c) =>
+            AiWritebackService.promptTargetsDbtSource(prompt, c),
+        );
+        if (matches.length === 1) {
+            return { kind: 'resolved', candidate: matches[0] };
+        }
+
+        return {
+            kind: 'select',
+            options: candidates.map(AiWritebackService.toDbtSourceOption),
+        };
+    }
+
+    private static isWritebackTargetable(type: DbtProjectType): boolean {
+        // Mirrors getGitProvider: only GitHub and GitLab can have a PR opened.
+        return type === DbtProjectType.GITHUB || type === DbtProjectType.GITLAB;
+    }
+
+    /** Git identity safe to surface (repo/branch/subpath); nulls for non-git. */
+    private static dbtSourceGitIdentity(connection: DbtProjectConfig): {
+        repository: string | null;
+        branch: string | null;
+        projectSubPath: string | null;
+    } {
+        if (
+            connection.type === DbtProjectType.GITHUB ||
+            connection.type === DbtProjectType.GITLAB ||
+            connection.type === DbtProjectType.BITBUCKET ||
+            connection.type === DbtProjectType.AZURE_DEVOPS
+        ) {
+            return {
+                repository: connection.repository,
+                branch: connection.branch,
+                projectSubPath: connection.project_sub_path,
+            };
+        }
+        return { repository: null, branch: null, projectSubPath: null };
+    }
+
+    private static toDbtSourceOption(
+        candidate: DbtTargetCandidate,
+    ): AiWritebackDbtSourceOption {
+        return {
+            projectDbtSourceUuid: candidate.optionUuid,
+            name: candidate.name,
+            isPrimary: candidate.isPrimary,
+            ...AiWritebackService.dbtSourceGitIdentity(candidate.connection),
+        };
+    }
+
+    /**
+     * Whether the prompt plausibly names this dbt source — used only to choose
+     * between several. Matches the repo (`owner/repo` or repo name) or a
+     * non-generic source name as a case-insensitive substring. Deliberately
+     * conservative: 0 or >1 matches across candidates fall through to asking.
+     */
+    private static promptTargetsDbtSource(
+        prompt: string,
+        candidate: DbtTargetCandidate,
+    ): boolean {
+        const haystack = prompt.toLowerCase();
+        const { repository } = AiWritebackService.dbtSourceGitIdentity(
+            candidate.connection,
+        );
+        const needles: string[] = [];
+        if (repository) {
+            needles.push(repository.toLowerCase());
+            const repoName = repository.split('/').pop();
+            if (repoName) {
+                needles.push(repoName.toLowerCase());
+            }
+        }
+        // Skip the synthesised primary's generic name — it names nothing useful.
+        if (!candidate.isPrimary && candidate.name.trim().length >= 3) {
+            needles.push(candidate.name.toLowerCase());
+        }
+        return needles.some(
+            (needle) => needle.length >= 3 && haystack.includes(needle),
+        );
+    }
+
+    /**
+     * The "which dbt source?" response: a normal run result that opened no PR,
+     * carrying the options to choose from plus a human-readable `output` so every
+     * surface (API, MCP, Slack, web) can present the choice with no bespoke code.
+     */
+    private static buildDbtSourceSelectionResult(
+        projectName: string,
+        options: AiWritebackDbtSourceOption[],
+    ): AiWritebackRunResult {
+        const lines = options.map((option) => {
+            const repo = option.repository ? ` (${option.repository})` : '';
+            const tag = option.isPrimary ? ' [primary]' : '';
+            return `- ${option.name}${repo}${tag}`;
+        });
+        const output = [
+            "This project has more than one dbt source, so I couldn't tell which one to change. Pick one and run the writeback again with that dbt source selected:",
+            ...lines,
+        ].join('\n');
+        return {
+            output,
+            exitCode: 0,
+            prUrl: null,
+            prAction: null,
+            commitSha: null,
+            additions: null,
+            deletions: null,
+            projectName,
+            repository: '',
+            steps: [],
+            dbtSourceUuid: null,
+            needsDbtSourceSelection: true,
+            dbtSourceOptions: options,
         };
     }
 
@@ -2453,6 +2751,9 @@ export class AiWritebackService extends BaseService {
                 aiThreadUuid,
                 sandboxUuid,
                 pullRequestUuid: pullRequest.pullRequestUuid,
+                // Bind the thread to the source it targeted so every resume
+                // re-resolves to the same repo — one thread, one PR.
+                projectDbtSourceUuid: turn.projectDbtSourceUuid,
             });
         }
     }

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -110,6 +110,13 @@ export type TurnContext = {
     /** Resolved once from the dbt connection type; the service never re-branches. */
     provider: GitProvider;
     gitConnection: GitConnection;
+    /**
+     * The dbt source this turn targets: a `project_dbt_sources` row uuid for an
+     * additional source, or null for the project's primary dbt connection.
+     * Persisted on the thread row when a PR is opened so resumes stay bound to
+     * the same source (one thread, one PR).
+     */
+    projectDbtSourceUuid: string | null;
     existingRow: ResumableWritebackThread | null;
     isResume: boolean;
     /**
@@ -216,6 +223,15 @@ export type AiWritebackRunArgs = {
     user: SessionUser;
     projectUuid: string;
     prompt: string;
+    /**
+     * Which of the project's dbt sources to target, when it has more than one:
+     * the project's own uuid (or undefined) for the primary dbt connection, or
+     * a `project_dbt_sources` row uuid for an additional source. When undefined
+     * and the project has several sources, the run infers the target from the
+     * prompt and, failing that, returns the choices for the caller to pick from.
+     * Ignored on a resumed thread — it stays bound to its original source.
+     */
+    dbtSourceUuid?: string;
     // Honoured only when the thread has no writeback PR yet; the PR must live
     // in the project's own repo (validated before adoption).
     prUrl?: string | null;

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1113,12 +1113,35 @@ export class McpService extends BaseService {
                         user,
                         projectUuid,
                         prompt: args.prompt,
+                        dbtSourceUuid: args.dbtSourceUuid,
                         source: 'mcp',
                     });
 
-                    const summary = result.prUrl
-                        ? `AI writeback complete. Pull request opened: ${result.prUrl}`
-                        : 'AI writeback complete. The agent made no file changes, so no pull request was opened.';
+                    let summary: string;
+                    if (result.needsDbtSourceSelection) {
+                        // The project has several dbt sources and the prompt
+                        // didn't name one — surface the choices so the agent can
+                        // re-call with the chosen dbtSourceUuid. No PR was opened.
+                        const choices = (result.dbtSourceOptions ?? [])
+                            .map(
+                                (option) =>
+                                    `- ${option.name}${
+                                        option.repository
+                                            ? ` (${option.repository})`
+                                            : ''
+                                    }${
+                                        option.isPrimary ? ' [primary]' : ''
+                                    } — dbtSourceUuid: ${
+                                        option.projectDbtSourceUuid
+                                    }`,
+                            )
+                            .join('\n');
+                        summary = `This project has more than one dbt source. Re-run run_ai_writeback with one of these as dbtSourceUuid:\n${choices}`;
+                    } else {
+                        summary = result.prUrl
+                            ? `AI writeback complete. Pull request opened: ${result.prUrl}`
+                            : 'AI writeback complete. The agent made no file changes, so no pull request was opened.';
+                    }
 
                     return await this.buildScopedResponse(
                         ctx,

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1113,15 +1113,15 @@ export class McpService extends BaseService {
                         user,
                         projectUuid,
                         prompt: args.prompt,
-                        dbtSourceUuid: args.dbtSourceUuid,
                         source: 'mcp',
                     });
 
                     let summary: string;
                     if (result.needsDbtSourceSelection) {
                         // The project has several dbt sources and the prompt
-                        // didn't name one — surface the choices so the agent can
-                        // re-call with the chosen dbtSourceUuid. No PR was opened.
+                        // didn't name one. Surface the choices by name/repo and
+                        // ask the agent to re-run naming the source in the prompt
+                        // — no id round-trip. No PR was opened.
                         const choices = (result.dbtSourceOptions ?? [])
                             .map(
                                 (option) =>
@@ -1129,14 +1129,10 @@ export class McpService extends BaseService {
                                         option.repository
                                             ? ` (${option.repository})`
                                             : ''
-                                    }${
-                                        option.isPrimary ? ' [primary]' : ''
-                                    } — dbtSourceUuid: ${
-                                        option.projectDbtSourceUuid
-                                    }`,
+                                    }${option.isPrimary ? ' [primary]' : ''}`,
                             )
                             .join('\n');
-                        summary = `This project has more than one dbt source. Re-run run_ai_writeback with one of these as dbtSourceUuid:\n${choices}`;
+                        summary = `This project has more than one dbt source, so I couldn't tell which one to change. Ask again and name the source in your request (e.g. "In jaffle-2, ..."). Available sources:\n${choices}`;
                     } else {
                         summary = result.prUrl
                             ? `AI writeback complete. Pull request opened: ${result.prUrl}`

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -7348,10 +7348,10 @@ Requirements:
 Important:
 - This tool is NOT read-only and NOT idempotent — each call can open a new pull request. Use it only when the user explicitly wants to change their dbt project.
 - The run is synchronous and can take a few minutes (cloning, running the agent, opening the PR).
+- Some projects have more than one dbt source. If the prompt doesn't make clear which one to change, the tool makes no change and returns the list of sources (by name and repository); re-run and name the intended source in the prompt itself (e.g. "In jaffle-2, add ..."). You never pass an id.
 
 Parameters:
-- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. "Add a 'total_revenue' metric to the orders model as the sum of amount").
-- dbtSourceUuid (optional): When the project has more than one dbt source, the uuid of the source to change. Omit it to let the run infer the target from the prompt; if it cannot, the response asks you to choose and lists the available sources, after which you re-call with the chosen dbtSourceUuid.
+- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. "Add a 'total_revenue' metric to the orders model as the sum of amount"). When the project has more than one dbt source, name the intended source here (e.g. "In the marketing dbt project, ...").
 
 Response shape (MCP CallToolResult):
 - content: [{ type: "text", text: "<human-readable summary including the PR URL>" }]
@@ -7365,12 +7365,8 @@ Response shape (MCP CallToolResult):
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
-          "dbtSourceUuid": {
-            "description": "Which of the project's dbt sources to change, when it has more than one. Omit to infer the target from the prompt; if the run cannot decide it returns the available sources to choose from, then you re-call with the chosen uuid.",
-            "type": "string",
-          },
           "prompt": {
-            "description": "A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project.",
+            "description": "A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project. If the project has more than one dbt source, name the intended one here (e.g. "In jaffle-2, add ...") — the tool resolves it from the prompt and asks (listing sources by name) if it can't tell.",
             "minLength": 1,
             "type": "string",
           },

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -7351,6 +7351,7 @@ Important:
 
 Parameters:
 - prompt: A clear, self-contained description of the change to make to the dbt project (e.g. "Add a 'total_revenue' metric to the orders model as the sum of amount").
+- dbtSourceUuid (optional): When the project has more than one dbt source, the uuid of the source to change. Omit it to let the run infer the target from the prompt; if it cannot, the response asks you to choose and lists the available sources, after which you re-call with the chosen dbtSourceUuid.
 
 Response shape (MCP CallToolResult):
 - content: [{ type: "text", text: "<human-readable summary including the PR URL>" }]
@@ -7364,6 +7365,10 @@ Response shape (MCP CallToolResult):
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "dbtSourceUuid": {
+            "description": "Which of the project's dbt sources to change, when it has more than one. Omit to infer the target from the prompt; if the run cannot decide it returns the available sources to choose from, then you re-call with the chosen uuid.",
+            "type": "string",
+          },
           "prompt": {
             "description": "A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project.",
             "minLength": 1,

--- a/packages/common/src/ee/aiWriteback/types.ts
+++ b/packages/common/src/ee/aiWriteback/types.ts
@@ -7,11 +7,37 @@ import { type ApiSuccess } from '../../types/api/success';
  * pull request is opened against the repo if the agent changes any files.
  *
  * The target repository (owner, repo) and the dbt project sub-folder are
- * resolved server-side from the Lightdash project's dbt connection — identified
- * by the `projectUuid` path parameter — so the caller only supplies the prompt.
+ * resolved server-side from the chosen dbt source — by default the Lightdash
+ * project's primary dbt connection (identified by the `projectUuid` path
+ * parameter), or the source named by `dbtSourceUuid` when the project has more
+ * than one dbt source.
  */
 export type AiWritebackRequestBody = {
     prompt: string;
+    /**
+     * Which of the project's dbt sources to target, when it has more than one
+     * (see {@link AiWritebackDbtSourceOption}). Pass the project's own uuid (or
+     * omit) to target the primary dbt connection. When omitted and the project
+     * has several sources, the run infers the target from the prompt and asks
+     * the caller to choose if it can't (see `needsDbtSourceSelection`).
+     */
+    dbtSourceUuid?: string;
+};
+
+/**
+ * One dbt source a writeback run can target, surfaced when a project has more
+ * than one and the run needs the caller to choose. `projectDbtSourceUuid` is
+ * the project's own uuid for the primary source and a row uuid for additional
+ * sources — the same identifier the project's dbt-sources list returns, so the
+ * caller can echo it straight back as `dbtSourceUuid`.
+ */
+export type AiWritebackDbtSourceOption = {
+    projectDbtSourceUuid: string;
+    name: string;
+    isPrimary: boolean;
+    repository: string | null;
+    branch: string | null;
+    projectSubPath: string | null;
 };
 
 /**
@@ -63,6 +89,21 @@ export type AiWritebackRunResult = {
     repository: string;
     /** Ordered actions the sandbox took, for the chat UI's step rows. */
     steps: AiWritebackStep[];
+    /**
+     * The dbt source this run targeted: a `project_dbt_sources` row uuid for an
+     * additional source, or `null` for the project's primary dbt connection. A
+     * thread stays bound to this source across resumes — one thread, one PR.
+     */
+    dbtSourceUuid: string | null;
+    /**
+     * Set when the project has several dbt sources and the run could not decide
+     * which one the prompt targets. No sandbox is started and no pull request is
+     * opened; `dbtSourceOptions` lists the choices and the caller should re-run
+     * with `dbtSourceUuid` set to one of them. Absent on a normal run.
+     */
+    needsDbtSourceSelection?: boolean;
+    /** The dbt sources to choose from when `needsDbtSourceSelection` is set. */
+    dbtSourceOptions?: AiWritebackDbtSourceOption[];
 };
 
 export type ApiAiWritebackResponse = ApiSuccess<AiWritebackRunResult>;
@@ -88,6 +129,7 @@ Important:
 
 Parameters:
 - prompt: A clear, self-contained description of the change to make to the dbt project (e.g. "Add a 'total_revenue' metric to the orders model as the sum of amount").
+- dbtSourceUuid (optional): When the project has more than one dbt source, the uuid of the source to change. Omit it to let the run infer the target from the prompt; if it cannot, the response asks you to choose and lists the available sources, after which you re-call with the chosen dbtSourceUuid.
 
 Response shape (MCP CallToolResult):
 - content: [{ type: "text", text: "<human-readable summary including the PR URL>" }]
@@ -104,6 +146,12 @@ export const mcpRunAiWritebackArgsSchema = z.object({
         .min(1)
         .describe(
             'A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project.',
+        ),
+    dbtSourceUuid: z
+        .string()
+        .optional()
+        .describe(
+            "Which of the project's dbt sources to change, when it has more than one. Omit to infer the target from the prompt; if the run cannot decide it returns the available sources to choose from, then you re-call with the chosen uuid.",
         ),
 });
 

--- a/packages/common/src/ee/aiWriteback/types.ts
+++ b/packages/common/src/ee/aiWriteback/types.ts
@@ -93,8 +93,10 @@ export type AiWritebackRunResult = {
      * The dbt source this run targeted: a `project_dbt_sources` row uuid for an
      * additional source, or `null` for the project's primary dbt connection. A
      * thread stays bound to this source across resumes — one thread, one PR.
+     * Optional so an older server's response (which omits it) doesn't surface as
+     * `undefined` on a newer typed client.
      */
-    dbtSourceUuid: string | null;
+    dbtSourceUuid?: string | null;
     /**
      * Set when the project has several dbt sources and the run could not decide
      * which one the prompt targets. No sandbox is started and no pull request is

--- a/packages/common/src/ee/aiWriteback/types.ts
+++ b/packages/common/src/ee/aiWriteback/types.ts
@@ -128,10 +128,10 @@ Requirements:
 Important:
 - This tool is NOT read-only and NOT idempotent — each call can open a new pull request. Use it only when the user explicitly wants to change their dbt project.
 - The run is synchronous and can take a few minutes (cloning, running the agent, opening the PR).
+- Some projects have more than one dbt source. If the prompt doesn't make clear which one to change, the tool makes no change and returns the list of sources (by name and repository); re-run and name the intended source in the prompt itself (e.g. "In jaffle-2, add ..."). You never pass an id.
 
 Parameters:
-- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. "Add a 'total_revenue' metric to the orders model as the sum of amount").
-- dbtSourceUuid (optional): When the project has more than one dbt source, the uuid of the source to change. Omit it to let the run infer the target from the prompt; if it cannot, the response asks you to choose and lists the available sources, after which you re-call with the chosen dbtSourceUuid.
+- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. "Add a 'total_revenue' metric to the orders model as the sum of amount"). When the project has more than one dbt source, name the intended source here (e.g. "In the marketing dbt project, ...").
 
 Response shape (MCP CallToolResult):
 - content: [{ type: "text", text: "<human-readable summary including the PR URL>" }]
@@ -147,13 +147,7 @@ export const mcpRunAiWritebackArgsSchema = z.object({
         .string()
         .min(1)
         .describe(
-            'A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project.',
-        ),
-    dbtSourceUuid: z
-        .string()
-        .optional()
-        .describe(
-            "Which of the project's dbt sources to change, when it has more than one. Omit to infer the target from the prompt; if the run cannot decide it returns the available sources to choose from, then you re-call with the chosen uuid.",
+            'A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project. If the project has more than one dbt source, name the intended one here (e.g. "In jaffle-2, add ...") — the tool resolves it from the prompt and asks (listing sources by name) if it can\'t tell.',
         ),
 });
 


### PR DESCRIPTION
## What

Builds dbt-source awareness into AI writeback. A project can now have more than one dbt source (primary `dbt_connection` + additional `project_dbt_sources`), but writeback always cloned and opened a PR against the **primary** connection. This change makes the run resolve *which* source to target before it spends a sandbox, and keeps one writeback thread bound to one source — **one thread, one PR**.

## How it decides (in `prepareTurn` → `resolveDbtTarget`, before any sandbox)

1. **Resumed thread** → stays bound to the source it started on (never re-infers, so a follow-up can't retarget the already-cloned repo).
2. **Explicit `dbtSourceUuid`** → a UI picker or an agent re-call (the project's own uuid means the primary).
3. **Single source** → used directly — unchanged behaviour for the common case.
4. **Inferred from the prompt** → when exactly one source's repo/name is named.
5. **Otherwise → ask.** No sandbox, no PR; the run returns the candidate sources (`needsDbtSourceSelection` + `dbtSourceOptions`) and a human-readable `output`, so the caller (API, MCP, Slack, web) can present the choice. The caller re-runs with the chosen `dbtSourceUuid`.

The chosen source is persisted on the `ai_writeback_thread` row (new nullable `project_dbt_source_uuid`, FK `ON DELETE SET NULL` — `null` = primary) so every resumed turn re-resolves to the same repo.

## Changes

- **common**: `dbtSourceUuid` on the request body + MCP args; `dbtSourceUuid` / `needsDbtSourceSelection` / `dbtSourceOptions` on the run result; new `AiWritebackDbtSourceOption`.
- **backend**: `resolveDbtTarget` + candidate building in `AiWritebackService` (injects `ProjectDbtSourcesModel`); thread-source binding (migration + entity + model); selection surfaced over the API controller and the `run_ai_writeback` MCP tool.
- Targeting is GitHub/GitLab-only (mirrors `getGitProvider`); non-git additional sources are filtered out.

## Testing

- Unit tests for explicit / inferred / ambiguous / resumed-binding / deleted-source-fallback targeting, plus a `run()` test asserting the selection path opens no sandbox.
- `pnpm -F backend typecheck`, backend + common eslint, and the writeback suite (42 tests) all pass.
- Migration applied against a local EE instance; column + `SET NULL` FK verified; backend boots healthy with the new DI.

## Notes / follow-ups

- Inference is a deliberately conservative substring match (repo slug, repo name, or non-generic source name); ambiguity falls through to asking rather than guessing.
- The frontend picker that sends `dbtSourceUuid` and renders `dbtSourceOptions` is not included here — the API/MCP contract and the structured options are in place for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)