### PR TITLE
feat(data-apps): Data Apps as Code — 1c cross-instance + rate limit + docs

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -842,6 +842,38 @@ The builder/preview inspector overlay is a **tabbed panel** (`AppInspectorPanel.
 
 ---
 
+## Data apps as code
+
+Data apps can be **downloaded as source, versioned in git, edited, and re-uploaded** — the server rebuilds them. This parallels charts/dashboards-as-code, but the artifact is the app's **source tree** and upload triggers a **server-side build** (no built `dist` is ever shipped by the client).
+
+### CLI
+
+Opt-in flags on the existing `lightdash download` / `lightdash upload` commands (off by default — core users never touch app code paths unless they ask):
+
+- **`lightdash download --apps [appUuids...]`** — download data apps into `lightdash/apps/<slug>/`. Bare `--apps` = all apps in the project (listed via the content API); with UUIDs = just those. Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
+- **`lightdash upload --apps [appUuids...]`** — upload each `lightdash/apps/<slug>/` folder; the server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
+
+**Identity:** the manifest's `appUuid` is the source of truth (apps have no persistent slug; the `<slug>` folder name is derived from the app name via `generateSlug`). Uploading to the **same project** appends a new version of that app; uploading to a **different project** creates a new app there.
+
+### What the endpoints do
+
+- **Download** — `GET /api/v1/ee/projects/{projectUuid}/apps/{appUuid}/download` reads the version's `source.tar` from S3, extracts it in-process (`tar-stream`), and returns the `src/` files + manifest (`AppGenerateService.getAppCode`).
+- **Upload** — `POST /api/v1/ee/projects/{projectUuid}/apps/upload` (`AppGenerateService.importAppCode`) validates the source (`validateDataAppCode` rejects path traversal), re-tars it, stores `source.tar` at the new version's prefix, creates a `pending` version, and enqueues the **build-only pipeline** `APP_BUILD_FROM_SOURCE` (`runBuildFromSourcePipeline`): sandbox → restore source → `pnpm build` (**fail-loud, no AI autofix**) → package → store → `ready`. Concurrent builds are **rate-limited per project** (`MAX_CONCURRENT_APP_BUILDS_PER_PROJECT`, HTTP 429 when exceeded).
+
+### Moving an app between projects or instances
+
+- **Different project (same instance):** `lightdash upload --apps --project <target-project>` — creates and builds the app in the target project.
+- **Different instance:** point the CLI at the destination first — `lightdash login <destination-url>` (or set `LIGHTDASH_URL` / `LIGHTDASH_API_KEY`) — then `lightdash upload --apps --project <target>`. The **destination builds the source in its own sandbox** (so it must have data apps / the build sandbox enabled); it never receives code built elsewhere.
+
+### Constraints & notes
+
+- **Enterprise-only** (`APP_RUNTIME_ENABLED`); the caller needs `view` / `create` / `manage:DataApp`.
+- **Fixed dependency set:** upload rebuilds against the sandbox template's pre-installed libraries — you can edit source but can't add libraries the sandbox lacks (a future "bring your own libraries" phase covers that via local builds).
+- **Semantic-layer coupling:** a moved app's queries run against the **target project's** fields *by name*; fields missing in the target surface as in-app query errors, not upload failures.
+- **Security:** because the server only ever builds source in its trusted, network-locked sandbox and never serves client-supplied *built* code, the runtime trust model is unchanged from AI-generated apps. See [Security Model](#security-model). (Follow-up: the query bridge runs as the *viewing* user — a pre-existing consideration for any app, generated or uploaded.)
+
+---
+
 ## Frontend Architecture
 
 ### Pages

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -1,5 +1,6 @@
 import {
     ParameterError,
+    TooManyRequestsError,
     type DataAppCode,
     type ImportAppCodeRequestBody,
 } from '@lightdash/common';
@@ -62,6 +63,7 @@ function buildService() {
         }),
         createVersion: vi.fn().mockResolvedValue({ version: 1 }),
         getLatestVersion: vi.fn().mockResolvedValue(null),
+        countInProgressVersionsForProject: vi.fn().mockResolvedValue(0),
     };
 
     const schedulerClient = {
@@ -269,5 +271,43 @@ describe('AppGenerateService.importAppCode', () => {
                 code: noSrcCode,
             } as ImportAppCodeRequestBody),
         ).rejects.toThrow('bundle has no src/ files to build');
+    });
+
+    it('throws TooManyRequestsError when in-progress build count is at the cap', async () => {
+        const { service, appModel, schedulerClient } = buildService();
+
+        appModel.findApp.mockResolvedValue(undefined);
+        appModel.countInProgressVersionsForProject.mockResolvedValue(5);
+
+        await expect(
+            service.importAppCode(makeUser(), PROJECT_UUID, {
+                code: makeCode(),
+            } as ImportAppCodeRequestBody),
+        ).rejects.toThrow(TooManyRequestsError);
+
+        await expect(
+            service.importAppCode(makeUser(), PROJECT_UUID, {
+                code: makeCode(),
+            } as ImportAppCodeRequestBody),
+        ).rejects.toThrow('Too many app builds in progress for this project');
+
+        // must not create a version or enqueue a build
+        expect(appModel.createWithVersion).not.toHaveBeenCalled();
+        expect(schedulerClient.appBuildFromSource).not.toHaveBeenCalled();
+    });
+
+    it('proceeds normally when in-progress build count is zero', async () => {
+        const { service, appModel, schedulerClient } = buildService();
+
+        appModel.findApp.mockResolvedValue(undefined);
+        appModel.countInProgressVersionsForProject.mockResolvedValue(0);
+
+        const result = await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(),
+        } as ImportAppCodeRequestBody);
+
+        expect(result.action).toBe('create');
+        expect(appModel.createWithVersion).toHaveBeenCalledOnce();
+        expect(schedulerClient.appBuildFromSource).toHaveBeenCalledOnce();
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -26,6 +26,7 @@ import {
     NotFoundError,
     ParameterError,
     QueryExecutionContext,
+    TooManyRequestsError,
     validateDataAppCode,
     type AnonymousAccount,
     type AppBuildFromSourceJobPayload,
@@ -192,6 +193,9 @@ const DATA_APP_WORKSPACE: PersistentWorkspace = {
     ],
     exclude: ['node_modules'],
 };
+// Maximum number of in-progress app builds allowed per project at one time.
+// Prevents trivial sandbox exhaustion via repeated POST /code calls.
+const MAX_CONCURRENT_APP_BUILDS_PER_PROJECT = 5;
 
 export class AppGenerateService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
@@ -6508,6 +6512,14 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             existingApp !== undefined ? 'append' : 'create';
 
         const organizationUuid = await this.getProjectOrgUuid(projectUuid);
+
+        const inProgressCount =
+            await this.appModel.countInProgressVersionsForProject(projectUuid);
+        if (inProgressCount >= MAX_CONCURRENT_APP_BUILDS_PER_PROJECT) {
+            throw new TooManyRequestsError(
+                `Too many app builds in progress for this project (${inProgressCount}/${MAX_CONCURRENT_APP_BUILDS_PER_PROJECT}). Wait for some to finish and try again.`,
+            );
+        }
 
         let newAppUuid: string;
         let newVersion: number;

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -936,4 +936,20 @@ export class AppModel {
         );
         return result.rowCount ?? 0;
     }
+
+    async countInProgressVersionsForProject(
+        projectUuid: string,
+    ): Promise<number> {
+        const [row] = await this.database(AppVersionsTableName)
+            .join(
+                AppsTableName,
+                `${AppsTableName}.app_id`,
+                `${AppVersionsTableName}.app_id`,
+            )
+            .where(`${AppsTableName}.project_uuid`, projectUuid)
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .whereNotIn('status', [...APP_VERSION_TERMINAL_STATUSES])
+            .count<{ count: string }[]>({ count: '*' });
+        return parseInt(row.count, 10);
+    }
 }


### PR DESCRIPTION
## Summary

Part of **Data Apps as Code** (spec: GLITCH-527). **Slice 1c** — hardening + docs for the source+build flow. Stacked on #24949.

## What's here

- **backend — build rate limit.** `importAppCode` now rejects with **429 `TooManyRequestsError`** when a project already has `MAX_CONCURRENT_APP_BUILDS_PER_PROJECT` (=5) builds in progress, preventing trivial sandbox exhaustion via `POST /code` (the one operational follow-up from the security review). Adds `AppModel.countInProgressVersionsForProject`.
- **docs — `docs/data-apps.md` "Data apps as code" section:** the `download --apps` / `upload --apps` UX, source→rebuild, moving across projects/instances, the fixed-dependency-set + semantic-layer caveats, and the security note (incl. the pre-existing confused-deputy consideration).
- **cross-instance:** works via the CLI's existing instance targeting — `lightdash login <destination-url>` or `LIGHTDASH_URL`/`LIGHTDASH_API_KEY` — so a download from instance A can be uploaded to instance B, which builds it in its own sandbox. Documented rather than adding redundant per-command `--url`/`--token` flags.

## Security context

Implements the operational follow-up from the adversarial-author review (which was otherwise all-SOLID — the server only builds source in its trusted sandbox and never serves client-built code). See spec GLITCH-527.

## Remaining follow-up (not in this PR)

- Surface the build `error` to the UI/CLI so a *failed* upload build shows *why* (upload is fire-and-forget; the app's build status is the current signal).

Relates: GLITCH-556
Closes: GLITCH-561

🤖 Generated with [Claude Code](https://claude.com/claude-code)