### PR TITLE
fix(ai): make invalid custom-metric baseDimensionName errors actionable

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -1466,7 +1466,7 @@ Example B — "Revenue by month with year-over-year comparison"
                       "additionalProperties": false,
                       "properties": {
                         "baseDimensionName": {
-                          "description": "Name of the base dimension/column this metric calculates from",
+                          "description": "Field ID (e.g. "customers_age") or bare column name (e.g. "age") of the base dimension to aggregate. Must be a dimension that already EXISTS in this explore — find it via findFields / getMetadata. Do NOT guess an id/primary-key column: many explores do not expose "<table>_id" as a queryable dimension.",
                           "type": "string",
                         },
                         "description": {

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1464,7 +1464,7 @@ Recommended Dashboard Structure:
                               "additionalProperties": false,
                               "properties": {
                                 "baseDimensionName": {
-                                  "description": "Name of the base dimension/column this metric calculates from",
+                                  "description": "Field ID (e.g. "customers_age") or bare column name (e.g. "age") of the base dimension to aggregate. Must be a dimension that already EXISTS in this explore — find it via findFields / getMetadata. Do NOT guess an id/primary-key column: many explores do not expose "<table>_id" as a queryable dimension.",
                                   "type": "string",
                                 },
                                 "description": {
@@ -4570,7 +4570,7 @@ Notes:
                         "additionalProperties": false,
                         "properties": {
                           "baseDimensionName": {
-                            "description": "Name of the base dimension/column this metric calculates from",
+                            "description": "Field ID (e.g. "customers_age") or bare column name (e.g. "age") of the base dimension to aggregate. Must be a dimension that already EXISTS in this explore — find it via findFields / getMetadata. Do NOT guess an id/primary-key column: many explores do not expose "<table>_id" as a queryable dimension.",
                             "type": "string",
                           },
                           "description": {

--- a/packages/backend/src/ee/services/ai/utils/validateCustomMetricsDefinition.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateCustomMetricsDefinition.test.ts
@@ -1,0 +1,48 @@
+import {
+    MetricType,
+    type CustomMetricBaseTransformed,
+} from '@lightdash/common';
+import { mockOrdersExplore } from './validationExplore.mock';
+import { validateCustomMetricsDefinition } from './validators';
+
+const customMetric = (
+    overrides: Partial<CustomMetricBaseTransformed>,
+): CustomMetricBaseTransformed => ({
+    table: 'orders',
+    name: 'my_metric',
+    label: 'My metric',
+    description: 'desc',
+    baseDimensionName: 'amount',
+    type: MetricType.COUNT_DISTINCT,
+    filters: undefined,
+    ...overrides,
+});
+
+describe('validateCustomMetricsDefinition', () => {
+    it('does not throw for a base dimension that exists', () => {
+        expect(() =>
+            validateCustomMetricsDefinition(mockOrdersExplore, [
+                customMetric({ baseDimensionName: 'amount' }),
+            ]),
+        ).not.toThrow();
+    });
+
+    it('reports the resolved field id and lists available dimensions when the base dimension does not exist', () => {
+        let error: Error | undefined;
+        try {
+            validateCustomMetricsDefinition(mockOrdersExplore, [
+                // The agent's classic mistake: guessing a "<table>_id" column.
+                customMetric({ baseDimensionName: 'missing_id' }),
+            ]);
+        } catch (e) {
+            error = e as Error;
+        }
+
+        expect(error).toBeDefined();
+        // Echoes the field id actually looked for, not the prefix-stripped name.
+        expect(error!.message).toContain('orders_missing_id');
+        // Gives the agent the real options to correct in one step.
+        expect(error!.message).toContain('Available dimensions:');
+        expect(error!.message).toContain('orders_customer_name');
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -123,8 +123,28 @@ export function validateCustomMetricsDefinition(
         );
 
         if (!field) {
+            // The transform strips the "<table>_" prefix from baseDimensionName,
+            // so show the field id we actually looked for and list the real
+            // dimensions — the agent can then correct in one step instead of
+            // guessing an id/primary-key column the explore may not expose.
+            const expectedFieldId = getItemId({
+                name: metric.baseDimensionName,
+                table: metric.table,
+            });
+            const availableDimensions = exploreFields
+                .filter(isDimension)
+                .map(getItemId);
+            const shown = availableDimensions.slice(0, 50);
+            const more =
+                availableDimensions.length > shown.length
+                    ? ` (and ${
+                          availableDimensions.length - shown.length
+                      } more — use findFields to search them)`
+                    : '';
             errors.push(
-                `Error: the base dimension name "${metric.baseDimensionName}" does not exist in the explore.`,
+                `Error: base dimension "${expectedFieldId}" does not exist in the explore "${metric.table}". ` +
+                    `baseDimensionName must be an existing dimension (do not invent an id/primary-key column). ` +
+                    `Available dimensions: ${shown.join(', ')}${more}`,
             );
             return;
         }

--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -74,7 +74,7 @@ const aggregationCustomMetricSchema = z.object({
     baseDimensionName: z
         .string()
         .describe(
-            'Name of the base dimension/column this metric calculates from',
+            'Field ID (e.g. "customers_age") or bare column name (e.g. "age") of the base dimension to aggregate. Must be a dimension that already EXISTS in this explore — find it via findFields / getMetadata. Do NOT guess an id/primary-key column: many explores do not expose "<table>_id" as a queryable dimension.',
         ),
     table: z
         .string()


### PR DESCRIPTION
## Problem

When the AI agent defines an aggregation `customMetric` whose `baseDimensionName` is not an existing dimension (commonly guessing a `<table>_id` primary key that the explore doesn't expose), it got:

```
The following custom metrics are invalid:
Error: the base dimension name "id" does not exist in the explore.
```

Two problems make the agent thrash:
1. The echoed name (`"id"`) is the **prefix-stripped** value, not the `"dim_opportunity_id"` the agent actually passed — confusing.
2. No valid options are given, so the agent re-guesses and retries.

## Fix

- The not-found error now echoes the **resolved `"<table>_<name>"` field id** and **lists the explore's actual dimensions** (capped at 50, pointing to `findFields` for the rest), so the agent can correct in one step.
- The `baseDimensionName` tool-schema description now tells the agent it must be an existing dimension and not to invent an id/primary-key column.

No behavioural change to valid custom metrics.

## Tests

- `validateCustomMetricsDefinition.test.ts`: valid base dimension passes; invalid one throws an error containing the resolved field id + `Available dimensions:` + a real dimension. 2/2 pass.
- `pnpm --filter backend typecheck:fast` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
