### PR TITLE
feat(data-apps): surface build error in the app UI

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -5299,6 +5299,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             prompt: string;
             status: AppVersionStatus;
             statusMessage: string | null;
+            error: string | null;
             createdAt: Date;
             statusUpdatedAt: Date | null;
             createdByUser: {
@@ -5348,6 +5349,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 prompt: v.prompt,
                 status: v.status,
                 statusMessage: v.status_message,
+                error: v.error,
                 // Backfill `clarifications` for rows persisted before the
                 // field existed on `resources`.
                 resources: v.resources

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9636,6 +9636,14 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 createdAt: { dataType: 'datetime', required: true },
+                error: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 statusMessage: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10930,6 +10930,10 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "error": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "statusMessage": {
                         "type": "string",
                         "nullable": true
@@ -10950,6 +10954,7 @@
                     "createdByUser",
                     "statusUpdatedAt",
                     "createdAt",
+                    "error",
                     "statusMessage",
                     "status",
                     "prompt",

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1886,22 +1886,21 @@ export const uploadHandler = async (
                         ),
                     );
                 } catch (appErr) {
-                    if (
-                        appErr instanceof LightdashError &&
-                        appErr.statusCode === 404
-                    ) {
-                        GlobalState.log(
-                            styles.error(
-                                `App folder "${subDir.name}": data apps are not enabled on this instance, or the app was not found.`,
-                            ),
-                        );
-                    } else {
-                        GlobalState.log(
-                            styles.error(
-                                `Failed to upload app folder "${subDir.name}": ${getErrorMessage(appErr)}`,
-                            ),
-                        );
-                    }
+                    const status =
+                        appErr instanceof LightdashError
+                            ? appErr.statusCode
+                            : undefined;
+                    const hint =
+                        status === 404
+                            ? ' — the enterprise "data apps" feature may not be enabled on this instance'
+                            : '';
+                    GlobalState.log(
+                        styles.error(
+                            `Failed to upload app folder "${subDir.name}"${
+                                status ? ` [HTTP ${status}]` : ''
+                            }: ${getErrorMessage(appErr)}${hint}`,
+                        ),
+                    );
                 }
             }
         }

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -237,6 +237,10 @@ export type ApiAppVersionSummary = {
     prompt: string;
     status: AppVersionStatus;
     statusMessage: string | null;
+    // Detailed failure reason (e.g. the build's stderr) when `status` is
+    // `error`; null otherwise. `statusMessage` carries the short user-facing
+    // line (e.g. "Build failed"); this carries the why.
+    error: string | null;
     createdAt: Date;
     // When the version last transitioned (e.g. into `ready` or `error`).
     // The chat UI shows this as the assistant-reply timestamp so it reflects

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -883,6 +883,7 @@ const AppGenerate: FC = () => {
                 msgs.push({
                     role: 'assistant',
                     content:
+                        v.error ??
                         v.statusMessage ??
                         'Generation failed. Please try again.',
                     imagePreviewUrls: [],


### PR DESCRIPTION
## Summary

Follow-up on the **Data Apps as Code** stack (spec: GLITCH-527), stacked on #24977 — surfaces **why** a build failed.

Previously a version's detailed failure reason (the build's stderr, set by `markError`) was stored in `app_versions.error` but **never exposed by the API** — only the short generic `statusMessage` ("Build failed") was returned. This exposes it and shows it in the builder UI.

## What's here

- **common** — `error: string | null` on `ApiAppVersionSummary`.
- **backend** — `getAppVersions` maps the DB `error` column into the summary; `generate-api` regenerated.
- **frontend** — the builder chat's error bubble now shows `error ?? statusMessage`, so a failed build shows the actual reason (Vite/tsc stderr), not just "Build failed". Applies to both AI-generated apps and uploaded (`upload --apps`) apps.

## Notes

- `upload --apps` is fire-and-forget, so this is the surfacing point for CLI-uploaded builds: open the app and the failed version shows why.
- The stderr is shown as-is (truncated to 4000 chars server-side); a nicer code-block rendering could be a small follow-up.

Relates: GLITCH-556

🤖 Generated with [Claude Code](https://claude.com/claude-code)