### PR TITLE
feat(data-apps): allow all REST methods on external connections

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -811,9 +811,11 @@ The sandboxed preview iframe has no network access of its own (`default-src 'non
 3. `executeExternalFetch` validates the request, enforces the SSRF guard (the request must resolve under the connection's configured base URL/host; private/loopback/link-local targets are rejected), injects the secret as the configured auth, reads a **bounded** response body, and returns `{ status, contentType, body, truncated }`.
 4. The bounded response is posted back to the iframe. The decrypted secret never crosses to the frontend.
 
-### GET / POST rules
+### Method rules
 
-Only `GET` and `POST` are allowed. `GET` is for reads; `POST` carries a JSON body. Other methods are rejected. The request `path` is resolved against the connection's base URL and cannot escape its host (SSRF guard). Responses are size-capped; oversized bodies come back with `truncated: true` rather than streaming unbounded data into the browser.
+Each connection carries a per-connection **allowed-methods** list; an admin opts a connection into whichever of `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` it needs (the shared universe is `EXTERNAL_CONNECTION_METHODS` in `packages/common/src/ee/externalConnections/types.ts`). A fetch whose method is not in that list is rejected. `GET` is for reads and carries no body; every other method may carry a server-serialized JSON body. The request `path` is resolved against the connection's base URL and cannot escape its host (SSRF guard). Responses are size-capped; oversized bodies come back with `truncated: true` rather than streaming unbounded data into the browser.
+
+New connections default to `['GET']` only; broadening the set is an explicit admin opt-in per connection, keeping the exfiltration surface (see [Why the exfiltration warning matters](#why-the-exfiltration-warning-matters)) as small as the app actually needs.
 
 ### Why the exfiltration warning matters
 

--- a/packages/backend/src/ee/analytics/externalConnections.ts
+++ b/packages/backend/src/ee/analytics/externalConnections.ts
@@ -1,3 +1,4 @@
+import { type ExternalConnectionMethod } from '@lightdash/common';
 import { Track as AnalyticsTrack } from '@rudderstack/rudder-sdk-node';
 
 type BaseTrack = Omit<AnalyticsTrack, 'context'>;
@@ -51,7 +52,7 @@ export type ExternalConnectionEvent = BaseTrack &
                   appUuid: string;
                   externalConnectionUuid: string;
                   connectionAlias: string;
-                  method: 'GET' | 'POST';
+                  method: ExternalConnectionMethod;
                   path: string;
                   status: number | null;
                   outcome:

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1450,7 +1450,7 @@ export class AppGenerateService extends BaseService {
                 {
                     alias: doc.alias,
                     signature:
-                        "externalFetch(alias: string, opts: { method?: 'GET' | 'POST'; path: string; query?: Record<string, string>; body?: unknown }): Promise<{ status: number; contentType: string; body: unknown; truncated: boolean }>",
+                        "externalFetch(alias: string, opts: { method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; path: string; query?: Record<string, string>; body?: unknown }): Promise<{ status: number; contentType: string; body: unknown; truncated: boolean }>",
                     origin: doc.origin,
                     // The single most-misread thing: `path` is the COMPLETE path from
                     // the origin, not relative to the prefix. Spell out origin + path.

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -251,6 +251,27 @@ describe('ExternalConnectionService.proxyFetch', () => {
         expect(opts.headers!['Content-Type']).toBe('application/json');
     });
 
+    it.each(['PUT', 'PATCH', 'DELETE'] as const)(
+        'happy %s: forwards the method and serializes the body when allowed',
+        async (method) => {
+            const { service } = buildService({
+                connection: baseConnection({
+                    allowedMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+                }),
+            });
+            await service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                method,
+                path: '/v1/echo',
+                body: { hello: 'world' },
+            });
+            const [, opts] = mockSecureFetch.mock.calls[0];
+            expect(opts.method).toBe(method);
+            expect(opts.body).toBe('{"hello":"world"}');
+            expect(opts.headers!['Content-Type']).toBe('application/json');
+        },
+    );
+
     it('POST over requestMaxBytes is rejected', async () => {
         const { service } = buildService({
             connection: baseConnection({ requestMaxBytes: 5 }),

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
@@ -119,10 +119,28 @@ describe('validateExternalConnectionConfig', () => {
         it('rejects an unsupported method', () => {
             expect(() =>
                 validateExternalConnectionConfig(
-                    { ...base, allowedMethods: ['DELETE'] },
+                    { ...base, allowedMethods: ['TRACE'] },
                     false,
                 ),
             ).toThrow(ParameterError);
+        });
+
+        it('accepts the extended write methods', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        allowedMethods: [
+                            'GET',
+                            'POST',
+                            'PUT',
+                            'PATCH',
+                            'DELETE',
+                        ],
+                    },
+                    false,
+                ),
+            ).not.toThrow();
         });
 
         it('rejects empty content types', () => {

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    EXTERNAL_CONNECTION_METHODS,
     ParameterError,
     type ApiKeyLocation,
     type ExternalConnectionAuthType,
@@ -12,7 +13,7 @@ const MAX_REQUEST_BYTES = 10 * 1024 * 1024; // 10 MiB
 const MAX_TIMEOUT_MS = 120_000; // 2 minutes
 const MAX_RATE_LIMIT = 100_000;
 
-const SUPPORTED_METHODS = new Set(['GET', 'POST']);
+const SUPPORTED_METHODS = new Set<string>(EXTERNAL_CONNECTION_METHODS);
 // RFC 7230 token chars — valid for HTTP header names and a safe set for query keys.
 const HTTP_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 const CONTENT_TYPE = /^[a-z0-9*]+\/[a-z0-9.+*-]+$/i;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1679,6 +1679,9 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { dataType: 'enum', enums: ['GET'] },
                 { dataType: 'enum', enums: ['POST'] },
+                { dataType: 'enum', enums: ['PUT'] },
+                { dataType: 'enum', enums: ['PATCH'] },
+                { dataType: 'enum', enums: ['DELETE'] },
             ],
             validators: {},
         },
@@ -2078,13 +2081,7 @@ const models: TsoaRoute.Models = {
                 body: { dataType: 'any' },
                 query: { ref: 'Record_string.string_' },
                 path: { dataType: 'string', required: true },
-                method: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['GET'] },
-                        { dataType: 'enum', enums: ['POST'] },
-                    ],
-                },
+                method: { ref: 'ExternalConnectionMethod' },
             },
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1666,7 +1666,7 @@
             },
             "ExternalConnectionMethod": {
                 "type": "string",
-                "enum": ["GET", "POST"]
+                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
             },
             "ApiKeyLocation": {
                 "type": "string",
@@ -2067,8 +2067,7 @@
                         "type": "string"
                     },
                     "method": {
-                        "type": "string",
-                        "enum": ["GET", "POST"]
+                        "$ref": "#/components/schemas/ExternalConnectionMethod"
                     }
                 },
                 "required": ["path"],

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -26,7 +26,7 @@ export class SecureFetchError extends Error {
 }
 
 export type SecureFetchOptions = {
-    method: 'GET' | 'POST';
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     body?: string;
     headers?: Record<string, string>;
     timeoutMs: number;

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -1,5 +1,16 @@
 export type ExternalConnectionAuthType = 'none' | 'api_key' | 'bearer_token';
-export type ExternalConnectionMethod = 'GET' | 'POST';
+
+/** HTTP methods an admin can opt a connection into. Single source of truth for
+ *  the backend validation allowlist and the frontend method pickers. */
+export const EXTERNAL_CONNECTION_METHODS = [
+    'GET',
+    'POST',
+    'PUT',
+    'PATCH',
+    'DELETE',
+] as const;
+export type ExternalConnectionMethod =
+    (typeof EXTERNAL_CONNECTION_METHODS)[number];
 export type ApiKeyLocation = 'header' | 'query';
 
 /** READ shape returned by the API — NEVER includes the secret value. */
@@ -74,7 +85,7 @@ export type ExternalFetchResponse = {
 };
 
 export type ApiTestExternalConnectionRequest = {
-    method?: 'GET' | 'POST';
+    method?: ExternalConnectionMethod;
     path: string;
     query?: Record<string, string>;
     body?: unknown;

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
@@ -1,5 +1,7 @@
 import {
+    EXTERNAL_CONNECTION_METHODS,
     type ExternalConnection,
+    type ExternalConnectionMethod,
     type ExternalConnectionSample,
     type ExternalConnectionSampleRequest,
     type ExternalFetchResponse,
@@ -10,7 +12,7 @@ import {
     Button,
     Divider,
     Group,
-    SegmentedControl,
+    Select,
     Stack,
     Text,
     Textarea,
@@ -89,7 +91,7 @@ const parsePathInput = (
 };
 
 const exampleFormSchema = z.object({
-    method: z.enum(['GET', 'POST']),
+    method: z.enum(EXTERNAL_CONNECTION_METHODS),
     path: z.string().min(1, 'Path is required'),
     queryParams: z.array(
         z.object({
@@ -244,7 +246,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                 path: values.path,
                 query: buildQuery(values.queryParams),
                 body:
-                    values.method === 'POST'
+                    values.method !== 'GET'
                         ? parseJson(values.requestBody)
                         : undefined,
             };
@@ -285,15 +287,20 @@ export const ConnectionExamplesPanel: FC<Props> = ({
             </Stack>
 
             <Group align="flex-end" gap="xs">
-                <SegmentedControl
+                <Select
+                    label="Method"
+                    w={110}
+                    allowDeselect={false}
                     value={form.values.method}
                     onChange={(v) => {
-                        form.setFieldValue('method', v as 'GET' | 'POST');
+                        if (!v) return;
+                        form.setFieldValue(
+                            'method',
+                            v as ExternalConnectionMethod,
+                        );
                         testMutation.reset();
                     }}
-                    data={['GET', 'POST']}
-                    size="xs"
-                    mb="xxs"
+                    data={[...EXTERNAL_CONNECTION_METHODS]}
                 />
                 <TextInput
                     label="Path"
@@ -356,7 +363,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                 </Button>
             </Stack>
 
-            {form.values.method === 'POST' && (
+            {form.values.method !== 'GET' && (
                 <Textarea
                     label="Request body (JSON)"
                     placeholder='{"key": "value"}'

--- a/packages/frontend/src/features/externalConnections/components/MethodsField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/MethodsField.tsx
@@ -1,9 +1,12 @@
-import { type ExternalConnectionMethod } from '@lightdash/common';
+import {
+    EXTERNAL_CONNECTION_METHODS,
+    type ExternalConnectionMethod,
+} from '@lightdash/common';
 import { Chip, Group, Stack, Text } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 
-// Extend here when the backend's supported-method set grows (e.g. PATCH/DELETE).
-const METHOD_OPTIONS: ExternalConnectionMethod[] = ['GET', 'POST'];
+const METHOD_OPTIONS: readonly ExternalConnectionMethod[] =
+    EXTERNAL_CONNECTION_METHODS;
 
 type Props = {
     label: string;
@@ -13,7 +16,7 @@ type Props = {
     disabled?: boolean;
 };
 
-/** Multi-select method chips (GET/POST). Shared by the onboarding wizard's
+/** Multi-select HTTP method chips. Shared by the onboarding wizard's
  *  Rules step and the Edit connection form. */
 export const MethodsField: FC<Props> = ({
     label,

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -28,6 +28,7 @@ export type {
     DownloadResultsResult,
     DownloadResultsValues,
     DownloadUnderlyingDataOptions,
+    ExternalFetchMethod,
     ExternalFetchOptions,
     ExternalFetchResult,
     Filter,

--- a/packages/query-sdk/src/postMessageTransport.ts
+++ b/packages/query-sdk/src/postMessageTransport.ts
@@ -11,6 +11,7 @@
 
 import { createApiTransport, type FetchAdapter } from './apiTransport';
 import type {
+    ExternalFetchMethod,
     ExternalFetchOptions,
     ExternalFetchResult,
     Transport,
@@ -114,7 +115,7 @@ export type SdkExternalFetchRequest = {
     type: 'lightdash:sdk:external-fetch';
     id: string;
     alias: string;
-    method?: 'GET' | 'POST';
+    method?: ExternalFetchMethod;
     path: string;
     query?: Record<string, string>;
     body?: unknown;

--- a/packages/query-sdk/src/types.ts
+++ b/packages/query-sdk/src/types.ts
@@ -276,14 +276,21 @@ export type ExternalFetchResult = {
     truncated: boolean;
 };
 
+/**
+ * HTTP methods an external connection can be configured to allow. Mirror of
+ * `ExternalConnectionMethod` in `@lightdash/common` — the SDK is published
+ * standalone with no `@lightdash/common` dependency, so keep the two in sync.
+ */
+export type ExternalFetchMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
 export type ExternalFetchOptions = {
     /** HTTP method. Defaults to `'GET'`. */
-    method?: 'GET' | 'POST';
+    method?: ExternalFetchMethod;
     /** Relative path appended to the connection's configured base URL. */
     path: string;
     /** Query-string params, merged into the request URL by the backend. */
     query?: Record<string, string>;
-    /** JSON request body (POST only). */
+    /** JSON request body. Sent for every method except `GET`. */
     body?: unknown;
 };
 

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -948,10 +948,10 @@ Lightdash that stores the origin (host) and credentials. The app references it b
 
 ```tsx
 const res = await lightdash.externalFetch('stripe', {
-    method: 'GET',          // 'GET' | 'POST' — defaults to 'GET'
+    method: 'GET',          // 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' — defaults to 'GET'. Must be one of the connection's allowed methods.
     path: '/v1/charges',    // COMPLETE path appended to the connection's origin (host). Full URL = origin + path. Must start with an allowed prefix; it is NOT relative to the prefix.
     query: { limit: '10' }, // Record<string, string> — values MUST be strings
-    // body: { ... },       // JSON body (POST only)
+    // body: { ... },       // JSON body — sent for every method except GET
 });
 
 // res.status      — upstream HTTP status (number)


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-540/add-all-http-methods

### Description:
External connections were limited to GET/POST. Expand the selectable method universe to GET/POST/PUT/PATCH/DELETE so admins can opt a connection into the verbs it needs; the per-connection allowedMethods allowlist and the runtime includes() checks are unchanged, and new connections still default to ['GET'] only.

<img width="550" height="79" alt="image" src="https://github.com/user-attachments/assets/4554562a-0e40-4289-87b4-abd56cf3bff9" />

