### PR TITLE
feat(apps): link to connection creation from the builder

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/index.tsx
@@ -1,7 +1,8 @@
 import { type ExternalConnection } from '@lightdash/common';
 import { Button, Group, Skeleton, Stack, Text, Title } from '@mantine-8/core';
 import { IconPlug, IconPlus } from '@tabler/icons-react';
-import { type FC, useState } from 'react';
+import { useCallback, useState, type FC } from 'react';
+import { useSearchParams } from 'react-router';
 import { useExternalConnections } from '../../../features/externalConnections/hooks/useExternalConnections';
 import Callout from '../../common/Callout';
 import { EmptyState } from '../../common/EmptyState';
@@ -19,7 +20,19 @@ type Props = {
 const DataAppConnectionsPanel: FC<Props> = ({ projectUuid }) => {
     const { data: connections, isLoading } =
         useExternalConnections(projectUuid);
-    const [isCreating, setIsCreating] = useState(false);
+    // Deep-link support: the builder's connection picker links here with
+    // `?create=1` to open the wizard straight away.
+    const [searchParams, setSearchParams] = useSearchParams();
+    const [isCreating, setIsCreating] = useState(
+        () => searchParams.get('create') === '1',
+    );
+    const closeCreate = useCallback(() => {
+        setIsCreating(false);
+        if (searchParams.has('create')) {
+            searchParams.delete('create');
+            setSearchParams(searchParams, { replace: true });
+        }
+    }, [searchParams, setSearchParams]);
     const [connectionToEdit, setConnectionToEdit] = useState<
         ExternalConnection | undefined
     >(undefined);
@@ -97,7 +110,7 @@ const DataAppConnectionsPanel: FC<Props> = ({ projectUuid }) => {
             {isCreating && (
                 <AddConnectionWizard
                     opened={isCreating}
-                    onClose={() => setIsCreating(false)}
+                    onClose={closeCreate}
                     projectUuid={projectUuid}
                 />
             )}

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -2,7 +2,14 @@ import { subject } from '@casl/ability';
 import { FeatureFlags } from '@lightdash/common';
 import { Anchor, Stack, Text, Title } from '@mantine-8/core';
 import { useMemo, type FC } from 'react';
-import { Navigate, useParams, useRoutes, type RouteObject } from 'react-router';
+import {
+    matchPath,
+    Navigate,
+    useLocation,
+    useParams,
+    useRoutes,
+    type RouteObject,
+} from 'react-router';
 import SettingsEmbed from '../../ee/features/embed/SettingsEmbed';
 import { ProjectChangesets } from '../../features/changesets/components/ProjectChangesets';
 import PullRequestsPage from '../../features/pullRequests/components/PullRequestsPage';
@@ -39,6 +46,7 @@ const ProjectSettings: FC = () => {
     const { projectUuid } = useParams<{
         projectUuid: string;
     }>();
+    const location = useLocation();
 
     const { health, user } = useApp();
     const { isInitialLoading, data: project, error } = useProject(projectUuid);
@@ -48,9 +56,8 @@ const ProjectSettings: FC = () => {
     // section lists PRs opened against that repo.
     const isGitProject = useIsGitProject(projectUuid ?? '');
 
-    const { data: dataAppsFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableDataApps,
-    );
+    const { data: dataAppsFlag, isLoading: isDataAppsFlagLoading } =
+        useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const isDataAppsEnabled = dataAppsFlag?.enabled ?? false;
     const canManageExternalConnections =
         isDataAppsEnabled &&
@@ -253,7 +260,23 @@ const ProjectSettings: FC = () => {
         return <ErrorState error={error.error} />;
     }
 
-    if (isInitialLoading || !project || !projectUuid) {
+    // The dataAppConnections route only registers once the flag resolves. On a
+    // hard load (e.g. the builder's "New connection" deep link opening in a new
+    // tab) the flag is still pending, so without this wait the nested catch-all
+    // below bounces to the settings index before the route exists.
+    const isAwaitingDataAppConnectionsRoute =
+        isDataAppsFlagLoading &&
+        !!matchPath(
+            '/generalSettings/projectManagement/:projectUuid/dataAppConnections',
+            location.pathname,
+        );
+
+    if (
+        isInitialLoading ||
+        !project ||
+        !projectUuid ||
+        isAwaitingDataAppConnectionsRoute
+    ) {
         return (
             <div style={{ marginTop: '20px' }}>
                 <SuboptimalState title="Loading project" loading />

--- a/packages/frontend/src/features/apps/AppResourcePicker.module.css
+++ b/packages/frontend/src/features/apps/AppResourcePicker.module.css
@@ -37,6 +37,7 @@
 
 .attachPickerFooter {
     display: flex;
+    align-items: center;
     justify-content: flex-end;
     padding: var(--mantine-spacing-xs);
     border-top: 1px solid;

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ChartKind,
     type ChartContent,
@@ -6,6 +7,7 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Anchor,
     Box,
     Button,
     CloseButton,
@@ -15,6 +17,7 @@ import {
     LoadingOverlay,
     Popover,
     ScrollArea,
+    Stack,
     Text,
     TextInput,
     Tooltip,
@@ -45,6 +48,8 @@ import { ChartIcon, IconBox } from '../../components/common/ResourceIcon';
 import { getChartIcon } from '../../components/common/ResourceIcon/utils';
 import { useDashboards } from '../../hooks/dashboard/useDashboards';
 import { useChartSummariesV2 } from '../../hooks/useChartSummariesV2';
+import { useProject } from '../../hooks/useProject';
+import useApp from '../../providers/App/useApp';
 import { useExternalConnections } from '../externalConnections/hooks/useExternalConnections';
 import classes from './AppResourcePicker.module.css';
 
@@ -746,6 +751,24 @@ const ConnectionPickerView: FC<{
         enabled ? projectUuid : undefined,
     );
 
+    // Only project/org admins can create connections; mirror the gate the
+    // Project Settings → Data app connections page uses.
+    const { user } = useApp();
+    const { data: project } = useProject(projectUuid);
+    const canManageConnections =
+        !!project &&
+        (user.data?.ability.can(
+            'manage',
+            subject('ExternalConnection', {
+                organizationUuid: project.organizationUuid,
+                projectUuid: project.projectUuid,
+            }),
+        ) ??
+            false);
+    const createConnectionUrl = projectUuid
+        ? `/generalSettings/projectManagement/${projectUuid}/dataAppConnections?create=1`
+        : undefined;
+
     const selectedUuids = useMemo(
         () => new Set(selectedConnections.map((c) => c.externalConnectionUuid)),
         [selectedConnections],
@@ -795,9 +818,19 @@ const ConnectionPickerView: FC<{
                         <Loader size="sm" />
                     </Group>
                 ) : filtered.length === 0 ? (
-                    <Text size="xs" c="dimmed" ta="center" p="sm">
-                        No external connections found
-                    </Text>
+                    <Stack gap={4} align="center" p="sm">
+                        <Text size="xs" c="dimmed" ta="center">
+                            {(connections?.length ?? 0) === 0
+                                ? 'No external connections yet'
+                                : 'No connections match your search'}
+                        </Text>
+                        {(connections?.length ?? 0) === 0 &&
+                            !canManageConnections && (
+                                <Text size="xs" c="dimmed" ta="center">
+                                    Ask a project admin to add one.
+                                </Text>
+                            )}
+                    </Stack>
                 ) : (
                     filtered.map((connection) => {
                         const isSelected = selectedUuids.has(
@@ -838,6 +871,21 @@ const ConnectionPickerView: FC<{
                 )}
             </ScrollArea.Autosize>
             <Box className={classes.attachPickerFooter}>
+                {canManageConnections && createConnectionUrl && (
+                    <Anchor
+                        href={createConnectionUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        mr="auto"
+                    >
+                        <Group gap={4} wrap="nowrap">
+                            <MantineIcon icon={IconPlus} size={14} />
+                            <Text size="xs" fw={500}>
+                                New connection
+                            </Text>
+                        </Group>
+                    </Anchor>
+                )}
                 <Button size="compact-xs" radius="md" onClick={onDone}>
                     Done
                 </Button>

--- a/packages/frontend/src/features/externalConnections/hooks/useExternalConnections.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useExternalConnections.ts
@@ -14,4 +14,7 @@ export const useExternalConnections = (projectUuid: string | undefined) =>
         queryKey: ['external-connections', projectUuid],
         queryFn: () => getExternalConnections(projectUuid!),
         enabled: !!projectUuid,
+        // Refetch when the tab regains focus so connections created in another
+        // tab (e.g. from the builder's "New connection" link) show up on return.
+        refetchOnWindowFocus: true,
     });


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-562/link-to-connection-creation-from-builder-page

### Description:
External connections were only creatable from Project Settings and weren't discoverable while building a data app. Add an admin-gated "New connection" link in the builder's connection picker (footer + empty state) that deep-links to the settings wizard via ?create=1, opening in a new tab so the in-progress builder draft is preserved. Refetch connections on window focus so one created in the other tab shows up on return.

Also fixes a redirect bug this surfaced: on a cold load the dataAppConnections route isn't registered until the EnableDataApps flag resolves, so ProjectSettings' nested catch-all bounced to the settings index. Wait for the flag before evaluating routes on that path (same pattern already used for AI routes).

<img width="411" height="260" alt="image" src="https://github.com/user-attachments/assets/429cc5fa-5f0f-4aa1-b18b-f9148625bb42" />

