### PR TITLE
feat: block queries for expired-trial orgs behind feature flag

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -642,6 +642,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     permissionsService: repository.getPermissionsService(),
                     persistentDownloadFileService:
                         repository.getPersistentDownloadFileService(),
+                    organizationAccessService:
+                        repository.getOrganizationAccessService(),
                     preAggregateStrategy: new PreAggregateStrategy({
                         preAggregationDuckDbClient:
                             new PreAggregationDuckDbClient({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -12,6 +12,7 @@ import {
     FilterOperator,
     ForbiddenError,
     NotFoundError,
+    OrganizationAccessStatus,
     PossibleAbilities,
     QueryExecutionContext,
     QueryHistory,
@@ -68,6 +69,7 @@ import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CacheHitCacheResult, MissCacheResult } from '../CacheService/types';
+import { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
@@ -307,6 +309,11 @@ const getMockedAsyncQueryService = (
         }),
         permissionsService: {} as PermissionsService,
         persistentDownloadFileService: {} as PersistentDownloadFileService,
+        organizationAccessService: {
+            getOrganizationAccess: vi.fn(async () => ({
+                status: OrganizationAccessStatus.ACTIVE,
+            })),
+        } as unknown as OrganizationAccessService,
         preAggregateStrategy: new NoOpPreAggregateStrategy(),
         projectCompileLogModel: {} as ProjectCompileLogModel,
         adminNotificationService: {} as AdminNotificationService,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -166,8 +166,8 @@ import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
 import { ExcelService } from '../ExcelService/ExcelService';
-import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 import { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
+import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
@@ -3475,7 +3475,9 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
-    private async assertOrganizationNotBlocked(account: Account): Promise<void> {
+    private async assertOrganizationNotBlocked(
+        account: Account,
+    ): Promise<void> {
         const access =
             await this.organizationAccessService.getOrganizationAccess(account);
         if (access.status === OrganizationAccessStatus.TRIAL_EXPIRED) {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -72,6 +72,7 @@ import {
     normalizeIndexColumns,
     NotFoundError,
     NotSupportedError,
+    OrganizationAccessStatus,
     ParameterError,
     ParseError,
     PivotConfig,
@@ -84,6 +85,7 @@ import {
     S3Error,
     SchedulerFormat,
     SqlChart,
+    TrialExpiredError,
     UnexpectedServerError,
     UserAccessControls,
     WarehouseClient,
@@ -165,6 +167,7 @@ import { CreateCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
 import { ExcelService } from '../ExcelService/ExcelService';
 import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
+import { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
@@ -276,6 +279,7 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     natsClient: INatsClient;
     permissionsService: PermissionsService;
     persistentDownloadFileService: PersistentDownloadFileService;
+    organizationAccessService: OrganizationAccessService;
     preAggregateStrategy?: PreAggregateStrategy;
 };
 
@@ -364,6 +368,8 @@ export class AsyncQueryService extends ProjectService {
 
     persistentDownloadFileService: PersistentDownloadFileService;
 
+    private readonly organizationAccessService: OrganizationAccessService;
+
     protected readonly preAggregateStrategy: PreAggregateStrategy;
 
     constructor(args: AsyncQueryServiceArguments) {
@@ -380,6 +386,7 @@ export class AsyncQueryService extends ProjectService {
         this.natsClient = args.natsClient;
         this.permissionsService = args.permissionsService;
         this.persistentDownloadFileService = args.persistentDownloadFileService;
+        this.organizationAccessService = args.organizationAccessService;
         this.preAggregateStrategy =
             args.preAggregateStrategy ?? new NoOpPreAggregateStrategy();
     }
@@ -3468,6 +3475,14 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    private async assertOrganizationNotBlocked(account: Account): Promise<void> {
+        const access =
+            await this.organizationAccessService.getOrganizationAccess(account);
+        if (access.status === OrganizationAccessStatus.TRIAL_EXPIRED) {
+            throw new TrialExpiredError();
+        }
+    }
+
     private async executePreparedAsyncQuery(
         // TODO: remove metric query, fields, etc from args once they are no longer needed in the database
         args: ExecuteAsyncMetricQueryArgs & {
@@ -3489,6 +3504,7 @@ export class AsyncQueryService extends ProjectService {
         requestParameters: ExecuteAsyncQueryRequestParams,
         organizationUuid: string,
     ): Promise<ExecuteAsyncQueryReturn> {
+        await this.assertOrganizationNotBlocked(args.account);
         return wrapSentryTransaction(
             'ProjectService.executeAsyncQuery',
             {},

--- a/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.test.ts
+++ b/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.test.ts
@@ -51,4 +51,27 @@ describe('OrganizationAccessService', () => {
 
         expect(access.status).toBe(OrganizationAccessStatus.TRIAL_WARNING);
     });
+
+    it('returns trial expired when the block flag is enabled', async () => {
+        const service = buildService(
+            new Set([FeatureFlags.OrganizationTrialBlock]),
+        );
+
+        const access = await service.getOrganizationAccess(account);
+
+        expect(access.status).toBe(OrganizationAccessStatus.TRIAL_EXPIRED);
+    });
+
+    it('prioritises the block flag over the warning flag', async () => {
+        const service = buildService(
+            new Set([
+                FeatureFlags.OrganizationTrialBlock,
+                FeatureFlags.OrganizationTrialWarning,
+            ]),
+        );
+
+        const access = await service.getOrganizationAccess(account);
+
+        expect(access.status).toBe(OrganizationAccessStatus.TRIAL_EXPIRED);
+    });
 });

--- a/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.ts
+++ b/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.ts
@@ -70,6 +70,17 @@ export class OrganizationAccessService extends BaseService {
             organizationName: account.organization.name,
         };
 
+        const isBlocked = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.OrganizationTrialBlock,
+        });
+
+        if (isBlocked.enabled) {
+            return {
+                status: OrganizationAccessStatus.TRIAL_EXPIRED,
+            };
+        }
+
         const isWarning = await this.featureFlagService.get({
             user,
             featureFlagId: FeatureFlags.OrganizationTrialWarning,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -871,6 +871,8 @@ export class ServiceRepository
                     permissionsService: this.getPermissionsService(),
                     persistentDownloadFileService:
                         this.getPersistentDownloadFileService(),
+                    organizationAccessService:
+                        this.getOrganizationAccessService(),
                     projectCompileLogModel:
                         this.models.getProjectCompileLogModel(),
                     adminNotificationService:

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -70,6 +70,20 @@ export class DeactivatedAccountError extends LightdashError {
     }
 }
 
+export class TrialExpiredError extends LightdashError {
+    constructor(
+        message = "Your organization's trial has expired. Please contact your organization administrator.",
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'TrialExpiredError',
+            statusCode: 403,
+            data,
+        });
+    }
+}
+
 export class AuthorizationError extends LightdashError {
     constructor(
         message = "You don't have authorization to perform this action",

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -170,6 +170,13 @@ export enum FeatureFlags {
     OrganizationTrialWarning = 'organization-trial-warning',
 
     /**
+     * Block an organization from running queries because its trial has
+     * expired. Stronger than OrganizationTrialWarning — this DOES block a
+     * product action (query execution). Off by default; enable per-org.
+     */
+    OrganizationTrialBlock = 'organization-trial-block',
+
+    /**
      * Enable the (in-progress) AI writeback feature. Spins up an e2b
      * sandbox pre-loaded with dbt and the Claude Code CLI, then runs a
      * user-supplied prompt against it synchronously. Off by default — gated

--- a/packages/common/src/types/organizationAccess.ts
+++ b/packages/common/src/types/organizationAccess.ts
@@ -1,6 +1,7 @@
 export enum OrganizationAccessStatus {
     ACTIVE = 'active',
     TRIAL_WARNING = 'trial_warning',
+    TRIAL_EXPIRED = 'trial_expired',
 }
 
 export type OrganizationAccess =
@@ -9,6 +10,9 @@ export type OrganizationAccess =
       }
     | {
           status: OrganizationAccessStatus.TRIAL_WARNING;
+      }
+    | {
+          status: OrganizationAccessStatus.TRIAL_EXPIRED;
       };
 
 export type ApiOrganizationAccessResponse = {

--- a/packages/frontend/src/components/NavBar/TrialWarningBanner.tsx
+++ b/packages/frontend/src/components/NavBar/TrialWarningBanner.tsx
@@ -11,9 +11,14 @@ type Props = {
 };
 
 export const TrialWarningBanner = ({ access }: Props) => {
-    if (access.status !== OrganizationAccessStatus.TRIAL_WARNING) {
+    if (
+        access.status !== OrganizationAccessStatus.TRIAL_WARNING &&
+        access.status !== OrganizationAccessStatus.TRIAL_EXPIRED
+    ) {
         return null;
     }
+
+    const isExpired = access.status === OrganizationAccessStatus.TRIAL_EXPIRED;
 
     return (
         <Center
@@ -22,11 +27,18 @@ export const TrialWarningBanner = ({ access }: Props) => {
             w="100%"
             h={BANNER_HEIGHT}
             px="md"
-            bg="yellow.7"
+            bg={isExpired ? 'red.7' : 'yellow.7'}
             className={classes.banner}
         >
-            <Text c="gray.9" size="sm" fw={700} truncate>
-                Your Lightdash trial has expired. Contact sales@lightdash.com
+            <Text
+                c={isExpired ? 'white' : 'gray.9'}
+                size="sm"
+                fw={700}
+                truncate
+            >
+                {isExpired
+                    ? 'Your Lightdash trial has expired and queries are disabled. Contact sales@lightdash.com to reactivate.'
+                    : 'Your Lightdash trial has expired. Contact sales@lightdash.com'}
             </Text>
         </Center>
     );

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -82,7 +82,8 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     const showTrialWarning =
         !isImpersonating &&
         !isCurrentProjectPreview &&
-        (organizationAccess?.status === OrganizationAccessStatus.TRIAL_WARNING ||
+        (organizationAccess?.status ===
+            OrganizationAccessStatus.TRIAL_WARNING ||
             organizationAccess?.status ===
                 OrganizationAccessStatus.TRIAL_EXPIRED);
 

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -82,7 +82,9 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     const showTrialWarning =
         !isImpersonating &&
         !isCurrentProjectPreview &&
-        organizationAccess?.status === OrganizationAccessStatus.TRIAL_WARNING;
+        (organizationAccess?.status === OrganizationAccessStatus.TRIAL_WARNING ||
+            organizationAccess?.status ===
+                OrganizationAccessStatus.TRIAL_EXPIRED);
 
     const hasBanner =
         isImpersonating || isCurrentProjectPreview || showTrialWarning;


### PR DESCRIPTION
## What & why

Adds an **`organization-trial-block`** feature flag that blocks an org from **running queries** once its trial has expired — the query being the core action of a BI tool. This is the enforcement counterpart to the existing `organization-trial-warning` banner, and deliberately reuses the same mechanism.

## Design: cheap for orgs that will never be blocked

The primary constraint was **zero meaningful latency for the unaffected majority** of orgs. The check reuses `OrganizationAccessService`, which already caches per-org for **60s** and is where the trial-warning flag is evaluated:

- Healthy org → **one in-memory cached map read** on the query hot path.
- Cache miss (once per org per 60s) → a single ~1ms Postgres flag read, negligible next to a multi-second warehouse query.
- The flag defaults **off** globally, so no org is blocked without an explicit per-org override.

## How it works

- **`common`**: new `OrganizationTrialBlock` flag, `TRIAL_EXPIRED` access status, and a dedicated `TrialExpiredError` (403) so the client can recognise the block.
- **`OrganizationAccessService`**: evaluates the block flag first — `TRIAL_EXPIRED` takes precedence over `TRIAL_WARNING`. Inherits the existing 60s cache automatically.
- **`AsyncQueryService`**: a single guard at `executePreparedAsyncQuery` — the one funnel both metric queries and the SQL runner pass through — throws `TrialExpiredError` **before any warehouse work**, right alongside the existing `assertIsAccountWithOrg` check. Wired `organizationAccessService` in via `ServiceRepository` + EE index.
- **Frontend**: the NavBar banner now renders a red "trial expired / queries disabled" state for `TRIAL_EXPIRED`.

No middleware — enforcement is a service-level guard at the query chokepoint, so only queries are blocked (users can still browse).

## Verified locally

- Flag **on** → `POST /query/sql` → `403 TrialExpiredError` (blocked before warehouse dispatch).
- Flag **off** → `200`, query runs normally.
- Flipping the flag confirmed the 60s cache absorbs changes — unaffected orgs don't hit the DB per query.
- Unit tests: block-flag precedence in `OrganizationAccessService`; existing 50 `AsyncQueryService` tests still green.

## Scope / follow-ups

- Blocks the `AsyncQueryService` metric + SQL-runner paths. The legacy `ProjectService.runMetricQuery/runSqlQuery` path is **not** guarded (the app uses `AsyncQueryService`); can add belt-and-suspenders coverage there if wanted.
- The banner uses the existing `refetchOnMount: false` hook, so a trial expiring mid-session surfaces in the UI on next reload; the query block itself kicks in within the 60s cache window regardless. Optional follow-up: poll `/org/access` so the banner updates without a manual reload.

## Ticket

No Linear ticket was provided — please add a `Closes:`/`Relates:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
