### PR TITLE
fix(files): serve 404 for missing S3 objects instead of 500

### DIFF
--- a/packages/backend/src/clients/Aws/S3Client.ts
+++ b/packages/backend/src/clients/Aws/S3Client.ts
@@ -13,6 +13,7 @@ import {
     DownloadFileType,
     getErrorMessage,
     MissingConfigError,
+    NotFoundError,
     S3Error,
     type WarehouseResults,
 } from '@lightdash/common';
@@ -250,6 +251,9 @@ export class S3Client extends S3BaseClient implements FileStorageClient {
             }
             return response.Body as Readable;
         } catch (error) {
+            if (error instanceof NoSuchKey || error instanceof NotFound) {
+                throw new NotFoundError('File not found');
+            }
             if (error instanceof S3Error) {
                 Sentry.captureException(error);
                 throw error;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8516

## Summary

`GET /api/v1/file/:fileId` returned **500** when the backing S3 object was missing (e.g. an agent avatar whose file is gone). Only the missing-object case leaked a 500 — missing-row and expired-link already returned 404.

## Root cause

`S3Client.getFileStream` re-threw the raw AWS `NoSuchKey`/`NotFound` (subclasses of `S3ServiceException`), which TSOA rendered as a 500 and reported to Sentry. Sibling methods `objectExists`/`getFileUrl` already translate these; `getFileStream` was the outlier.

## Fix

`getFileStream` catches `NoSuchKey`/`NotFound` and throws `NotFoundError('File not found')` before the Sentry path, so the endpoint degrades to a clean 404. Genuine failures (e.g. `AccessDenied`) are still re-thrown and reported. Generic message — no S3 key/bucket leak.

```
Row exists, S3 object missing:   Before 500 (+Sentry)   →   After 404 (no noise)
```

## Test plan

- [x] `pnpm -F backend typecheck:fast` + eslint clean; no regressions (`PersistentDownloadFileService`, `S3BaseClient`, `UnfurlService`)
- [x] Manual: row → nonexistent key, `curl` endpoint → **404** (was 500)
- [ ] Does not restore avatars whose S3 bytes are already gone (unrecoverable from code); real cloud S3 not exercisable locally