### PR TITLE
fix(apps): allow app builders to list external connections

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -796,7 +796,7 @@ defences keep the path robust:
 
 ## External connections
 
-External connections let a project admin register a third-party HTTP API (base URL, auth) that generated data apps can fetch from at runtime, through a parent-mediated proxy that mirrors the metric-query [PostMessage Bridge](#postmessage-bridge-useappsdkbridge). The feature is enterprise-only and gated on the `manage:ExternalConnection` scope for configuration.
+External connections let a project admin register a third-party HTTP API (base URL, auth) that generated data apps can fetch from at runtime, through a parent-mediated proxy that mirrors the metric-query [PostMessage Bridge](#postmessage-bridge-useappsdkbridge). The feature is enterprise-only. Two scopes split the surface: **configuring** a connection (create / edit / delete, including its host, auth secret, and allowed methods) requires the admin-only `manage:ExternalConnection` scope; **viewing** the connection list — so an app builder can pick an existing connection to link in the builder — requires `view:ExternalConnection`, granted to interactive-viewer+ (the same tier that can build data apps). Linking a viewed connection to an app is gated by manage rights on the app itself (`manage:DataApp`, via `assertCanManageApp`), not by connection-manage — so a space editor can link an admin-created connection to an app they own.
 
 ### Connection model
 
@@ -819,7 +819,7 @@ New connections default to `['GET']` only; broadening the set is an explicit adm
 
 ### Why the exfiltration warning matters
 
-Because the proxy injects a server-held secret and can reach an admin-configured external host, a **generated app could be coaxed into exfiltrating warehouse data** to that host (e.g. POST query results to an attacker-influenced endpoint). The trust model is therefore: **only a project admin can configure and link connections** (`manage:ExternalConnection`), the base URL is admin-pinned (the app can't redirect the fetch to an arbitrary host), and methods/paths are constrained. Admins should only link connections to hosts they trust with project data, and review which apps are linked to which connections.
+Because the proxy injects a server-held secret and can reach an admin-configured external host, a **generated app could be coaxed into exfiltrating warehouse data** to that host (e.g. POST query results to an attacker-influenced endpoint). The trust decision that bounds this lives entirely with the admin: **only a project admin can configure a connection** (`manage:ExternalConnection`) — i.e. pin its host, secret, and allowed methods. Once a connection exists, an app builder can select it and link it to an app they manage (gated by `manage:DataApp`, not connection-manage), but the base URL stays admin-pinned (the app can't redirect the fetch to an arbitrary host) and methods/paths are constrained. So a builder can only ever reach hosts an admin already chose to trust with project data. Admins should only create connections to hosts they trust, keep the allowed-methods set as narrow as the apps need, and review which apps are linked to which connections.
 
 ### Admin "Test connection"
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -90,6 +90,8 @@ function buildService(opts: {
             .mockResolvedValue(
                 opts.connection !== undefined ? opts.connection : connection,
             ),
+        getProjectOrganizationUuid: vi.fn().mockResolvedValue(orgUuid),
+        list: vi.fn().mockResolvedValue([connection]),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? 's3cr3t'),
         saveSample: opts.saveSampleFn ?? vi.fn().mockResolvedValue(fakeSample),
         countSamples: opts.countSamplesFn ?? vi.fn().mockResolvedValue(0),
@@ -136,8 +138,84 @@ function mockAbility(
     });
 }
 
+// Action-aware ability: only the listed actions are allowed. Lets us assert
+// that reads gate on `view` while mutations still gate on `manage`.
+function mockAbilityByActions(
+    service: ExternalConnectionService,
+    allowedActions: string[],
+): void {
+    const allowed = new Set(allowedActions);
+    vi.spyOn(
+        service as unknown as { createAuditedAbility: () => unknown },
+        'createAuditedAbility',
+    ).mockReturnValue({
+        can: (action: string) => allowed.has(action),
+        cannot: (action: string) => !allowed.has(action),
+    });
+}
+
 const adminAccount = makeAccount(true);
 const viewerAccount = makeAccount(false);
+
+// -------------------------------------------------------------------
+// list / get — reads gate on `view`, not `manage`
+// -------------------------------------------------------------------
+describe('ExternalConnectionService reads (view, not manage)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('lists connections for a view-only principal (no manage)', async () => {
+        const { service, model } = buildService({});
+        mockAbilityByActions(service, ['view']);
+
+        const result = await service.list(viewerAccount, projectUuid);
+
+        expect(result).toEqual([connection]);
+        expect(model.list).toHaveBeenCalledWith(projectUuid, orgUuid);
+    });
+
+    it('gets a connection for a view-only principal (no manage)', async () => {
+        const { service } = buildService({});
+        mockAbilityByActions(service, ['view']);
+
+        const result = await service.get(
+            viewerAccount,
+            projectUuid,
+            connectionUuid,
+        );
+
+        expect(result).toEqual(connection);
+    });
+
+    it('rejects list when the principal cannot view', async () => {
+        const { service, model } = buildService({});
+        mockAbilityByActions(service, []);
+
+        await expect(service.list(viewerAccount, projectUuid)).rejects.toThrow(
+            ForbiddenError,
+        );
+        expect(model.list).not.toHaveBeenCalled();
+    });
+
+    it('still requires manage to create — view alone is rejected', async () => {
+        const { service } = buildService({});
+        mockAbilityByActions(service, ['view']);
+
+        await expect(
+            service.create(viewerAccount, projectUuid, {
+                name: 'API',
+                type: 'none',
+                origin: 'https://api.example.com',
+                allowedPathPrefixes: ['/'],
+                allowedMethods: ['GET'],
+                allowedContentTypes: ['application/json'],
+                responseMaxBytes: 1000,
+                secret: null,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+});
 
 // -------------------------------------------------------------------
 // testConnection

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -84,6 +84,27 @@ export class ExternalConnectionService extends BaseService {
         }
     }
 
+    private assertCanView(
+        account: RegisteredAccount,
+        projectUuid: string,
+        organizationUuid: string,
+    ): void {
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'view',
+                subject('ExternalConnection', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to view external connections',
+            );
+        }
+    }
+
     /**
      * Loads the app row and asserts the caller can `manage` the DataApp,
      * mirroring AppGenerateService's assertCanManageApp pattern (space
@@ -178,12 +199,11 @@ export class ExternalConnectionService extends BaseService {
         if (!organizationUuid) {
             throw new NotFoundError('Project not found');
         }
-        this.assertCanManage(account, projectUuid, organizationUuid);
+        this.assertCanView(account, projectUuid, organizationUuid);
         return this.externalConnectionModel.list(projectUuid, organizationUuid);
     }
 
-    private async getOwnedConnection(
-        account: RegisteredAccount,
+    private async loadConnection(
         projectUuid: string,
         connectionUuid: string,
     ): Promise<ExternalConnection> {
@@ -192,7 +212,36 @@ export class ExternalConnectionService extends BaseService {
         if (!connection || connection.projectUuid !== projectUuid) {
             throw new NotFoundError('External connection not found');
         }
+        return connection;
+    }
+
+    private async getOwnedConnection(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+    ): Promise<ExternalConnection> {
+        const connection = await this.loadConnection(
+            projectUuid,
+            connectionUuid,
+        );
         this.assertCanManage(
+            account,
+            connection.projectUuid,
+            connection.organizationUuid,
+        );
+        return connection;
+    }
+
+    private async getViewableConnection(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+    ): Promise<ExternalConnection> {
+        const connection = await this.loadConnection(
+            projectUuid,
+            connectionUuid,
+        );
+        this.assertCanView(
             account,
             connection.projectUuid,
             connection.organizationUuid,
@@ -205,7 +254,7 @@ export class ExternalConnectionService extends BaseService {
         projectUuid: string,
         connectionUuid: string,
     ): Promise<ExternalConnection> {
-        return this.getOwnedConnection(account, projectUuid, connectionUuid);
+        return this.getViewableConnection(account, projectUuid, connectionUuid);
     }
 
     async update(

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -220,6 +220,11 @@ export const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
             createdByUserUuid: member.userUuid,
         });
+        // View external connections to select and link them when building a
+        // data app. Managing (create/edit/delete) stays admin-only.
+        can('view', 'ExternalConnection', {
+            organizationUuid: member.organizationUuid,
+        });
 
         can('manage', 'Space', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -181,6 +181,11 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
             createdByUserUuid: member.userUuid,
         });
+        // View external connections to select and link them when building a
+        // data app. Managing (create/edit/delete) stays admin-only.
+        can('view', 'ExternalConnection', {
+            projectUuid: member.projectUuid,
+        });
 
         can('manage', 'Space', {
             projectUuid: member.projectUuid,

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -71,6 +71,7 @@ const BASE_ROLE_SCOPES = {
         'create:DataApp', // Personal apps (not yet in a space)
         'view:DataApp@self', // Own personal apps
         'manage:DataApp@self', // Own personal apps
+        'view:ExternalConnection', // Select/link connections in the app builder (manage stays admin-only)
     ],
 
     [ProjectMemberRole.EDITOR]: [
@@ -270,6 +271,7 @@ export const getNonEnterpriseScopesForRole = (
         'create:DataApp',
         'view:DataApp@self',
         'manage:DataApp@self',
+        'view:ExternalConnection',
         'manage:ExternalConnection',
         'view:OrganizationDesign',
         'manage:OrganizationDesign',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -901,7 +901,16 @@ const scopes: Scope[] = [
     },
 
     // External Connections — project-scoped allowlisted outbound HTTP endpoints
-    // that data apps reach through the secure fetch proxy. Admin-only.
+    // that data apps reach through the secure fetch proxy. Managing (create/
+    // edit/delete) is admin-only; viewing is available to app builders so they
+    // can select an existing connection to link in the data app builder.
+    {
+        name: 'view:ExternalConnection',
+        description: 'View external API connections to link them in data apps',
+        isEnterprise: true,
+        group: ScopeGroup.AI,
+        getConditions: addDefaultUuidCondition,
+    },
     {
         name: 'manage:ExternalConnection',
         description:


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-566/non-admins-cant-use-external-connections

### Description:
Listing/getting external connections gated on `manage:ExternalConnection` (admin-only), so non-admin app builders got a 403 when selecting an existing connection in the data app builder — even though linking already gates on `manage:DataApp` (not connection-manage) and the picker UI is built for them.

Add a `view:ExternalConnection` scope (interactive_viewer+) and switch the `list`/`get` service paths to a `view` check; create/edit/delete stay on `manage`. This restores the intended three tiers: admins configure connections, builders view/select them, and linking follows app-manage rights.
