### PR TITLE
ci: surface upgrade-stop structure on the release-safety marker (PROD-8359)

### DIFF
--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -704,6 +704,70 @@ test('NO DRIFT: ownExpandContractFloor equals the floor buildMarker advertises',
     assert.strictEqual(ownExpandContractFloor(input), '0.3240.0');
 });
 
+// --- upgrade.sourceVersion / kind / requiredStops (structured, no prose) -----
+
+test('carriedFloor from a required stop => kind=requiredStop + sourceVersion (the stop to LAND on)', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        carriedFloor: { minPreviousVersion: '0.3280.0', sourceVersion: '0.3280.0', kind: 'requiredStop' },
+    });
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3280.0');
+    assert.strictEqual(m.upgrade.kind, 'requiredStop');
+    assert.strictEqual(m.upgrade.sourceVersion, '0.3280.0');
+});
+
+test('carriedFloor from a drop floor => kind=minPrevious + the source release', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        carriedFloor: { minPreviousVersion: '0.3260.0', sourceVersion: '0.3265.0', kind: 'minPrevious' },
+    });
+    assert.strictEqual(m.upgrade.kind, 'minPrevious');
+    assert.strictEqual(m.upgrade.sourceVersion, '0.3265.0');
+});
+
+test("this release's own expand/contract floor is attributed to this version", () => {
+    const m = buildMarker({
+        ...base, // version 0.3261.0
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: true, findings: ['drop-column'] },
+        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'cleared' },
+        expandContractFloor: '0.3240.0',
+    });
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3240.0');
+    assert.strictEqual(m.upgrade.sourceVersion, '0.3261.0'); // this release set it
+    assert.strictEqual(m.upgrade.kind, 'minPrevious');
+});
+
+test('a default floor => kind=default, sourceVersion null', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        carriedFloor: { minPreviousVersion: '0.3000.0', sourceVersion: null, kind: 'default' },
+    });
+    assert.strictEqual(m.upgrade.kind, 'default');
+    assert.strictEqual(m.upgrade.sourceVersion, null);
+});
+
+test('no floor => sourceVersion null and kind null', () => {
+    const m = buildMarker({ ...base, migrations: noMig });
+    assert.strictEqual(m.upgrade.minPreviousVersion, null);
+    assert.strictEqual(m.upgrade.sourceVersion, null);
+    assert.strictEqual(m.upgrade.kind, null);
+});
+
+test('requiredStops list surfaces verbatim on the marker; defaults to []', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        requiredStops: ['0.3280.0', '0.3290.0'],
+    });
+    assert.deepStrictEqual(m.upgrade.requiredStops, ['0.3280.0', '0.3290.0']);
+    const m2 = buildMarker({ ...base, migrations: noMig });
+    assert.deepStrictEqual(m2.upgrade.requiredStops, []);
+});
+
 // --- report ------------------------------------------------------------------
 
 if (failures.length > 0) {

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -22,10 +22,12 @@ import { diffRestApi } from './rest-api-diff';
 import { diffMcpTools } from './mcp-tools-diff';
 import {
     CarriedFloor,
+    CarriedFloorKind,
     carriedUpgradeFloor,
     DEFAULT_OVERRIDES_PATH,
     loadUpgradeOverrides,
     recordDerivedFloor,
+    requiredStopsUpTo,
     resolveUpgrade,
     UpgradeResolution,
 } from './upgrade-overrides';
@@ -89,8 +91,26 @@ export interface ReleaseSafetyMarker {
     };
     upgrade: {
         minPreviousVersion: string | null;
+        /** Whether THIS release is itself a required stop (its own declaration). */
         requiredStop: boolean;
         note: string | null;
+        /**
+         * The release whose declaration established `minPreviousVersion`; null when
+         * there is no floor. Lets a consumer act without parsing `note`: when
+         * `kind === 'requiredStop'` this is the release to LAND on.
+         */
+        sourceVersion: string | null;
+        /**
+         * How `minPreviousVersion` was set: `'requiredStop'` (a mandatory waypoint),
+         * `'minPrevious'` (a floor — just start from >= it), `'default'`, or null.
+         */
+        kind: CarriedFloorKind;
+        /**
+         * Every required-stop release at or before this one, oldest-first. An
+         * operator upgrading to this release must land on each one newer than the
+         * version they are currently on.
+         */
+        requiredStops: string[];
     };
 }
 
@@ -190,6 +210,12 @@ export interface BuildMarkerInput {
      * something their old pods use. null/absent leaves the per-release floor as-is.
      */
     carriedFloor?: CarriedFloor | null;
+    /**
+     * Optional list of required-stop releases at or before this version (from the
+     * committed overrides). Surfaced verbatim as `upgrade.requiredStops`. Absent →
+     * empty list.
+     */
+    requiredStops?: string[];
 }
 
 export interface AiReviewSummary {
@@ -378,7 +404,13 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     // claimed) only when a committed overrides file was consulted; otherwise the
     // honest null stub. A malformed file fails loud upstream — it never silently
     // degrades here, because that would drop a maintainer's required-stop signal.
-    let upgrade: ReleaseSafetyMarker['upgrade'] = {
+    // Working floor object (the 3 core fields); the structured attribution
+    // (sourceVersion/kind/requiredStops) is derived once, after the fold, below.
+    let upgrade: {
+        minPreviousVersion: string | null;
+        requiredStop: boolean;
+        note: string | null;
+    } = {
         minPreviousVersion: null,
         requiredStop: false,
         note: null,
@@ -450,6 +482,27 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
         upgradeKnown = true;
     }
 
+    // Attribute the FINAL floor to a source + kind, so a consumer can branch
+    // without parsing `note`. When the carried high-water mark won, reuse its
+    // attribution (it correctly identifies a required stop vs a min-previous floor
+    // vs the default). Otherwise the floor came from THIS release — its own
+    // expand/contract drop or a this-version human override — both anchored here as
+    // a min-previous floor.
+    let floorSource: string | null = null;
+    let floorKind: CarriedFloorKind = null;
+    if (upgrade.minPreviousVersion !== null) {
+        if (
+            input.carriedFloor &&
+            upgrade.minPreviousVersion === input.carriedFloor.minPreviousVersion
+        ) {
+            floorSource = input.carriedFloor.sourceVersion;
+            floorKind = input.carriedFloor.kind;
+        } else {
+            floorSource = version;
+            floorKind = 'minPrevious';
+        }
+    }
+
     if (upgradeKnown) {
         capabilities.push('upgrade');
     }
@@ -478,7 +531,12 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
             // P3: mcp is populated by the tool-snapshot diff when it ran.
             mcp,
         },
-        upgrade,
+        upgrade: {
+            ...upgrade,
+            sourceVersion: floorSource,
+            kind: floorKind,
+            requiredStops: input.requiredStops ?? [],
+        },
     };
 }
 
@@ -691,6 +749,9 @@ async function main(): Promise<void> {
     // declared in any release at or before this one, so the marker is self-
     // sufficient for a version-skip (see buildMarker's carriedFloor fold).
     const carriedFloor = carriedUpgradeFloor(overrides, args.version);
+    // Full list of required stops at/before this release, so a consumer can read
+    // every mandatory waypoint from a single marker (see upgrade.requiredStops).
+    const requiredStops = requiredStopsUpTo(overrides, args.version);
 
     const marker = buildMarker({
         version: args.version,
@@ -704,6 +765,7 @@ async function main(): Promise<void> {
         mcpApi,
         upgrade,
         carriedFloor,
+        requiredStops,
     });
 
     // Persist THIS release's own auto-derived expand/contract floor into the

--- a/scripts/release-safety.schema.json
+++ b/scripts/release-safety.schema.json
@@ -86,11 +86,27 @@
         "upgrade": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["minPreviousVersion", "requiredStop", "note"],
+            "required": [
+                "minPreviousVersion",
+                "requiredStop",
+                "note",
+                "sourceVersion",
+                "kind",
+                "requiredStops"
+            ],
             "properties": {
                 "minPreviousVersion": { "type": ["string", "null"] },
                 "requiredStop": { "type": "boolean" },
-                "note": { "type": ["string", "null"] }
+                "note": { "type": ["string", "null"] },
+                "sourceVersion": { "type": ["string", "null"] },
+                "kind": {
+                    "type": ["string", "null"],
+                    "enum": ["minPrevious", "requiredStop", "default", null]
+                },
+                "requiredStops": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
             }
         }
     }

--- a/scripts/upgrade-overrides.test.ts
+++ b/scripts/upgrade-overrides.test.ts
@@ -13,6 +13,7 @@ import {
     carriedUpgradeFloor,
     loadUpgradeOverrides,
     recordDerivedFloor,
+    requiredStopsUpTo,
     resolveUpgrade,
     validateOverrides,
 } from './upgrade-overrides';
@@ -141,6 +142,38 @@ test('the highest (most restrictive) floor wins across mixed sources', () => {
     );
     assert.strictEqual(f.minPreviousVersion, '0.3280.0');
     assert.strictEqual(f.kind, 'requiredStop');
+});
+
+// --- requiredStopsUpTo (full mandatory-waypoint list) ------------------------
+
+test('null overrides => empty list', () => {
+    assert.deepStrictEqual(requiredStopsUpTo(null, '0.3300.0'), []);
+});
+
+test('no required stops => empty list (min-previous entries are not stops)', () => {
+    const ov = { versions: { '0.3265.0': { minPreviousVersion: '0.3260.0' } } };
+    assert.deepStrictEqual(requiredStopsUpTo(ov, '0.3300.0'), []);
+});
+
+test('lists required stops at or before the version, oldest-first', () => {
+    const ov = {
+        versions: {
+            '0.3290.0': { requiredStop: true },
+            '0.3280.0': { requiredStop: true },
+            '0.3265.0': { minPreviousVersion: '0.3260.0' }, // not a stop
+        },
+    };
+    assert.deepStrictEqual(requiredStopsUpTo(ov, '0.3300.0'), ['0.3280.0', '0.3290.0']);
+});
+
+test('excludes required stops newer than the version', () => {
+    const ov = { versions: { '0.3400.0': { requiredStop: true } } };
+    assert.deepStrictEqual(requiredStopsUpTo(ov, '0.3300.0'), []);
+});
+
+test('includes the version itself when it is a required stop', () => {
+    const ov = { versions: { '0.3300.0': { requiredStop: true } } };
+    assert.deepStrictEqual(requiredStopsUpTo(ov, '0.3300.0'), ['0.3300.0']);
 });
 
 // --- validateOverrides (fail loud) -------------------------------------------

--- a/scripts/upgrade-overrides.ts
+++ b/scripts/upgrade-overrides.ts
@@ -152,6 +152,29 @@ export function carriedUpgradeFloor(
 }
 
 /**
+ * PURE. Every declared required-stop release at or before `version`, oldest-first.
+ *
+ * Where `carriedUpgradeFloor` collapses the stops into a single binding floor, this
+ * returns the full list so a consumer reading ONE marker learns every mandatory
+ * waypoint on the path to this release (an operator lands on each stop whose version
+ * is greater than the one they're currently on). Includes `version` itself when it
+ * is a required stop. A null `overrides` (file absent) yields an empty list.
+ */
+export function requiredStopsUpTo(
+    overrides: UpgradeOverridesFile | null,
+    version: string,
+): string[] {
+    if (!overrides) return [];
+    return Object.entries(overrides.versions ?? {})
+        .filter(
+            ([v, block]) =>
+                block.requiredStop === true && compareVersions(v, version) <= 0,
+        )
+        .map(([v]) => v)
+        .sort(compareVersions);
+}
+
+/**
  * PURE. Validate the parsed overrides object, throwing a clear error on any
  * shape violation. Strict on purpose: a typo in a maintainer's required-stop
  * declaration must fail the release, not be silently dropped.


### PR DESCRIPTION
## What & why

Follow-up to the forward-carried upgrade floor (already merged). Today an operator can read `upgrade.minPreviousVersion` off a single marker, but **"what release must I stop at?"** isn't machine-answerable — the marker doesn't say *which* release set the floor, or whether it's a **mandatory waypoint** (`requiredStop`, land on it) vs a **version floor** (`minPreviousVersion`, just start from ≥ it). That distinction lived only in the free-text `note`, so a CI/CD gate had to parse English, or fetch every marker in the range and filter `requiredStop`.

This surfaces structure that `carriedUpgradeFloor` already computes but was discarding into prose.

## Changes to `upgrade`

- **`sourceVersion`** + **`kind`** (`'requiredStop' | 'minPrevious' | 'default' | null`) — the release that set `minPreviousVersion` and how. A consumer branches directly:
  - `kind === 'requiredStop'` → land on `sourceVersion`
  - `kind === 'minPrevious'` → just be on ≥ `minPreviousVersion`
  Attribution reuses the carried floor's own `sourceVersion`/`kind` when the high-water mark wins; otherwise it anchors to this release (its own expand/contract drop, or a this-version override).
- **`requiredStops`** — every required-stop release at or before this version, oldest-first (new pure `requiredStopsUpTo`). One read yields the full mandatory-waypoint list; an operator lands on each stop newer than their current version, no chain-walk.

Live example (target `0.3300.0`, with a drop-floor at `0.3265.0` and a required stop at `0.3280.0`):
```json
"upgrade": {
  "minPreviousVersion": "0.3280.0",
  "requiredStop": false,
  "note": "Release 0.3280.0 is a required stop — upgrade from 0.3280.0 or later; …",
  "sourceVersion": "0.3280.0",
  "kind": "requiredStop",
  "requiredStops": ["0.3280.0"]
}
```

## Compatibility

Schema-additive: existing `upgrade` fields are unchanged; the three new fields are added to `scripts/release-safety.schema.json`. `schemaVersion` stays `"1"` — the generator always emits the new fields, and there are no external consumers pinned to the old shape yet. **Flagging for review:** if we'd rather signal the shape change, this is a one-line bump to `"2"` — happy to do it either way.

## Testing

- `npx tsx scripts/upgrade-overrides.test.ts` — 27 pass (+5: `requiredStopsUpTo` — ordering, `<=` boundary, excludes-newer, non-stop entries)
- `npx tsx scripts/gen-release-safety.test.ts` — 57 pass (+6: `kind`/`sourceVersion` for each floor origin, `requiredStops` passthrough)
- `release-safety-pr-comment.test.ts` — 14 pass (unchanged; reads a subset)
- `tsc --strict` clean; schema is valid JSON; verified end-to-end against the real generator (output above).

No runtime/app code touched — release-pipeline only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
