### PR TITLE
fix(prometheus): emit http_server_request_duration_seconds without a Sentry DSN

### DIFF
--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -15,7 +15,10 @@ import Logger from './logging/logger';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import { STREAM_CONFIGS, type NatsWorkerStream } from './nats/natsConfig';
 import { NatsWorker } from './nats/NatsWorker';
-import { initOtelHttpMetrics } from './prometheus/otelHttpMetrics';
+import {
+    initOtelHttpMetrics,
+    shouldSelfRegisterHttpInstrumentation,
+} from './prometheus/otelHttpMetrics';
 import PrometheusMetrics from './prometheus/PrometheusMetrics';
 import { IGNORE_ERRORS } from './sentry';
 import { createOrganizationNameResolver } from './sentry/organizationNameResolver';
@@ -173,7 +176,12 @@ export default class NatsWorkerApp {
     }
 
     private async initSentry() {
-        initOtelHttpMetrics(this.lightdashConfig.prometheus);
+        initOtelHttpMetrics(this.lightdashConfig.prometheus, {
+            registerHttpInstrumentation: shouldSelfRegisterHttpInstrumentation({
+                hasSentryDsn: !!this.lightdashConfig.sentry.backend.dsn,
+                isOtelTracingEnabled: otelTracingEnabled(),
+            }),
+        });
         Sentry.init({
             release: VERSION,
             dsn: this.lightdashConfig.sentry.backend.dsn,

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -14,7 +14,10 @@ import { setGithubRateLimitObserver } from './clients/github/Github';
 import { LightdashConfig } from './config/parseConfig';
 import Logger from './logging/logger';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
-import { initOtelHttpMetrics } from './prometheus/otelHttpMetrics';
+import {
+    initOtelHttpMetrics,
+    shouldSelfRegisterHttpInstrumentation,
+} from './prometheus/otelHttpMetrics';
 import PrometheusMetrics from './prometheus/PrometheusMetrics';
 import { SchedulerWorker } from './scheduler/SchedulerWorker';
 import schedulerWorkerEventEmitter, {
@@ -212,7 +215,12 @@ export default class SchedulerApp {
     }
 
     private async initSentry() {
-        initOtelHttpMetrics(this.lightdashConfig.prometheus);
+        initOtelHttpMetrics(this.lightdashConfig.prometheus, {
+            registerHttpInstrumentation: shouldSelfRegisterHttpInstrumentation({
+                hasSentryDsn: !!this.lightdashConfig.sentry.backend.dsn,
+                isOtelTracingEnabled: otelTracingEnabled(),
+            }),
+        });
         Sentry.init({
             release: VERSION,
             dsn: this.lightdashConfig.sentry.backend.dsn,

--- a/packages/backend/src/prometheus/otelHttpMetrics.test.ts
+++ b/packages/backend/src/prometheus/otelHttpMetrics.test.ts
@@ -1,0 +1,40 @@
+import { shouldSelfRegisterHttpInstrumentation } from './otelHttpMetrics';
+
+describe('shouldSelfRegisterHttpInstrumentation', () => {
+    it('registers only when no Sentry DSN and OTel tracing is off', () => {
+        // The bug: self-hosted without Sentry — nobody else instruments http.
+        expect(
+            shouldSelfRegisterHttpInstrumentation({
+                hasSentryDsn: false,
+                isOtelTracingEnabled: false,
+            }),
+        ).toBe(true);
+    });
+
+    it('does not register when a Sentry DSN is configured (Sentry instruments http)', () => {
+        expect(
+            shouldSelfRegisterHttpInstrumentation({
+                hasSentryDsn: true,
+                isOtelTracingEnabled: false,
+            }),
+        ).toBe(false);
+    });
+
+    it('does not register when OTel tracing is enabled (tracing path instruments http)', () => {
+        expect(
+            shouldSelfRegisterHttpInstrumentation({
+                hasSentryDsn: false,
+                isOtelTracingEnabled: true,
+            }),
+        ).toBe(false);
+    });
+
+    it('does not register when both a DSN and OTel tracing are set', () => {
+        expect(
+            shouldSelfRegisterHttpInstrumentation({
+                hasSentryDsn: true,
+                isOtelTracingEnabled: true,
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/backend/src/prometheus/otelHttpMetrics.ts
+++ b/packages/backend/src/prometheus/otelHttpMetrics.ts
@@ -3,6 +3,7 @@ import {
     PrometheusExporter,
     PrometheusSerializer,
 } from '@opentelemetry/exporter-prometheus';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { AggregationType, MeterProvider } from '@opentelemetry/sdk-metrics';
 import type { LightdashConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
@@ -17,13 +18,39 @@ const HTTP_SERVER_DURATION_BUCKETS = [
 let initialized = false;
 let reader: PrometheusExporter | null = null;
 let provider: MeterProvider | null = null;
+let httpInstrumentation: HttpInstrumentation | null = null;
 
-// Registers a global OTel MeterProvider before Sentry.init() so Sentry's
-// already-registered http instrumentation emits the stable semconv metric
-// http.server.request.duration. Idempotent; one provider per process. Kept in a
-// lightweight module so importing it before Sentry.init() does not drag express/
-// http into scope and break Sentry's instrumentation patching.
-export function initOtelHttpMetrics(config: LightdashConfig['prometheus']) {
+// True when nothing else registers @opentelemetry/instrumentation-http, so we must
+// register it ourselves for http.server.request.duration to be recorded. Sentry's
+// default httpIntegration registers it when a DSN is configured; the OTel tracing
+// path registers its own when enabled. Registering when either is true would
+// double-count. Pure so it can be unit-tested as the regression guard.
+export function shouldSelfRegisterHttpInstrumentation({
+    hasSentryDsn,
+    isOtelTracingEnabled,
+}: {
+    hasSentryDsn: boolean;
+    isOtelTracingEnabled: boolean;
+}): boolean {
+    return !hasSentryDsn && !isOtelTracingEnabled;
+}
+
+// Registers a global OTel MeterProvider before Sentry.init() so the http
+// instrumentation emits the stable semconv metric http.server.request.duration
+// into it. Idempotent; one provider per process. Kept in a lightweight module so
+// importing it before Sentry.init() does not drag express/http into scope and
+// break instrumentation patching.
+//
+// `registerHttpInstrumentation` must be true only when nothing else registers
+// @opentelemetry/instrumentation-http. Sentry's default httpIntegration registers
+// it when a DSN is configured, and the OTel tracing path registers its own when
+// enabled; in either case we must NOT register a second one (double-counting).
+// When neither does (self-hosted with no Sentry DSN), the metric was never
+// recorded — so we register the instrumentation ourselves.
+export function initOtelHttpMetrics(
+    config: LightdashConfig['prometheus'],
+    { registerHttpInstrumentation }: { registerHttpInstrumentation: boolean },
+) {
     if (initialized) {
         return;
     }
@@ -57,6 +84,15 @@ export function initOtelHttpMetrics(config: LightdashConfig['prometheus']) {
             ],
         });
         metrics.setGlobalMeterProvider(provider);
+
+        if (registerHttpInstrumentation) {
+            // Constructing after setGlobalMeterProvider binds the instrumentation
+            // to our provider and enables the require-in-the-middle http patch,
+            // and OTEL_SEMCONV_STABILITY_OPT_IN (set above) is read in the
+            // constructor so the stable metric name is used.
+            httpInstrumentation = new HttpInstrumentation();
+            httpInstrumentation.setMeterProvider(provider);
+        }
     } catch (e) {
         Logger.error('Error initializing OTel HTTP metrics', e);
     }
@@ -73,5 +109,6 @@ export async function serializeOtelHttpMetrics(): Promise<string> {
 }
 
 export async function shutdownOtelHttpMetrics() {
+    httpInstrumentation?.disable();
     await provider?.shutdown();
 }

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -1,13 +1,37 @@
 import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { lightdashConfig } from './config/lightdashConfig';
-import { initOtelHttpMetrics } from './prometheus/otelHttpMetrics';
+import {
+    initOtelHttpMetrics,
+    shouldSelfRegisterHttpInstrumentation,
+} from './prometheus/otelHttpMetrics';
 import { otelTracingEnabled } from './tracing/tracing';
 import { VERSION } from './version';
 
-// Register the global OTel MeterProvider before Sentry.init() so Sentry's http
-// instrumentation captures it and emits http.server.request.duration.
-initOtelHttpMetrics(lightdashConfig.prometheus);
+const spotlightEnabled =
+    process.env.NODE_ENV === 'development' && !!process.env.SENTRY_SPOTLIGHT;
+
+// Use a dummy DSN when Spotlight is enabled but no real DSN is configured.
+// This allows Sentry to initialize and send events to Spotlight locally.
+const SPOTLIGHT_DUMMY_DSN = 'https://0@o0.ingest.sentry.io/0';
+
+const sentryDsn =
+    lightdashConfig.sentry.backend.dsn ||
+    (spotlightEnabled ? SPOTLIGHT_DUMMY_DSN : '');
+
+// Register the global OTel MeterProvider before Sentry.init() so the http
+// instrumentation emits http.server.request.duration into it. Register our own
+// instrumentation only when nobody else will: Sentry's httpIntegration registers
+// it when a DSN is set (unless it skips OTel setup for the tracing path), and the
+// OTel tracing path registers its own when enabled. With no DSN and no tracing
+// (self-hosted without Sentry), we must register it or the metric is never
+// recorded.
+initOtelHttpMetrics(lightdashConfig.prometheus, {
+    registerHttpInstrumentation: shouldSelfRegisterHttpInstrumentation({
+        hasSentryDsn: sentryDsn !== '',
+        isOtelTracingEnabled: otelTracingEnabled(),
+    }),
+});
 
 export const IGNORE_ERRORS = [
     'WarehouseConnectionError',
@@ -29,19 +53,10 @@ export const IGNORE_ERRORS = [
     'ParameterError',
 ];
 
-const spotlightEnabled =
-    process.env.NODE_ENV === 'development' && !!process.env.SENTRY_SPOTLIGHT;
-
-// Use a dummy DSN when Spotlight is enabled but no real DSN is configured.
-// This allows Sentry to initialize and send events to Spotlight locally.
-const SPOTLIGHT_DUMMY_DSN = 'https://0@o0.ingest.sentry.io/0';
-
 Sentry.init({
     release: VERSION,
     enabled: process.env.NODE_ENV !== 'test',
-    dsn:
-        lightdashConfig.sentry.backend.dsn ||
-        (spotlightEnabled ? SPOTLIGHT_DUMMY_DSN : ''),
+    dsn: sentryDsn,
     environment:
         process.env.NODE_ENV === 'development'
             ? 'development'


### PR DESCRIPTION
Closes #24976

## Summary

On a self-hosted deployment with **no Sentry DSN configured**, enabling `LIGHTDASH_PROMETHEUS_HTTP_METRICS_ENABLED=true` did not expose the `http_server_request_duration_seconds` histogram on `/metrics`, even though every other Prometheus metric appeared. The flag silently did nothing.

Affects any deployment without a Sentry DSN and without `LIGHTDASH_OTEL_TRACES_ENABLED`. Deployments with a DSN (e.g. Lightdash Cloud) or with OTel tracing were unaffected.

## Root cause

`initOtelHttpMetrics()` registers a global OTel `MeterProvider` but **no HTTP instrumentation** — it relied entirely on Sentry's default `httpIntegration` to emit `http.server.request.duration` into that meter. Sentry's integration only activates when the client has a transport, i.e. when a DSN is set:

```ts
// sentry.ts — with no DSN and no Spotlight, dsn is ''
dsn: lightdashConfig.sentry.backend.dsn || (spotlightEnabled ? SPOTLIGHT_DUMMY_DSN : ''),
```

With an empty DSN, `@sentry/core` creates no transport, `_setupIntegrations()` is skipped, `httpIntegration.setupOnce()` never runs, and `@opentelemetry/instrumentation-http` is never registered — so nothing ever records the metric. The coupling shipped in #24532; the no-DSN failure mode was never called out. It went unnoticed because local dev sets `SENTRY_SPOTLIGHT`, which enables the client via a dummy DSN.

## Fix

Register `@opentelemetry/instrumentation-http` directly inside `initOtelHttpMetrics()` — but only when nobody else will, so we never double-instrument.

- `packages/backend/src/prometheus/otelHttpMetrics.ts` — construct `new HttpInstrumentation()` (bound to our global meter provider) when `registerHttpInstrumentation` is set; disable it on shutdown. Adds pure, exported `shouldSelfRegisterHttpInstrumentation()` guard.
- `packages/backend/src/sentry.ts` — hoist the effective DSN computation; pass `registerHttpInstrumentation: !hasSentryDsn && !otelTracingEnabled()`.
- `packages/backend/src/{SchedulerApp,NatsWorkerApp}.ts` — thread the same guard via the shared helper.
- `otelHttpMetrics.test.ts` — unit test for the guard truth table.

Exactly one registrar across all states — this is the invariant the guard protects:

    no DSN, no traces (self-hosted)  -> we register        -> metric appears (the fix)
    DSN set, no traces (Sentry prod) -> Sentry registers   -> we skip -> no double-count
    traces on, no DSN                -> tracing.ts registers-> we skip -> no double-count
    traces on, DSN set               -> tracing.ts registers-> we skip -> no double-count

Intentionally out of scope: no `ignoreIncomingRequestHook` — the metric stays identical to the Sentry-instrumented path (health checks included in both).

## Before

No DSN, flag on, after 20 requests — metric absent:

```
$ curl -s localhost:9110/metrics | grep -c http_server_request_duration_seconds
0
```

## After

Same condition — metric present with the stable semconv name and labels:

```
# HELP http_server_request_duration_seconds Duration of HTTP server requests.
# TYPE http_server_request_duration_seconds histogram
http_server_request_duration_seconds_count{http_request_method="GET",http_response_status_code="200",...} 21
```

Duplication check (Sentry client enabled + flag on): 40 requests → count delta **41** (single, not ~80) and exactly one instrumentation-http scope present.

## Test plan

- [x] `pnpm -F backend typecheck:fast && pnpm -F backend lint`
- [x] `pnpm -F backend test otelHttpMetrics` — 4 pass (regression: `shouldSelfRegisterHttpInstrumentation`)
- [x] Manual E2E: reproduced absence with no DSN, confirmed present after fix (stable name, not legacy)
- [x] Manual E2E: with Sentry client enabled, verified single registration (delta 41 for 40 reqs, one scope)
- [x] Manual: default dev (Spotlight on) still healthy; other metrics unaffected
