### PR TITLE
fix(data-apps): fall back to parameter key when label is missing

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -6112,8 +6112,10 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             typeof v === 'number' ? String(v) : AppGenerateService.yamlQuote(v);
 
         const lines: string[] = [`${indent}${key}:`];
+        // Parameters authored before labels existed have no label at runtime;
+        // fall back to the key rather than crashing in yamlQuote(undefined).
         lines.push(
-            `${inner}label: ${AppGenerateService.yamlQuote(param.label)}`,
+            `${inner}label: ${AppGenerateService.yamlQuote(param.label ?? key)}`,
         );
         if (param.description) {
             lines.push(


### PR DESCRIPTION
### Description:
The data-app catalog stage renders project/model parameters to YAML via yamlQuote(param.label). Parameters authored before parameter labels were introduced (#20639) have no label at runtime, so yamlQuote(undefined) threw "Cannot read properties of undefined (reading 'replace')" and failed the whole generation with "Failed to load your data models. Please try again."

Fall back to the parameter key when no label is present, matching Lightdash's key-as-label convention. Covers both render paths (model-level via exploresToYaml and project-level via projectParametersToConfigYaml).

