### PR TITLE
feat(data-apps): add external requests inspector tab

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -829,6 +829,15 @@ From a successful test, an admin can **Save as sample** (`POST .../external-conn
 
 During a generation, for every linked connection that has a saved sample, the pipeline (`AppGenerateService.writeCatalogAndPrompt` → `writeExternalConnectionSamples`) writes `/tmp/external-data/{alias}.json` into the sandbox and prepends a one-line reference to `/tmp/prompt.txt`, mirroring how chart-reference and image files are surfaced. This grounds Claude in the API's response shape (field names, nesting, formats) so its fetch/render code matches reality. The sample is for code generation only — at runtime the app fetches live data through the proxy, never from these files. The skill (`sandboxes/data-apps/template/skill.md`, "Linked external connections" section) documents the convention; keep the prompt-prepend wording and that section in sync.
 
+### Inspecting external requests at runtime
+
+The builder/preview inspector overlay is a **tabbed panel** (`AppInspectorPanel.tsx`) with two tabs that mirror each other: **Queries** (metric queries) and **External requests** (external-connection fetches). Both are captured client-side from the same `useAppSdkBridge` postMessage bridge — nothing is persisted server-side beyond the existing `external_connection.fetch` audit event (which stores byte counts, not bodies).
+
+- **Capture.** The bridge's external-fetch branch emits an `ExternalRequestEvent` when a fetch starts (`pending`) and a terminal `ready`/`error` event when it settles (carrying the upstream HTTP status, content type, response body, `truncated` flag, and round-trip duration). Because an external fetch is a single request → single response, entries merge by `id` with no `queryUuid` remap — `useTrackedExternalRequests` is the simpler sibling of `useTrackedAppQueries`.
+- **Always visible.** Both tabs are always shown (the Requests tab reads `Requests (0)` when idle), so clearing the log doesn't yank the tab out from under the user, and the tab surfaces the feature to apps that haven't used a connection yet.
+- **What's shown.** Per request: connection alias, method + path, query params, request body, response status/content-type/body (collapsible + copy), truncation, error, and duration. The frontend only knows the **alias + path**, never the connection's origin or secret — auth is injected server-side in `executeExternalFetch`, so the panel can never display credential material.
+- **Persistence.** Entries live in in-memory React state, cleared on iframe refresh / new-version load unless the shared **Persist** toggle is on (the same `data-apps:persist-logs` preference the Queries tab uses). "Persist" moves still-`pending` entries to a terminal `error` on reload rather than dropping them.
+
 ---
 
 ## Frontend Architecture

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -9,6 +9,7 @@ import {
 import {
     useAppSdkBridge,
     type ElementSelectedEvent,
+    type ExternalRequestEvent,
     type QueryEvent,
 } from './hooks/useAppSdkBridge';
 import { useIframeScreenshot } from './hooks/useIframeScreenshot';
@@ -36,6 +37,10 @@ type Props = {
      *  Inspect/Screenshot buttons don't flicker off-then-back-on each time. */
     identityKey: string;
     onQueryEvent?: (event: QueryEvent) => void;
+    /** Reports external-connection fetches for the external-requests inspector
+     *  tab. Left undefined by hosts that don't surface the inspector (embed,
+     *  dashboard tiles). */
+    onExternalRequestEvent?: (event: ExternalRequestEvent) => void;
     onElementSelected?: (event: ElementSelectedEvent) => void;
     /** When true, the iframe-side inspector overlay is active and clicks
      *  are intercepted to produce element-selected events. */
@@ -112,6 +117,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             appUuid,
             identityKey,
             onQueryEvent,
+            onExternalRequestEvent,
             onElementSelected,
             inspectorEnabled,
             onInspectorAvailabilityChange,
@@ -163,6 +169,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             capabilities,
             handleLineageAnnounce,
             onLineageSelected,
+            onExternalRequestEvent,
         );
         const { captureScreenshot } = useIframeScreenshot(iframeRef);
 

--- a/packages/frontend/src/features/apps/AppInspector.module.css
+++ b/packages/frontend/src/features/apps/AppInspector.module.css
@@ -18,11 +18,13 @@
     }
 }
 
-/* Collapsed: only take 1/3 of the available width, anchored bottom-left. */
+/* Collapsed: size to the title-bar content (tabs + actions), anchored
+ * bottom-left, capped at the full available width. */
 .containerCollapsed {
     right: auto;
-    width: calc(
-        (100% - var(--mantine-spacing-sm) - var(--mantine-spacing-sm)) / 3
+    width: max-content;
+    max-width: calc(
+        100% - var(--mantine-spacing-sm) - var(--mantine-spacing-sm)
     );
 }
 
@@ -36,6 +38,68 @@
     }
     @mixin dark {
         border-bottom: 1px solid var(--mantine-color-ldDark-4);
+    }
+}
+
+/* Segmented-control-style tab switcher: a subtle track holding two pills,
+ * with an elevated "thumb" marking the active tab. */
+.tabBar {
+    display: flex;
+    gap: 2px;
+    min-width: 0;
+    padding: 2px;
+    border-radius: var(--mantine-radius-md);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-1);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-8);
+    }
+}
+
+.tab {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px var(--mantine-spacing-sm);
+    /* Reset native <button> chrome so it doesn't render the UA bevel. */
+    appearance: none;
+    -webkit-appearance: none;
+    border: none;
+    margin: 0;
+    font: inherit;
+    line-height: 1;
+    border-radius: var(--mantine-radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    background-color: transparent;
+    color: var(--mantine-color-dimmed);
+    transition:
+        color 120ms ease,
+        background-color 120ms ease,
+        box-shadow 120ms ease;
+
+    &:hover:not(.tabActive) {
+        @mixin light {
+            color: var(--mantine-color-dark-6);
+        }
+        @mixin dark {
+            color: var(--mantine-color-gray-3);
+        }
+    }
+}
+
+.tabActive {
+    @mixin light {
+        background-color: var(--mantine-color-white);
+        color: var(--mantine-color-dark-9);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-5);
+        color: var(--mantine-color-white);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
     }
 }
 

--- a/packages/frontend/src/features/apps/AppInspectorPanel.test.tsx
+++ b/packages/frontend/src/features/apps/AppInspectorPanel.test.tsx
@@ -1,7 +1,8 @@
-// QueryInspector.test.tsx
+// AppInspectorPanel.test.tsx
 import { MantineProvider } from '@mantine-8/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import QueryInspector from './QueryInspector';
+import AppInspectorPanel from './AppInspectorPanel';
+import type { ExternalRequestEvent } from './hooks/useAppSdkBridge';
 
 const baseQuery = {
     id: '1',
@@ -23,25 +24,44 @@ const baseQuery = {
     rawMetricQuery: null,
 };
 
-const renderInspector = (
-    props: Partial<React.ComponentProps<typeof QueryInspector>>,
+const baseExternalRequest: ExternalRequestEvent = {
+    id: 'ext-1',
+    timestamp: 0,
+    alias: 'stripe',
+    method: 'GET',
+    path: '/v1/charges',
+    query: null,
+    requestBody: null,
+    status: 'ready',
+    httpStatus: 200,
+    contentType: 'application/json',
+    responseBody: { ok: true },
+    truncated: false,
+    durationMs: 42,
+    error: null,
+};
+
+const renderPanel = (
+    props: Partial<React.ComponentProps<typeof AppInspectorPanel>>,
 ) =>
     render(
         <MantineProvider>
-            <QueryInspector
+            <AppInspectorPanel
                 queries={[baseQuery]}
+                externalRequests={[]}
                 projectUuid="p-1"
-                onClear={() => {}}
+                onClearQueries={() => {}}
+                onClearExternalRequests={() => {}}
                 onDismiss={() => {}}
                 {...props}
             />
         </MantineProvider>,
     );
 
-describe('QueryInspector lineage hooks', () => {
+describe('AppInspectorPanel lineage hooks', () => {
     it('calls onHoverQuery with the queryUuid on hover and null on leave', () => {
         const onHoverQuery = vi.fn();
-        renderInspector({ onHoverQuery });
+        renderPanel({ onHoverQuery, defaultCollapsed: false });
         const row = document.querySelector('[data-query-uuid="q-1"]')!;
         fireEvent.mouseEnter(row);
         expect(onHoverQuery).toHaveBeenCalledWith('q-1');
@@ -69,7 +89,7 @@ describe('QueryInspector lineage hooks', () => {
         });
 
         it('scrolls the focused row into view with smooth behavior', () => {
-            renderInspector({
+            renderPanel({
                 focusedQueryUuid: 'q-1',
                 defaultCollapsed: false,
             });
@@ -80,7 +100,7 @@ describe('QueryInspector lineage hooks', () => {
         });
 
         it('does NOT scroll when focusedQueryUuid does not match any row', () => {
-            renderInspector({
+            renderPanel({
                 focusedQueryUuid: 'does-not-exist',
                 defaultCollapsed: false,
             });
@@ -88,7 +108,7 @@ describe('QueryInspector lineage hooks', () => {
         });
 
         it('applies the focused CSS class to the matching row', () => {
-            renderInspector({
+            renderPanel({
                 focusedQueryUuid: 'q-1',
                 defaultCollapsed: false,
             });
@@ -98,9 +118,9 @@ describe('QueryInspector lineage hooks', () => {
 
         it('auto-uncollapses the panel when a matching focusedQueryUuid arrives', async () => {
             // Panel starts collapsed (defaultCollapsed defaults to true).
-            // The effect in QueryInspector should call setCollapsed(false)
-            // because 'q-1' matches a query in the list, making the row visible.
-            renderInspector({ focusedQueryUuid: 'q-1' });
+            // The effect should call setCollapsed(false) because 'q-1' matches
+            // a query in the list, making the row visible.
+            renderPanel({ focusedQueryUuid: 'q-1' });
             await waitFor(() =>
                 expect(screen.getByText('Revenue')).toBeVisible(),
             );
@@ -110,7 +130,7 @@ describe('QueryInspector lineage hooks', () => {
     describe('inspect data toggle', () => {
         it('calls onToggleLineage when the header toggle is clicked', () => {
             const onToggleLineage = vi.fn();
-            renderInspector({
+            renderPanel({
                 onToggleLineage,
                 lineageAvailable: true,
                 defaultCollapsed: false,
@@ -122,7 +142,7 @@ describe('QueryInspector lineage hooks', () => {
         });
 
         it('disables the toggle when lineage is unavailable', () => {
-            renderInspector({
+            renderPanel({
                 onToggleLineage: vi.fn(),
                 lineageAvailable: false,
                 defaultCollapsed: false,
@@ -131,5 +151,48 @@ describe('QueryInspector lineage hooks', () => {
                 screen.getByLabelText('Toggle data lineage inspector'),
             ).toBeDisabled();
         });
+    });
+});
+
+describe('AppInspectorPanel external requests tab', () => {
+    it('always shows the requests tab, even with none', () => {
+        renderPanel({ externalRequests: [], defaultCollapsed: false });
+        expect(screen.getByText('Requests (0)')).toBeInTheDocument();
+    });
+
+    it('reflects the request count in the tab label', () => {
+        renderPanel({
+            externalRequests: [baseExternalRequest],
+            defaultCollapsed: false,
+        });
+        expect(screen.getByText('Requests (1)')).toBeInTheDocument();
+    });
+
+    it('switches to the requests tab and renders the request', () => {
+        renderPanel({
+            externalRequests: [baseExternalRequest],
+            defaultCollapsed: false,
+        });
+        fireEvent.click(screen.getByText('Requests (1)'));
+        // Rendered in the row header (Mantine Collapse keeps the expanded
+        // detail mounted, so the same text can also appear there).
+        expect(screen.getAllByText('GET /v1/charges').length).toBeGreaterThan(
+            0,
+        );
+    });
+
+    it('clears the active tab: external requests when the requests tab is active', () => {
+        const onClearQueries = vi.fn();
+        const onClearExternalRequests = vi.fn();
+        renderPanel({
+            externalRequests: [baseExternalRequest],
+            onClearQueries,
+            onClearExternalRequests,
+            defaultCollapsed: false,
+        });
+        fireEvent.click(screen.getByText('Requests (1)'));
+        fireEvent.click(screen.getByLabelText('Clear external requests'));
+        expect(onClearExternalRequests).toHaveBeenCalledTimes(1);
+        expect(onClearQueries).not.toHaveBeenCalled();
     });
 });

--- a/packages/frontend/src/features/apps/AppInspectorPanel.tsx
+++ b/packages/frontend/src/features/apps/AppInspectorPanel.tsx
@@ -1,0 +1,338 @@
+import {
+    ActionIcon,
+    Box,
+    Collapse,
+    Group,
+    ScrollArea,
+    Switch,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import {
+    IconChevronDown,
+    IconChevronRight,
+    IconDatabase,
+    IconDatabaseSearch,
+    IconTrash,
+    IconWorld,
+    IconX,
+} from '@tabler/icons-react';
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type FC,
+    type ReactNode,
+} from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+import classes from './AppInspector.module.css';
+import { ExternalRequestInspectorContent } from './ExternalRequestInspector';
+import type { ExternalRequestEvent, QueryEvent } from './hooks/useAppSdkBridge';
+import { QueryInspectorContent } from './QueryInspector';
+
+type InspectorTab = 'queries' | 'external';
+
+type Props = {
+    projectUuid: string;
+    /** Metric queries for the "Queries" tab. */
+    queries: QueryEvent[];
+    onClearQueries: () => void;
+    onHoverQuery?: (queryUuid: string | null) => void;
+    focusedQueryUuid?: string | null;
+    /** Data-lineage ("Inspect data") toggle — only shown on the Queries tab.
+     *  When `onToggleLineage` is omitted, the toggle is hidden. */
+    lineageEnabled?: boolean;
+    lineageAvailable?: boolean;
+    onToggleLineage?: () => void;
+    /** External-connection fetches for the "Requests" tab. The tab is always
+     *  shown (even at zero) so it survives a clear and surfaces the feature. */
+    externalRequests: ExternalRequestEvent[];
+    onClearExternalRequests: () => void;
+    /** Persist preference + handler — when omitted, the "Persist" switch is
+     *  hidden. Governs both tabs (see `useTrackedAppQueries`). */
+    persistLogs?: boolean;
+    onPersistLogsChange?: (value: boolean) => void;
+    /** Initial value of the internal `collapsed` state. Defaults to `true` so
+     *  the builder's panel boots as a collapsed title bar. */
+    defaultCollapsed?: boolean;
+    /** Called when the user clicks the X. The parent owns visibility and should
+     *  unmount the panel in response. */
+    onDismiss: () => void;
+    /** When `false`, the panel stays visible (as a collapsed title bar) even
+     *  with nothing to show. */
+    hideWhenEmpty?: boolean;
+};
+
+const MIN_HEIGHT = 100;
+const MAX_HEIGHT = 600;
+const DEFAULT_HEIGHT = 300;
+
+const TabButton: FC<{
+    active: boolean;
+    icon: ReactNode;
+    label: string;
+    onSelect: () => void;
+}> = ({ active, icon, label, onSelect }) => (
+    <Box
+        component="button"
+        type="button"
+        className={`${classes.tab}${active ? ` ${classes.tabActive}` : ''}`}
+        onClick={(e) => {
+            e.stopPropagation();
+            onSelect();
+        }}
+    >
+        {icon}
+        <Text size="xs" fw={500}>
+            {label}
+        </Text>
+    </Box>
+);
+
+const AppInspectorPanel: FC<Props> = ({
+    projectUuid,
+    queries,
+    onClearQueries,
+    onHoverQuery,
+    focusedQueryUuid,
+    lineageEnabled,
+    lineageAvailable,
+    onToggleLineage,
+    externalRequests,
+    onClearExternalRequests,
+    persistLogs,
+    onPersistLogsChange,
+    defaultCollapsed = true,
+    onDismiss,
+    hideWhenEmpty = true,
+}) => {
+    const [collapsed, setCollapsed] = useState(defaultCollapsed);
+    const [height, setHeight] = useState(DEFAULT_HEIGHT);
+    const [activeTab, setActiveTab] = useState<InspectorTab>('queries');
+    const dragRef = useRef<{ startY: number; startHeight: number } | null>(
+        null,
+    );
+
+    const queriesLabel = `Queries (${queries.length})`;
+    // Kept short so both tabs fit the collapsed (content-width) title bar.
+    const externalLabel = `Requests (${externalRequests.length})`;
+
+    const toggle = useCallback(() => setCollapsed((v) => !v), []);
+
+    const selectTab = useCallback((tab: InspectorTab) => {
+        setActiveTab(tab);
+        setCollapsed(false);
+    }, []);
+
+    const handleResizeStart = useCallback(
+        (e: React.PointerEvent<HTMLDivElement>) => {
+            e.preventDefault();
+            e.currentTarget.setPointerCapture(e.pointerId);
+            dragRef.current = { startY: e.clientY, startHeight: height };
+        },
+        [height],
+    );
+
+    const handleResizeMove = useCallback(
+        (e: React.PointerEvent<HTMLDivElement>) => {
+            if (!dragRef.current) return;
+            const delta = dragRef.current.startY - e.clientY;
+            const newHeight = Math.min(
+                MAX_HEIGHT,
+                Math.max(MIN_HEIGHT, dragRef.current.startHeight + delta),
+            );
+            setHeight(newHeight);
+        },
+        [],
+    );
+
+    const handleResizeEnd = useCallback(() => {
+        dragRef.current = null;
+    }, []);
+
+    const handleDismiss = useCallback(
+        (e: React.MouseEvent) => {
+            e.stopPropagation();
+            onDismiss();
+        },
+        [onDismiss],
+    );
+
+    const handleClear = useCallback(
+        (e: React.MouseEvent) => {
+            e.stopPropagation();
+            if (activeTab === 'external') onClearExternalRequests();
+            else onClearQueries();
+        },
+        [activeTab, onClearExternalRequests, onClearQueries],
+    );
+
+    // Auto-uncollapse and switch to the Queries tab when a matching focused
+    // query arrives so the focused row is not hidden inside a closed collapse
+    // region or behind the other tab.
+    useEffect(() => {
+        if (
+            focusedQueryUuid != null &&
+            queries.some((q) => q.queryUuid === focusedQueryUuid)
+        ) {
+            setCollapsed(false);
+            setActiveTab('queries');
+        }
+    }, [focusedQueryUuid, queries]);
+
+    // Hide the panel entirely only when there's nothing to show *and* the user
+    // hasn't engaged with it. Once expanded it stays mounted with an empty
+    // state so the next entry lands somewhere visible.
+    if (
+        hideWhenEmpty &&
+        queries.length === 0 &&
+        externalRequests.length === 0 &&
+        collapsed
+    ) {
+        return null;
+    }
+
+    const clearLabel =
+        activeTab === 'external' ? 'Clear external requests' : 'Clear queries';
+
+    return (
+        <Box
+            className={
+                collapsed
+                    ? `${classes.container} ${classes.containerCollapsed}`
+                    : classes.container
+            }
+        >
+            <Group
+                gap="xs"
+                wrap="nowrap"
+                className={classes.titleBar}
+                onClick={toggle}
+            >
+                {/* Both tabs are always shown — the Requests tab stays visible
+                    even at zero (surviving a clear, and surfacing the feature). */}
+                <Group gap={2} wrap="nowrap" className={classes.tabBar}>
+                    <TabButton
+                        active={activeTab === 'queries'}
+                        icon={<MantineIcon icon={IconDatabase} size={14} />}
+                        label={queriesLabel}
+                        onSelect={() => selectTab('queries')}
+                    />
+                    <TabButton
+                        active={activeTab === 'external'}
+                        icon={<MantineIcon icon={IconWorld} size={14} />}
+                        label={externalLabel}
+                        onSelect={() => selectTab('external')}
+                    />
+                </Group>
+                <Box ml="auto" />
+                {!collapsed && (
+                    <>
+                        {onToggleLineage && activeTab === 'queries' && (
+                            <Tooltip
+                                label={
+                                    lineageEnabled
+                                        ? 'Inspect data: on'
+                                        : 'Inspect data'
+                                }
+                                withArrow
+                                position="top"
+                            >
+                                <ActionIcon
+                                    variant={
+                                        lineageEnabled ? 'filled' : 'subtle'
+                                    }
+                                    color={lineageEnabled ? 'violet' : 'gray'}
+                                    size="xs"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onToggleLineage();
+                                    }}
+                                    disabled={!lineageAvailable}
+                                    aria-label="Toggle data lineage inspector"
+                                >
+                                    <MantineIcon
+                                        icon={IconDatabaseSearch}
+                                        size={12}
+                                    />
+                                </ActionIcon>
+                            </Tooltip>
+                        )}
+                        <Tooltip label={clearLabel} withArrow position="top">
+                            <ActionIcon
+                                variant="subtle"
+                                size="xs"
+                                color="gray"
+                                onClick={handleClear}
+                                aria-label={clearLabel}
+                            >
+                                <MantineIcon icon={IconTrash} size={12} />
+                            </ActionIcon>
+                        </Tooltip>
+                        {onPersistLogsChange && (
+                            <Tooltip
+                                label="Preserve logs across iframe refreshes and new app versions"
+                                withArrow
+                                position="top"
+                            >
+                                <Box onClick={(e) => e.stopPropagation()}>
+                                    <Switch
+                                        size="xs"
+                                        label="Persist"
+                                        checked={persistLogs ?? false}
+                                        onChange={(e) =>
+                                            onPersistLogsChange(
+                                                e.currentTarget.checked,
+                                            )
+                                        }
+                                    />
+                                </Box>
+                            </Tooltip>
+                        )}
+                    </>
+                )}
+                <ActionIcon variant="subtle" size="xs" color="gray">
+                    {collapsed ? (
+                        <MantineIcon icon={IconChevronRight} size={12} />
+                    ) : (
+                        <MantineIcon icon={IconChevronDown} size={12} />
+                    )}
+                </ActionIcon>
+                <ActionIcon
+                    variant="subtle"
+                    size="xs"
+                    color="gray"
+                    onClick={handleDismiss}
+                    aria-label="Close inspector panel"
+                >
+                    <MantineIcon icon={IconX} size={12} />
+                </ActionIcon>
+            </Group>
+            <Collapse in={!collapsed}>
+                <Box
+                    className={classes.resizeHandle}
+                    onPointerDown={handleResizeStart}
+                    onPointerMove={handleResizeMove}
+                    onPointerUp={handleResizeEnd}
+                />
+                <ScrollArea h={height}>
+                    {activeTab === 'external' ? (
+                        <ExternalRequestInspectorContent
+                            requests={externalRequests}
+                        />
+                    ) : (
+                        <QueryInspectorContent
+                            queries={queries}
+                            projectUuid={projectUuid}
+                            onHoverQuery={onHoverQuery}
+                            focusedQueryUuid={focusedQueryUuid}
+                        />
+                    )}
+                </ScrollArea>
+            </Collapse>
+        </Box>
+    );
+};
+
+export default AppInspectorPanel;

--- a/packages/frontend/src/features/apps/ExternalRequestInspector.tsx
+++ b/packages/frontend/src/features/apps/ExternalRequestInspector.tsx
@@ -1,0 +1,260 @@
+import {
+    ActionIcon,
+    Badge,
+    Box,
+    Code,
+    Collapse,
+    CopyButton,
+    Group,
+    ScrollArea,
+    Text,
+} from '@mantine-8/core';
+import {
+    IconChevronDown,
+    IconChevronRight,
+    IconCopy,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+import classes from './AppInspector.module.css';
+import type { ExternalRequestEvent } from './hooks/useAppSdkBridge';
+
+const statusColor = (request: ExternalRequestEvent): string => {
+    if (request.status === 'pending') return 'blue';
+    if (request.status === 'error') return 'red';
+    if (request.httpStatus !== null && request.httpStatus >= 400) return 'red';
+    if (
+        request.httpStatus !== null &&
+        request.httpStatus >= 200 &&
+        request.httpStatus < 300
+    ) {
+        return 'green';
+    }
+    return 'gray';
+};
+
+const statusLabel = (request: ExternalRequestEvent): string =>
+    request.status === 'ready' && request.httpStatus !== null
+        ? String(request.httpStatus)
+        : request.status;
+
+const toJson = (value: unknown): string =>
+    typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+
+const ExternalRequestRow: FC<{ request: ExternalRequestEvent }> = ({
+    request,
+}) => {
+    const [expanded, setExpanded] = useState(false);
+    const [jsonExpanded, setJsonExpanded] = useState(false);
+
+    const queryEntries = request.query ? Object.entries(request.query) : [];
+
+    return (
+        <Box className={classes.queryRow}>
+            <Group
+                gap="xs"
+                wrap="nowrap"
+                className={classes.queryHeader}
+                onClick={() => setExpanded((v) => !v)}
+            >
+                <ActionIcon variant="subtle" size="xs" color="gray">
+                    {expanded ? (
+                        <MantineIcon icon={IconChevronDown} size={12} />
+                    ) : (
+                        <MantineIcon icon={IconChevronRight} size={12} />
+                    )}
+                </ActionIcon>
+                <Badge size="xs" variant="light" color="gray">
+                    {request.alias}
+                </Badge>
+                <Text size="xs" fw={500} truncate="end">
+                    {request.method} {request.path}
+                </Text>
+                <Badge size="xs" variant="light" color={statusColor(request)}>
+                    {statusLabel(request)}
+                </Badge>
+                <Box ml="auto" />
+                {request.truncated && (
+                    <Badge size="xs" variant="light" color="yellow">
+                        truncated
+                    </Badge>
+                )}
+                {request.durationMs !== null && (
+                    <Text size="xs" c="dimmed">
+                        {request.durationMs}ms
+                    </Text>
+                )}
+            </Group>
+            <Collapse in={expanded}>
+                <Group
+                    gap={0}
+                    wrap="nowrap"
+                    align="stretch"
+                    className={classes.queryDetailsRow}
+                >
+                    <Box className={classes.queryDetails}>
+                        <Box>
+                            <Text size="xs" fw={600} c="dimmed">
+                                Connection
+                            </Text>
+                            <Text size="xs">{request.alias}</Text>
+                        </Box>
+                        <Box>
+                            <Text size="xs" fw={600} c="dimmed">
+                                Request
+                            </Text>
+                            <Text size="xs" ff="monospace">
+                                {request.method} {request.path}
+                            </Text>
+                        </Box>
+                        {queryEntries.length > 0 && (
+                            <Box>
+                                <Text size="xs" fw={600} c="dimmed">
+                                    Query params
+                                </Text>
+                                <Text size="xs" ff="monospace">
+                                    {queryEntries
+                                        .map(([k, v]) => `${k}=${v}`)
+                                        .join('&')}
+                                </Text>
+                            </Box>
+                        )}
+                        {request.requestBody !== null && (
+                            <Box>
+                                <Text size="xs" fw={600} c="dimmed">
+                                    Request body
+                                </Text>
+                                <Code block fz={10}>
+                                    {toJson(request.requestBody)}
+                                </Code>
+                            </Box>
+                        )}
+                        {request.httpStatus !== null && (
+                            <Box>
+                                <Text size="xs" fw={600} c="dimmed">
+                                    Response status
+                                </Text>
+                                <Text size="xs">{request.httpStatus}</Text>
+                            </Box>
+                        )}
+                        {request.contentType && (
+                            <Box>
+                                <Text size="xs" fw={600} c="dimmed">
+                                    Content type
+                                </Text>
+                                <Text size="xs">{request.contentType}</Text>
+                            </Box>
+                        )}
+                        {request.truncated && (
+                            <Box>
+                                <Text size="xs" fw={600} c="yellow">
+                                    Response truncated
+                                </Text>
+                                <Text size="xs" c="dimmed">
+                                    The upstream response exceeded the
+                                    connection's size cap and was truncated.
+                                </Text>
+                            </Box>
+                        )}
+                        {request.error && (
+                            <Box>
+                                <Text size="xs" fw={600} c="red">
+                                    Error
+                                </Text>
+                                <Text size="xs" c="red">
+                                    {request.error}
+                                </Text>
+                            </Box>
+                        )}
+                        {request.durationMs !== null && (
+                            <Box>
+                                <Text size="xs" fw={600} c="dimmed">
+                                    Duration
+                                </Text>
+                                <Text size="xs">{request.durationMs}ms</Text>
+                            </Box>
+                        )}
+                    </Box>
+                    {request.responseBody !== null && (
+                        <Box className={classes.rawJsonPanel}>
+                            <Group
+                                gap={4}
+                                onClick={() => setJsonExpanded((v) => !v)}
+                                style={{ cursor: 'pointer' }}
+                            >
+                                <ActionIcon
+                                    variant="subtle"
+                                    size="xs"
+                                    color="gray"
+                                >
+                                    {jsonExpanded ? (
+                                        <MantineIcon
+                                            icon={IconChevronDown}
+                                            size={10}
+                                        />
+                                    ) : (
+                                        <MantineIcon
+                                            icon={IconChevronRight}
+                                            size={10}
+                                        />
+                                    )}
+                                </ActionIcon>
+                                <Text size="xs" fw={600} c="dimmed">
+                                    Response body
+                                </Text>
+                                <CopyButton
+                                    value={toJson(request.responseBody)}
+                                >
+                                    {({ copied, copy }) => (
+                                        <ActionIcon
+                                            variant="subtle"
+                                            size="xs"
+                                            color={copied ? 'green' : 'gray'}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                copy();
+                                            }}
+                                        >
+                                            <MantineIcon
+                                                icon={IconCopy}
+                                                size={10}
+                                            />
+                                        </ActionIcon>
+                                    )}
+                                </CopyButton>
+                            </Group>
+                            <Collapse in={jsonExpanded}>
+                                <ScrollArea.Autosize mah={200}>
+                                    <Code block fz={10}>
+                                        {toJson(request.responseBody)}
+                                    </Code>
+                                </ScrollArea.Autosize>
+                            </Collapse>
+                        </Box>
+                    )}
+                </Group>
+            </Collapse>
+        </Box>
+    );
+};
+
+/**
+ * Body of the "External requests" inspector tab: the scrollable list of
+ * external-connection fetches the app made at runtime. The panel chrome lives
+ * in `AppInspectorPanel`.
+ */
+export const ExternalRequestInspectorContent: FC<{
+    requests: ExternalRequestEvent[];
+}> = ({ requests }) => (
+    <Box className={classes.queryList}>
+        {requests.length === 0 ? (
+            <Box className={classes.emptyState}>
+                <Text size="xs" c="dimmed">
+                    No external requests yet
+                </Text>
+            </Box>
+        ) : (
+            requests.map((r) => <ExternalRequestRow key={r.id} request={r} />)
+        )}
+    </Box>
+);

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -9,65 +9,22 @@ import {
     CopyButton,
     Group,
     ScrollArea,
-    Switch,
     Text,
-    Tooltip,
 } from '@mantine-8/core';
 import {
     IconChevronDown,
     IconChevronRight,
     IconCopy,
-    IconDatabase,
-    IconDatabaseSearch,
     IconExternalLink,
-    IconTrash,
-    IconX,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useRef, useState, type FC } from 'react';
+import { useEffect, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
+import classes from './AppInspector.module.css';
 import type { QueryEvent } from './hooks/useAppSdkBridge';
-import classes from './QueryInspector.module.css';
 
 type TrackedQuery = QueryEvent & {
     /** Merged from the initial POST + subsequent poll results */
-};
-
-type Props = {
-    queries: TrackedQuery[];
-    projectUuid: string;
-    onClear: () => void;
-    /** Persist preference + handler — when omitted, the "Persist" switch is
-     *  hidden. The builder wires this up; the preview omits it because the
-     *  preview iframe doesn't reload mid-session so the toggle would be a
-     *  no-op, and sharing the localStorage key would let viewers flip
-     *  builder behavior. */
-    persistLogs?: boolean;
-    onPersistLogsChange?: (value: boolean) => void;
-    /** Initial value of the internal `collapsed` state. Defaults to `true`
-     *  so the builder's panel boots as a collapsed title bar. The preview
-     *  passes `false` to open expanded when the user clicks "View queries". */
-    defaultCollapsed?: boolean;
-    /** Called when the user clicks the X. The parent owns visibility and
-     *  should unmount the panel in response — both builder and preview
-     *  re-open it via a "View queries" menu item. */
-    onDismiss: () => void;
-    /** When `false`, the panel stays visible (as a collapsed title bar) even
-     *  with no queries. The builder defaults to `true` so the panel hides
-     *  until queries arrive; the preview passes `false` so once opened from
-     *  the menu the panel remains visible. */
-    hideWhenEmpty?: boolean;
-    /** Data-lineage ("Inspect data") toggle rendered in the panel header.
-     *  When `onToggleLineage` is omitted, the toggle is hidden. */
-    lineageEnabled?: boolean;
-    lineageAvailable?: boolean;
-    onToggleLineage?: () => void;
-    /** Called with the queryUuid when a row is hovered, and null on leave.
-     *  The parent forwards this to the iframe to outline matching elements. */
-    onHoverQuery?: (queryUuid: string | null) => void;
-    /** When set, the matching row auto-expands, scrolls into view, and flashes.
-     *  Driven by element→query lineage selection from the parent. */
-    focusedQueryUuid?: string | null;
 };
 
 const statusColor = (status: TrackedQuery['status']): string => {
@@ -375,230 +332,37 @@ const QueryRow: FC<{
     );
 };
 
-const MIN_HEIGHT = 100;
-const MAX_HEIGHT = 600;
-const DEFAULT_HEIGHT = 300;
-
-const QueryInspector: FC<Props> = ({
-    queries,
-    projectUuid,
-    onClear,
-    persistLogs,
-    onPersistLogsChange,
-    defaultCollapsed = true,
-    onDismiss,
-    hideWhenEmpty = true,
-    onHoverQuery,
-    focusedQueryUuid,
-    lineageEnabled,
-    lineageAvailable,
-    onToggleLineage,
-}) => {
-    const [collapsed, setCollapsed] = useState(defaultCollapsed);
-    const [height, setHeight] = useState(DEFAULT_HEIGHT);
-    const dragRef = useRef<{
-        startY: number;
-        startHeight: number;
-    } | null>(null);
-
-    const toggle = useCallback(() => setCollapsed((v) => !v), []);
-
-    const handleResizeStart = useCallback(
-        (e: React.PointerEvent<HTMLDivElement>) => {
-            e.preventDefault();
-            e.currentTarget.setPointerCapture(e.pointerId);
-            dragRef.current = { startY: e.clientY, startHeight: height };
-        },
-        [height],
-    );
-
-    const handleResizeMove = useCallback(
-        (e: React.PointerEvent<HTMLDivElement>) => {
-            if (!dragRef.current) return;
-            const delta = dragRef.current.startY - e.clientY;
-            const newHeight = Math.min(
-                MAX_HEIGHT,
-                Math.max(MIN_HEIGHT, dragRef.current.startHeight + delta),
-            );
-            setHeight(newHeight);
-        },
-        [],
-    );
-
-    const handleResizeEnd = useCallback(() => {
-        dragRef.current = null;
-    }, []);
-
-    const handleDismiss = useCallback(
-        (e: React.MouseEvent) => {
-            e.stopPropagation();
-            onDismiss();
-        },
-        [onDismiss],
-    );
-
-    const handleClear = useCallback(
-        (e: React.MouseEvent) => {
-            e.stopPropagation();
-            onClear();
-        },
-        [onClear],
-    );
-
-    // Auto-uncollapse the panel when a matching focused query arrives so
-    // the focused row is not hidden inside a closed collapse region.
-    useEffect(() => {
-        if (
-            focusedQueryUuid != null &&
-            queries.some((q) => q.queryUuid === focusedQueryUuid)
-        ) {
-            setCollapsed(false);
-        }
-    }, [focusedQueryUuid, queries]);
-
-    // Hide the panel entirely only when there's nothing to show *and* the
-    // user hasn't engaged with it. If they've expanded it (e.g. cleared the
-    // log to wait for fresh queries), keep it mounted with an empty state so
-    // the next query lands somewhere visible. The preview opts out of this
-    // hide-when-empty behavior (`hideWhenEmpty={false}`) so once opened from
-    // the menu the panel stays visible even before queries arrive.
-    if (hideWhenEmpty && queries.length === 0 && collapsed) return null;
-
-    return (
-        <Box
-            className={
-                collapsed
-                    ? `${classes.container} ${classes.containerCollapsed}`
-                    : classes.container
-            }
-        >
-            <Group
-                gap="xs"
-                wrap="nowrap"
-                className={classes.titleBar}
-                onClick={toggle}
-            >
-                <MantineIcon icon={IconDatabase} size={14} />
-                <Text size="xs" fw={600}>
-                    Queries ({queries.length})
+/**
+ * Body of the "Queries" inspector tab: the scrollable list of tracked metric
+ * queries. The panel chrome (container, tabs, resize, collapse) lives in
+ * `AppInspectorPanel`.
+ */
+export const QueryInspectorContent: FC<{
+    queries: TrackedQuery[];
+    projectUuid: string;
+    onHoverQuery?: (queryUuid: string | null) => void;
+    focusedQueryUuid?: string | null;
+}> = ({ queries, projectUuid, onHoverQuery, focusedQueryUuid }) => (
+    <Box className={classes.queryList}>
+        {queries.length === 0 ? (
+            <Box className={classes.emptyState}>
+                <Text size="xs" c="dimmed">
+                    No queries yet
                 </Text>
-                <Box ml="auto" />
-                {!collapsed && (
-                    <>
-                        {onToggleLineage && (
-                            <Tooltip
-                                label={
-                                    lineageEnabled
-                                        ? 'Inspect data: on'
-                                        : 'Inspect data'
-                                }
-                                withArrow
-                                position="top"
-                            >
-                                <ActionIcon
-                                    variant={
-                                        lineageEnabled ? 'filled' : 'subtle'
-                                    }
-                                    color={lineageEnabled ? 'violet' : 'gray'}
-                                    size="xs"
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        onToggleLineage();
-                                    }}
-                                    disabled={!lineageAvailable}
-                                    aria-label="Toggle data lineage inspector"
-                                >
-                                    <MantineIcon
-                                        icon={IconDatabaseSearch}
-                                        size={12}
-                                    />
-                                </ActionIcon>
-                            </Tooltip>
-                        )}
-                        <Tooltip label="Clear queries" withArrow position="top">
-                            <ActionIcon
-                                variant="subtle"
-                                size="xs"
-                                color="gray"
-                                onClick={handleClear}
-                                aria-label="Clear queries"
-                            >
-                                <MantineIcon icon={IconTrash} size={12} />
-                            </ActionIcon>
-                        </Tooltip>
-                        {onPersistLogsChange && (
-                            <Tooltip
-                                label="Preserve queries across iframe refreshes and new app versions"
-                                withArrow
-                                position="top"
-                            >
-                                <Box onClick={(e) => e.stopPropagation()}>
-                                    <Switch
-                                        size="xs"
-                                        label="Persist"
-                                        checked={persistLogs ?? false}
-                                        onChange={(e) =>
-                                            onPersistLogsChange(
-                                                e.currentTarget.checked,
-                                            )
-                                        }
-                                    />
-                                </Box>
-                            </Tooltip>
-                        )}
-                    </>
-                )}
-                <ActionIcon variant="subtle" size="xs" color="gray">
-                    {collapsed ? (
-                        <MantineIcon icon={IconChevronRight} size={12} />
-                    ) : (
-                        <MantineIcon icon={IconChevronDown} size={12} />
-                    )}
-                </ActionIcon>
-                <ActionIcon
-                    variant="subtle"
-                    size="xs"
-                    color="gray"
-                    onClick={handleDismiss}
-                    aria-label="Close queries panel"
-                >
-                    <MantineIcon icon={IconX} size={12} />
-                </ActionIcon>
-            </Group>
-            <Collapse in={!collapsed}>
-                <Box
-                    className={classes.resizeHandle}
-                    onPointerDown={handleResizeStart}
-                    onPointerMove={handleResizeMove}
-                    onPointerUp={handleResizeEnd}
+            </Box>
+        ) : (
+            queries.map((q) => (
+                <QueryRow
+                    key={q.queryUuid ?? q.id}
+                    query={q}
+                    projectUuid={projectUuid}
+                    onHover={onHoverQuery}
+                    focused={
+                        focusedQueryUuid != null &&
+                        q.queryUuid === focusedQueryUuid
+                    }
                 />
-                <ScrollArea h={height}>
-                    <Box className={classes.queryList}>
-                        {queries.length === 0 ? (
-                            <Box className={classes.emptyState}>
-                                <Text size="xs" c="dimmed">
-                                    No queries yet
-                                </Text>
-                            </Box>
-                        ) : (
-                            queries.map((q) => (
-                                <QueryRow
-                                    key={q.queryUuid ?? q.id}
-                                    query={q}
-                                    projectUuid={projectUuid}
-                                    onHover={onHoverQuery}
-                                    focused={
-                                        focusedQueryUuid != null &&
-                                        q.queryUuid === focusedQueryUuid
-                                    }
-                                />
-                            ))
-                        )}
-                    </Box>
-                </ScrollArea>
-            </Collapse>
-        </Box>
-    );
-};
-
-export default QueryInspector;
+            ))
+        )}
+    </Box>
+);

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -5,8 +5,8 @@ import {
 } from '@lightdash/common';
 import { ActionIcon, Menu, Tooltip } from '@mantine-8/core';
 import {
+    IconArrowsUpDown,
     IconCopy,
-    IconDatabase,
     IconDatabaseExport,
     IconDots,
     IconEdit,
@@ -46,7 +46,7 @@ type Props = {
     latestVersionStatus: AppVersionStatus | null;
     onRefresh: () => void;
     refreshDisabled: boolean;
-    onViewQueries: () => void;
+    onViewNetwork: () => void;
     /** Called after a successful delete so the page can navigate away. */
     onDeleted: () => void;
     /** The single cross-navigation menu item that differs per surface:
@@ -75,7 +75,7 @@ const AppHeaderActions: FC<Props> = ({
     latestVersionStatus,
     onRefresh,
     refreshDisabled,
-    onViewQueries,
+    onViewNetwork,
     onDeleted,
     navItem,
 }) => {
@@ -166,11 +166,11 @@ const AppHeaderActions: FC<Props> = ({
                     />
                     <Menu.Item
                         leftSection={
-                            <MantineIcon icon={IconDatabase} size={14} />
+                            <MantineIcon icon={IconArrowsUpDown} size={14} />
                         }
-                        onClick={onViewQueries}
+                        onClick={onViewNetwork}
                     >
-                        View queries
+                        View network
                     </Menu.Item>
                     {canEdit && scheduledDeliveriesFlag.data?.enabled && (
                         <Menu.Item

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -10,7 +10,11 @@ import {
     vi,
     type Mock,
 } from 'vitest';
-import { useAppSdkBridge, type QueryEvent } from './useAppSdkBridge';
+import {
+    useAppSdkBridge,
+    type ExternalRequestEvent,
+    type QueryEvent,
+} from './useAppSdkBridge';
 
 const mockUseEmbed = vi.fn(() => ({
     embedToken: undefined as string | undefined,
@@ -492,6 +496,32 @@ describe('external-fetch branch', () => {
         });
     }
 
+    function renderBridgeExternal(
+        onExternalRequestEvent: (event: ExternalRequestEvent) => void,
+    ) {
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge(
+                iframeRef,
+                window.location.origin,
+                PROJECT_UUID,
+                APP_UUID,
+                undefined, // onQueryEvent
+                undefined, // onElementSelected
+                undefined, // onInspectorAvailable
+                undefined, // onScreenshotAvailable
+                undefined, // dashboardFilters
+                undefined, // invalidateCache
+                undefined, // capabilities
+                undefined, // onLineageAvailable
+                undefined, // onLineageSelected
+                onExternalRequestEvent,
+            ),
+        );
+    }
+
     function captureResponses() {
         const responses: Array<Record<string, unknown>> = [];
         const spy = vi
@@ -636,6 +666,65 @@ describe('external-fetch branch', () => {
                 )?.['result'],
             ).toBeDefined(),
         );
+    });
+
+    it('emits pending then ready external-request events on success', async () => {
+        const events: ExternalRequestEvent[] = [];
+        renderBridgeExternal((e) => events.push(e));
+        mockFetchOk({
+            status: 'ok',
+            results: {
+                status: 200,
+                contentType: 'application/json',
+                body: { ok: true },
+                truncated: false,
+            },
+        });
+
+        postExternalFetch({
+            alias: 'stripe',
+            method: 'GET',
+            path: '/v1/charges',
+        });
+
+        await vi.waitFor(() =>
+            expect(events.map((e) => e.status)).toEqual(['pending', 'ready']),
+        );
+        expect(events[0]).toMatchObject({
+            id: POST_ID,
+            alias: 'stripe',
+            method: 'GET',
+            path: '/v1/charges',
+            status: 'pending',
+        });
+        expect(events[1]).toMatchObject({
+            id: POST_ID,
+            status: 'ready',
+            httpStatus: 200,
+            contentType: 'application/json',
+            truncated: false,
+        });
+        expect(events[1].responseBody).toEqual({ ok: true });
+    });
+
+    it('emits pending then error external-request events when the EE call fails', async () => {
+        const events: ExternalRequestEvent[] = [];
+        renderBridgeExternal((e) => events.push(e));
+        mockFetchNonOk({
+            status: 'error',
+            error: { message: 'Connection alias not found' },
+        });
+
+        postExternalFetch({ alias: 'nope', method: 'GET', path: '/x' });
+
+        await vi.waitFor(() =>
+            expect(events.map((e) => e.status)).toEqual(['pending', 'error']),
+        );
+        expect(events[1]).toMatchObject({
+            id: POST_ID,
+            status: 'error',
+            error: 'Connection alias not found',
+        });
     });
 
     it('rejects external-fetch messages from a spoofed sender (wrong source AND wrong origin)', async () => {

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -70,6 +70,33 @@ export type QueryEvent = {
 };
 
 /**
+ * A single external-connection fetch proxied through the bridge, reported for
+ * the external-requests inspector tab. Single-shot lifecycle: one `pending`
+ * event when the fetch starts, one terminal `ready`/`error` event when it
+ * settles — matched by `id` (no queryUuid remap like metric queries need).
+ */
+export type ExternalRequestEvent = {
+    id: string;
+    timestamp: number;
+    /** Connection alias the app called, e.g. `stripe`. */
+    alias: string;
+    method: 'GET' | 'POST';
+    path: string;
+    query: Record<string, string> | null;
+    /** JSON request body (POST); null for GET or an empty body. */
+    requestBody: unknown;
+    status: 'pending' | 'ready' | 'error';
+    /** Upstream HTTP status (null until the fetch settles / on proxy error). */
+    httpStatus: number | null;
+    contentType: string | null;
+    /** Parsed response body; null until the fetch settles. */
+    responseBody: unknown;
+    truncated: boolean | null;
+    durationMs: number | null;
+    error: string | null;
+};
+
+/**
  * Routes the SDK is allowed to call through the postMessage bridge.
  * Everything else is rejected. Patterns use :param for path segments.
  */
@@ -188,6 +215,13 @@ export function useAppSdkBridge(
     capabilities?: { gsheetExport?: boolean },
     onLineageAvailable?: () => void,
     onLineageSelected?: (event: { queryUuid: string }) => void,
+    /**
+     * When provided, external-connection fetches proxied through this bridge
+     * are reported for the external-requests inspector tab — mirrors
+     * `onQueryEvent` for metric queries. Emits `pending` when the fetch starts
+     * and a terminal `ready`/`error` event when it settles.
+     */
+    onExternalRequestEvent?: (event: ExternalRequestEvent) => void,
 ) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -344,13 +378,53 @@ export function useAppSdkBridge(
                     );
                 };
 
+                // Report the fetch to the external-requests inspector. Base
+                // request fields are captured up front; each call overlays the
+                // lifecycle status (and, on settle, the response/duration).
+                const startedAt = Date.now();
+                const emitExternal = (
+                    fields: Partial<ExternalRequestEvent> & {
+                        status: ExternalRequestEvent['status'];
+                    },
+                ) => {
+                    onExternalRequestEvent?.({
+                        id: externalId,
+                        timestamp: startedAt,
+                        alias: typeof alias === 'string' ? alias : 'unknown',
+                        method: externalMethod === 'POST' ? 'POST' : 'GET',
+                        path:
+                            typeof externalPath === 'string'
+                                ? externalPath
+                                : '',
+                        query:
+                            (externalQuery as
+                                | Record<string, string>
+                                | undefined) ?? null,
+                        requestBody: externalBody ?? null,
+                        httpStatus: null,
+                        contentType: null,
+                        responseBody: null,
+                        truncated: null,
+                        durationMs: null,
+                        error: null,
+                        ...fields,
+                    });
+                };
+
+                emitExternal({ status: 'pending' });
+
                 // External fetch is not available to embedded apps: the proxy
                 // endpoint requires a registered session, not an embed JWT.
                 // Fail clearly rather than make a doomed authenticated call.
                 if (embedToken) {
-                    respondExternal({
-                        error: 'External data access is not available in embedded apps',
+                    const embedError =
+                        'External data access is not available in embedded apps';
+                    emitExternal({
+                        status: 'error',
+                        error: embedError,
+                        durationMs: Date.now() - startedAt,
                     });
+                    respondExternal({ error: embedError });
                     return;
                 }
 
@@ -381,21 +455,43 @@ export function useAppSdkBridge(
                     );
                     const json = await res.json();
                     if (json.status === 'ok') {
+                        const result = json.results as
+                            | {
+                                  status?: number;
+                                  contentType?: string;
+                                  body?: unknown;
+                                  truncated?: boolean;
+                              }
+                            | undefined;
+                        emitExternal({
+                            status: 'ready',
+                            httpStatus: result?.status ?? null,
+                            contentType: result?.contentType ?? null,
+                            responseBody: result?.body ?? null,
+                            truncated: result?.truncated ?? null,
+                            durationMs: Date.now() - startedAt,
+                        });
                         respondExternal({ result: json.results });
                     } else {
-                        respondExternal({
-                            error:
-                                json.error?.message ??
-                                `External fetch failed (${res.status})`,
+                        const errorMessage =
+                            json.error?.message ??
+                            `External fetch failed (${res.status})`;
+                        emitExternal({
+                            status: 'error',
+                            error: errorMessage,
+                            durationMs: Date.now() - startedAt,
                         });
+                        respondExternal({ error: errorMessage });
                     }
                 } catch (err) {
-                    respondExternal({
-                        error:
-                            err instanceof Error
-                                ? err.message
-                                : 'Unknown error',
+                    const errorMessage =
+                        err instanceof Error ? err.message : 'Unknown error';
+                    emitExternal({
+                        status: 'error',
+                        error: errorMessage,
+                        durationMs: Date.now() - startedAt,
                     });
+                    respondExternal({ error: errorMessage });
                 }
                 return;
             }
@@ -683,6 +779,7 @@ export function useAppSdkBridge(
             capabilities,
             onLineageAvailable,
             onLineageSelected,
+            onExternalRequestEvent,
             health.data,
             user.data,
         ],

--- a/packages/frontend/src/features/apps/hooks/useTrackedExternalRequests.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedExternalRequests.ts
@@ -1,0 +1,81 @@
+import { useCallback, useRef, useState } from 'react';
+import type { ExternalRequestEvent } from './useAppSdkBridge';
+
+export type UseTrackedExternalRequestsResult = {
+    externalRequests: ExternalRequestEvent[];
+    handleExternalRequestEvent: (event: ExternalRequestEvent) => void;
+    clearExternalRequests: () => void;
+    interruptInFlightRequests: () => void;
+};
+
+/**
+ * Tracks external-connection fetches emitted by the app preview iframe SDK
+ * bridge. Simpler sibling of `useTrackedAppQueries`: an external fetch is a
+ * single request → single response, so entries merge by `id` with no
+ * queryUuid remap. Owns the "interrupted by reload" recovery used by the
+ * builder when the preview iframe restarts while a fetch is still in flight.
+ *
+ * The persist-log preference is NOT owned here — it lives in
+ * `useTrackedAppQueries` and is applied to both lists by the page.
+ */
+export const useTrackedExternalRequests =
+    (): UseTrackedExternalRequestsResult => {
+        const [externalRequests, setExternalRequests] = useState<
+            ExternalRequestEvent[]
+        >([]);
+        // IDs of requests moved to a terminal `error` on iframe reload. The
+        // parent-side fetch keeps running after the iframe dies and can emit a
+        // late `ready`/`error` — this guard drops those so they neither
+        // resurrect the entry nor append a ghost.
+        const interruptedIdsRef = useRef<Set<string>>(new Set());
+
+        const clearExternalRequests = useCallback(() => {
+            setExternalRequests([]);
+        }, []);
+
+        const interruptInFlightRequests = useCallback(() => {
+            setExternalRequests((prev) => {
+                let mutated = false;
+                const next = prev.map((r) => {
+                    if (r.status !== 'pending') return r;
+                    mutated = true;
+                    interruptedIdsRef.current.add(r.id);
+                    return {
+                        ...r,
+                        status: 'error' as const,
+                        error: 'Interrupted by reload',
+                    };
+                });
+                return mutated ? next : prev;
+            });
+        }, []);
+
+        const handleExternalRequestEvent = useCallback(
+            (event: ExternalRequestEvent) => {
+                if (interruptedIdsRef.current.has(event.id)) return;
+                setExternalRequests((prev) => {
+                    const idx = prev.findIndex((r) => r.id === event.id);
+                    if (idx < 0) return [...prev, event];
+                    const existing = prev[idx];
+                    // Don't resurrect a terminal entry (late duplicate event).
+                    if (
+                        existing.status === 'ready' ||
+                        existing.status === 'error'
+                    ) {
+                        return prev;
+                    }
+                    return prev.map((r, i) =>
+                        i === idx ? { ...r, ...event } : r,
+                    );
+                });
+            },
+            [],
+        );
+
+        return {
+            externalRequests,
+            handleExternalRequestEvent,
+            clearExternalRequests,
+            interruptInFlightRequests,
+        };
+    };

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -69,6 +69,7 @@ import SuboptimalState from '../components/common/SuboptimalState/SuboptimalStat
 import AppIframePreview, {
     type AppIframePreviewHandle,
 } from '../features/apps/AppIframePreview';
+import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import AppPromptEditor, {
     type AppPromptEditorHandle,
     type ElementRef,
@@ -95,7 +96,10 @@ import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
-import type { QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
+import type {
+    ExternalRequestEvent,
+    QueryEvent,
+} from '../features/apps/hooks/useAppSdkBridge';
 import { useAppThumbnailUpload } from '../features/apps/hooks/useAppThumbnail';
 import { useBuildNotification } from '../features/apps/hooks/useBuildNotification';
 import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion';
@@ -105,8 +109,8 @@ import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
 import { useRestoreAppVersion } from '../features/apps/hooks/useRestoreAppVersion';
 import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
+import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
-import QueryInspector from '../features/apps/QueryInspector';
 import { getTemplate } from '../features/apps/templates';
 import {
     mergeChatMessages,
@@ -186,6 +190,7 @@ type AppPreviewProps = {
      *  refresh button so a manual refresh always re-runs against the warehouse. */
     invalidateCache?: boolean;
     onQueryEvent?: (event: QueryEvent) => void;
+    onExternalRequestEvent?: (event: ExternalRequestEvent) => void;
     inspectorEnabled?: boolean;
     onElementSelected?: (event: { label: string }) => void;
     onInspectorAvailabilityChange?: (available: boolean) => void;
@@ -207,6 +212,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
             refreshKey,
             invalidateCache,
             onQueryEvent,
+            onExternalRequestEvent,
             inspectorEnabled,
             onElementSelected,
             onInspectorAvailabilityChange,
@@ -263,6 +269,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 identityKey={appUuid}
                 invalidateCache={invalidateCache}
                 onQueryEvent={onQueryEvent}
+                onExternalRequestEvent={onExternalRequestEvent}
                 inspectorEnabled={inspectorEnabled}
                 onElementSelected={onElementSelected}
                 onInspectorAvailabilityChange={onInspectorAvailabilityChange}
@@ -525,11 +532,17 @@ const AppGenerate: FC = () => {
         clearQueries,
         interruptInFlightQueries,
     } = useTrackedAppQueries();
+    const {
+        externalRequests,
+        handleExternalRequestEvent,
+        clearExternalRequests,
+        interruptInFlightRequests,
+    } = useTrackedExternalRequests();
     // Parent-owned visibility so the X dismisses the panel completely and the
     // user re-opens it from the dots menu — same model as preview, for
     // consistency. Defaults to visible because the builder is the technical
     // workflow where seeing queries as they fire is the point.
-    const [queriesPanelHidden, setQueriesPanelHidden] = useState(false);
+    const [networkPanelHidden, setNetworkPanelHidden] = useState(false);
     const handleElementSelected = useCallback((event: { label: string }) => {
         const ref = parseElementRefLabel(event.label);
         if (!ref) {
@@ -548,7 +561,7 @@ const AppGenerate: FC = () => {
     }, []);
     const handleLineageSelected = useCallback(
         (event: { queryUuid: string }) => {
-            setQueriesPanelHidden(false);
+            setNetworkPanelHidden(false);
             setFocusedQueryUuid(event.queryUuid);
         },
         [],
@@ -642,6 +655,7 @@ const AppGenerate: FC = () => {
         setLocalMessages([]);
         setPin(null);
         clearQueries();
+        clearExternalRequests();
         setInspectorEnabled(false);
         setInspectorAvailable(false);
         setScreenshotAvailable(false);
@@ -660,7 +674,7 @@ const AppGenerate: FC = () => {
             urls.forEach((url) => URL.revokeObjectURL(url)),
         );
         sentImagesByPrompt.current.clear();
-    }, [clearQueries]);
+    }, [clearQueries, clearExternalRequests]);
     useEffect(() => {
         const prev = prevUrlAppUuid.current;
         prevUrlAppUuid.current = urlAppUuid;
@@ -1224,14 +1238,18 @@ const AppGenerate: FC = () => {
         if (prev === null) return; // Initial render — nothing to clean up.
         if (persistLogs) {
             interruptInFlightQueries();
+            interruptInFlightRequests();
         } else {
             clearQueries();
+            clearExternalRequests();
         }
     }, [
         previewApp?.version,
         persistLogs,
         interruptInFlightQueries,
         clearQueries,
+        interruptInFlightRequests,
+        clearExternalRequests,
     ]);
 
     // Manual refresh counter for the preview iframe. The iframe URL embeds
@@ -1249,10 +1267,18 @@ const AppGenerate: FC = () => {
         setInvalidatePreviewCache(true);
         if (persistLogs) {
             interruptInFlightQueries();
+            interruptInFlightRequests();
         } else {
             clearQueries();
+            clearExternalRequests();
         }
-    }, [persistLogs, interruptInFlightQueries, clearQueries]);
+    }, [
+        persistLogs,
+        interruptInFlightQueries,
+        clearQueries,
+        interruptInFlightRequests,
+        clearExternalRequests,
+    ]);
 
     const scrollToBottom = useCallback(() => {
         // Scroll the chat container itself rather than calling scrollIntoView
@@ -2853,8 +2879,8 @@ const AppGenerate: FC = () => {
                                             }
                                             onRefresh={handleRefreshPreview}
                                             refreshDisabled={!previewApp}
-                                            onViewQueries={() =>
-                                                setQueriesPanelHidden(false)
+                                            onViewNetwork={() =>
+                                                setNetworkPanelHidden(false)
                                             }
                                             onDeleted={() =>
                                                 void navigate(
@@ -2943,6 +2969,9 @@ const AppGenerate: FC = () => {
                                         refreshKey={previewRefreshKey}
                                         invalidateCache={invalidatePreviewCache}
                                         onQueryEvent={handleQueryEvent}
+                                        onExternalRequestEvent={
+                                            handleExternalRequestEvent
+                                        }
                                         inspectorEnabled={inspectorEnabled}
                                         onElementSelected={
                                             handleElementSelected
@@ -2978,15 +3007,19 @@ const AppGenerate: FC = () => {
                                         </Text>
                                     </Box>
                                 )}
-                                {!queriesPanelHidden && (
-                                    <QueryInspector
+                                {!networkPanelHidden && (
+                                    <AppInspectorPanel
                                         queries={trackedQueries}
                                         projectUuid={projectUuid!}
-                                        onClear={clearQueries}
+                                        onClearQueries={clearQueries}
+                                        externalRequests={externalRequests}
+                                        onClearExternalRequests={
+                                            clearExternalRequests
+                                        }
                                         persistLogs={persistLogs}
                                         onPersistLogsChange={setPersistLogs}
                                         onDismiss={() =>
-                                            setQueriesPanelHidden(true)
+                                            setNetworkPanelHidden(true)
                                         }
                                         onHoverQuery={setHoveredQueryUuid}
                                         focusedQueryUuid={focusedQueryUuid}

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -7,6 +7,7 @@ import MantineIcon from '../components/common/MantineIcon';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
+import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppSpaceChip from '../features/apps/components/AppSpaceChip';
@@ -14,8 +15,8 @@ import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
+import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
-import QueryInspector from '../features/apps/QueryInspector';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import classes from './AppPreviewTest.module.css';
 
@@ -63,7 +64,7 @@ export default function AppPreviewTest() {
         error: tokenError,
     } = useAppPreviewToken(projectUuid, appUuid, version);
 
-    const [queriesPanelHidden, setQueriesPanelHidden] = useState(true);
+    const [networkPanelHidden, setNetworkPanelHidden] = useState(true);
 
     // Data-lineage ("Inspect data"): click a value to reveal the query behind
     // it; hover a query row to highlight where it renders.
@@ -81,6 +82,11 @@ export default function AppPreviewTest() {
     // up the SDK bridge callback unconditionally so queries that run before
     // the user opens the panel are still captured.
     const { queries, handleQueryEvent, clearQueries } = useTrackedAppQueries();
+    const {
+        externalRequests,
+        handleExternalRequestEvent,
+        clearExternalRequests,
+    } = useTrackedExternalRequests();
 
     // Manual refresh: bumping the counter changes the iframe URL, forcing a
     // reload so the app's metric queries re-fire. `invalidateCache` latches on
@@ -92,7 +98,8 @@ export default function AppPreviewTest() {
         setRefreshKey((k) => k + 1);
         setInvalidateCache(true);
         clearQueries();
-    }, [clearQueries]);
+        clearExternalRequests();
+    }, [clearQueries, clearExternalRequests]);
 
     const handleToggleLineage = useCallback(
         () => setLineageEnabled((v) => !v),
@@ -100,7 +107,7 @@ export default function AppPreviewTest() {
     );
     const handleLineageSelected = useCallback(
         (event: { queryUuid: string }) => {
-            setQueriesPanelHidden(false);
+            setNetworkPanelHidden(false);
             setFocusedQueryUuid(event.queryUuid);
         },
         [],
@@ -228,7 +235,7 @@ export default function AppPreviewTest() {
                         }
                         onRefresh={handleRefresh}
                         refreshDisabled={false}
-                        onViewQueries={() => setQueriesPanelHidden(false)}
+                        onViewNetwork={() => setNetworkPanelHidden(false)}
                         onDeleted={() => {
                             void navigate(`/projects/${projectUuid}/home`);
                         }}
@@ -263,6 +270,7 @@ export default function AppPreviewTest() {
                     identityKey={`${appUuid}:${version}`}
                     invalidateCache={invalidateCache}
                     onQueryEvent={handleQueryEvent}
+                    onExternalRequestEvent={handleExternalRequestEvent}
                     capabilities={{ gsheetExport: true }}
                     lineageEnabled={lineageEnabled}
                     onLineageAvailabilityChange={setLineageAvailable}
@@ -270,14 +278,16 @@ export default function AppPreviewTest() {
                     lineageHighlightQueryUuid={hoveredQueryUuid}
                     onLineageCancelled={handleLineageCancelled}
                 />
-                {!queriesPanelHidden && (
-                    <QueryInspector
+                {!networkPanelHidden && (
+                    <AppInspectorPanel
                         queries={queries}
                         projectUuid={projectUuid}
-                        onClear={clearQueries}
+                        onClearQueries={clearQueries}
+                        externalRequests={externalRequests}
+                        onClearExternalRequests={clearExternalRequests}
                         defaultCollapsed={false}
                         hideWhenEmpty={false}
-                        onDismiss={() => setQueriesPanelHidden(true)}
+                        onDismiss={() => setNetworkPanelHidden(true)}
                         onHoverQuery={setHoveredQueryUuid}
                         focusedQueryUuid={focusedQueryUuid}
                         lineageEnabled={lineageEnabled}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-543/integrate-external-requests-with-the-queries-panel

### Description:
Turn the data-app query inspector into a tabbed "network" panel with a new "Requests" tab that lists the external-connection fetches an app makes at runtime, so users can analyze and validate them.


<img width="978" height="1060" alt="image" src="https://github.com/user-attachments/assets/2af4ecee-fe31-4faa-bdda-6923ff4ac943" />
