### PR TITLE
feat: add AI agent embed support with code snippets and preview form

### DIFF
--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -415,6 +415,127 @@ func main() {
 `,
 };
 
+const aiAgentIframeCodeTemplates: Record<SnippetLanguage, string> = {
+    [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
+const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
+const projectUuid = '{{projectUuid}}';
+const agentUuid = '{{agentUuid}}';
+const data = {
+    content: {
+        type: 'aiAgent',
+        projectUuid: projectUuid,
+        agentUuid: agentUuid,
+    },
+    user: {
+        externalId: {{externalId}},
+        email: {{email}}
+    },
+    userAttributes: {{userAttributes}},
+{{writeActionsSnippet}}
+};
+const token = jwt.sign(data, LIGHTDASH_EMBED_SECRET, { expiresIn: '{{expiresIn}}' });
+const url = \`{{siteUrl}}/embed/\${projectUuid}/ai-agents/\${agentUuid}/threads#\${token}\`;
+`,
+    [SnippetLanguage.PYTHON]: `import datetime
+import jwt # pip install pyjwt
+
+key = "secret" # replace with your secret
+projectUuid = '{{projectUuid}}'
+agentUuid = '{{agentUuid}}'
+
+data = {
+    "exp": datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(hours=1), # replace with your expiration time,
+    "iat": datetime.datetime.now(tz=datetime.timezone.utc),
+    "content": {
+        "type": "aiAgent",
+        "projectUuid": projectUuid,
+        "agentUuid": agentUuid,
+    },
+    "user": {
+        "externalId": {{externalId}},
+        "email": {{email}}
+    },
+    "userAttributes": {{userAttributes}},
+{{writeActionsSnippet}}
+};
+token = jwt.encode(data, key, algorithm="HS256")
+url = f"{{siteUrl}}/embed/{projectUuid}/ai-agents/{agentUuid}/threads#{token}"
+`,
+    [SnippetLanguage.GO]: `
+package main
+
+import (
+    "fmt"
+    "time"
+
+    jwt "github.com/dgrijalva/jwt-go"
+)
+
+const LIGHTDASH_EMBED_SECRET = "secret" // replace with your secret
+const projectUuid = "{{projectUuid}}"
+const agentUuid = "{{agentUuid}}"
+
+func main() {
+    {{externalIdDef}}
+    {{emailDef}}
+
+    type CustomClaims struct {
+        Content struct {
+            Type        string \`json:"type"\`
+            ProjectUuid string \`json:"projectUuid"\`
+            AgentUuid   string \`json:"agentUuid"\`
+        } \`json:"content"\`
+        UserAttributes map[string]string \`json:"userAttributes"\`
+        WriteActions *struct {
+            ServiceAccountUserUuid string \`json:"serviceAccountUserUuid,omitempty"\`
+            UserUuid               string \`json:"userUuid,omitempty"\`
+            SpaceUuid              string \`json:"spaceUuid"\`
+        } \`json:"writeActions,omitempty"\`
+        jwt.StandardClaims
+        User *struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        } \`json:"user,omitempty"\`
+    }
+
+    claims := CustomClaims{
+        Content: struct {
+            Type        string \`json:"type"\`
+            ProjectUuid string \`json:"projectUuid"\`
+            AgentUuid   string \`json:"agentUuid"\`
+        }{
+            Type:        "aiAgent",
+            ProjectUuid: projectUuid,
+            AgentUuid:   agentUuid,
+        },
+        User: &struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        }{
+            ExternalId: {{externalIdUsage}},
+            Email:      {{emailUsage}},
+        },
+        UserAttributes: map[string]string{{userAttributes}},
+        // ServiceAccountUserUuid is the selected service account's user UUID.
+        // To run actions as a user instead, set UserUuid and leave ServiceAccountUserUuid empty.
+        WriteActions: {{writeActionsGo}},
+        StandardClaims: jwt.StandardClaims{
+            ExpiresAt: time.Now().Add(time.Hour).Unix(), // replace with your expiration
+        },
+    }
+
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+    signedToken, err := token.SignedString([]byte(LIGHTDASH_EMBED_SECRET))
+    if err != nil {
+        panic(err)
+    }
+
+    url := fmt.Sprintf("{{siteUrl}}/embed/%s/ai-agents/%s/threads#%s", projectUuid, agentUuid, signedToken)
+    fmt.Println("URL:", url)
+}
+`,
+};
+
 const dashboardIframeCodeTemplates: Record<SnippetLanguage, string> = {
     [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
 const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
@@ -970,10 +1091,6 @@ const getBackendCodeSnippet = (
     },
     mode: EmbedMethod,
 ): string => {
-    if (data.content.type === 'aiAgent') {
-        return '';
-    }
-
     let codeTemplate;
     if (isDashboardContent(data.content)) {
         codeTemplate =
@@ -984,6 +1101,9 @@ const getBackendCodeSnippet = (
         // Standalone data apps are iframe-only — there is no React SDK
         // component for them yet.
         codeTemplate = dataAppIframeCodeTemplates[language];
+    } else if (data.content.type === 'aiAgent') {
+        // AI agent embeds are iframe-only.
+        codeTemplate = aiAgentIframeCodeTemplates[language];
     } else {
         codeTemplate =
             mode === 'iframe'
@@ -1129,6 +1249,14 @@ const getBackendCodeSnippet = (
                 'appUuid' in data.content
                     ? data.content.appUuid || '<APP_UUID>'
                     : '<APP_UUID>',
+            );
+            break;
+        case 'aiAgent':
+            codeTemplate = codeTemplate.replace(
+                '{{agentUuid}}',
+                'agentUuid' in data.content
+                    ? data.content.agentUuid || '<AGENT_UUID>'
+                    : '<AGENT_UUID>',
             );
             break;
         case 'apiAccess':

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewAiAgentForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewAiAgentForm.tsx
@@ -1,0 +1,365 @@
+import {
+    type AiAgentSummary,
+    type ApiError,
+    type CreateEmbedJwt,
+    type EmbedJwtContentAiAgent,
+    type EmbedUrl,
+    type IntrinsicUserAttributes,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    Flex,
+    Group,
+    Input,
+    Paper,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconEye, IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback, type FC, type ReactNode } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { lightdashApi } from '../../../../api';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import useToaster from '../../../../hooks/toaster/useToaster';
+import { useAsyncClipboard } from '../../../../hooks/useAsyncClipboard';
+import useUser from '../../../../hooks/user/useUser';
+import EmbedCodeSnippet from './EmbedCodeSnippet';
+
+const useEmbedUrlCreateMutation = (projectUuid: string) => {
+    const { showToastError } = useToaster();
+    return useMutation<EmbedUrl, ApiError, CreateEmbedJwt>(
+        (data: CreateEmbedJwt) =>
+            lightdashApi<EmbedUrl>({
+                url: `/embed/${projectUuid}/get-embed-url`,
+                method: 'POST',
+                body: JSON.stringify(data),
+            }),
+        {
+            mutationKey: ['create-embed-url'],
+            onError: (error) => {
+                showToastError({
+                    title: `We couldn't create your embed url.`,
+                    subtitle: error.error.message,
+                });
+            },
+        },
+    );
+};
+
+type FormValues = {
+    agentUuid: string | undefined;
+    expiresIn: string;
+    userAttributes: Array<{
+        uuid: string;
+        key: string;
+        value: string;
+    }>;
+    externalId?: string;
+} & IntrinsicUserAttributes;
+
+const EmbedPreviewAiAgentForm: FC<{
+    projectUuid: string;
+    siteUrl: string;
+    agents: AiAgentSummary[];
+    writeActions?: CreateEmbedJwt['writeActions'];
+    writeActionsPanel?: ReactNode;
+}> = ({ projectUuid, siteUrl, agents, writeActions, writeActionsPanel }) => {
+    const { showToastError } = useToaster();
+    const { mutateAsync: createEmbedUrl } =
+        useEmbedUrlCreateMutation(projectUuid);
+    const { colorScheme } = useMantineColorScheme();
+    const { data: user } = useUser(true);
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            agentUuid: undefined,
+            expiresIn: '1 hour',
+            userAttributes: [{ uuid: uuidv4(), key: '', value: '' }] as Array<{
+                uuid: string;
+                key: string;
+                value: string;
+            }>,
+            email: user?.email,
+        },
+        validate: {
+            agentUuid: (value: undefined | string) => {
+                return value && value.length > 0
+                    ? null
+                    : 'AI agent is required';
+            },
+        },
+    });
+    const { onSubmit, values: formValues } = form;
+    const hasRequiredWriteActions =
+        !!writeActions?.serviceAccountUserUuid && !!writeActions.spaceUuid;
+
+    const convertFormValuesToCreateEmbedJwt = useCallback(
+        (
+            values: FormValues,
+        ): Omit<CreateEmbedJwt, 'content'> & {
+            content: EmbedJwtContentAiAgent;
+        } => {
+            return {
+                expiresIn: values.expiresIn,
+                content: {
+                    type: 'aiAgent',
+                    projectUuid,
+                    agentUuid: values.agentUuid!,
+                },
+                writeActions,
+                userAttributes: values.userAttributes.reduce<
+                    Record<string, string>
+                >((acc, item) => {
+                    const key = item.key.trim();
+                    if (!key) {
+                        return acc;
+                    }
+
+                    return {
+                        ...acc,
+                        [key]: item.value,
+                    };
+                }, {}),
+                user: {
+                    externalId: values.externalId,
+                    email: values.email,
+                },
+            };
+        },
+        [projectUuid, writeActions],
+    );
+
+    const validateWriteActions = useCallback(() => {
+        if (hasRequiredWriteActions) {
+            return true;
+        }
+
+        showToastError({
+            title: 'Service account required',
+            subtitle:
+                'Select a service account and target space before generating an AI agent embed.',
+        });
+        return false;
+    }, [hasRequiredWriteActions, showToastError]);
+
+    const handlePreview = useCallback(async () => {
+        const state = form.validate();
+        if (state.hasErrors || !validateWriteActions()) {
+            return;
+        }
+
+        const data = await createEmbedUrl(
+            convertFormValuesToCreateEmbedJwt(formValues),
+        );
+        const previewUrl = new URL(data.url);
+        previewUrl.searchParams.set('theme', colorScheme);
+        window.open(previewUrl.toString(), '_blank');
+    }, [
+        colorScheme,
+        convertFormValuesToCreateEmbedJwt,
+        createEmbedUrl,
+        form,
+        formValues,
+        validateWriteActions,
+    ]);
+
+    const generateUrl = useCallback(async () => {
+        if (!validateWriteActions()) {
+            return undefined;
+        }
+
+        const data = await createEmbedUrl(
+            convertFormValuesToCreateEmbedJwt(form.values),
+        );
+        const url = new URL(data.url);
+        url.searchParams.set('theme', colorScheme);
+        return url.toString();
+    }, [
+        colorScheme,
+        convertFormValuesToCreateEmbedJwt,
+        createEmbedUrl,
+        form.values,
+        validateWriteActions,
+    ]);
+
+    const { handleCopy } = useAsyncClipboard(generateUrl);
+    const handleCopySubmit = onSubmit(handleCopy);
+
+    return (
+        <form id="generate-embed-url-ai-agent" onSubmit={handleCopySubmit}>
+            <Stack gap="md" mb="md">
+                <Select
+                    required
+                    label="AI agent"
+                    data={agents.map((agent) => ({
+                        value: agent.uuid,
+                        label: agent.name,
+                    }))}
+                    placeholder={
+                        agents.length === 0
+                            ? 'No AI agents available to embed'
+                            : 'Select an AI agent...'
+                    }
+                    disabled={agents.length === 0}
+                    searchable
+                    {...form.getInputProps('agentUuid')}
+                />
+
+                <Stack gap="xs">
+                    <Text size="sm" fw={500}>
+                        Expires in
+                    </Text>
+                    <SegmentedControl
+                        value={form.values.expiresIn}
+                        onChange={(value) =>
+                            form.setFieldValue('expiresIn', value)
+                        }
+                        radius="md"
+                        data={[
+                            { label: '1 hour', value: '1 hour' },
+                            { label: '1 day', value: '1 day' },
+                            { label: '1 week', value: '1 week' },
+                            { label: '30 days', value: '30 days' },
+                            { label: '1 year', value: '1 year' },
+                        ]}
+                        size="xs"
+                    />
+                </Stack>
+
+                <Paper p="md" withBorder>
+                    <Stack gap="md">
+                        <Title order={6}>Identification & Security</Title>
+                        <Stack gap="xs">
+                            <Input.Wrapper label="User identifier">
+                                <TextInput
+                                    size="xs"
+                                    placeholder="1234"
+                                    {...form.getInputProps('externalId')}
+                                />
+                            </Input.Wrapper>
+
+                            <Input.Wrapper label="User email">
+                                <TextInput
+                                    size="xs"
+                                    placeholder="Type an email to add as intrinsic user attribute"
+                                    {...form.getInputProps('email')}
+                                />
+                            </Input.Wrapper>
+
+                            <Input.Wrapper label="User attributes">
+                                <Stack gap="xs" mt="xs">
+                                    {form.values.userAttributes.map(
+                                        (item, index) => (
+                                            <Group
+                                                key={item.uuid}
+                                                gap="xs"
+                                                wrap="nowrap"
+                                            >
+                                                <TextInput
+                                                    size="xs"
+                                                    placeholder="E.g. user_country"
+                                                    flex={1}
+                                                    {...form.getInputProps(
+                                                        `userAttributes.${index}.key`,
+                                                    )}
+                                                />
+                                                <TextInput
+                                                    size="xs"
+                                                    placeholder="E.g. US"
+                                                    flex={1}
+                                                    {...form.getInputProps(
+                                                        `userAttributes.${index}.value`,
+                                                    )}
+                                                />
+                                                <ActionIcon
+                                                    variant="light"
+                                                    color="red"
+                                                    onClick={() =>
+                                                        form.removeListItem(
+                                                            'userAttributes',
+                                                            index,
+                                                        )
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                    />
+                                                </ActionIcon>
+                                            </Group>
+                                        ),
+                                    )}
+                                    <Button
+                                        size="xs"
+                                        variant="default"
+                                        leftSection={
+                                            <MantineIcon icon={IconPlus} />
+                                        }
+                                        onClick={() =>
+                                            form.insertListItem(
+                                                'userAttributes',
+                                                {
+                                                    key: '',
+                                                    value: '',
+                                                    uuid: uuidv4(),
+                                                },
+                                            )
+                                        }
+                                    >
+                                        Add attribute
+                                    </Button>
+                                </Stack>
+                            </Input.Wrapper>
+                        </Stack>
+                    </Stack>
+                </Paper>
+
+                {writeActionsPanel}
+
+                <Flex justify="flex-end" gap="sm">
+                    <Button
+                        variant="light"
+                        leftSection={<MantineIcon icon={IconEye} />}
+                        onClick={handlePreview}
+                        disabled={!hasRequiredWriteActions}
+                    >
+                        Preview
+                    </Button>
+                    <Button
+                        variant="default"
+                        type="submit"
+                        leftSection={<MantineIcon icon={IconLink} />}
+                        disabled={!hasRequiredWriteActions}
+                    >
+                        Generate & copy URL
+                    </Button>
+                </Flex>
+            </Stack>
+
+            <Stack gap="md" mb="md">
+                <Stack gap="xs">
+                    <Title order={5}>Iframe embed code</Title>
+                    <Text c="dimmed" fz="sm">
+                        Use this for iframe or direct embedding with a full
+                        embed URL.
+                    </Text>
+                </Stack>
+                <EmbedCodeSnippet
+                    mode="iframe"
+                    projectUuid={projectUuid}
+                    siteUrl={siteUrl}
+                    data={convertFormValuesToCreateEmbedJwt(formValues)}
+                />
+            </Stack>
+        </form>
+    );
+};
+
+export default EmbedPreviewAiAgentForm;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedWriteActionsForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedWriteActionsForm.tsx
@@ -1,4 +1,5 @@
 import {
+    ProjectMemberRole,
     ServiceAccountScope,
     type CreateEmbedJwt,
     type ServiceAccount,
@@ -49,6 +50,14 @@ const SYSTEM_ROLE_OPTIONS = [
     { value: ServiceAccountScope.SYSTEM_VIEWER, label: 'Viewer' },
 ];
 
+const AI_AGENT_SYSTEM_ROLE_OPTIONS = SYSTEM_ROLE_OPTIONS.filter(
+    (option) =>
+        ![
+            ServiceAccountScope.SYSTEM_INTERACTIVE_VIEWER,
+            ServiceAccountScope.SYSTEM_VIEWER,
+        ].includes(option.value),
+);
+
 const SCOPE_LABEL: Partial<Record<ServiceAccountScope, string>> = {
     [ServiceAccountScope.SYSTEM_ADMIN]: 'Admin',
     [ServiceAccountScope.SYSTEM_DEVELOPER]: 'Developer',
@@ -70,13 +79,27 @@ const WRITABLE_SERVICE_ACCOUNT_SCOPES = [
     ServiceAccountScope.ORG_EDIT,
 ];
 
+const SERVICE_ACCOUNT_SCOPE_PROJECT_ROLE_MAP: Partial<
+    Record<ServiceAccountScope, ProjectMemberRole>
+> = {
+    [ServiceAccountScope.SYSTEM_ADMIN]: ProjectMemberRole.ADMIN,
+    [ServiceAccountScope.SYSTEM_DEVELOPER]: ProjectMemberRole.DEVELOPER,
+    [ServiceAccountScope.SYSTEM_EDITOR]: ProjectMemberRole.EDITOR,
+};
+
 type Props = {
     projectUuid: string;
     value: CreateEmbedJwt['writeActions'] | undefined;
     onChange: (value: CreateEmbedJwt['writeActions'] | undefined) => void;
+    required?: boolean;
 };
 
-const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
+const EmbedWriteActionsForm: FC<Props> = ({
+    projectUuid,
+    value,
+    onChange,
+    required = false,
+}) => {
     const { listAccounts, createAccount } = useServiceAccounts();
     const { listRoles } = useCustomRoles();
     const createSpaceMutation = useCreateMutation(projectUuid);
@@ -84,7 +107,7 @@ const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
         projectUuid,
         true,
     );
-    const [isEnabled, setIsEnabled] = useState(!!value);
+    const [isEnabled, setIsEnabled] = useState(required || !!value);
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
     const [isCreateSpaceModalOpen, setIsCreateSpaceModalOpen] = useState(false);
     const [selectedServiceAccountUuid, setSelectedServiceAccountUuid] =
@@ -96,7 +119,11 @@ const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
         'Embedded customer content',
     );
     const [roleType, setRoleType] = useState<'system' | 'custom'>('system');
-    const [systemRole, setSystemRole] = useState(SYSTEM_ROLE_OPTIONS[1].value);
+    const [systemRole, setSystemRole] = useState(
+        required
+            ? ServiceAccountScope.SYSTEM_EDITOR
+            : SYSTEM_ROLE_OPTIONS[1].value,
+    );
     const [customRole, setCustomRole] = useState<string | null>(null);
 
     const serviceAccounts = useMemo(
@@ -119,15 +146,34 @@ const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
         return map;
     }, [customRoleOptions]);
 
+    const systemRoleOptions = required
+        ? AI_AGENT_SYSTEM_ROLE_OPTIONS
+        : SYSTEM_ROLE_OPTIONS;
     const selectedRole = roleType === 'system' ? systemRole : customRole;
     const canCreateServiceAccount = roleType === 'system' || !!customRole;
 
+    const selectableServiceAccounts = useMemo(
+        () =>
+            required
+                ? serviceAccounts.filter(
+                      (account) =>
+                          account.roleUuid ||
+                          ('projectAccessCount' in account &&
+                              account.projectAccessCount > 0) ||
+                          account.scopes.some((scope) =>
+                              WRITABLE_SERVICE_ACCOUNT_SCOPES.includes(scope),
+                          ),
+                  )
+                : serviceAccounts,
+        [required, serviceAccounts],
+    );
+
     const selectedServiceAccount = useMemo(
         () =>
-            serviceAccounts.find(
+            selectableServiceAccounts.find(
                 (account) => account.uuid === selectedServiceAccountUuid,
             ),
-        [selectedServiceAccountUuid, serviceAccounts],
+        [selectableServiceAccounts, selectedServiceAccountUuid],
     );
     const selectedSpace = useMemo(
         () => spaces.find((space) => space.uuid === selectedSpaceUuid),
@@ -135,30 +181,47 @@ const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
     );
 
     useEffect(() => {
-        const matchingAccount = serviceAccounts.find(
+        if (required) {
+            setIsEnabled(true);
+            if (
+                !AI_AGENT_SYSTEM_ROLE_OPTIONS.some(
+                    (option) => option.value === systemRole,
+                )
+            ) {
+                setSystemRole(ServiceAccountScope.SYSTEM_EDITOR);
+            }
+        }
+    }, [required, systemRole]);
+
+    useEffect(() => {
+        const matchingAccount = selectableServiceAccounts.find(
             (account) => account.userUuid === value?.serviceAccountUserUuid,
         );
         const defaultAccount =
-            serviceAccounts.find(
+            selectableServiceAccounts.find(
                 (account) =>
                     account.roleUuid ||
+                    ('projectAccessCount' in account &&
+                        account.projectAccessCount > 0) ||
                     account.scopes.some((scope) =>
                         WRITABLE_SERVICE_ACCOUNT_SCOPES.includes(scope),
                     ),
-            ) ?? serviceAccounts[0];
+            ) ?? selectableServiceAccounts[0];
         const nextServiceAccountUuid =
             matchingAccount?.uuid ?? defaultAccount?.uuid;
 
         setSelectedServiceAccountUuid((currentUuid) => {
             if (
                 currentUuid &&
-                serviceAccounts.some((account) => account.uuid === currentUuid)
+                selectableServiceAccounts.some(
+                    (account) => account.uuid === currentUuid,
+                )
             ) {
                 return currentUuid;
             }
             return nextServiceAccountUuid;
         });
-    }, [serviceAccounts, value?.serviceAccountUserUuid]);
+    }, [selectableServiceAccounts, value?.serviceAccountUserUuid]);
 
     useEffect(() => {
         const nextSpaceUuid =
@@ -206,12 +269,34 @@ const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
     const handleCreateServiceAccount = async () => {
         const label =
             newServiceAccountDescription.trim() || 'Embedded customer actions';
+        const projectRole =
+            roleType === 'system'
+                ? SERVICE_ACCOUNT_SCOPE_PROJECT_ROLE_MAP[
+                      systemRole as ServiceAccountScope
+                  ]
+                : undefined;
+        if (required && roleType === 'system' && !projectRole) {
+            return;
+        }
         const newAccount = await createAccount.mutateAsync({
             description: label,
             expiresAt: null,
-            ...(roleType === 'system'
-                ? { scopes: [systemRole as ServiceAccountScope] }
-                : { roleUuid: customRole ?? undefined }),
+            ...(required
+                ? {
+                      scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+                      projectAccess:
+                          roleType === 'system'
+                              ? [{ projectUuid, role: projectRole }]
+                              : [
+                                    {
+                                        projectUuid,
+                                        roleUuid: customRole ?? undefined,
+                                    },
+                                ],
+                  }
+                : roleType === 'system'
+                  ? { scopes: [systemRole as ServiceAccountScope] }
+                  : { roleUuid: customRole ?? undefined }),
         });
 
         setSelectedServiceAccountUuid(newAccount.uuid);
@@ -230,22 +315,26 @@ const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
 
     return (
         <Stack gap="md">
-            <Switch
-                checked={isEnabled}
-                onChange={(event) => setIsEnabled(event.currentTarget.checked)}
-                label="Enable write actions"
-                description="Allow embedded users to perform actions that create or update Lightdash resources."
-            />
+            {!required && (
+                <Switch
+                    checked={isEnabled}
+                    onChange={(event) =>
+                        setIsEnabled(event.currentTarget.checked)
+                    }
+                    label="Enable write actions"
+                    description="Allow embedded users to perform actions that create or update Lightdash resources."
+                />
+            )}
 
             {isEnabled && (
                 <Stack gap="md">
-                    <Divider />
+                    {!required && <Divider />}
 
                     <Stack gap="xs">
                         <Title order={6}>Run actions as</Title>
                         <Text c="dimmed" fz="sm">
                             Select the service account Lightdash should use when
-                            an embed action needs write permissions.
+                            an embed action needs read or write permissions.
                         </Text>
                     </Stack>
 
@@ -279,27 +368,34 @@ const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
                                     className={styles.dropdownScrollArea}
                                     type="auto"
                                 >
-                                    {serviceAccounts.map((account) => (
-                                        <Menu.Item
-                                            key={account.uuid}
-                                            onClick={() =>
-                                                setSelectedServiceAccountUuid(
-                                                    account.uuid,
-                                                )
-                                            }
-                                        >
-                                            <Stack gap={0}>
-                                                <Text fz="sm">
-                                                    {account.description}
-                                                </Text>
-                                                <Text fz="xs" c="dimmed">
-                                                    {getServiceAccountRoleLabel(
-                                                        account,
-                                                    )}
-                                                </Text>
-                                            </Stack>
-                                        </Menu.Item>
-                                    ))}
+                                    {selectableServiceAccounts.map(
+                                        (account) => (
+                                            <Menu.Item
+                                                key={account.uuid}
+                                                onClick={() =>
+                                                    setSelectedServiceAccountUuid(
+                                                        account.uuid,
+                                                    )
+                                                }
+                                            >
+                                                <Stack gap={0}>
+                                                    <Text fz="sm">
+                                                        {account.description}
+                                                    </Text>
+                                                    <Text fz="xs" c="dimmed">
+                                                        {getServiceAccountRoleLabel(
+                                                            account,
+                                                        )}
+                                                    </Text>
+                                                </Stack>
+                                            </Menu.Item>
+                                        ),
+                                    )}
+                                    {selectableServiceAccounts.length === 0 && (
+                                        <Menu.Label>
+                                            No compatible service accounts
+                                        </Menu.Label>
+                                    )}
                                 </ScrollArea.Autosize>
                                 <Menu.Divider />
                                 <Menu.Item
@@ -486,7 +582,7 @@ const EmbedWriteActionsForm: FC<Props> = ({ projectUuid, value, onChange }) => {
                         }
                         data={
                             roleType === 'system'
-                                ? SYSTEM_ROLE_OPTIONS
+                                ? systemRoleOptions
                                 : customRoleOptions
                         }
                         value={selectedRole}

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -32,7 +32,10 @@ import useToaster from '../../../../hooks/toaster/useToaster';
 import { useCharts } from '../../../../hooks/useCharts';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
+import { useAiOrganizationSettings } from '../../aiCopilot/hooks/useAiOrganizationSettings';
+import { useProjectAiAgents } from '../../aiCopilot/hooks/useProjectAiAgents';
 import EmbedAllowListForm from './EmbedAllowListForm';
+import EmbedPreviewAiAgentForm from './EmbedPreviewAiAgentForm';
 import EmbedPreviewAppForm from './EmbedPreviewAppForm';
 import EmbedPreviewChartForm from './EmbedPreviewChartForm';
 import EmbedPreviewDashboardForm from './EmbedPreviewDashboardForm';
@@ -139,6 +142,19 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const { isLoading: isLoadingApps, data: apps } = useProjectApps(
         dataAppsEnabled ? projectUuid : undefined,
     );
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const aiAgentsEnabled =
+        aiOrganizationSettingsQuery.isSuccess &&
+        aiOrganizationSettingsQuery.data.aiAgentsVisible &&
+        (aiOrganizationSettingsQuery.data.isCopilotEnabled ||
+            aiOrganizationSettingsQuery.data.isTrial);
+    const { isLoading: isLoadingAgents, data: agents } = useProjectAiAgents({
+        projectUuid,
+        redirectOnUnauthorized: false,
+        options: {
+            enabled: aiAgentsEnabled,
+        },
+    });
     const { mutate: createEmbedConfig, isLoading: isCreating } =
         useEmbedConfigCreateMutation(projectUuid);
     const { mutate: updateEmbedConfig, isLoading: isUpdating } =
@@ -146,7 +162,7 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const [writeActions, setWriteActions] =
         useState<CreateEmbedJwt['writeActions']>();
     const [activeTab, setActiveTab] = useState<
-        'dashboards' | 'charts' | 'apps'
+        'dashboards' | 'charts' | 'apps' | 'aiAgents'
     >('dashboards');
 
     const isSaving = isCreating || isUpdating;
@@ -177,6 +193,7 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         isLoadingDashboards ||
         isLoadingCharts ||
         (dataAppsEnabled && isLoadingApps) ||
+        (aiAgentsEnabled && isLoadingAgents) ||
         !health.data
     ) {
         return (
@@ -298,7 +315,9 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     value={activeTab}
                     onChange={(value) =>
                         setActiveTab(
-                            value === 'charts' || value === 'apps'
+                            value === 'charts' ||
+                                value === 'apps' ||
+                                value === 'aiAgents'
                                 ? value
                                 : 'dashboards',
                         )
@@ -310,6 +329,9 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                         <Tabs.Tab value="charts">Charts</Tabs.Tab>
                         {dataAppsEnabled && (
                             <Tabs.Tab value="apps">Data apps</Tabs.Tab>
+                        )}
+                        {aiAgentsEnabled && (
+                            <Tabs.Tab value="aiAgents">AI agents</Tabs.Tab>
                         )}
                     </Tabs.List>
                     <Tabs.Panel value="dashboards">
@@ -357,6 +379,28 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                                     projectUuid={projectUuid}
                                     siteUrl={health.data.siteUrl}
                                     apps={allowedApps}
+                                />
+                            </Stack>
+                        </Tabs.Panel>
+                    )}
+                    {aiAgentsEnabled && (
+                        <Tabs.Panel value="aiAgents">
+                            <Stack mt="md">
+                                <EmbedPreviewAiAgentForm
+                                    projectUuid={projectUuid}
+                                    siteUrl={health.data.siteUrl}
+                                    agents={agents || []}
+                                    writeActions={writeActions}
+                                    writeActionsPanel={
+                                        activeTab === 'aiAgents' ? (
+                                            <EmbedWriteActionsForm
+                                                projectUuid={projectUuid}
+                                                value={writeActions}
+                                                onChange={setWriteActions}
+                                                required
+                                            />
+                                        ) : null
+                                    }
                                 />
                             </Stack>
                         </Tabs.Panel>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-541/include-snippet-and-preview-for-ai-agent

<img width="863" height="715" alt="CleanShot 2026-07-01 at 12 08 41" src="https://github.com/user-attachments/assets/4f815451-ceaa-4fb5-8826-350592c843cc" />

<img width="1334" height="917" alt="CleanShot 2026-07-01 at 12 16 17" src="https://github.com/user-attachments/assets/a39bed37-bd43-405d-bb63-4eb69a05a8f3" />



## Permission checks



![CleanShot 2026-07-01 at 12.46.05.png](https://app.graphite.com/user-attachments/assets/d92fe336-919f-41c2-a6bf-e5fccd770058.png)



### Description:

Adds AI agent embed support to the embed settings page, allowing users to generate JWT-signed embed URLs for AI agents via iframe.

Key changes include:

- A new `EmbedPreviewAiAgentForm` component that lets users select an AI agent, configure token expiration, set user identification fields (external ID, email), and manage user attributes. It supports previewing the embed in a new tab and generating/copying the embed URL.
- Code snippet templates for Node.js, Python, and Go that show how to generate a signed JWT for AI agent embeds, pointing to the `/embed/{projectUuid}/ai-agents/{agentUuid}/threads` URL.
- An "AI agents" tab in the embed settings page, visible only when AI agents are enabled for the organization. The tab always requires a service account (write actions are mandatory for AI agent embeds), so the `EmbedWriteActionsForm` toggle is hidden and the form is shown in a required state.
- The `agentUuid` placeholder is now correctly substituted in the backend code snippet generator, and the earlier early-return that blocked AI agent snippet generation has been replaced with proper template selection logic.