### PR TITLE
fix(frontend): recover from route-lazy chunk load failures

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import { AiAgentsGlobalProvider } from './ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider';
 import { parseEmbedThemeParams } from './ee/providers/Embed/parseEmbedThemeParams';
 import { installChunkLoadErrorHandler } from './features/chunkErrorHandler';
+import ChunkErrorRouteBoundary from './features/errorBoundary/ChunkErrorRouteBoundary';
 import ErrorBoundary from './features/errorBoundary/ErrorBoundary';
 import { SourceCodeEditorProvider } from './features/sourceCodeEditor';
 import ChartColorMappingContextProvider from './hooks/useChartColorConfig/ChartColorMappingContextProvider';
@@ -52,6 +53,7 @@ const sentryCreateBrowserRouter =
 const router = sentryCreateBrowserRouter([
     {
         path: '/',
+        errorElement: <ChunkErrorRouteBoundary />,
         element: (
             <AppProvider>
                 <FullscreenProvider enabled={isMobile || !isMinimalPage}>

--- a/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.test.tsx
+++ b/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ChunkErrorRouteBoundary from './ChunkErrorRouteBoundary';
+
+const mockUseRouteError = vi.fn();
+const mockIsChunkLoadErrorObject = vi.fn();
+const mockHasRecentChunkReload = vi.fn();
+const mockTriggerChunkErrorReload = vi.fn();
+const mockCaptureException = vi.fn((_error: unknown) => 'event-123');
+
+vi.mock('react-router', () => ({
+    useRouteError: () => mockUseRouteError(),
+}));
+
+vi.mock('../chunkErrorHandler', () => ({
+    isChunkLoadErrorObject: (e: unknown) => mockIsChunkLoadErrorObject(e),
+    hasRecentChunkReload: () => mockHasRecentChunkReload(),
+    triggerChunkErrorReload: () => mockTriggerChunkErrorReload(),
+}));
+
+vi.mock('@sentry/react', () => ({
+    captureException: (e: unknown) => mockCaptureException(e),
+}));
+
+vi.mock('./ErrorFallbacks', () => ({
+    ChunkErrorFallback: () => <div>chunk-fallback</div>,
+    GeneralErrorFallback: ({ eventId }: { eventId: string }) => (
+        <div>general-fallback:{eventId}</div>
+    ),
+}));
+
+describe('ChunkErrorRouteBoundary', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('auto-reloads once on a chunk error with no recent reload', () => {
+        mockUseRouteError.mockReturnValue(new Error('Failed to fetch'));
+        mockIsChunkLoadErrorObject.mockReturnValue(true);
+        mockHasRecentChunkReload.mockReturnValue(false);
+
+        const { container } = render(<ChunkErrorRouteBoundary />);
+
+        expect(mockTriggerChunkErrorReload).toHaveBeenCalledTimes(1);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('shows the chunk fallback when a reload was already attempted', () => {
+        mockUseRouteError.mockReturnValue(new Error('Failed to fetch'));
+        mockIsChunkLoadErrorObject.mockReturnValue(true);
+        mockHasRecentChunkReload.mockReturnValue(true);
+
+        render(<ChunkErrorRouteBoundary />);
+
+        expect(mockTriggerChunkErrorReload).not.toHaveBeenCalled();
+        expect(screen.getByText('chunk-fallback')).toBeInTheDocument();
+    });
+
+    it('captures non-chunk errors to Sentry and shows the general fallback', () => {
+        mockUseRouteError.mockReturnValue(new Error('boom'));
+        mockIsChunkLoadErrorObject.mockReturnValue(false);
+
+        render(<ChunkErrorRouteBoundary />);
+
+        expect(mockCaptureException).toHaveBeenCalledTimes(1);
+        expect(mockTriggerChunkErrorReload).not.toHaveBeenCalled();
+        expect(
+            screen.getByText('general-fallback:event-123'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.tsx
@@ -1,7 +1,7 @@
 import { ERROR_BOUNDARY_ID } from '@lightdash/common';
 import { Flex } from '@mantine/core';
 import * as Sentry from '@sentry/react';
-import { type FC } from 'react';
+import { useEffect, useState, type FC } from 'react';
 import { useRouteError } from 'react-router';
 import {
     hasRecentChunkReload,
@@ -17,8 +17,18 @@ import { ChunkErrorFallback, GeneralErrorFallback } from './ErrorFallbacks';
  */
 const ChunkErrorRouteBoundary: FC = () => {
     const error = useRouteError();
+    const isChunkError = isChunkLoadErrorObject(error);
+    const [eventId, setEventId] = useState<string>('');
 
-    if (isChunkLoadErrorObject(error)) {
+    // Chunk errors are kept out of Sentry until auto-reload fails; capture in an
+    // effect so we don't report a side effect (or duplicates) on every render.
+    useEffect(() => {
+        if (!isChunkError) {
+            setEventId(Sentry.captureException(error));
+        }
+    }, [error, isChunkError]);
+
+    if (isChunkError) {
         if (!hasRecentChunkReload()) {
             triggerChunkErrorReload();
             return null;
@@ -36,8 +46,6 @@ const ChunkErrorRouteBoundary: FC = () => {
             </Flex>
         );
     }
-
-    const eventId = Sentry.captureException(error);
 
     return (
         <Flex

--- a/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.tsx
@@ -1,0 +1,59 @@
+import { ERROR_BOUNDARY_ID } from '@lightdash/common';
+import { Flex } from '@mantine/core';
+import * as Sentry from '@sentry/react';
+import { type FC } from 'react';
+import { useRouteError } from 'react-router';
+import {
+    hasRecentChunkReload,
+    isChunkLoadErrorObject,
+    triggerChunkErrorReload,
+} from '../chunkErrorHandler';
+import { ChunkErrorFallback, GeneralErrorFallback } from './ErrorFallbacks';
+
+/**
+ * Route `errorElement` for react-router. Route-level `lazy` chunk failures are
+ * caught by react-router itself and never reach the React ErrorBoundary or the
+ * window `unhandledrejection` listener, so they need chunk-aware handling here.
+ */
+const ChunkErrorRouteBoundary: FC = () => {
+    const error = useRouteError();
+
+    if (isChunkLoadErrorObject(error)) {
+        if (!hasRecentChunkReload()) {
+            triggerChunkErrorReload();
+            return null;
+        }
+        return (
+            <Flex
+                id={ERROR_BOUNDARY_ID}
+                data-error-message="Application update required (chunk load error)"
+                justify="flex-start"
+                align="center"
+                direction="column"
+                mt="4xl"
+            >
+                <ChunkErrorFallback />
+            </Flex>
+        );
+    }
+
+    const eventId = Sentry.captureException(error);
+
+    return (
+        <Flex
+            id={ERROR_BOUNDARY_ID}
+            data-error-message={
+                error instanceof Error ? error.message : String(error)
+            }
+            data-sentry-event-id={eventId}
+            justify="flex-start"
+            align="center"
+            direction="column"
+            mt="4xl"
+        >
+            <GeneralErrorFallback eventId={eventId} error={error} />
+        </Flex>
+    );
+};
+
+export default ChunkErrorRouteBoundary;

--- a/packages/frontend/src/features/errorBoundary/ErrorBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorBoundary.tsx
@@ -1,84 +1,13 @@
 import { ERROR_BOUNDARY_ID } from '@lightdash/common';
-import { Box, Button, Flex, Stack, Text, type FlexProps } from '@mantine/core';
-import { Prism } from '@mantine/prism';
+import { Flex, type FlexProps } from '@mantine/core';
 import * as Sentry from '@sentry/react';
-import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
 import { type FC, type PropsWithChildren } from 'react';
-import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
 import {
     hasRecentChunkReload,
     isChunkLoadErrorObject,
     triggerChunkErrorReload,
 } from '../chunkErrorHandler';
-
-/**
- * Fallback UI shown when a chunk load error occurs after auto-reload has failed.
- * This happens when the browser cache is aggressive or there are network issues.
- */
-const ChunkErrorFallback: FC = () => (
-    <SuboptimalState
-        icon={IconAlertCircle}
-        title="Application update required"
-        description={
-            <Box>
-                <Text mb="xs">
-                    A new version of Lightdash is available. Please refresh your
-                    browser to load the latest version.
-                </Text>
-                <Text size="sm" c="dimmed">
-                    If this persists after refreshing, try clearing your browser
-                    cache or opening in an incognito window.
-                </Text>
-            </Box>
-        }
-        action={
-            <Button
-                variant="default"
-                size="xs"
-                leftSection={<IconRefresh size={16} />}
-                onClick={triggerChunkErrorReload}
-            >
-                Refresh page
-            </Button>
-        }
-    />
-);
-
-/**
- * Fallback UI shown for general application errors.
- * Displays error details and Sentry event ID for support.
- */
-const GeneralErrorFallback: FC<{ eventId: string; error: unknown }> = ({
-    eventId,
-    error,
-}) => (
-    <SuboptimalState
-        icon={IconAlertCircle}
-        title="Something went wrong."
-        description={
-            <Stack
-                spacing="xs"
-                sx={(theme) => ({
-                    borderRadius: theme.radius.md,
-                    padding: theme.spacing.xs,
-                    backgroundColor: theme.colors.ldGray[1],
-                })}
-            >
-                <Text>You can contact support with the following error ID</Text>
-                <Prism
-                    language="javascript"
-                    ta="left"
-                    maw="400"
-                    styles={{ copy: { right: 0 } }}
-                >
-                    {`Error ID: ${eventId}\n${
-                        error instanceof Error ? error.toString() : ''
-                    }`}
-                </Prism>
-            </Stack>
-        }
-    />
-);
+import { ChunkErrorFallback, GeneralErrorFallback } from './ErrorFallbacks';
 
 /**
  * Renders the appropriate fallback based on error type.

--- a/packages/frontend/src/features/errorBoundary/ErrorFallbacks.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorFallbacks.tsx
@@ -1,0 +1,75 @@
+import { Box, Button, Stack, Text } from '@mantine/core';
+import { Prism } from '@mantine/prism';
+import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
+import { type FC } from 'react';
+import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
+import { triggerChunkErrorReload } from '../chunkErrorHandler';
+
+/**
+ * Fallback UI shown when a chunk load error occurs after auto-reload has failed.
+ * This happens when the browser cache is aggressive or there are network issues.
+ */
+export const ChunkErrorFallback: FC = () => (
+    <SuboptimalState
+        icon={IconAlertCircle}
+        title="Application update required"
+        description={
+            <Box>
+                <Text mb="xs">
+                    A new version of Lightdash is available. Please refresh your
+                    browser to load the latest version.
+                </Text>
+                <Text size="sm" c="dimmed">
+                    If this persists after refreshing, try clearing your browser
+                    cache or opening in an incognito window.
+                </Text>
+            </Box>
+        }
+        action={
+            <Button
+                variant="default"
+                size="xs"
+                leftSection={<IconRefresh size={16} />}
+                onClick={triggerChunkErrorReload}
+            >
+                Refresh page
+            </Button>
+        }
+    />
+);
+
+/**
+ * Fallback UI shown for general application errors.
+ * Displays error details and Sentry event ID for support.
+ */
+export const GeneralErrorFallback: FC<{ eventId: string; error: unknown }> = ({
+    eventId,
+    error,
+}) => (
+    <SuboptimalState
+        icon={IconAlertCircle}
+        title="Something went wrong."
+        description={
+            <Stack
+                spacing="xs"
+                sx={(theme) => ({
+                    borderRadius: theme.radius.md,
+                    padding: theme.spacing.xs,
+                    backgroundColor: theme.colors.ldGray[1],
+                })}
+            >
+                <Text>You can contact support with the following error ID</Text>
+                <Prism
+                    language="javascript"
+                    ta="left"
+                    maw="400"
+                    styles={{ copy: { right: 0 } }}
+                >
+                    {`Error ID: ${eventId}\n${
+                        error instanceof Error ? error.toString() : ''
+                    }`}
+                </Prism>
+            </Stack>
+        }
+    />
+);


### PR DESCRIPTION
## What & why

Closes a gap in our recovery from `Failed to fetch dynamically imported module` errors.

Routes are declared with react-router's route-level `lazy: async () => import(...)`. When that import 404s — either because a deploy purged the old content-hashed chunk while a user still had a stale `index.html`, or because of an intermittent CDN fetch failure — **react-router catches the rejection itself and renders its default "Unexpected Application Error" page.** The failure never reaches:

- the React `<ErrorBoundary>` in `App.tsx` (it only catches render errors of mounted children), or
- the `window 'unhandledrejection'` listener in `chunkErrorHandler` (react-router *handles* the rejection, so it's never "unhandled").

So the existing `chunkErrorHandler` recovery — which the rest of the app relies on — simply doesn't fire for route navigations. That's the exact screen users hit on `/projects/:uuid/metrics` and other lazily-loaded routes.

Refs #24685 (recurring stale-chunk / intermittent-CDN errors).

## The fix

Add a chunk-aware route `errorElement` on the root route that reuses the existing chunk-error helpers:

- **Chunk error, no recent reload** → `triggerChunkErrorReload()` (self-heals both stale-HTML and transient-CDN causes; fetches fresh HTML + chunks).
- **Chunk error, reload already attempted** (60s `sessionStorage` cooldown) → branded "Application update required" card instead of the react-router default.
- **Non-chunk route error** → captured to Sentry with an event id + branded fallback (so we don't lose observability by replacing the default page).

Also extracts `ChunkErrorFallback` / `GeneralErrorFallback` out of `ErrorBoundary.tsx` into `ErrorFallbacks.tsx` so the Sentry render boundary and the new route boundary share one UI — no behavior change to the existing boundary.

## Scope / regression notes

- One-line change to the root route (`errorElement`), so it covers **every** route-lazy failure in both the web and mobile route trees (both are children of the same root route).
- Existing recovery paths (`vite:preloadError`, `unhandledrejection`, React `ErrorBoundary`) are untouched — this only adds the missing react-router channel.
- Reload-loop protection is the existing 60s cooldown; private-mode `sessionStorage` failure falls through to the manual card (no infinite loop).
- **Not** in scope: server-side `Cache-Control` on `index.html` and grace-period chunk retention (the infra-level durable fixes for cause #1 in #24685) — worth a follow-up.

## Testing

- Unit tests for the boundary's three branches (`ChunkErrorRouteBoundary.test.tsx`).
- `pnpm -F frontend typecheck:fast` and oxlint pass on the changed files.
