### PR TITLE
feat(ai-agents): honor filter_autocomplete curated values in searchFieldValues

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -9,6 +9,8 @@ import {
     Explore,
     FeatureFlags,
     filterExploreByTags,
+    filterStaticFilterAutocompleteValues,
+    findFieldByIdInExplore,
     ForbiddenError,
     getContentAsCodePathFromLtreePath,
     getErrorMessage,
@@ -16,6 +18,7 @@ import {
     getLtreePathFromContentAsCodePath,
     getValidAiQueryLimit,
     isDashboardChartTileType,
+    isDimension,
     isExploreError,
     isGitProjectType,
     JobStatusType,
@@ -25,11 +28,13 @@ import {
     QueryHistoryStatus,
     RequestMethod,
     SessionUser,
+    shouldUseStaticFilterAutocomplete,
     TimeoutError,
     UserAttributeValueMap,
     WarehouseQueryError,
     type ChartAsCode,
     type DashboardAsCode,
+    type FieldValueSearchResult,
 } from '@lightdash/common';
 import * as JsonPatch from 'fast-json-patch';
 import Logger from '../../../logging/logger';
@@ -1863,6 +1868,23 @@ export class AiAgentToolsService extends BaseService {
                 const query = args.query ?? '';
                 const isEmptyQuery = query.trim() === '';
 
+                // Serve curated filter_autocomplete values before the warehouse guard.
+                const curatedResult = await this.getStaticFieldValues(
+                    context,
+                    args,
+                    query,
+                );
+                if (curatedResult) {
+                    Logger.info(
+                        `[ai-field-values] served ${curatedResult.results.length} ` +
+                            `curated values source=${context.source} ` +
+                            `table=${args.table} fieldId=${args.fieldId}`,
+                    );
+                    return context.source === 'mcp'
+                        ? curatedResult
+                        : curatedResult.results;
+                }
+
                 // Live PostHog toggle; default off => byte-identical to today.
                 const { enabled: guardEnabled } =
                     await this.featureFlagService.get({
@@ -1935,6 +1957,47 @@ export class AiAgentToolsService extends BaseService {
                 return output;
             },
         );
+    }
+
+    /**
+     * Serve a dimension's curated `filter_autocomplete` values without touching
+     * the warehouse, mirroring the Explore filter UI (`useFieldValues`). Returns
+     * undefined when the field isn't curated (or can't be resolved) so the
+     * caller falls back to the warehouse lookup.
+     */
+    private async getStaticFieldValues(
+        context: AiAgentToolsRuntimeContext,
+        args: Parameters<SearchFieldValuesFn>[0],
+        query: string,
+    ): Promise<FieldValueSearchResult<string> | undefined> {
+        let explore: Explore;
+        try {
+            explore = await this.getExploreForRuntime(context, {
+                table: args.table,
+            });
+        } catch (e) {
+            Logger.warn(
+                `[ai-field-values] could not resolve explore "${args.table}" for curated values: ${getErrorMessage(e)}`,
+            );
+            return undefined;
+        }
+        const field = findFieldByIdInExplore(explore, args.fieldId);
+        if (!field || !isDimension(field)) return undefined;
+        if (
+            !shouldUseStaticFilterAutocomplete(field.filterAutocomplete, query)
+        ) {
+            return undefined;
+        }
+        const results = filterStaticFilterAutocompleteValues(
+            field.filterAutocomplete?.values ?? [],
+            query,
+        ).slice(0, 100);
+        return {
+            search: query,
+            results,
+            cached: false,
+            refreshedAt: new Date(),
+        };
     }
 
     private listKnowledgeDocuments(

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -688,6 +688,49 @@ export type FilterAutocompleteConfig = {
     fetchFromWarehouse: boolean;
 };
 
+/**
+ * Whether a dimension's curated `filter_autocomplete` values can answer a value
+ * search without querying the warehouse. Mirrors the Explore filter UI
+ * (`useFieldValues`): always use curated values when the warehouse fetch is
+ * turned off; otherwise only as the fast path for an empty ("list all") search.
+ */
+export const shouldUseStaticFilterAutocomplete = (
+    filterAutocomplete: FilterAutocompleteConfig | undefined,
+    search: string,
+): boolean => {
+    if (!filterAutocomplete) return false;
+    const hasValues = (filterAutocomplete.values?.length ?? 0) > 0;
+    return (
+        !filterAutocomplete.fetchFromWarehouse ||
+        (hasValues && search.trim().length === 0)
+    );
+};
+
+export const filterStaticFilterAutocompleteValues = (
+    values: FilterAutocompleteValue[],
+    search: string,
+): string[] => {
+    const normalizedSearch = search.trim().toLowerCase();
+    const matched =
+        normalizedSearch.length === 0
+            ? values
+            : values.filter(
+                  ({ value, label }) =>
+                      value.toLowerCase().includes(normalizedSearch) ||
+                      (label?.toLowerCase().includes(normalizedSearch) ??
+                          false),
+              );
+    const seen = new Set<string>();
+    return matched
+        .map(({ value }) => value)
+        .filter((value) => {
+            if (seen.has(value)) return false;
+            seen.add(value);
+            return true;
+        })
+        .sort((a, b) => a.localeCompare(b));
+};
+
 export interface Dimension extends Field {
     fieldType: FieldType.DIMENSION;
     type: DimensionType;


### PR DESCRIPTION
Closes: ZAP-571

### Description

The AI agent's `searchFieldValues` tool always issued a warehouse query to discover a dimension's values, ignoring the dimension's `filter_autocomplete` config — even though the Explore filter UI already honors it.

This wires the agent path to that config. Before falling back to the warehouse, it resolves the target dimension's `filter_autocomplete` in-memory, mirroring the frontend `useFieldValues` logic:

- `values` configured → filter them by the search term, **no warehouse query**
- `fetch_from_warehouse: false` → **never** query the warehouse
- otherwise → existing warehouse lookup (unchanged)

Runs before the empty-query guard so a curated "list all" stays cheap. Shared helpers (`shouldUseStaticFilterAutocomplete`, `filterStaticFilterAutocompleteValues`) live in `@lightdash/common` so the resolution stays consistent with the UI.

**Why:** curated fields skip an often slow/expensive warehouse distinct-scan, and the agent gets the exact stored values (agent filters are case-sensitive by default, so a wrong-case guess silently returns nothing).
