### PR TITLE
feat(ai): observability + optional empty-query guard for agent field-value search

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -7,6 +7,7 @@ import {
     CatalogType,
     ContentType,
     Explore,
+    FeatureFlags,
     filterExploreByTags,
     ForbiddenError,
     getContentAsCodePathFromLtreePath,
@@ -1722,11 +1723,52 @@ export class AiAgentToolsService extends BaseService {
                     );
                 }
 
+                const query = args.query ?? '';
+                const isEmptyQuery = query.trim() === '';
+
+                // Live PostHog toggle; default off => byte-identical to today.
+                const { enabled: guardEnabled } =
+                    await this.featureFlagService.get({
+                        user: context.user,
+                        featureFlagId: FeatureFlags.AiFieldValueSearchGuard,
+                    });
+
+                // Observability. Deliberately does NOT log the query text or any
+                // returned values (they can contain user data) — only the field
+                // identifier, the request shape and timing.
+                Logger.info(
+                    `[ai-field-values] search source=${context.source} ` +
+                        `table=${args.table} fieldId=${args.fieldId} ` +
+                        `isEmptyQuery=${isEmptyQuery} queryLen=${query.length} ` +
+                        `guard=${guardEnabled}`,
+                );
+
+                // An empty query compiles to `LIKE '%%'` — "distinct the whole
+                // column" — the worst case on a high-cardinality field. With the
+                // guard on, refuse it up front (0s) with a message the agent can
+                // act on, instead of paying for a full-column scan first.
+                if (guardEnabled && isEmptyQuery) {
+                    Logger.warn(
+                        `[ai-field-values] guard blocked empty-query scan ` +
+                            `source=${context.source} table=${args.table} ` +
+                            `fieldId=${args.fieldId}`,
+                    );
+                    throw new Error(
+                        'Listing all values for this field is disabled because ' +
+                            'it requires a full-column scan that is too slow on ' +
+                            'large tables. Search for a specific value instead ' +
+                            '(e.g. part of a name, status or code), or filter by ' +
+                            'an exact value you already know.',
+                    );
+                }
+
                 const dimensionFilters = args.filters?.dimensions;
                 const andFilters =
                     dimensionFilters && 'and' in dimensionFilters
                         ? dimensionFilters
                         : undefined;
+
+                const startedAt = Date.now();
                 const results =
                     await this.projectService.searchFieldUniqueValues(
                         context.user,
@@ -1743,7 +1785,17 @@ export class AiAgentToolsService extends BaseService {
                             ? QueryExecutionContext.MCP_SEARCH_FIELD_VALUES
                             : undefined,
                     );
-                return context.source === 'mcp' ? results : results.results;
+                const output =
+                    context.source === 'mcp' ? results : results.results;
+                Logger.info(
+                    `[ai-field-values] done source=${context.source} ` +
+                        `fieldId=${args.fieldId} elapsedMs=${
+                            Date.now() - startedAt
+                        } resultCount=${
+                            Array.isArray(output) ? output.length : 'n/a'
+                        }`,
+                );
+                return output;
             },
         );
     }

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -260,6 +260,17 @@ export enum FeatureFlags {
      * instead of paying the discoverFields sub-agent round-trip. Experimental.
      */
     AiGrepFields = 'ai-grep-fields',
+
+    /**
+     * Guard the agent's `searchFieldValues` tool against pathological warehouse
+     * scans. When on, an empty/whitespace query — which compiles to
+     * `LIKE '%%'`, i.e. "distinct the entire column" — is rejected immediately
+     * with an actionable message instead of running a leading-wildcard full
+     * scan that can take minutes on high-cardinality fields. Default off, so
+     * behaviour is byte-identical to today when disabled; a live toggle lets the
+     * new behaviour be trialled per-org without a redeploy. Experimental.
+     */
+    AiFieldValueSearchGuard = 'ai-field-value-search-guard',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
## Problem

The AI agent's `searchFieldValues` tool compiles to a leading-wildcard `LIKE '%…%'` scan. An **empty query** compiles to `LIKE '%%'` — "distinct the entire column" — a full-column scan that can take minutes on high-cardinality fields and can't use any index/sort key. The agent hits this constantly ("let me see what's in this field"), and there's currently no visibility into how often it happens or how slow it is.

## What this does

- **Observability (always on)** — `[ai-field-values]` structured logs on the agent search path: `source`, `table`, `fieldId`, `isEmptyQuery`, `queryLen`, `guard`, `elapsedMs`, `resultCount`. Deliberately **does not log the query text or any returned values** (they can contain user data) — only field identifiers, request shape, and timing.
- **Live feature flag (`ai-field-value-search-guard`, default off)** — when enabled, an empty/whitespace query is rejected up front (0s) with an actionable message telling the agent to search a specific value or filter by an exact one, instead of paying for a `LIKE '%%'` full-column scan. PostHog-backed, so it can be toggled per-org without a redeploy.

## Safety

Flag defaults **off** → byte-identical to today when disabled. The guard only short-circuits the empty-query case; non-empty searches are unchanged. The message is surfaced to the model via the existing tool error path (same mechanism as any tool failure), so the agent handles it gracefully.

## Notes / follow-ups

- Complements (does not replace) the failfast-timeout work — this removes the worst-case scan rather than just capping the wait.
- Candidate follow-ups: min-query-length variant, a warehouse-side `statement_timeout` so a slow search is cancelled rather than abandoned, and caching / surfacing low-cardinality enum values so the agent rarely needs to search at all.

## Testing

- `pnpm --filter backend typecheck:fast` ✅

Ref: ZAP-569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
