### PR TITLE
fix(athena): don't inherit parent assumeRoleArn in CLI previews

### DIFF
--- a/packages/common/src/types/projects.test.ts
+++ b/packages/common/src/types/projects.test.ts
@@ -3,6 +3,12 @@ import {
     getInvalidDbtEnvironmentVariableKeys,
     isSafeDbtEnvironmentVariableKey,
     LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX,
+    mergeWarehouseCredentials,
+    WarehouseTypes,
+    type CreateAthenaCredentials,
+    type CreatePostgresCredentials,
+    type CreateRedshiftCredentials,
+    type CreateWarehouseCredentials,
 } from './projects';
 
 describe('dbt environment variable validation', () => {
@@ -48,5 +54,170 @@ describe('dbt environment variable validation', () => {
                 { key: 'PYTHONPATH', value: '/tmp' },
             ]),
         ).toEqual(['GIT_SSH_COMMAND', 'PYTHONPATH']);
+    });
+});
+
+describe('mergeWarehouseCredentials', () => {
+    const athenaBase: CreateAthenaCredentials = {
+        type: WarehouseTypes.ATHENA,
+        region: 'us-east-2',
+        database: 'awsdatacatalog',
+        schema: 'dbt',
+        s3StagingDir: 's3://staging/',
+        accessKeyId: 'PARENT_KEY',
+        secretAccessKey: 'PARENT_SECRET',
+        assumeRoleArn: 'arn:aws:iam::111:role/parent-role',
+        assumeRoleExternalId: 'parent-external-id',
+    };
+
+    test('does not inherit parent assumeRoleArn when preview supplies its own base credentials', () => {
+        // The preview credentials come from profiles.yml with no assume-role config.
+        // JSON transport strips undefined keys, so the incoming object simply omits them.
+        const previewCredentials: CreateAthenaCredentials = {
+            type: WarehouseTypes.ATHENA,
+            region: 'us-east-2',
+            database: 'awsdatacatalog',
+            schema: 'dbt',
+            s3StagingDir: 's3://staging/',
+            accessKeyId: 'PREVIEW_KEY',
+            secretAccessKey: 'PREVIEW_SECRET',
+            sessionToken: 'PREVIEW_TOKEN',
+        };
+
+        const merged = mergeWarehouseCredentials(
+            athenaBase,
+            previewCredentials,
+        );
+
+        expect(merged.assumeRoleArn).toBeUndefined();
+        expect(merged.assumeRoleExternalId).toBeUndefined();
+        // The preview's own base credentials are still used
+        expect(merged.accessKeyId).toBe('PREVIEW_KEY');
+    });
+
+    test('uses the preview assumeRoleArn when it supplies its own', () => {
+        const previewCredentials: CreateAthenaCredentials = {
+            ...athenaBase,
+            accessKeyId: 'PREVIEW_KEY',
+            secretAccessKey: 'PREVIEW_SECRET',
+            assumeRoleArn: 'arn:aws:iam::222:role/preview-role',
+            assumeRoleExternalId: 'preview-external-id',
+        };
+
+        const merged = mergeWarehouseCredentials(
+            athenaBase,
+            previewCredentials,
+        );
+
+        expect(merged.assumeRoleArn).toBe('arn:aws:iam::222:role/preview-role');
+        expect(merged.assumeRoleExternalId).toBe('preview-external-id');
+    });
+
+    test('still inherits non-sensitive advanced settings the preview omits', () => {
+        // Guards against the exclusion being too broad: excluding the assume-role
+        // fields must not stop other parent-only config from being inherited.
+        const previewCredentials: CreateAthenaCredentials = {
+            type: WarehouseTypes.ATHENA,
+            region: 'us-east-2',
+            database: 'awsdatacatalog',
+            schema: 'dbt',
+            s3StagingDir: 's3://staging/',
+            accessKeyId: 'PREVIEW_KEY',
+            secretAccessKey: 'PREVIEW_SECRET',
+        };
+
+        const merged = mergeWarehouseCredentials(
+            { ...athenaBase, workGroup: 'data_platform', numRetries: 7 },
+            previewCredentials,
+        );
+
+        expect(merged.workGroup).toBe('data_platform');
+        expect(merged.numRetries).toBe(7);
+        expect(merged.assumeRoleArn).toBeUndefined();
+    });
+
+    test('does not inherit parent assumeRoleArn for Redshift either', () => {
+        const redshiftBase: CreateRedshiftCredentials = {
+            type: WarehouseTypes.REDSHIFT,
+            host: 'cluster.redshift.amazonaws.com',
+            user: '',
+            port: 5439,
+            dbname: 'dev',
+            schema: 'public',
+            accessKeyId: 'PARENT_KEY',
+            secretAccessKey: 'PARENT_SECRET',
+            assumeRoleArn: 'arn:aws:iam::111:role/parent-role',
+            assumeRoleExternalId: 'parent-external-id',
+        };
+        const previewCredentials: CreateRedshiftCredentials = {
+            type: WarehouseTypes.REDSHIFT,
+            host: 'cluster.redshift.amazonaws.com',
+            user: '',
+            port: 5439,
+            dbname: 'dev',
+            schema: 'public',
+            accessKeyId: 'PREVIEW_KEY',
+            secretAccessKey: 'PREVIEW_SECRET',
+        };
+
+        const merged = mergeWarehouseCredentials(
+            redshiftBase,
+            previewCredentials,
+        );
+
+        expect(merged.assumeRoleArn).toBeUndefined();
+        expect(merged.assumeRoleExternalId).toBeUndefined();
+    });
+
+    test('returns preview credentials as-is when warehouse types differ', () => {
+        const postgresPreview: CreatePostgresCredentials = {
+            type: WarehouseTypes.POSTGRES,
+            host: 'localhost',
+            user: 'preview',
+            password: 'preview',
+            port: 5432,
+            dbname: 'dev',
+            schema: 'public',
+        };
+
+        const parent: CreateWarehouseCredentials = {
+            ...athenaBase,
+            requireUserCredentials: true,
+        };
+        const merged = mergeWarehouseCredentials<CreateWarehouseCredentials>(
+            parent,
+            postgresPreview,
+        );
+
+        expect(merged).toEqual(postgresPreview);
+        expect(merged).not.toHaveProperty('requireUserCredentials');
+    });
+
+    test('preserves requireUserCredentials from either side', () => {
+        const previewCredentials: CreateAthenaCredentials = {
+            type: WarehouseTypes.ATHENA,
+            region: 'us-east-2',
+            database: 'awsdatacatalog',
+            schema: 'dbt',
+            s3StagingDir: 's3://staging/',
+            accessKeyId: 'PREVIEW_KEY',
+            secretAccessKey: 'PREVIEW_SECRET',
+        };
+
+        // Inherited from the parent
+        expect(
+            mergeWarehouseCredentials(
+                { ...athenaBase, requireUserCredentials: true },
+                previewCredentials,
+            ).requireUserCredentials,
+        ).toBe(true);
+
+        // Set by the preview itself
+        expect(
+            mergeWarehouseCredentials(athenaBase, {
+                ...previewCredentials,
+                requireUserCredentials: true,
+            }).requireUserCredentials,
+        ).toBe(true);
     });
 });

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -623,10 +623,15 @@ export const mergeWarehouseCredentials = <T extends CreateWarehouseCredentials>(
         return newCredentials;
     }
 
-    // Only add non sensitive fields from base credentials to avoid conflicts with authentication methods
+    // Only add non sensitive fields from base credentials to avoid conflicts with authentication methods.
+    // assumeRoleArn/assumeRoleExternalId are authentication config tied to the base credentials, so they
+    // must not be inherited when the preview supplies its own credentials (otherwise the preview tries to
+    // assume the parent's role with credentials that aren't authorized to).
     const keysToExclude = [
         ...sensitiveCredentialsFieldNames,
         'authenticationType',
+        'assumeRoleArn',
+        'assumeRoleExternalId',
     ];
     const filteredBaseCredentials = Object.fromEntries(
         Object.entries(baseCredentials).filter(


### PR DESCRIPTION
Closes #24974

## Summary

An Athena `lightdash preview` created with credentials from the user's own `profiles.yml` silently inherited the **parent project's** `assumeRoleArn`. Lightdash then issued `sts:AssumeRole` on that role using the user's personal credentials, which usually aren't authorized to assume it, so every chart query in the preview failed with `[AccessDenied 403] ... is not authorized to perform: sts:AssumeRole`.

This affects the CLI preview path where the user supplies their own warehouse credentials. The `--no-warehouse-credentials` path (which copies the parent connection wholesale) is unaffected. Redshift shares the same fields and the same failure mode.

## Root cause

`mergeWarehouseCredentials` builds a preview connection by layering the CLI-supplied credentials over the parent project's stored credentials, keeping the parent's non-sensitive config. It excluded `sensitiveCredentialsFieldNames` + `authenticationType`, but not the assume-role fields:

```ts
const keysToExclude = [...sensitiveCredentialsFieldNames, 'authenticationType'];
// filteredBaseCredentials keeps the parent's assumeRoleArn...
return { ...filteredBaseCredentials, ...newCredentials }; // ...and newCredentials has no key to override it
```

The user's `profiles.yml` has no `aws_assume_role_arn`, so the CLI serializes `assumeRoleArn: undefined`; JSON transport strips the `undefined` key, so `newCredentials` never overrides the inherited value. The merged preview connection ends up with the user's own base credentials **plus** the parent's `assumeRoleArn`, and `AthenaWarehouseClient` unconditionally assumes that role.

The session-token fix (#24838 / v0.3258.1) didn't introduce this; it unmasked it by letting temporary-credential previews get far enough to run a query.

## Fix

Treat `assumeRoleArn` / `assumeRoleExternalId` as authentication config bound to the base credentials, so they're never inherited when the preview brings its own credentials.

- `packages/common/src/types/projects.ts` — add `assumeRoleArn` and `assumeRoleExternalId` to `keysToExclude` in `mergeWarehouseCredentials`. A preview that sets its own assume-role in `profiles.yml` still uses it (it arrives via `newCredentials`); non-sensitive advanced settings are still inherited from the parent.
- Not added to `sensitiveCredentialsFieldNames` — an ARN is connection config, not a secret, and should stay visible on stored/returned credentials.

## Behaviour

```
Preview built from user's own profiles.yml credentials (no assume-role)

Before:  merged = { accessKeyId: PREVIEW, ..., assumeRoleArn: role/parent }  ->  sts:AssumeRole  ->  AccessDenied 403
After:   merged = { accessKeyId: PREVIEW, ... }                              ->  direct query    ->  ok
```

## Test plan

- [x] `pnpm -F common typecheck:fast` + `eslint` on changed files — clean
- [x] `pnpm -F common test` — 2554 pass; added `mergeWarehouseCredentials` suite (6 cases): Athena regression (the repro), Redshift regression, preview-own-ARN-wins, over-exclusion guard, type-mismatch short-circuit, `requireUserCredentials` both directions
- [x] `pnpm -F backend typecheck:fast` — clean (consumer of `mergeWarehouseCredentials`)
- [ ] Manual (needs real Athena + STS temp creds, not available in CI): run `lightdash preview` from a profiles.yml with own base creds against a project whose stored connection uses an assume-role ARN; charts render instead of `AccessDenied`
