### PR TITLE
fix(common): correct findExplores/findFields tool annotations for TS7 build

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -320,11 +320,12 @@ const routeAgentStructuredOutputSchema = z.object({
     ),
 });
 
-export const findExploresToolDefinition: ToolDefinitionWithoutMcpOutput<
+export const findExploresToolDefinition: ToolDefinitionWithMcpOutput<
     'findExplores',
     typeof toolFindExploresArgsSchemaV3,
     typeof toolFindExploresArgsSchemaV3,
-    typeof toolFindExploresOutputSchema
+    typeof toolFindExploresOutputSchema,
+    typeof findExploresResultSchema
 > = defineTool({
     name: 'findExplores',
     title: 'Find explores',
@@ -338,11 +339,12 @@ export const findExploresToolDefinition: ToolDefinitionWithoutMcpOutput<
     },
 });
 
-export const findFieldsToolDefinition: ToolDefinitionWithoutMcpOutput<
+export const findFieldsToolDefinition: ToolDefinitionWithMcpOutput<
     'findFields',
     typeof toolFindFieldsArgsSchema,
     typeof toolFindFieldsArgsSchema,
-    typeof toolFindFieldsOutputSchema
+    typeof toolFindFieldsOutputSchema,
+    typeof findFieldsResultSchema
 > = defineTool({
     name: 'findFields',
     title: 'Find fields',


### PR DESCRIPTION
## What

Follow-up fix to #24960. During that PR's rebase, `main` had independently added an `mcp.structuredContentSchema` to `findExplores` and `findFields`, which git auto-merged alongside their (now-stale) `ToolDefinitionWithoutMcpOutput` annotations. With a structured content schema, `defineTool` returns `ToolDefinitionWithMcpOutput`, so the annotations were wrong.

`tsc` (TS6) tolerated the mismatch, so it passed local typecheck and the TS6 build. **`tsgo` (TS7), which `build:fast` uses in CI, rejects it** with `TS2322`, which broke `Build & Test` on `main`.

This annotates both tools with `ToolDefinitionWithMcpOutput<…, typeof <structuredSchema>>`.

## Verification

- `pnpm -F common build:fast` (tsgo/TS7) — clean.
- `pnpm -F common build` (tsc/TS6) — clean.
- Audited all annotated `defineTool` exports: 0 remaining annotation/body mismatches.

Relates: PROD-8596
