### PR TITLE
feat(warehouses): log SSH tunnel idle-timeout drops

### DIFF
--- a/packages/warehouses/src/ssh/sshTunnel.ts
+++ b/packages/warehouses/src/ssh/sshTunnel.ts
@@ -25,6 +25,10 @@ class SSH2Tunnel {
 
     private error: Error | undefined = undefined;
 
+    // Wall-clock (ms) when this tunnel was constructed. Used only for logging:
+    // how long a connection survived before it was closed / dropped / timed out.
+    private readonly openedAt: number = Date.now();
+
     constructor(args: {
         sshHost: string;
         sshPort: number;
@@ -108,8 +112,18 @@ class SSH2Tunnel {
                 socket.destroy();
             });
             socket.setTimeout(60000 * 5, () => {
-                console.log(
-                    `SSH tunnel ${this.id} - local tcp server connection timed out after 5 minutes`,
+                // A query that scanned without streaming rows back sends no
+                // bytes on this socket, so bytesToClient stays ~0 and
+                // elapsedSinceOpen ~= 5 minutes. Destroying the socket here is
+                // what surfaces to pg as "Connection terminated unexpectedly",
+                // so log elapsed + byte counts to make such drops measurable
+                // rather than inferred.
+                console.warn(
+                    `[ssh-tunnel] ${this.id} local socket idle timeout after ` +
+                        `5 minutes (elapsedSinceOpen=${Date.now() - this.openedAt}ms ` +
+                        `bytesFromClient=${socket.bytesRead} ` +
+                        `bytesToClient=${socket.bytesWritten}) - destroying ` +
+                        `pg<->tunnel socket`,
                 );
                 socket.destroy();
             });


### PR DESCRIPTION
## Problem

For SSH-tunneled Postgres/Redshift warehouses, the tunnel's local (pg ↔ tunnel) socket has a hardcoded 5-minute idle timeout (`socket.setTimeout(60000 * 5)`) that destroys the connection on inactivity. A warehouse query that scans for a long time **without streaming any rows back** sends no bytes over this socket, so on slow queries this idle timeout — not the remote host — can be what tears the connection down, surfacing to the client as `Connection terminated unexpectedly` at ~300s.

Today this is invisible: the timeout log line carries no timing or byte counts, so an idle-drop can't be distinguished from a remote/network drop.

## What this does

- **Observability** — when the idle timeout fires, log `elapsedSinceOpen` and byte counts (`bytesFromClient` / `bytesToClient`). A silent-scan idle-drop shows `bytesToClient ≈ 0` and `elapsedSinceOpen ≈ timeout`, making the cause directly measurable instead of inferred.



## Testing

- `pnpm --filter @lightdash/warehouses typecheck:fast` ✅

Ref: ZAP-568

