### PR TITLE
feat(ai): cap generateVisualization retry loops (ZAP-574)

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -70,6 +70,7 @@ import {
 } from '../utils/errorMessages';
 import { summarizeToolCall, summarizeToolResult } from '../utils/toolSummaries';
 import { getDiscoverFields } from './discoverFields/tool';
+import { buildQueryRetryStepOverride } from './queryRetryCap';
 import { getAgentTelemetryConfig, getAiAgentModelName } from './telemetry';
 
 const createAiAgentLogger =
@@ -228,30 +229,54 @@ const buildPrepareStep = ({
         messages: ModelMessage[];
     }) => {
         const forced = forcedFirstStep?.({ stepNumber }) ?? {};
+
+        const extraMessages: ModelMessage[] = [];
+        let activeTools: string[] | undefined;
+
+        // ZAP-574: bound repeated query-tool failures so a slow/looping
+        // visualization can't stack multi-minute warehouse scans in one turn.
+        const retryOverride = buildQueryRetryStepOverride(
+            messages,
+            Object.keys(tools),
+        );
+        if (retryOverride) {
+            activeTools = retryOverride.activeTools;
+            extraMessages.push({
+                role: 'user' as const,
+                content: retryOverride.nudge,
+            });
+            logger(
+                'Prepare Step',
+                `Query retry cap tripped for prompt UUID: ${args.promptUuid}`,
+            );
+        }
+
         const steers = await dependencies.consumePromptSteers({
             promptUuid: args.promptUuid,
             stepNumber,
         });
+        if (steers.length > 0) {
+            logger(
+                'Prepare Step',
+                `Injecting ${steers.length} steer(s) for prompt UUID: ${args.promptUuid}`,
+            );
+            extraMessages.push({
+                role: 'user' as const,
+                content: [
+                    'Additional guidance from the user while you were working:',
+                    ...steers.map((steer) => `- ${steer.message}`),
+                ].join('\n'),
+            });
+        }
 
-        if (steers.length === 0) return forced;
-
-        logger(
-            'Prepare Step',
-            `Injecting ${steers.length} steer(s) for prompt UUID: ${args.promptUuid}`,
-        );
+        if (extraMessages.length === 0 && activeTools === undefined) {
+            return forced;
+        }
 
         return {
             ...forced,
-            messages: [
-                ...messages,
-                {
-                    role: 'user' as const,
-                    content: [
-                        'Additional guidance from the user while you were working:',
-                        ...steers.map((steer) => `- ${steer.message}`),
-                    ].join('\n'),
-                },
-            ],
+            ...(activeTools !== undefined ? { activeTools } : {}),
+            messages: [...messages, ...extraMessages],
         };
     };
 };

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
@@ -1,0 +1,152 @@
+import type { ModelMessage } from 'ai';
+import { describe, expect, it } from 'vitest';
+import {
+    buildQueryRetryStepOverride,
+    classifyQueryResult,
+    collectQueryResultClasses,
+    QUERY_TOOL_NAMES,
+    shouldCapQueryRetries,
+} from './queryRetryCap';
+
+const toolResultMessage = (
+    toolName: string,
+    output: { type: string; value: string },
+): ModelMessage =>
+    ({
+        role: 'tool',
+        content: [{ type: 'tool-result', toolCallId: 'id', toolName, output }],
+    }) as unknown as ModelMessage;
+
+describe('classifyQueryResult', () => {
+    it('treats a non-error result as ok', () => {
+        expect(classifyQueryResult({ type: 'text', value: 'Total\n42' })).toBe(
+            'ok',
+        );
+    });
+
+    it('classifies a warehouse timeout as warehouse-slow', () => {
+        expect(
+            classifyQueryResult({
+                type: 'error-text',
+                value: 'Error running query. Query polling timed out after 300000ms',
+            }),
+        ).toBe('warehouse-slow');
+    });
+
+    it('classifies a dropped connection as warehouse-slow', () => {
+        expect(
+            classifyQueryResult({
+                type: 'error-text',
+                value: 'Error running query. Connection terminated unexpectedly',
+            }),
+        ).toBe('warehouse-slow');
+    });
+
+    it('classifies an invalid custom metric as fixable', () => {
+        expect(
+            classifyQueryResult({
+                type: 'error-text',
+                value: 'Error running query. Invalid custom metric: unknown field foo',
+            }),
+        ).toBe('fixable');
+    });
+
+    it('classifies an unknown error as other', () => {
+        expect(
+            classifyQueryResult({
+                type: 'error-text',
+                value: 'Error running query. Something inexplicable happened',
+            }),
+        ).toBe('other');
+    });
+});
+
+describe('shouldCapQueryRetries', () => {
+    it('does not cap below the thresholds', () => {
+        expect(shouldCapQueryRetries(['ok', 'fixable']).capped).toBe(false);
+        expect(shouldCapQueryRetries(['warehouse-slow', 'ok']).capped).toBe(
+            false,
+        );
+    });
+
+    it('caps after two warehouse-slow errors', () => {
+        expect(
+            shouldCapQueryRetries(['warehouse-slow', 'warehouse-slow']).capped,
+        ).toBe(true);
+    });
+
+    it('caps after three errors of any kind', () => {
+        expect(
+            shouldCapQueryRetries(['fixable', 'other', 'fixable']).capped,
+        ).toBe(true);
+    });
+
+    it('does not count successful (ok) calls toward the cap', () => {
+        expect(
+            shouldCapQueryRetries(['ok', 'ok', 'ok', 'ok', 'fixable']).capped,
+        ).toBe(false);
+    });
+});
+
+describe('collectQueryResultClasses', () => {
+    it('collects and classifies query-tool results in order', () => {
+        const messages: ModelMessage[] = [
+            toolResultMessage('generateVisualization', {
+                type: 'error-text',
+                value: 'Error running query. Query polling timed out after 300000ms',
+            }),
+            toolResultMessage('grepFields', {
+                type: 'text',
+                value: 'some fields',
+            }),
+            toolResultMessage('runQuery', {
+                type: 'error-text',
+                value: 'Error running query. Invalid custom metric',
+            }),
+        ];
+        expect(collectQueryResultClasses(messages, QUERY_TOOL_NAMES)).toEqual([
+            'warehouse-slow',
+            'fixable',
+        ]);
+    });
+
+    it('ignores non-query tools', () => {
+        const messages: ModelMessage[] = [
+            toolResultMessage('searchFieldValues', {
+                type: 'error-text',
+                value: 'timed out',
+            }),
+        ];
+        expect(collectQueryResultClasses(messages, QUERY_TOOL_NAMES)).toEqual(
+            [],
+        );
+    });
+});
+
+describe('buildQueryRetryStepOverride', () => {
+    const allTools = ['generateVisualization', 'runQuery', 'grepFields'];
+
+    it('returns null when the cap has not tripped', () => {
+        const messages: ModelMessage[] = [
+            toolResultMessage('generateVisualization', {
+                type: 'error-text',
+                value: 'Error running query. Invalid custom metric',
+            }),
+        ];
+        expect(buildQueryRetryStepOverride(messages, allTools)).toBeNull();
+    });
+
+    it('drops the query tools and nudges once tripped', () => {
+        const err = {
+            type: 'error-text',
+            value: 'Error running query. Query polling timed out after 300000ms',
+        };
+        const messages: ModelMessage[] = [
+            toolResultMessage('generateVisualization', err),
+            toolResultMessage('generateVisualization', err),
+        ];
+        const override = buildQueryRetryStepOverride(messages, allTools);
+        expect(override?.activeTools).toEqual(['grepFields']);
+        expect(override?.nudge.toLowerCase()).toContain('do not');
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
@@ -1,0 +1,116 @@
+import type { ModelMessage } from 'ai';
+
+/**
+ * Query-execution tools whose repeated failures we bound within a turn. Both
+ * names resolve to the same underlying runQuery implementation.
+ */
+export const QUERY_TOOL_NAMES: ReadonlySet<string> = new Set([
+    'generateVisualization',
+    'runQuery',
+]);
+
+export type QueryResultClass = 'ok' | 'warehouse-slow' | 'fixable' | 'other';
+
+// A tool result as it appears in the model messages (see toModelOutput):
+// success → { type: 'text' }, error → { type: 'error-text' }.
+type ToolResultOutput = { type: string; value: string };
+
+const WAREHOUSE_SLOW =
+    /timed out|timeout|polling|connection (terminated|lost)|econnreset/i;
+const FIXABLE =
+    /invalid|unknown|not found|custom metric|dimension|filter|axis|chart ?config/i;
+
+/**
+ * Classify a single query-tool result. Only `error-text` outputs count as
+ * failures; a successful result is `ok` and never contributes to the cap.
+ */
+export const classifyQueryResult = (
+    output: ToolResultOutput,
+): QueryResultClass => {
+    if (output.type !== 'error-text') return 'ok';
+    if (WAREHOUSE_SLOW.test(output.value)) return 'warehouse-slow';
+    if (FIXABLE.test(output.value)) return 'fixable';
+    return 'other';
+};
+
+/**
+ * Decide whether to stop the agent re-issuing query tools this turn. Trips on
+ * repeated *failures* only, so legitimate multi-chart turns (several successful
+ * queries) are never capped.
+ *  - ≥2 warehouse-slow: re-running a heavy scan that already timed out won't help.
+ *  - ≥3 errors total: the model is looping instead of converging.
+ */
+export const shouldCapQueryRetries = (
+    classes: QueryResultClass[],
+): { capped: boolean; reason: string } => {
+    const warehouseSlow = classes.filter((c) => c === 'warehouse-slow').length;
+    const errors = classes.filter((c) => c !== 'ok').length;
+    if (warehouseSlow >= 2) {
+        return {
+            capped: true,
+            reason: 'the warehouse query timed out repeatedly',
+        };
+    }
+    if (errors >= 3) {
+        return {
+            capped: true,
+            reason: 'the visualization query failed repeatedly',
+        };
+    }
+    return { capped: false, reason: '' };
+};
+
+/**
+ * Walk the model messages and classify every query-tool result, in order.
+ * Non-query tool results are ignored.
+ */
+export const collectQueryResultClasses = (
+    messages: ModelMessage[],
+    queryToolNames: ReadonlySet<string>,
+): QueryResultClass[] => {
+    const classes: QueryResultClass[] = [];
+    for (const message of messages) {
+        if (message.role === 'tool' && Array.isArray(message.content)) {
+            for (const part of message.content) {
+                if (
+                    part &&
+                    typeof part === 'object' &&
+                    'type' in part &&
+                    part.type === 'tool-result' &&
+                    'toolName' in part &&
+                    queryToolNames.has(part.toolName as string) &&
+                    'output' in part
+                ) {
+                    classes.push(
+                        classifyQueryResult(part.output as ToolResultOutput),
+                    );
+                }
+            }
+        }
+    }
+    return classes;
+};
+
+/**
+ * Given the current model messages and the full tool set, decide the
+ * `prepareStep` override that bounds query-tool retries: returns the reduced
+ * `activeTools` (query tools removed) and a nudge message, or null when the cap
+ * has not tripped. Pure so the `prepareStep` wiring stays trivial.
+ */
+export const buildQueryRetryStepOverride = (
+    messages: ModelMessage[],
+    allToolNames: string[],
+): { activeTools: string[]; nudge: string } | null => {
+    const decision = shouldCapQueryRetries(
+        collectQueryResultClasses(messages, QUERY_TOOL_NAMES),
+    );
+    if (!decision.capped) return null;
+    return {
+        activeTools: allToolNames.filter((name) => !QUERY_TOOL_NAMES.has(name)),
+        nudge: [
+            `The visualization query has repeatedly failed (${decision.reason}).`,
+            'Do not run it again — answer using the information you already have,',
+            'or briefly explain what is blocking the result.',
+        ].join(' '),
+    };
+};


### PR DESCRIPTION
## What

The AI agent loop caps only the *total* step count; there is no per-tool limit. `generateVisualization` (an alias of `runQuery`) returns failures back to the model as errors, so the model simply re-issues the query. When the failure is a slow warehouse query (timeout / dropped connection), the model re-runs the same heavy scan repeatedly, stacking multiple multi-minute executions into a single turn — and, worst case, a user-facing hang.

This adds a **per-turn cap** in the existing `prepareStep` hook:

- `classifyQueryResult` — classifies a query tool result as `ok` / `warehouse-slow` / `fixable` / `other` (only `error-text` outputs count as failures).
- `shouldCapQueryRetries` — trips on **≥2 warehouse-slow** errors (re-running a scan that already timed out won't help) or **≥3 errors total** (the model is looping). Successful queries never count, so legitimate multi-chart turns are unaffected.
- `buildQueryRetryStepOverride` — when tripped, removes the query tools from `activeTools` for the rest of the turn and appends a short nudge telling the model to answer with what it has or explain the blocker.

## Why

Repeated query failures within a turn are a real source of very long turns / hangs. Capping them keeps a failed or slow visualization from monopolising a turn.

## Scope

Just the retry cap. Reducing how often the model generates *invalid custom metrics* in the first place (one driver of the fixable-error retries) is a separate follow-up tracked in ZAP-574.

Out of scope / tracked elsewhere: `searchFieldValues` bounding + fail-fast timeout (ZAP-566 / ZAP-569).

## Testing

- New unit tests (vitest) for the classifier, the cap decision, message extraction, and the step-override builder — all TDD'd (red → green).
- `typecheck:fast` + lint clean; existing agent + tool-contract snapshot tests pass unchanged.

_Context / metrics motivating this live in Linear ZAP-574 (kept out of this repo)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)