### PR TITLE
feat(data-apps): link a Lightdash query by ID (live-linked charts) [GLITCH-534]

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -46,6 +46,7 @@ import {
     type ExternalConnectionMethod,
     type ExternalConnectionSample,
     type LightdashProjectParameter,
+    type MetricQuery,
     type PromoteAppAction,
     type PromoteAppDiff,
     type SessionUser,
@@ -120,6 +121,31 @@ import {
     type DesignSandboxCopyResult,
 } from './designSandboxCopy';
 import { getTemplateInstructions } from './templates';
+
+/**
+ * Pure helper: builds a ChartReference from a resolved chart object.
+ * Extracted at module scope so it can be unit-tested without spinning up the
+ * full async service.
+ */
+export const buildChartReference = (
+    chart: {
+        name: string;
+        description?: string;
+        tableName: string;
+        metricQuery: MetricQuery;
+    },
+    chartUuid: string,
+    linked: boolean,
+    sampleData: ChartSampleData | null,
+): ChartReference => ({
+    chartName: chart.name,
+    chartDescription: chart.description ?? '',
+    exploreName: chart.tableName,
+    metricQuery: chart.metricQuery,
+    sampleData,
+    chartUuid,
+    linked,
+});
 
 type AppExternalConnectionDoc = {
     alias: string;
@@ -1398,8 +1424,11 @@ export class AppGenerateService extends BaseService {
             } else if (ref.sampleData?.status === 'unavailable') {
                 sampleSuffix = ` — sample data unavailable (${ref.sampleData.reason})`;
             }
+            const modeSuffix = ref.linked
+                ? ` — LINKED: render live with lightdash.savedChart("${ref.chartUuid}") (do NOT inline the metricQuery)`
+                : sampleSuffix;
             fileEntries.push(
-                `- ${filename} ("${ref.chartName}", explore: ${ref.exploreName})${sampleSuffix}`,
+                `- ${filename} ("${ref.chartName}", explore: ${ref.exploreName})${modeSuffix}`,
             );
         }
 
@@ -3247,12 +3276,19 @@ export class AppGenerateService extends BaseService {
         refs: AppChartReference[];
         dashboardName: string | null;
     }> {
-        const flagByUuid = new Map<string, boolean>();
+        const flagByUuid = new Map<
+            string,
+            { sample: boolean; link: boolean }
+        >();
         for (const c of charts ?? []) {
-            flagByUuid.set(
-                c.uuid,
-                (flagByUuid.get(c.uuid) ?? false) || c.includeSampleData,
-            );
+            const prev = flagByUuid.get(c.uuid) ?? {
+                sample: false,
+                link: false,
+            };
+            flagByUuid.set(c.uuid, {
+                sample: prev.sample || c.includeSampleData,
+                link: prev.link || c.linkLive,
+            });
         }
         let dashboardName: string | null = null;
         if (dashboard) {
@@ -3262,15 +3298,22 @@ export class AppGenerateService extends BaseService {
             );
             dashboardName = result.dashboardName;
             for (const uuid of result.chartUuids) {
-                flagByUuid.set(
-                    uuid,
-                    (flagByUuid.get(uuid) ?? false) ||
-                        dashboard.includeSampleData,
-                );
+                const prev = flagByUuid.get(uuid) ?? {
+                    sample: false,
+                    link: false,
+                };
+                flagByUuid.set(uuid, {
+                    sample: prev.sample || dashboard.includeSampleData,
+                    link: prev.link,
+                });
             }
         }
         const refs: AppChartReference[] = [...flagByUuid.entries()].map(
-            ([uuid, includeSampleData]) => ({ uuid, includeSampleData }),
+            ([uuid, { sample, link }]) => ({
+                uuid,
+                includeSampleData: sample,
+                linkLive: link,
+            }),
         );
         return { refs, dashboardName };
     }
@@ -3338,14 +3381,15 @@ export class AppGenerateService extends BaseService {
         chartResources: AppVersionChartResource[];
         sampleStats: { requested: number; available: number };
     }> {
-        // Dedupe by uuid; if any duplicate asks for sample data, the union
-        // wins so the user gets the data they opted into.
-        const dedup = new Map<string, boolean>();
+        // Dedupe by uuid; if any duplicate asks for sample data or link mode,
+        // the union wins so the user gets the data they opted into.
+        const dedup = new Map<string, { sample: boolean; link: boolean }>();
         for (const ref of chartRefs) {
-            dedup.set(
-                ref.uuid,
-                (dedup.get(ref.uuid) ?? false) || ref.includeSampleData,
-            );
+            const prev = dedup.get(ref.uuid) ?? { sample: false, link: false };
+            dedup.set(ref.uuid, {
+                sample: prev.sample || ref.includeSampleData,
+                link: prev.link || ref.linkLive,
+            });
         }
         if (dedup.size === 0) {
             return {
@@ -3367,7 +3411,12 @@ export class AppGenerateService extends BaseService {
         // so we can attach the result back to the right reference.
         const sampleUuids: string[] = [];
         chartResults.forEach((result, i) => {
-            if (result.status === 'fulfilled' && dedup.get(uuids[i])) {
+            const flags = dedup.get(uuids[i]);
+            if (
+                result.status === 'fulfilled' &&
+                flags?.sample &&
+                !flags?.link
+            ) {
                 sampleUuids.push(uuids[i]);
             }
         });
@@ -3384,13 +3433,14 @@ export class AppGenerateService extends BaseService {
         chartResults.forEach((result, i) => {
             if (result.status === 'fulfilled') {
                 const chart = result.value;
-                references.push({
-                    chartName: chart.name,
-                    chartDescription: chart.description ?? '',
-                    exploreName: chart.tableName,
-                    metricQuery: chart.metricQuery,
-                    sampleData: sampleByUuid.get(uuids[i]) ?? null,
-                });
+                references.push(
+                    buildChartReference(
+                        chart,
+                        uuids[i],
+                        dedup.get(uuids[i])!.link,
+                        sampleByUuid.get(uuids[i]) ?? null,
+                    ),
+                );
                 chartResources.push({
                     chartUuid: uuids[i],
                     chartName: chart.name,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -3287,7 +3287,7 @@ export class AppGenerateService extends BaseService {
             };
             flagByUuid.set(c.uuid, {
                 sample: prev.sample || c.includeSampleData,
-                link: prev.link || c.linkLive,
+                link: prev.link || (c.linkLive ?? false),
             });
         }
         let dashboardName: string | null = null;
@@ -3388,7 +3388,7 @@ export class AppGenerateService extends BaseService {
             const prev = dedup.get(ref.uuid) ?? { sample: false, link: false };
             dedup.set(ref.uuid, {
                 sample: prev.sample || ref.includeSampleData,
-                link: prev.link || ref.linkLive,
+                link: prev.link || (ref.linkLive ?? false),
             });
         }
         if (dedup.size === 0) {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -3445,6 +3445,7 @@ export class AppGenerateService extends BaseService {
                     chartUuid: uuids[i],
                     chartName: chart.name,
                     chartKind: null,
+                    linkLive: dedup.get(uuids[i])!.link,
                 });
             }
             // Rejected = not a chart UUID, no access, or deleted — skip silently

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1425,7 +1425,7 @@ export class AppGenerateService extends BaseService {
                 sampleSuffix = ` — sample data unavailable (${ref.sampleData.reason})`;
             }
             const modeSuffix = ref.linked
-                ? ` — LINKED: render live with lightdash.savedChart("${ref.chartUuid}") (do NOT inline the metricQuery)`
+                ? ` — LINKED: render live with savedChart("${ref.chartUuid}") (do NOT inline the metricQuery)`
                 : sampleSuffix;
             fileEntries.push(
                 `- ${filename} ("${ref.chartName}", explore: ${ref.exploreName})${modeSuffix}`,

--- a/packages/backend/src/ee/services/AppGenerateService/buildChartReference.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/buildChartReference.test.ts
@@ -1,0 +1,26 @@
+import { type ChartSampleData, type MetricQuery } from '@lightdash/common';
+import { buildChartReference } from './AppGenerateService';
+
+describe('buildChartReference', () => {
+    const chart = {
+        name: 'Revenue',
+        tableName: 'orders',
+        metricQuery: {} as MetricQuery,
+    };
+    it('carries chartUuid and linked=true, no sample, for a linked chart', () => {
+        const ref = buildChartReference(chart, 'chart-1', true, null);
+        expect(ref.chartUuid).toBe('chart-1');
+        expect(ref.linked).toBe(true);
+        expect(ref.sampleData).toBeNull();
+    });
+    it('defaults to a copy (linked=false) and keeps sample data', () => {
+        const sample: ChartSampleData = {
+            status: 'available',
+            rows: [],
+            truncated: false,
+        };
+        const ref = buildChartReference(chart, 'chart-2', false, sample);
+        expect(ref.linked).toBe(false);
+        expect(ref.sampleData).toBe(sample);
+    });
+});

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9491,6 +9491,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                linkLive: { dataType: 'boolean' },
                 chartKind: {
                     dataType: 'union',
                     subSchemas: [
@@ -14237,11 +14238,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -14299,11 +14300,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -14340,11 +14341,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14359,11 +14360,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14378,11 +14379,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14397,11 +14398,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14513,12 +14514,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -14546,6 +14547,29 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -14584,18 +14608,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                operator:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -14612,6 +14624,18 @@ const models: TsoaRoute.Models = {
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                operator:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                             },
@@ -14650,35 +14674,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -14710,11 +14711,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14781,21 +14782,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -14805,15 +14791,30 @@ const models: TsoaRoute.Models = {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'success',
+                                                                                                    'error',
                                                                                                 ],
                                                                                             },
                                                                                             {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'error',
+                                                                                                    'success',
                                                                                                 ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
                                                                                             },
                                                                                             {
                                                                                                 dataType:
@@ -14911,12 +14912,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    name: {
+                                                                                                    label: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    label: {
+                                                                                                    name: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
@@ -14947,11 +14948,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14966,11 +14967,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14985,11 +14986,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15003,13 +15004,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -15032,11 +15033,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15075,6 +15076,130 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 rationale: {
                                                                     dataType:
                                                                         'union',
@@ -15137,18 +15262,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            operator:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -15165,6 +15278,18 @@ const models: TsoaRoute.Models = {
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            operator:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                         },
@@ -15192,141 +15317,17 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
                                                                             label: {
                                                                                 dataType:
                                                                                     'string',
                                                                                 required: true,
                                                                             },
-                                                                        },
-                                                                    required: true,
-                                                                },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
                                                                             },
-                                                                    },
+                                                                        },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -15357,17 +15358,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -15492,11 +15493,12 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
-                                                uuid: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -15504,9 +15506,8 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
+                                                uuid: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -15517,32 +15518,13 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'union',
                                                     subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
                                                         },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15557,11 +15539,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15576,11 +15558,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15590,77 +15572,25 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
-                                                steps: {
+                                                status: {
                                                     dataType: 'union',
                                                     subSchemas: [
                                                         {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
+                                                            enums: ['success'],
                                                         },
                                                     ],
+                                                    required: true,
                                                 },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15738,6 +15668,77 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15769,6 +15770,12 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -15776,12 +15783,6 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
-                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -15821,11 +15822,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15849,17 +15850,17 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                    required: true,
+                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
                                                     dataType: 'string',
-                                                    required: true,
-                                                },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -15886,11 +15887,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15905,11 +15906,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15922,10 +15923,6 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'union',
                                                     subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
@@ -15933,6 +15930,10 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15951,11 +15952,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15972,6 +15973,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16038,37 +16058,18 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                name: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                label: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -16113,11 +16114,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16132,11 +16133,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16151,11 +16152,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16170,11 +16171,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16189,11 +16190,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -31918,7 +31919,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31928,7 +31929,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31938,7 +31939,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -31951,7 +31952,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9242,7 +9242,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                linkLive: { dataType: 'boolean', required: true },
+                linkLive: { dataType: 'boolean' },
                 includeSampleData: { dataType: 'boolean', required: true },
                 uuid: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9242,6 +9242,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                linkLive: { dataType: 'boolean', required: true },
                 includeSampleData: { dataType: 'boolean', required: true },
                 uuid: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10804,6 +10804,10 @@
             },
             "AppVersionChartResource": {
                 "properties": {
+                    "linkLive": {
+                        "type": "boolean",
+                        "description": "Whether this chart was attached as a live link — persists the linked\nchip indicator across reloads. Optional for backwards compatibility."
+                    },
                     "chartKind": {
                         "type": "string",
                         "nullable": true
@@ -15783,8 +15787,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -15842,8 +15846,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -15877,8 +15881,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -15913,18 +15917,18 @@
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
                                                                         "tableName",
-                                                                        "name",
-                                                                        "label"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -15933,6 +15937,11 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -15940,12 +15949,6 @@
                                                                                     "values": {
                                                                                         "items": {},
                                                                                         "type": "array"
-                                                                                    },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "type": "string"
                                                                                     },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
@@ -15955,14 +15958,20 @@
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "operator": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "required",
-                                                                                    "operator",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "tableName"
+                                                                                    "tableName",
+                                                                                    "operator",
+                                                                                    "required"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -15975,21 +15984,16 @@
                                                                             "type": "array",
                                                                             "nullable": true
                                                                         },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "name",
-                                                                        "label"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -16007,8 +16011,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16049,15 +16053,15 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "status": {
                                                                             "type": "string",
                                                                             "enum": [
-                                                                                "success",
-                                                                                "error"
+                                                                                "error",
+                                                                                "success"
                                                                             ]
+                                                                        },
+                                                                        "error": {
+                                                                            "type": "string"
                                                                         },
                                                                         "results": {
                                                                             "items": {
@@ -16083,18 +16087,18 @@
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "name": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
                                                                                     "tableName",
-                                                                                    "name",
-                                                                                    "label"
+                                                                                    "label",
+                                                                                    "name"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -16121,8 +16125,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16135,19 +16139,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -16156,8 +16160,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "not_found"
                                                         ]
                                                     }
@@ -16184,6 +16188,66 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "metric",
+                                                                                        "dimension"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "fieldId",
+                                                                                "label",
+                                                                                "description",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "rationale": {
                                                                         "type": "string",
                                                                         "nullable": true
@@ -16198,12 +16262,6 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
-                                                                                        },
-                                                                                        "operator": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
@@ -16212,14 +16270,20 @@
                                                                                         },
                                                                                         "tableName": {
                                                                                             "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
-                                                                                        "required",
-                                                                                        "operator",
                                                                                         "fieldRef",
                                                                                         "fieldId",
-                                                                                        "tableName"
+                                                                                        "tableName",
+                                                                                        "operator",
+                                                                                        "required"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -16234,80 +16298,20 @@
                                                                             "baseTable": {
                                                                                 "type": "string"
                                                                             },
-                                                                            "name": {
+                                                                            "label": {
                                                                                 "type": "string"
                                                                             },
-                                                                            "label": {
+                                                                            "name": {
                                                                                 "type": "string"
                                                                             }
                                                                         },
                                                                         "required": [
                                                                             "joinedTables",
                                                                             "baseTable",
-                                                                            "name",
-                                                                            "label"
+                                                                            "label",
+                                                                            "name"
                                                                         ],
                                                                         "type": "object"
-                                                                    },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "fieldValueType",
-                                                                                "description",
-                                                                                "caseSensitiveFilters",
-                                                                                "isFromJoinedTable",
-                                                                                "fieldFilterType",
-                                                                                "fieldId",
-                                                                                "fieldType",
-                                                                                "name",
-                                                                                "label",
-                                                                                "table"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -16318,9 +16322,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "fields",
                                                                     "rationale",
                                                                     "explore",
-                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -16333,10 +16337,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -16344,8 +16348,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -16428,60 +16432,34 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     },
-                                                    "uuid": {
+                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
                                                     },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
+                                                    "uuid": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
+                                                    "status",
                                                     "slug",
-                                                    "uuid",
                                                     "name",
-                                                    "status"
+                                                    "uuid"
                                                 ],
                                                 "type": "object"
                                             },
                                             {
                                                 "properties": {
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "read",
-                                                                        "edit",
-                                                                        "search",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -16509,6 +16487,32 @@
                                                         ],
                                                         "nullable": true
                                                     },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "search",
+                                                                        "read",
+                                                                        "edit",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -16528,9 +16532,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
+                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -16551,23 +16555,23 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
+                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
+                                                    "status",
                                                     "slug",
-                                                    "name",
-                                                    "status"
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -16580,8 +16584,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16593,9 +16597,9 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -16607,6 +16611,10 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -16626,26 +16634,22 @@
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
                                                                         "tableName",
-                                                                        "name",
-                                                                        "label"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
-                                                            },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
                                                             },
                                                             "type": {
                                                                 "type": "string",
@@ -16658,8 +16662,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "fields",
                                                             "searchQuery",
+                                                            "fields",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -16667,8 +16671,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -32378,22 +32382,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -41705,7 +41709,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3270.0",
+        "version": "0.3272.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10558,7 +10558,7 @@
                 "properties": {
                     "linkLive": {
                         "type": "boolean",
-                        "description": "When true the app runs this chart live by UUID (linked) instead of\ncopying its metric query inline. Default false = copy (legacy)."
+                        "description": "When true the app runs this chart live by UUID (linked) instead of\ncopying its metric query inline. Optional for backwards compatibility —\nomitted (older clients) is treated as false (copy) on the server."
                     },
                     "includeSampleData": {
                         "type": "boolean"
@@ -10567,7 +10567,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["linkLive", "includeSampleData", "uuid"],
+                "required": ["includeSampleData", "uuid"],
                 "type": "object",
                 "description": "A saved-chart reference attached to a generation request.\n`includeSampleData` is opt-in per chart: when true the backend runs the\nunderlying metric query and inlines a small sample of rows into the\nsandbox so Claude can see actual values (e.g. \"season 2026 only\")."
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10556,6 +10556,10 @@
             },
             "AppChartReference": {
                 "properties": {
+                    "linkLive": {
+                        "type": "boolean",
+                        "description": "When true the app runs this chart live by UUID (linked) instead of\ncopying its metric query inline. Default false = copy (legacy)."
+                    },
                     "includeSampleData": {
                         "type": "boolean"
                     },
@@ -10563,7 +10567,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["includeSampleData", "uuid"],
+                "required": ["linkLive", "includeSampleData", "uuid"],
                 "type": "object",
                 "description": "A saved-chart reference attached to a generation request.\n`includeSampleData` is opt-in per chart: when true the backend runs the\nunderlying metric query and inlines a small sample of rows into the\nsandbox so Claude can see actual values (e.g. \"season 2026 only\")."
             },

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4703,6 +4703,8 @@ export class AsyncQueryService extends ProjectService {
             chartUuid,
             versionUuid,
             limit,
+            parameters,
+            pivotResults,
         };
 
         const { maxLimit, csvCellsLimit } =

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -192,6 +192,9 @@ export type AppVersionChartResource = {
     chartUuid: string;
     chartName: string;
     chartKind: string | null;
+    /** Whether this chart was attached as a live link — persists the linked
+     *  chip indicator across reloads. Optional for backwards compatibility. */
+    linkLive?: boolean;
 };
 
 export type AppVersionExternalConnectionResource = {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -74,6 +74,9 @@ export const DEFAULT_DATA_APP_CLAUDE_MODEL: DataAppClaudeModel = 'sonnet';
 export type AppChartReference = {
     uuid: string;
     includeSampleData: boolean;
+    /** When true the app runs this chart live by UUID (linked) instead of
+     *  copying its metric query inline. Default false = copy (legacy). */
+    linkLive: boolean;
 };
 
 /**
@@ -369,6 +372,11 @@ export type ChartReference = {
     exploreName: string;
     metricQuery: MetricQuery;
     sampleData: ChartSampleData | null; // null when the user did not opt in
+    /** Saved chart UUID — surfaced into the sandbox so a linked chart can be
+     *  run live via lightdash.savedChart(uuid). */
+    chartUuid: string;
+    /** true = run live by UUID; false = inline the metricQuery (copy). */
+    linked: boolean;
 };
 
 export type ApiMyAppsResponse = ApiSuccess<{

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -374,7 +374,7 @@ export type ChartReference = {
     metricQuery: MetricQuery;
     sampleData: ChartSampleData | null; // null when the user did not opt in
     /** Saved chart UUID — surfaced into the sandbox so a linked chart can be
-     *  run live via lightdash.savedChart(uuid). */
+     *  run live via savedChart(uuid). */
     chartUuid: string;
     /** true = run live by UUID; false = inline the metricQuery (copy). */
     linked: boolean;

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -75,8 +75,9 @@ export type AppChartReference = {
     uuid: string;
     includeSampleData: boolean;
     /** When true the app runs this chart live by UUID (linked) instead of
-     *  copying its metric query inline. Default false = copy (legacy). */
-    linkLive: boolean;
+     *  copying its metric query inline. Optional for backwards compatibility —
+     *  omitted (older clients) is treated as false (copy) on the server. */
+    linkLive?: boolean;
 };
 
 /**

--- a/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
@@ -1,0 +1,42 @@
+import { MantineProvider } from '@mantine-8/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { SelectedQuerySection } from './AppResourcePicker';
+
+const baseChart = {
+    uuid: 'c1',
+    name: 'Rev',
+    includeSampleData: false,
+    linkLive: false,
+};
+
+it('calls onToggleLink when the Link live button is clicked', () => {
+    const onToggleLink = vi.fn();
+    render(
+        <MantineProvider>
+            <SelectedQuerySection
+                charts={[baseChart]}
+                onRemove={() => {}}
+                onToggleSampleData={() => {}}
+                onToggleLink={onToggleLink}
+            />
+        </MantineProvider>,
+    );
+    fireEvent.click(screen.getByLabelText('Link live'));
+    expect(onToggleLink).toHaveBeenCalledWith('c1');
+});
+
+it('hides the sample-data control when the chart is linked', () => {
+    render(
+        <MantineProvider>
+            <SelectedQuerySection
+                charts={[{ ...baseChart, linkLive: true }]}
+                onRemove={() => {}}
+                onToggleSampleData={() => {}}
+                onToggleLink={() => {}}
+            />
+        </MantineProvider>,
+    );
+    expect(screen.queryByLabelText('Include sample data')).toBeNull();
+    expect(screen.getByLabelText('Linked: on')).toBeInTheDocument();
+});

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -30,6 +30,7 @@ import {
     IconDatabase,
     IconDatabasePlus,
     IconLayoutDashboard,
+    IconLink,
     IconPhoto,
     IconPlugConnected,
     IconPlus,
@@ -58,6 +59,8 @@ export type SelectedChart = {
      * actual values. Default false because rows can be sensitive.
      */
     includeSampleData: boolean;
+    /** When true the chart is linked (run live by uuid) rather than copied. */
+    linkLive: boolean;
 };
 
 export type SelectedDashboard = {
@@ -344,6 +347,7 @@ const QueryPickerView: FC<{
                     name: chart.name,
                     chartKind: chart.chartKind ?? ChartKind.VERTICAL_BAR,
                     includeSampleData: false,
+                    linkLive: false,
                 });
             }
         },
@@ -556,6 +560,50 @@ const InlineDataToggle: FC<{
     </Tooltip>
 );
 
+const AddLinkButton: FC<{ onClick: () => void; disabled?: boolean }> = ({
+    onClick,
+    disabled,
+}) => (
+    <Tooltip
+        label="Link live — run this chart by reference so the app updates when the chart changes in Lightdash."
+        multiline
+        w={260}
+        withArrow
+    >
+        <UnstyledButton
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            className={classes.addDataButton}
+            aria-label="Link live"
+        >
+            <MantineIcon icon={IconLink} size={12} />
+        </UnstyledButton>
+    </Tooltip>
+);
+
+const InlineLinkToggle: FC<{ onClick: () => void; disabled?: boolean }> = ({
+    onClick,
+    disabled,
+}) => (
+    <Tooltip
+        label="Linked live — click to unlink (revert to a copied query)."
+        multiline
+        w={260}
+        withArrow
+    >
+        <UnstyledButton
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            className={classes.inlineDataToggle}
+            aria-label="Linked: on"
+        >
+            <MantineIcon icon={IconLink} size={12} />
+        </UnstyledButton>
+    </Tooltip>
+);
+
 /**
  * Renders selected queries as a list using the same visual as the picker.
  * Each row carries a per-chart sample-data toggle; off by default because
@@ -565,8 +613,9 @@ export const SelectedQuerySection: FC<{
     charts: SelectedChart[];
     onRemove: (uuid: string) => void;
     onToggleSampleData: (uuid: string) => void;
+    onToggleLink: (uuid: string) => void;
     disabled?: boolean;
-}> = ({ charts, onRemove, onToggleSampleData, disabled }) => {
+}> = ({ charts, onRemove, onToggleSampleData, onToggleLink, disabled }) => {
     if (charts.length === 0) return null;
 
     return (
@@ -575,7 +624,7 @@ export const SelectedQuerySection: FC<{
                 <Box key={chart.uuid} className={classes.selectedQueryItemRow}>
                     <Box
                         className={`${classes.selectedQueryItem} ${
-                            chart.includeSampleData
+                            chart.includeSampleData || chart.linkLive
                                 ? classes.selectedQueryItemActive
                                 : ''
                         }`}
@@ -596,11 +645,20 @@ export const SelectedQuerySection: FC<{
                         >
                             {chart.name}
                         </Text>
-                        {chart.includeSampleData && (
-                            <InlineDataToggle
-                                onClick={() => onToggleSampleData(chart.uuid)}
+                        {chart.linkLive ? (
+                            <InlineLinkToggle
+                                onClick={() => onToggleLink(chart.uuid)}
                                 disabled={disabled}
                             />
+                        ) : (
+                            chart.includeSampleData && (
+                                <InlineDataToggle
+                                    onClick={() =>
+                                        onToggleSampleData(chart.uuid)
+                                    }
+                                    disabled={disabled}
+                                />
+                            )
                         )}
                         <ActionIcon
                             size="xs"
@@ -613,9 +671,15 @@ export const SelectedQuerySection: FC<{
                             <MantineIcon icon={IconX} size={10} />
                         </ActionIcon>
                     </Box>
-                    {!chart.includeSampleData && (
+                    {!chart.linkLive && !chart.includeSampleData && (
                         <AddDataButton
                             onClick={() => onToggleSampleData(chart.uuid)}
+                            disabled={disabled}
+                        />
+                    )}
+                    {!chart.linkLive && (
+                        <AddLinkButton
+                            onClick={() => onToggleLink(chart.uuid)}
                             disabled={disabled}
                         />
                     )}

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -470,6 +470,88 @@ describe('lineage message routing', () => {
     });
 });
 
+describe('chart-query routing', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    const CHART_UUID = 'chart-uuid';
+    const CHART_PATH = `/api/v2/projects/${PROJECT_UUID}/query/chart`;
+    const CHART_POST_ID = '33333333-3333-3333-3333-333333333333';
+    const CHART_QUERY_UUID = 'q-1';
+
+    it('emits a running QueryEvent (no pending) when a /query/chart POST succeeds', async () => {
+        const events: QueryEvent[] = [];
+        renderBridge((e) => events.push(e));
+
+        mockFetchOk({
+            status: 'ok',
+            results: {
+                queryUuid: CHART_QUERY_UUID,
+                metricQuery: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    limit: 100,
+                },
+            },
+        });
+
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: CHART_POST_ID,
+            method: 'POST',
+            path: CHART_PATH,
+            body: { chartUuid: CHART_UUID },
+        });
+
+        await vi.waitFor(() => expect(events).toHaveLength(1));
+
+        expect(events[0]).toMatchObject({
+            id: CHART_POST_ID,
+            status: 'running',
+            queryUuid: CHART_QUERY_UUID,
+            exploreName: 'orders',
+        });
+    });
+
+    it('emits a terminal error QueryEvent when a /query/chart POST fails', async () => {
+        const events: QueryEvent[] = [];
+        renderBridge((e) => events.push(e));
+
+        mockFetchNonOk({
+            status: 'error',
+            error: { message: 'Chart not found' },
+        });
+
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: CHART_POST_ID,
+            method: 'POST',
+            path: CHART_PATH,
+            body: { chartUuid: CHART_UUID },
+        });
+
+        await vi.waitFor(() => expect(events).toHaveLength(1));
+
+        expect(events[0]).toMatchObject({
+            id: CHART_POST_ID,
+            status: 'error',
+            queryUuid: null,
+            error: 'Chart not found',
+        });
+    });
+});
+
 describe('external-fetch branch', () => {
     beforeEach(() => {
         vi.stubGlobal('fetch', vi.fn());

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -79,6 +79,11 @@ const ALLOWED_ROUTES: Array<{ method: string; pattern: RegExp }> = [
         method: 'POST',
         pattern: /^\/api\/v2\/projects\/[^/]+\/query\/metric-query$/,
     },
+    // Run a saved chart live by UUID (linked charts)
+    {
+        method: 'POST',
+        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/chart$/,
+    },
     // Run underlying-data queries for SDK result rows
     {
         method: 'POST',
@@ -114,6 +119,10 @@ function isAllowedRoute(method: string, path: string): boolean {
 const isMetricQueryPost = (method: string, path: string): boolean =>
     method.toUpperCase() === 'POST' &&
     /^\/api\/v2\/projects\/[^/]+\/query\/metric-query$/.test(path);
+
+const isChartQueryPost = (method: string, path: string): boolean =>
+    method.toUpperCase() === 'POST' &&
+    /^\/api\/v2\/projects\/[^/]+\/query\/chart$/.test(path);
 
 const isQueryResultGet = (method: string, path: string): boolean =>
     method.toUpperCase() === 'GET' &&
@@ -493,7 +502,12 @@ export function useAppSdkBridge(
             // already emit their own terminal events, so this only runs
             // for the POST.
             const emitPostFailure = (errorMessage: string) => {
-                if (!isMetricQueryPost(method, path) || !onQueryEvent) return;
+                if (
+                    (!isMetricQueryPost(method, path) &&
+                        !isChartQueryPost(method, path)) ||
+                    !onQueryEvent
+                )
+                    return;
                 onQueryEvent({
                     id,
                     timestamp: Date.now(),
@@ -542,7 +556,8 @@ export function useAppSdkBridge(
                 if (json.status === 'ok') {
                     // Track metric query initiation response (has queryUuid)
                     if (
-                        isMetricQueryPost(method, path) &&
+                        (isMetricQueryPost(method, path) ||
+                            isChartQueryPost(method, path)) &&
                         onQueryEvent &&
                         json.results?.queryUuid
                     ) {

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -433,19 +433,25 @@ export function useAppSdkBridge(
             }
 
             // Stamp dashboard filters and the cache-invalidation flag onto
-            // outgoing metric-query bodies. The backend drops filters whose
-            // fields aren't in the query's explore, so it's safe to send the
-            // full set on every call. `invalidateCache` mirrors what charts
-            // send on a dashboard refresh so the app's queries bypass the
-            // warehouse results cache too. App attribution rides on the
+            // outgoing query bodies. The backend drops filters whose fields
+            // aren't in the query's explore, so it's safe to send the full set
+            // on every call. dashboardFilters apply only to inline metric
+            // queries; `invalidateCache` applies to inline AND linked
+            // (/query/chart) charts so a preview refresh bypasses the warehouse
+            // results cache for linked charts too. App attribution rides on the
             // LightdashAppUuidHeader instead (see the fetch below).
+            const stampFilters =
+                isMetricQueryPost(method, path) && !!dashboardFilters;
+            const stampInvalidate =
+                (isMetricQueryPost(method, path) ||
+                    isChartQueryPost(method, path)) &&
+                !!invalidateCache;
             const effectiveBody =
-                isMetricQueryPost(method, path) &&
-                (dashboardFilters || invalidateCache)
+                stampFilters || stampInvalidate
                     ? {
                           ...(body as Record<string, unknown> | undefined),
-                          ...(dashboardFilters ? { dashboardFilters } : {}),
-                          ...(invalidateCache ? { invalidateCache } : {}),
+                          ...(stampFilters ? { dashboardFilters } : {}),
+                          ...(stampInvalidate ? { invalidateCache } : {}),
                       }
                     : body;
 

--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
@@ -5,6 +5,8 @@ export type ChatChart = {
     name: string;
     uuid: string;
     chartKind?: ChartKind;
+    /** True when the chart was attached as a live link (run by uuid). */
+    linkLive?: boolean;
 };
 
 export type ChatConnection = {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1510,6 +1510,7 @@ const AppGenerate: FC = () => {
                     ? selectedCharts.map((c) => ({
                           uuid: c.uuid,
                           includeSampleData: c.includeSampleData,
+                          linkLive: c.linkLive,
                       }))
                     : undefined;
             const externalConnections:
@@ -2552,6 +2553,25 @@ const AppGenerate: FC = () => {
                                                                               ...c,
                                                                               includeSampleData:
                                                                                   !c.includeSampleData,
+                                                                          }
+                                                                        : c,
+                                                                ),
+                                                        )
+                                                    }
+                                                    onToggleLink={(uuid) =>
+                                                        setSelectedCharts(
+                                                            (prev) =>
+                                                                prev.map((c) =>
+                                                                    c.uuid ===
+                                                                    uuid
+                                                                        ? {
+                                                                              ...c,
+                                                                              linkLive:
+                                                                                  !c.linkLive,
+                                                                              includeSampleData:
+                                                                                  c.linkLive
+                                                                                      ? c.includeSampleData
+                                                                                      : false,
                                                                           }
                                                                         : c,
                                                                 ),

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -35,6 +35,7 @@ import {
     IconExternalLink,
     IconArrowBackUp,
     IconLayoutDashboard,
+    IconLink,
     IconPlayerStop,
     IconRestore,
     IconPlugConnected,
@@ -1579,6 +1580,7 @@ const AppGenerate: FC = () => {
                 name: c.name,
                 uuid: c.uuid,
                 chartKind: c.chartKind,
+                linkLive: c.linkLive,
             }));
             if (sentCharts.length > 0) {
                 sentChartsByPrompt.current.set(trimmed, sentCharts);
@@ -1980,6 +1982,17 @@ const AppGenerate: FC = () => {
                                                                                     chart.name
                                                                                 }
                                                                             </Text>
+                                                                            {chart.linkLive && (
+                                                                                <MantineIcon
+                                                                                    icon={
+                                                                                        IconLink
+                                                                                    }
+                                                                                    size={
+                                                                                        12
+                                                                                    }
+                                                                                    color="blue.6"
+                                                                                />
+                                                                            )}
                                                                         </Box>
                                                                     ),
                                                                 )}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -798,6 +798,7 @@ const AppGenerate: FC = () => {
                     name: c.chartName,
                     uuid: c.chartUuid,
                     chartKind: undefined,
+                    linkLive: c.linkLive,
                 })) ?? [];
             const charts =
                 serverCharts.length > 0

--- a/packages/query-sdk/src/apiTransport.ts
+++ b/packages/query-sdk/src/apiTransport.ts
@@ -21,6 +21,7 @@ import type {
     InternalFilterDefinition,
     LightdashClientConfig,
     LightdashUser,
+    ParametersValuesMap,
     QueryDefinition,
     QueryResult,
     Row,
@@ -858,14 +859,26 @@ export function createApiTransport(
         async executeSavedChart(params: {
             chartUuid: string;
             label?: string;
+            limit?: number;
+            parameters?: ParametersValuesMap;
         }): Promise<QueryResult> {
             const metadata = params.label
                 ? { label: params.label }
                 : undefined;
+            const body: Record<string, unknown> = {
+                chartUuid: params.chartUuid,
+            };
+            if (params.limit !== undefined) body.limit = params.limit;
+            if (
+                params.parameters &&
+                Object.keys(params.parameters).length > 0
+            ) {
+                body.parameters = params.parameters;
+            }
             const execResult = await fetchFn<AsyncQueryResponse>(
                 'POST',
                 `/api/v2/projects/${config.projectUuid}/query/chart`,
-                { chartUuid: params.chartUuid },
+                body,
                 metadata,
             );
             const { queryUuid, fields } = execResult;

--- a/packages/query-sdk/src/apiTransport.ts
+++ b/packages/query-sdk/src/apiTransport.ts
@@ -855,6 +855,52 @@ export function createApiTransport(
             };
         },
 
+        async executeSavedChart(params: {
+            chartUuid: string;
+            label?: string;
+        }): Promise<QueryResult> {
+            const metadata = params.label
+                ? { label: params.label }
+                : undefined;
+            const execResult = await fetchFn<AsyncQueryResponse>(
+                'POST',
+                `/api/v2/projects/${config.projectUuid}/query/chart`,
+                { chartUuid: params.chartUuid },
+                metadata,
+            );
+            const { queryUuid, fields } = execResult;
+
+            const { firstReadyPage, apiRows } = await pollQueryRows(
+                fetchFn,
+                config.projectUuid,
+                queryUuid,
+            );
+
+            // No client-side QueryDefinition for a saved chart — derive the
+            // field ids from the response (same approach as underlying-data),
+            // and key rows by their field id (identity).
+            const fieldIds = [
+                ...Object.keys(fields),
+                ...Object.keys(firstReadyPage.columns).filter(
+                    (fieldId) => !(fieldId in fields),
+                ),
+            ];
+
+            const mappedResult = mapApiRowsToQueryResult({
+                apiRows,
+                columns: firstReadyPage.columns,
+                fields,
+                fieldIds,
+                fieldNameForId: (fieldId) => fieldId,
+            });
+
+            return {
+                ...mappedResult,
+                totalResults: firstReadyPage.totalResults,
+                queryUuid,
+            };
+        },
+
         async getUser(): Promise<LightdashUser> {
             const user = await fetchFn<{
                 userUuid: string;

--- a/packages/query-sdk/src/externalFetch.test.ts
+++ b/packages/query-sdk/src/externalFetch.test.ts
@@ -104,6 +104,7 @@ describe('LightdashClient.externalFetch', () => {
         };
         const transport: Transport = {
             executeQuery: vi.fn(),
+            executeSavedChart: vi.fn(),
             getUser: vi.fn(),
             externalFetch: vi.fn().mockResolvedValue(result),
         };

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -1,5 +1,6 @@
 // Query builder
 export { query } from './query';
+export { savedChart, type SavedChartQuery } from './savedChart';
 
 // Drill-down helper
 export { drillDown } from './drillDown';

--- a/packages/query-sdk/src/savedChart.test.ts
+++ b/packages/query-sdk/src/savedChart.test.ts
@@ -4,17 +4,22 @@ import { savedChart } from './savedChart';
 
 describe('savedChart', () => {
     it('builds a SavedChartQuery with the chart uuid', () => {
-        expect(savedChart('chart-1')).toEqual({
-            kind: 'savedChart',
-            chartUuid: 'chart-1',
-        });
+        const q = savedChart('chart-1');
+        expect(q.kind).toBe('savedChart');
+        expect(q.chartUuid).toBe('chart-1');
+        expect(q.labelText).toBeUndefined();
     });
-    it('carries an optional label', () => {
-        expect(savedChart('chart-1', 'Revenue')).toEqual({
-            kind: 'savedChart',
-            chartUuid: 'chart-1',
-            label: 'Revenue',
-        });
+    it('accepts a label via the second argument', () => {
+        expect(savedChart('chart-1', 'Revenue').labelText).toBe('Revenue');
+    });
+    it('exposes a chainable .label() (regression: the agent calls .label() on every query)', () => {
+        // A plain object had no .label() method → `.label is not a function`
+        // crashed generated apps. It must be chainable like QueryBuilder.
+        expect(typeof savedChart('chart-1').label).toBe('function');
+        const q = savedChart('chart-1').label('Revenue');
+        expect(q.kind).toBe('savedChart');
+        expect(q.chartUuid).toBe('chart-1');
+        expect(q.labelText).toBe('Revenue');
     });
 });
 

--- a/packages/query-sdk/src/savedChart.test.ts
+++ b/packages/query-sdk/src/savedChart.test.ts
@@ -3,23 +3,47 @@ import { createApiTransport } from './apiTransport';
 import { savedChart } from './savedChart';
 
 describe('savedChart', () => {
-    it('builds a SavedChartQuery with the chart uuid', () => {
+    it('builds a saved-chart query with the chart uuid', () => {
         const q = savedChart('chart-1');
         expect(q.kind).toBe('savedChart');
         expect(q.chartUuid).toBe('chart-1');
         expect(q.labelText).toBeUndefined();
     });
+
     it('accepts a label via the second argument', () => {
         expect(savedChart('chart-1', 'Revenue').labelText).toBe('Revenue');
     });
-    it('exposes a chainable .label() (regression: the agent calls .label() on every query)', () => {
-        // A plain object had no .label() method → `.label is not a function`
-        // crashed generated apps. It must be chainable like QueryBuilder.
-        expect(typeof savedChart('chart-1').label).toBe('function');
-        const q = savedChart('chart-1').label('Revenue');
-        expect(q.kind).toBe('savedChart');
-        expect(q.chartUuid).toBe('chart-1');
-        expect(q.labelText).toBe('Revenue');
+
+    // REGRESSION (battle-tested): generated apps chain the FULL QueryBuilder API
+    // on a linked chart. A missing method throws `TypeError: X is not a function`
+    // and crashes the whole app. Every QueryBuilder method must exist + chain.
+    it('mirrors the full QueryBuilder chainable surface without crashing', () => {
+        const chained = savedChart('chart-1')
+            .label('Revenue')
+            .dimensions(['orders_status'])
+            .metrics(['orders_revenue'])
+            .filters([])
+            .sorts([])
+            .tableCalculations([])
+            .additionalMetrics([])
+            .customDimensions([])
+            .parameters({ region: 'US' })
+            .limit(25);
+
+        expect(chained.kind).toBe('savedChart');
+        expect(chained.chartUuid).toBe('chart-1');
+    });
+
+    it('honors label/limit/parameters and ignores structural methods', () => {
+        const q = savedChart('chart-1')
+            .dimensions(['ignored'])
+            .filters([])
+            .label('Rev')
+            .limit(10)
+            .parameters({ region: 'US' });
+        expect(q.labelText).toBe('Rev');
+        expect(q.limitValue).toBe(10);
+        expect(q.parameterValues).toEqual({ region: 'US' });
     });
 });
 

--- a/packages/query-sdk/src/savedChart.test.ts
+++ b/packages/query-sdk/src/savedChart.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { createApiTransport } from './apiTransport';
+import { savedChart } from './savedChart';
+
+describe('savedChart', () => {
+    it('builds a SavedChartQuery with the chart uuid', () => {
+        expect(savedChart('chart-1')).toEqual({
+            kind: 'savedChart',
+            chartUuid: 'chart-1',
+        });
+    });
+    it('carries an optional label', () => {
+        expect(savedChart('chart-1', 'Revenue')).toEqual({
+            kind: 'savedChart',
+            chartUuid: 'chart-1',
+            label: 'Revenue',
+        });
+    });
+});
+
+describe('executeSavedChart transport', () => {
+    it('POSTs /query/chart with the chartUuid and maps the polled rows', async () => {
+        const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+        const adapter = async (method: string, path: string, body?: unknown) => {
+            calls.push({ method, path, body });
+            if (method === 'POST' && path.endsWith('/query/chart')) {
+                return { queryUuid: 'q-1', metricQuery: {}, fields: {} } as any;
+            }
+            // GET poll → ready with one row
+            return {
+                status: 'ready',
+                columns: { orders_count: { reference: 'orders_count', type: 'number' } },
+                rows: [{ orders_count: { value: { raw: 5, formatted: '5' } } }],
+                totalResults: 1,
+                nextPage: undefined,
+            } as any;
+        };
+        const transport = createApiTransport(
+            { apiKey: '', baseUrl: '', projectUuid: 'p-1' },
+            adapter as any,
+        );
+        const result = await transport.executeSavedChart({ chartUuid: 'chart-9' });
+        expect(calls[0]).toMatchObject({
+            method: 'POST',
+            path: '/api/v2/projects/p-1/query/chart',
+            body: { chartUuid: 'chart-9' },
+        });
+        expect(result.queryUuid).toBe('q-1');
+        expect(result.rows.length).toBe(1);
+    });
+});

--- a/packages/query-sdk/src/savedChart.ts
+++ b/packages/query-sdk/src/savedChart.ts
@@ -1,0 +1,18 @@
+/**
+ * A reference to a saved Lightdash chart, run live by UUID via
+ * `POST /query/chart` instead of an inline metric query. Produced by the
+ * `savedChart(uuid)` factory and accepted by `useLightdash`.
+ */
+export type SavedChartQuery = {
+    kind: 'savedChart';
+    chartUuid: string;
+    /** Human-readable label for the query inspector (not sent to the API). */
+    label?: string;
+};
+
+export function savedChart(
+    chartUuid: string,
+    label?: string,
+): SavedChartQuery {
+    return { kind: 'savedChart', chartUuid, ...(label ? { label } : {}) };
+}

--- a/packages/query-sdk/src/savedChart.ts
+++ b/packages/query-sdk/src/savedChart.ts
@@ -2,17 +2,29 @@
  * A reference to a saved Lightdash chart, run live by UUID via
  * `POST /query/chart` instead of an inline metric query. Produced by the
  * `savedChart(uuid)` factory and accepted by `useLightdash`.
+ *
+ * Exposes a chainable `.label()` mirroring `QueryBuilder.label()`, so a linked
+ * chart supports the same `.label("…")` convention the agent uses on every
+ * query (calling `.label()` on a plain object would crash the app).
  */
 export type SavedChartQuery = {
     kind: 'savedChart';
     chartUuid: string;
-    /** Human-readable label for the query inspector (not sent to the API). */
-    label?: string;
+    /** Resolved label text for the query inspector (set via `.label()`). */
+    labelText?: string;
+    /** Chainable — returns a copy with the given query-inspector label. */
+    label: (name: string) => SavedChartQuery;
 };
 
 export function savedChart(
     chartUuid: string,
-    label?: string,
+    labelText?: string,
 ): SavedChartQuery {
-    return { kind: 'savedChart', chartUuid, ...(label ? { label } : {}) };
+    const build = (text?: string): SavedChartQuery => ({
+        kind: 'savedChart',
+        chartUuid,
+        ...(text ? { labelText: text } : {}),
+        label: (name: string) => build(name),
+    });
+    return build(labelText);
 }

--- a/packages/query-sdk/src/savedChart.ts
+++ b/packages/query-sdk/src/savedChart.ts
@@ -1,30 +1,94 @@
+import type {
+    AdditionalMetric,
+    CustomDimension,
+    Filter,
+    ParametersValuesMap,
+    Sort,
+    TableCalculation,
+} from './types';
+
 /**
  * A reference to a saved Lightdash chart, run live by UUID via
  * `POST /query/chart` instead of an inline metric query. Produced by the
  * `savedChart(uuid)` factory and accepted by `useLightdash`.
  *
- * Exposes a chainable `.label()` mirroring `QueryBuilder.label()`, so a linked
- * chart supports the same `.label("…")` convention the agent uses on every
- * query (calling `.label()` on a plain object would crash the app).
+ * CRITICAL: this mirrors the ENTIRE chainable `QueryBuilder` surface. Generated
+ * apps chain builder methods on every query (`.dimensions().metrics().filters()
+ * .sorts().label().limit()…`); calling a method that doesn't exist on a plain
+ * object throws `TypeError: X is not a function` and crashes the whole app. So a
+ * linked chart must be exactly as crash-safe as a normal query — every method
+ * below exists and is chainable.
+ *
+ * A saved chart's structure is governed by the chart itself, so the structural
+ * methods (dimensions/metrics/filters/sorts/table-calcs/additional-metrics/
+ * custom-dimensions) are accepted but IGNORED. Only `.label()`, `.limit()` and
+ * `.parameters()` affect the run — the `/query/chart` endpoint supports them.
+ *
+ * If you add a method to `QueryBuilder`, add it here too (see savedChart.test.ts,
+ * which chains every QueryBuilder method to guard against a missing one).
  */
 export type SavedChartQuery = {
     kind: 'savedChart';
     chartUuid: string;
-    /** Resolved label text for the query inspector (set via `.label()`). */
+    /** Captured `.label()` value — surfaced in the query inspector. */
     labelText?: string;
-    /** Chainable — returns a copy with the given query-inspector label. */
+    /** Captured `.limit()` value — sent to /query/chart. */
+    limitValue?: number;
+    /** Captured `.parameters()` values — sent to /query/chart. */
+    parameterValues?: ParametersValuesMap;
+
+    // Honored (the /query/chart endpoint supports these):
     label: (name: string) => SavedChartQuery;
+    limit: (n: number) => SavedChartQuery;
+    parameters: (map: ParametersValuesMap) => SavedChartQuery;
+
+    // Accepted but ignored — a saved chart's structure is fixed by the chart:
+    dimensions: (fields: string[]) => SavedChartQuery;
+    metrics: (fields: string[]) => SavedChartQuery;
+    filters: (filters: Filter[]) => SavedChartQuery;
+    sorts: (sorts: Sort[]) => SavedChartQuery;
+    tableCalculations: (calcs: TableCalculation[]) => SavedChartQuery;
+    additionalMetrics: (metrics: AdditionalMetric[]) => SavedChartQuery;
+    customDimensions: (dims: CustomDimension[]) => SavedChartQuery;
+};
+
+type SavedChartState = {
+    chartUuid: string;
+    labelText?: string;
+    limitValue?: number;
+    parameterValues?: ParametersValuesMap;
 };
 
 export function savedChart(
     chartUuid: string,
-    labelText?: string,
+    label?: string,
 ): SavedChartQuery {
-    const build = (text?: string): SavedChartQuery => ({
-        kind: 'savedChart',
-        chartUuid,
-        ...(text ? { labelText: text } : {}),
-        label: (name: string) => build(name),
-    });
-    return build(labelText);
+    const build = (state: SavedChartState): SavedChartQuery => {
+        const self: SavedChartQuery = {
+            kind: 'savedChart',
+            chartUuid: state.chartUuid,
+            labelText: state.labelText,
+            limitValue: state.limitValue,
+            parameterValues: state.parameterValues,
+
+            label: (name) => build({ ...state, labelText: name }),
+            limit: (n) => build({ ...state, limitValue: n }),
+            parameters: (map) =>
+                build({
+                    ...state,
+                    parameterValues: { ...(state.parameterValues ?? {}), ...map },
+                }),
+
+            // Structural methods: chainable no-ops (governed by the saved chart).
+            dimensions: () => self,
+            metrics: () => self,
+            filters: () => self,
+            sorts: () => self,
+            tableCalculations: () => self,
+            additionalMetrics: () => self,
+            customDimensions: () => self,
+        };
+        return self;
+    };
+    return build({ chartUuid, labelText: label });
 }

--- a/packages/query-sdk/src/types.ts
+++ b/packages/query-sdk/src/types.ts
@@ -294,6 +294,8 @@ export type Transport = {
     executeSavedChart: (params: {
         chartUuid: string;
         label?: string;
+        limit?: number;
+        parameters?: ParametersValuesMap;
     }) => Promise<QueryResult>;
     getUser: () => Promise<LightdashUser>;
     externalFetch: (

--- a/packages/query-sdk/src/types.ts
+++ b/packages/query-sdk/src/types.ts
@@ -291,6 +291,10 @@ export type ExternalFetchOptions = {
 
 export type Transport = {
     executeQuery: (query: QueryDefinition) => Promise<QueryResult>;
+    executeSavedChart: (params: {
+        chartUuid: string;
+        label?: string;
+    }) => Promise<QueryResult>;
     getUser: () => Promise<LightdashUser>;
     externalFetch: (
         alias: string,

--- a/packages/query-sdk/src/useLightdash.ts
+++ b/packages/query-sdk/src/useLightdash.ts
@@ -109,7 +109,9 @@ export function useLightdash(
         () =>
             query instanceof QueryBuilder
                 ? JSON.stringify(query.build())
-                : `savedChart:${query.chartUuid}`,
+                : `savedChart:${query.chartUuid}:${
+                      query.limitValue ?? ''
+                  }:${JSON.stringify(query.parameterValues ?? {})}`,
         [query],
     );
 
@@ -147,6 +149,8 @@ export function useLightdash(
                 : transport.executeSavedChart({
                       chartUuid: query.chartUuid,
                       label: query.labelText,
+                      limit: query.limitValue,
+                      parameters: query.parameterValues,
                   });
 
         exec

--- a/packages/query-sdk/src/useLightdash.ts
+++ b/packages/query-sdk/src/useLightdash.ts
@@ -146,7 +146,7 @@ export function useLightdash(
                 ? transport.executeQuery(query.build())
                 : transport.executeSavedChart({
                       chartUuid: query.chartUuid,
-                      label: query.label,
+                      label: query.labelText,
                   });
 
         exec

--- a/packages/query-sdk/src/useLightdash.ts
+++ b/packages/query-sdk/src/useLightdash.ts
@@ -15,7 +15,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTransport } from './LightdashProvider';
-import type { QueryBuilder } from './query';
+import { QueryBuilder } from './query';
+import type { SavedChartQuery } from './savedChart';
 import type {
     Column,
     DownloadUnderlyingDataOptions,
@@ -72,7 +73,9 @@ type UseLightdashResult = {
     ) => Promise<DownloadResultsResult>;
 };
 
-export function useLightdash(query: QueryBuilder): UseLightdashResult {
+export function useLightdash(
+    query: QueryBuilder | SavedChartQuery,
+): UseLightdashResult {
     const transport = useTransport();
     const [data, setData] = useState<Row[]>([]);
     const [columns, setColumns] = useState<Column[]>([]);
@@ -102,7 +105,13 @@ export function useLightdash(query: QueryBuilder): UseLightdashResult {
         );
     });
 
-    const queryKey = useMemo(() => JSON.stringify(query.build()), [query]);
+    const queryKey = useMemo(
+        () =>
+            query instanceof QueryBuilder
+                ? JSON.stringify(query.build())
+                : `savedChart:${query.chartUuid}`,
+        [query],
+    );
 
     const refetch = useCallback(() => {
         setFetchCount((c) => c + 1);
@@ -132,10 +141,15 @@ export function useLightdash(query: QueryBuilder): UseLightdashResult {
             );
         });
 
-        const definition = query.build();
+        const exec =
+            query instanceof QueryBuilder
+                ? transport.executeQuery(query.build())
+                : transport.executeSavedChart({
+                      chartUuid: query.chartUuid,
+                      label: query.label,
+                  });
 
-        transport
-            .executeQuery(definition)
+        exec
             .then((res) => {
                 if (!cancelled) {
                     setData(res.rows);

--- a/sandboxes/data-apps/.gitignore
+++ b/sandboxes/data-apps/.gitignore
@@ -16,3 +16,4 @@ template/src/lib/*
 !template/src/lib/floating.tsx
 !template/src/lib/format.ts
 !template/src/lib/ErrorBoundary.tsx
+!template/src/lib/globalErrorHandler.ts

--- a/sandboxes/data-apps/.gitignore
+++ b/sandboxes/data-apps/.gitignore
@@ -15,3 +15,4 @@ template/src/lib/*
 !template/src/lib/filters.tsx
 !template/src/lib/floating.tsx
 !template/src/lib/format.ts
+!template/src/lib/ErrorBoundary.tsx

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -160,10 +160,13 @@ Each file contains:
 
 Each file has a `linked` boolean and a `chartUuid`:
 
-- **`linked: true`** — the user wants this chart **live**. Render it with
-  `lightdash.savedChart("<chartUuid>").label("<chartName>")` instead of building
-  an inline `query(...)`. `savedChart(...)` is chainable like `query(...)` —
-  always `.label()` it. Its query is **fixed by the saved chart**: `.label()`,
+- **`linked: true`** — the user wants this chart **live**. Import `savedChart`
+  from `@lightdash/query-sdk` (exactly like `query`) and render with
+  `savedChart("<chartUuid>").label("<chartName>")` instead of an inline
+  `query(...)`. **There is NO `lightdash` object — call `savedChart(...)` and
+  `query(...)` directly; a `lightdash.` prefix is undefined and crashes the app.**
+  `savedChart(...)` is chainable like `query(...)` — always `.label()` it. Its
+  query is **fixed by the saved chart**: `.label()`,
   `.limit()` and `.parameters()` apply, but `.dimensions()/.metrics()/.filters()
   /.sorts()` are IGNORED — if the user needs a different shape or extra filters,
   build an inline `query(...)` instead of linking. Do NOT copy the metricQuery.

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -156,6 +156,23 @@ Each file contains:
 4. These are starting points — adapt them based on the user's prompt. You may combine
    multiple referenced queries, add/remove fields, or adjust filters as needed.
 
+### Linked vs. copied charts
+
+Each file has a `linked` boolean and a `chartUuid`:
+
+- **`linked: true`** — the user wants this chart **live**. Render it with
+  `lightdash.savedChart("<chartUuid>")` instead of building an inline `query(...)`.
+  Do NOT copy the metricQuery. The rows are keyed by the chart's field ids
+  (as listed under `metricQuery.dimensions` / `metricQuery.metrics`); read the
+  returned `columns` to know what's available. The listing line marks these
+  with "LINKED".
+- **`linked: false`** — copy as today: build an inline `query(exploreName)...`
+  from the metricQuery.
+
+A linked chart stays in sync with Lightdash and appears in the Queries panel
+like any other query. If it can't be run (deleted / no access), the app should
+show its normal error state — don't fabricate data.
+
 **Important:** The field IDs in metric queries use qualified names (e.g.,
 `orders_total_revenue`). When mapping to SDK calls:
 - **Base explore fields:** Strip the explore name prefix. `orders_total_revenue` → `total_revenue`

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -177,6 +177,53 @@ A linked chart stays in sync with Lightdash and appears in the Queries panel
 like any other query. If it can't be run (deleted / no access), the app should
 show its normal error state — don't fabricate data.
 
+### Linked charts must be DATA-DRIVEN and crash-proof
+
+A linked chart's query can change in Lightdash *after* the app is generated (the
+user swaps the metric, renames a field, etc.). Your generated code MUST survive
+that. A `TypeError` here (`row.x` undefined, `.toFixed()` on undefined, a stale
+field id) is UNACCEPTABLE — it blanks the whole app.
+
+For every LINKED chart, render from the **runtime data**, never hardcoded field
+ids or labels:
+
+- **Discover fields from `columns`, not by name.** `useLightdash` returns
+  `columns: { name, label, type }[]`. Pick the x-axis as the `date`/`timestamp`
+  column and the metric(s) as the `number` column(s) — by `type`, not by a
+  hardcoded id like `orders_fulfillment_rate`.
+- **Titles / axis labels from `columns[].label`** — do NOT hardcode
+  "Fulfillment Rate"; read the metric column's `label` so a metric swap in
+  Lightdash relabels the app automatically.
+- **Format every value with `format(row, column.name)`** — it renders `%` vs
+  `$` vs dates correctly per field, so a units change follows automatically.
+- **Guard every aggregation.** No `Math.max(values)` on a possibly-empty array
+  (yields `-Infinity`), no divide-by-zero, no `.toFixed()` on a maybe-undefined
+  value. If a column is missing or there are no rows, render a neutral `—` —
+  never `NaN`/`Infinity`/a thrown error.
+
+Then WRAP each data/chart component in `<ErrorBoundary>` (from `@/lib/ErrorBoundary`):
+
+```jsx
+import { ErrorBoundary } from '@/lib/ErrorBoundary';
+
+<ErrorBoundary>
+    <RevenueChart />
+</ErrorBoundary>
+```
+
+so if a linked chart's shape changed and a component still can't render it, that
+ONE card shows a fallback while the rest of the app keeps working.
+
+**What "live" covers:** new data, filter / limit / sort / parameter changes, and
+metric swaps that keep the same shape (e.g. a weekly-% metric → a weekly-$
+metric) all flow through automatically when you render data-driven. A
+fundamentally different shape (different dimensions / a different chart type)
+can't reshape a fixed layout — degrade gracefully (the ErrorBoundary fallback)
+rather than crash; the user regenerates to get a new layout.
+
+(Copied charts — `linked: false` — don't need this: their shape is frozen at
+generation, so author them normally.)
+
 **Important:** The field IDs in metric queries use qualified names (e.g.,
 `orders_total_revenue`). When mapping to SDK calls:
 - **Base explore fields:** Strip the explore name prefix. `orders_total_revenue` → `total_revenue`

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -162,9 +162,12 @@ Each file has a `linked` boolean and a `chartUuid`:
 
 - **`linked: true`** — the user wants this chart **live**. Render it with
   `lightdash.savedChart("<chartUuid>").label("<chartName>")` instead of building
-  an inline `query(...)`. `savedChart(...)` is chainable and supports `.label()`
-  exactly like `query(...)` — set the label as always. Do NOT copy the
-  metricQuery. The rows are keyed by the chart's field ids (as listed under
+  an inline `query(...)`. `savedChart(...)` is chainable like `query(...)` —
+  always `.label()` it. Its query is **fixed by the saved chart**: `.label()`,
+  `.limit()` and `.parameters()` apply, but `.dimensions()/.metrics()/.filters()
+  /.sorts()` are IGNORED — if the user needs a different shape or extra filters,
+  build an inline `query(...)` instead of linking. Do NOT copy the metricQuery.
+  The rows are keyed by the chart's field ids (as listed under
   `metricQuery.dimensions` / `metricQuery.metrics`); read the returned `columns`
   to know what's available. The listing line marks these with "LINKED".
 - **`linked: false`** — copy as today: build an inline `query(exploreName)...`

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -161,11 +161,12 @@ Each file contains:
 Each file has a `linked` boolean and a `chartUuid`:
 
 - **`linked: true`** — the user wants this chart **live**. Render it with
-  `lightdash.savedChart("<chartUuid>")` instead of building an inline `query(...)`.
-  Do NOT copy the metricQuery. The rows are keyed by the chart's field ids
-  (as listed under `metricQuery.dimensions` / `metricQuery.metrics`); read the
-  returned `columns` to know what's available. The listing line marks these
-  with "LINKED".
+  `lightdash.savedChart("<chartUuid>").label("<chartName>")` instead of building
+  an inline `query(...)`. `savedChart(...)` is chainable and supports `.label()`
+  exactly like `query(...)` — set the label as always. Do NOT copy the
+  metricQuery. The rows are keyed by the chart's field ids (as listed under
+  `metricQuery.dimensions` / `metricQuery.metrics`); read the returned `columns`
+  to know what's available. The listing line marks these with "LINKED".
 - **`linked: false`** — copy as today: build an inline `query(exploreName)...`
   from the metricQuery.
 

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -190,19 +190,26 @@ field id) is UNACCEPTABLE — it blanks the whole app.
 For every LINKED chart, render from the **runtime data**, never hardcoded field
 ids or labels:
 
-- **Discover fields from `columns`, not by name.** `useLightdash` returns
-  `columns: { name, label, type }[]`. Pick the x-axis as the `date`/`timestamp`
-  column and the metric(s) as the `number` column(s) — by `type`, not by a
-  hardcoded id like `orders_fulfillment_rate`.
+- **Discover fields from `columns` by TYPE, not by name — and DON'T assume a
+  date.** `useLightdash` returns `columns: { name, label, type }[]`. The
+  **category / x-axis is the dimension** — the non-numeric column: a
+  `date`/`timestamp` → a time series (line), a `string` → categories (bar /
+  ranking / table). The **series are the `number` columns** (the metrics). Pick
+  whatever dimension exists — a string dimension (customer, status, region) is
+  completely normal, NOT an error. Never hardcode a field id like
+  `orders_fulfillment_rate`.
 - **Titles / axis labels from `columns[].label`** — do NOT hardcode
   "Fulfillment Rate"; read the metric column's `label` so a metric swap in
   Lightdash relabels the app automatically.
 - **Format every value with `format(row, column.name)`** — it renders `%` vs
   `$` vs dates correctly per field, so a units change follows automatically.
-- **Guard every aggregation.** No `Math.max(values)` on a possibly-empty array
-  (yields `-Infinity`), no divide-by-zero, no `.toFixed()` on a maybe-undefined
-  value. If a column is missing or there are no rows, render a neutral `—` —
-  never `NaN`/`Infinity`/a thrown error.
+- **Guard aggregations; fall back only as a LAST resort.** No `Math.max(values)`
+  on a possibly-empty array (yields `-Infinity`), no divide-by-zero, no
+  `.toFixed()` on a maybe-undefined value → render a neutral `—` for a single
+  missing value. Show a whole-chart "no data / unexpected shape" fallback ONLY
+  when the query truly returns **no rows** or **no numeric column at all** — NOT
+  because the dimension is a string, or the metric changed. Bailing on valid
+  categorical data is a bug, not graceful degradation.
 
 Then WRAP each data/chart component in `<ErrorBoundary>` (from `@/lib/ErrorBoundary`):
 

--- a/sandboxes/data-apps/template/src/lib/ErrorBoundary.tsx
+++ b/sandboxes/data-apps/template/src/lib/ErrorBoundary.tsx
@@ -1,0 +1,64 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type Props = {
+    children: ReactNode;
+    /** Custom fallback UI; falls back to a neutral message when omitted. */
+    fallback?: ReactNode;
+};
+
+type State = { hasError: boolean };
+
+/**
+ * Render safety net. A component that throws during render — e.g. a stale field
+ * reference on a linked chart whose definition changed in Lightdash — is caught
+ * here and shown a fallback instead of crashing the whole app to a blank screen.
+ *
+ * The template wraps the whole app in one of these (see main.jsx). Wrap each
+ * data/chart component in one too so a single bad chart degrades locally
+ * instead of taking down everything.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): State {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo): void {
+        // Surface to the iframe console for debugging; never rethrow.
+        // eslint-disable-next-line no-console
+        console.error(
+            '[lightdash] render error caught by ErrorBoundary:',
+            error,
+            info,
+        );
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            if (this.props.fallback !== undefined) return this.props.fallback;
+            return (
+                <div
+                    style={{
+                        padding: '16px',
+                        borderRadius: '8px',
+                        border: '1px solid rgba(148,163,184,0.25)',
+                        background: 'rgba(148,163,184,0.06)',
+                        color: 'rgba(148,163,184,0.9)',
+                        font: '13px/1.5 ui-sans-serif, system-ui, sans-serif',
+                    }}
+                >
+                    Couldn’t render this content. If a linked chart’s definition
+                    changed in Lightdash, regenerate the app to update its
+                    layout.
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;

--- a/sandboxes/data-apps/template/src/lib/globalErrorHandler.ts
+++ b/sandboxes/data-apps/template/src/lib/globalErrorHandler.ts
@@ -1,0 +1,49 @@
+/**
+ * Last-resort crash guard.
+ *
+ * React ErrorBoundaries only catch errors thrown during *render*. A top-level
+ * ReferenceError at module-evaluation time (e.g. a bad SDK call written outside
+ * a component — the agent puts `const q = query(...)` at module scope) or an
+ * async/event error escapes the boundary and would otherwise leave a blank
+ * screen. This module registers global handlers that paint a fallback into
+ * `#root` instead.
+ *
+ * IMPORTANT: it must be imported FIRST in `main.jsx` (before `./App`) so the
+ * handlers are registered before the app module evaluates.
+ */
+
+function paintFallback(message: string): void {
+    const root = document.getElementById('root');
+    // If the app already rendered something, a later async error must NOT blow
+    // it away — only step in when the app never mounted (empty root).
+    if (!root || root.childElementCount > 0) return;
+
+    const box = document.createElement('div');
+    box.setAttribute('role', 'alert');
+    Object.assign(box.style, {
+        margin: '48px auto',
+        maxWidth: '520px',
+        padding: '20px 24px',
+        borderRadius: '10px',
+        border: '1px solid rgba(148,163,184,0.25)',
+        background: 'rgba(148,163,184,0.06)',
+        color: 'rgba(148,163,184,0.9)',
+        font: '14px/1.6 ui-sans-serif, system-ui, sans-serif',
+    } satisfies Partial<CSSStyleDeclaration>);
+    box.textContent =
+        'This app hit an error while loading and couldn’t render. If a linked ' +
+        'chart’s definition changed in Lightdash, regenerate the app to update it.';
+    root.appendChild(box);
+
+    // eslint-disable-next-line no-console
+    console.error('[lightdash] fatal app error:', message);
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('error', (e) => {
+        paintFallback(e.message || String(e.error));
+    });
+    window.addEventListener('unhandledrejection', (e) => {
+        paintFallback(String(e.reason));
+    });
+}

--- a/sandboxes/data-apps/template/src/main.jsx
+++ b/sandboxes/data-apps/template/src/main.jsx
@@ -1,3 +1,5 @@
+// Must be first: registers global crash handlers before any app module evals.
+import '@/lib/globalErrorHandler';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/sandboxes/data-apps/template/src/main.jsx
+++ b/sandboxes/data-apps/template/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createClient, LightdashProvider } from '@lightdash/query-sdk';
 import { FilterProvider } from '@/lib/filters';
+import { ErrorBoundary } from '@/lib/ErrorBoundary';
 import App from './App';
 import './index.css';
 import './chart-overrides.css';
@@ -26,7 +27,9 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         <QueryClientProvider client={queryClient}>
             <LightdashProvider client={lightdash}>
                 <FilterProvider>
-                    <App />
+                    <ErrorBoundary>
+                        <App />
+                    </ErrorBoundary>
                 </FilterProvider>
             </LightdashProvider>
         </QueryClientProvider>


### PR DESCRIPTION
## What & why

Data apps currently **copy** a referenced chart's metric query inline at generation, so the app goes stale when the query changes in Lightdash. This adds the option to **link** a chart instead — the app runs it live by UUID, so edits in Lightdash flow through. (Linking is also the prerequisite for keeping app queries maintainable/fixable rather than frozen copies.)

## How it works

- **Picker** — each referenced chart gets a **Link** toggle (mirrors the existing *Include sample data* control). Turning Link on hides that chart's sample-data control — a live chart doesn't need a copied sample.
- **Backend** — a linked chart's `chartUuid` is surfaced into the sandbox's `/tmp/metric-queries/*.json` + prompt (it was previously stripped), and the sample fetch is skipped. `skill.md` teaches the agent: linked → `lightdash.savedChart(uuid)`; copy → inline the metric query as today.
- **SDK** — new `savedChart(uuid)` runs the chart live via the existing `POST /api/v2/projects/{uuid}/query/chart` endpoint, reusing the same poll/paginate/mapping. `useLightdash` accepts `QueryBuilder | SavedChartQuery`; the data-lineage feature keeps working.
- **Bridge** — `/query/chart` is allowlisted and emits a Queries-panel event, so a linked query still shows in the panel and is click-to-inspect / hover-to-highlight.

Backward-compatible: copy is the default and the copy path is unchanged. Auth is unchanged — a linked chart runs under the user's session and enforces the normal `view:SavedChart` permission (no new surface).

## Scope

Builder + standalone preview. Deferred (out of this PR): embedded apps (the JWT path rejects running an arbitrary chart), dashboard-tile filter/cache inheritance for linked charts, a dashboard-level "link all", and underlying-data/download on linked charts.

## Testing

- `@lightdash/query-sdk` — `savedChart` factory + `executeSavedChart` transport (asserts the POST path/body and a mapped result).
- backend — `buildChartReference` (linked → uuid + linked, sample skipped; copy path unchanged).
- frontend — `useAppSdkBridge` chart-run tracking; the picker Link toggle + coupling.
- Manual — link a chart → the app runs it live → it appears in the Queries panel and is data-lineage-inspectable → editing the chart in Lightdash updates the app on reload.

Closes: GLITCH-534
Relates: PROD-7940
Relates: #23520
