### PR TITLE
fix(ai): treat aggregation custom metrics as selected metrics in axis validation

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -125,6 +125,7 @@ export const validateRunQueryTool = (
         queryTool.queryConfig.dimensions,
         queryTool.queryConfig.metrics,
         queryTool.queryConfig.tableCalculations,
+        aggregations,
     );
 
     // Validate sort fields exist

--- a/packages/backend/src/ee/services/ai/utils/validateAxisFields.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateAxisFields.test.ts
@@ -1,4 +1,6 @@
 import {
+    MetricType,
+    type CustomMetricBaseTransformed,
     type TableCalcsSchema,
     type ToolRunQueryArgsTransformed,
 } from '@lightdash/common';
@@ -441,6 +443,69 @@ describe('validateAxisFields', () => {
                     selectedMetrics,
                 ),
             ).not.toThrow();
+        });
+
+        it('should not throw when a yAxis custom metric is provided via the customMetrics arg but is not in queryConfig.metrics', () => {
+            // The agent commonly defines an aggregation custom metric and puts
+            // its id on the Y-axis without also adding it to queryConfig.metrics.
+            // A custom metric is a selected metric, so this must be accepted.
+            const chartConfig: ToolRunQueryArgsTransformed['chartConfig'] = {
+                defaultVizType: 'bar',
+                xAxisDimension: 'orders_order_date',
+                yAxisMetrics: ['orders_won_opportunities'],
+                groupBy: null,
+                xAxisType: 'time',
+                stackBars: null,
+                lineType: null,
+                funnelDataInput: null,
+                xAxisLabel: 'xAxisLabel',
+                yAxisLabel: 'yAxisLabel',
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
+            };
+
+            const customMetrics: CustomMetricBaseTransformed[] = [
+                {
+                    table: 'orders',
+                    name: 'won_opportunities',
+                    label: 'Won opportunities',
+                    description: 'Distinct count of won opportunities',
+                    baseDimensionName: 'order_id',
+                    type: MetricType.COUNT_DISTINCT,
+                    filters: undefined,
+                },
+            ];
+
+            expect(() =>
+                validateAxisFields(
+                    chartConfig,
+                    ['orders_order_date'],
+                    [], // empty queryConfig.metrics on purpose
+                    undefined,
+                    customMetrics,
+                ),
+            ).not.toThrow();
+        });
+
+        it('should throw when the yAxis custom metric is in neither queryConfig.metrics nor customMetrics', () => {
+            const chartConfig: ToolRunQueryArgsTransformed['chartConfig'] = {
+                defaultVizType: 'bar',
+                xAxisDimension: 'orders_order_date',
+                yAxisMetrics: ['orders_won_opportunities'],
+                groupBy: null,
+                xAxisType: 'time',
+                stackBars: null,
+                lineType: null,
+                funnelDataInput: null,
+                xAxisLabel: 'xAxisLabel',
+                yAxisLabel: 'yAxisLabel',
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
+            };
+
+            expect(() =>
+                validateAxisFields(chartConfig, ['orders_order_date'], []),
+            ).toThrow(/orders_won_opportunities/);
         });
     });
 });

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -1180,10 +1180,19 @@ export function validateAxisFields(
     selectedDimensions: string[],
     selectedMetrics: string[],
     tableCalculations?: TableCalcsSchema | TableCalculation[],
+    customMetrics?: CustomMetricBaseTransformed[] | null,
 ) {
     if (!chartConfig) {
         return;
     }
+
+    // Aggregation custom metrics are selected metrics too — they compile to
+    // "<table>_<name>" field ids and are valid on the axes. Fold them in like
+    // the sort / table-calculation / field-existence validators already do,
+    // otherwise a custom metric referenced in yAxisMetrics fails validation
+    // even though it is part of the query.
+    const customMetricIds = customMetrics?.map(getItemId) ?? [];
+    const selectableMetrics = [...selectedMetrics, ...customMetricIds];
 
     // Validate both axis fields
     const xAxisErrors = validateXAxisField(
@@ -1192,14 +1201,14 @@ export function validateAxisFields(
     );
     const yAxisErrors = validateYAxisMetrics(
         chartConfig.yAxisMetrics,
-        selectedMetrics,
+        selectableMetrics,
         tableCalculations,
     );
     if (chartConfig.secondaryYAxisMetric) {
         yAxisErrors.push(
             ...validateYAxisMetrics(
                 [chartConfig.secondaryYAxisMetric],
-                selectedMetrics,
+                selectableMetrics,
                 tableCalculations,
             ),
         );


### PR DESCRIPTION
## Problem

The AI agent frequently defines an aggregation `customMetric` and references its id in `chartConfig.yAxisMetrics` without also duplicating it into `queryConfig.metrics`. `generateVisualization` then fails with:

```
Invalid axis field configuration:
Error: yAxisMetric "<table>_<name>" is not included in queryConfig.metrics or tableCalculations. Selected metrics:
```

`validateAxisFields` validated the Y-axis against **only** `queryConfig.metrics`. Its sibling validators — `validateSortFieldsAreSelected`, `validateTableCalculations`, `validateSelectedFieldsExistence` — are all additionally passed the aggregation custom metrics and treat them as selectable; axis validation was the one place that wasn't, so a legitimately-defined custom metric on an axis was rejected. The agent then retries repeatedly.

## Fix

Pass the aggregation custom metrics into `validateAxisFields` and fold their compiled `"<table>_<name>"` ids into the selectable-metric set (same pattern the sibling validators already use). Byte-identical when no custom metrics are present.

## Tests

- `validateAxisFields.test.ts`: custom metric on the Y-axis passes when supplied via `customMetrics` even though `queryConfig.metrics` is empty; still throws when the metric is in neither. 16/16 pass.
- `pnpm --filter backend typecheck:fast` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
