### PR TITLE
fix(explore): apply Auto compact number format on dimensions

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -16,7 +16,6 @@ import {
     CalculateSubtotalsFromQuery,
     CalculateTotalFromQuery,
     CompiledDimension,
-    convertCustomFormatToFormatExpression,
     convertFieldRefToFieldId,
     createVirtualView as createVirtualViewObject,
     CreateWarehouseCredentials,
@@ -48,6 +47,7 @@ import {
     getDimensions,
     getDimensionsWithValidParameters,
     getErrorMessage,
+    getFieldFormatOverrideProps,
     getFieldsFromMetricQuery,
     getItemId,
     getItemMap,
@@ -3432,14 +3432,7 @@ export class AsyncQueryService extends ProjectService {
                             key,
                             {
                                 ...value,
-                                // Override the format expression with the metric/dimension query override instead of adding `formatOptions` to the item
-                                // This ensures that legacy `formatOptions` are kept as is and we don't need to change logic over which format takes precedence
-                                format: convertCustomFormatToFormatExpression(
-                                    formatOptions,
-                                ),
-                                // The format expression can't encode the separator, so carry it
-                                // separately for the render paths (getEffectiveSeparator reads it).
-                                separator: formatOptions.separator,
+                                ...getFieldFormatOverrideProps(formatOptions),
                             },
                         ];
                     }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -83,6 +83,7 @@ import {
     getDbtEnvironmentVariableKeyError,
     getDimensions,
     getErrorMessage,
+    getFieldFormatOverrideProps,
     getFields,
     getIntrinsicUserAttributes,
     getItemId,
@@ -5428,12 +5429,15 @@ export class ProjectService extends BaseService {
                             const override =
                                 resolvedMetricOverrides[key] ||
                                 metricQuery.dimensionOverrides?.[key];
-                            if (override) {
+                            const formatOptions = override?.formatOptions;
+                            if (formatOptions) {
                                 return [
                                     key,
                                     {
                                         ...value,
-                                        ...override,
+                                        ...getFieldFormatOverrideProps(
+                                            formatOptions,
+                                        ),
                                     },
                                 ];
                             }

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -28,6 +28,7 @@ import {
     formatValueWithExpression,
     getCustomFormatFromLegacy,
     getEffectiveSeparator,
+    getFieldFormatOverrideProps,
     getFormatExpressionLocale,
     getFormatterTimezone,
     isCalendarValueItem,
@@ -3470,6 +3471,80 @@ describe('Formatting', () => {
                 expect(getFormatExpressionLocale(metric)).toBeUndefined();
                 expect(getFormatExpressionLocale(undefined)).toBeUndefined();
             });
+        });
+    });
+
+    describe('getFieldFormatOverrideProps', () => {
+        const numericDimension: Dimension = {
+            ...dimension,
+            type: DimensionType.NUMBER,
+        };
+
+        test('encodes a non-dynamic override as a format expression, no formatOptions', () => {
+            const props = getFieldFormatOverrideProps({
+                type: CustomFormatType.NUMBER,
+                compact: Compact.THOUSANDS,
+            });
+            expect(props.format).toEqual('#,##0.###,"K"');
+            expect(props.formatOptions).toBeUndefined();
+        });
+
+        test('preserves structured formatOptions for dynamic AUTO compact (no expression form)', () => {
+            const formatOptions: CustomFormat = {
+                type: CustomFormatType.NUMBER,
+                compact: Compact.AUTO,
+            };
+            // AUTO has no ECMA-376 representation, so the expression must be
+            // cleared and the structured options carried through instead.
+            expect(
+                convertCustomFormatToFormatExpression(formatOptions),
+            ).toBeNull();
+            const props = getFieldFormatOverrideProps(formatOptions);
+            expect(props.format).toBeUndefined();
+            expect(props.formatOptions).toEqual(formatOptions);
+        });
+
+        test('preserves structured formatOptions for dynamic AUTO compact on CURRENCY too', () => {
+            const formatOptions: CustomFormat = {
+                type: CustomFormatType.CURRENCY,
+                currency: 'USD',
+                compact: Compact.AUTO,
+            };
+            expect(
+                convertCustomFormatToFormatExpression(formatOptions),
+            ).toBeNull();
+            const props = getFieldFormatOverrideProps(formatOptions);
+            expect(props.format).toBeUndefined();
+            expect(props.formatOptions).toEqual(formatOptions);
+        });
+
+        test('AUTO override on a numeric dimension compacts the value (the reported bug)', () => {
+            const field = {
+                ...numericDimension,
+                ...getFieldFormatOverrideProps({
+                    type: CustomFormatType.NUMBER,
+                    compact: Compact.AUTO,
+                }),
+            };
+            expect(formatItemValue(field, 929_000_000)).toEqual('929M');
+            expect(formatItemValue(field, 1_500)).toEqual('1.5K');
+        });
+
+        test('AUTO override clears a legacy field format expression so it cannot shadow the structured options', () => {
+            // legacy YAML expression that would otherwise win in formatItemValue
+            const fieldWithLegacyFormat = {
+                ...numericDimension,
+                format: '#,##0',
+            };
+            const field = {
+                ...fieldWithLegacyFormat,
+                ...getFieldFormatOverrideProps({
+                    type: CustomFormatType.NUMBER,
+                    compact: Compact.AUTO,
+                }),
+            };
+            // Without clearing the legacy expression this renders '929,000,000'.
+            expect(formatItemValue(field, 929_000_000)).toEqual('929M');
         });
     });
 });

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1125,6 +1125,39 @@ export function convertCustomFormatToFormatExpression(
     );
 }
 
+/**
+ * Converts a UI format override (a metric/dimension `formatOptions`) into the
+ * field-level format props to spread onto a query result field.
+ *
+ * Formats that have an ECMA-376 representation are encoded as a `format`
+ * expression so every render and export path shares a single source of truth.
+ * When there is no expression form — notably dynamic compact (`Compact.AUTO`),
+ * where `convertCustomFormatToFormatExpression` returns null — the structured
+ * `formatOptions` is preserved and any legacy `format` expression cleared,
+ * letting the render path apply it via the structured `applyCompact` path.
+ */
+export function getFieldFormatOverrideProps(formatOptions: CustomFormat): {
+    format: string | undefined;
+    formatOptions?: CustomFormat;
+    separator: NumberSeparator | undefined;
+} {
+    const formatExpression =
+        convertCustomFormatToFormatExpression(formatOptions);
+    if (formatExpression === null) {
+        return {
+            format: undefined,
+            formatOptions,
+            separator: formatOptions.separator,
+        };
+    }
+    return {
+        // The format expression can't encode the separator, so carry it
+        // separately for the render paths (getEffectiveSeparator reads it).
+        format: formatExpression,
+        separator: formatOptions.separator,
+    };
+}
+
 export function getFormatExpression(
     item: Item | AdditionalMetric,
 ): string | undefined {


### PR DESCRIPTION
## Summary

The dynamic **Auto** compact format (`Compact.AUTO` → K/M/B/T) had no effect on a **dimension** in the Explore results table — a column set to Auto still rendered `8,000`, `12,000` instead of `8K`, `12K`. Metrics in the table were affected too.

## Root cause

When applying a UI format override, the backend encoded `formatOptions` as an ECMA-376 `format` expression and dropped the structured options:

```ts
format: convertCustomFormatToFormatExpression(formatOptions), // null for AUTO
```

AUTO has no expression form (the modal even shows *"runtime only"*), so the field ended up with `format: null` and no `formatOptions` → the structured `applyCompact` render path never ran.

## Fix

New shared `getFieldFormatOverrideProps` helper (`packages/common/.../formatting.ts`): for formats with no expression form it keeps the structured `formatOptions` (and clears any legacy `format` string); otherwise output is unchanged. Used in both the async (`AsyncQueryService`) and legacy (`ProjectService`) override loops, removing the drift. No API/schema/frontend change.

## Before / After

Numeric dimension formatted as Number · Compact: Auto:

```
 Before (bug)   After (fix)
   8,000          8K
  12,000         12K
  20,000         20K
```

## Test plan

- [x] `typecheck:fast` (common + backend), formatting suite **179 pass** (5 new helper tests)
- [x] Manual: dimension → Auto in Explore compacts to `8K/12K`; non-AUTO overrides unchanged