### PR TITLE
feat(ai): suggest closest fields on unknown filter field (ZAP-573)

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/suggestClosestFieldIds.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/suggestClosestFieldIds.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { suggestClosestFieldIds } from './suggestClosestFieldIds';
+
+const candidates = [
+    'orders_status',
+    'orders_total_revenue',
+    'customers_status',
+    'customers_country',
+];
+
+describe('suggestClosestFieldIds', () => {
+    it('ranks the closest field ids first by shared tokens', () => {
+        // Target shares "orders" + "status" with orders_status.
+        expect(
+            suggestClosestFieldIds('orders_order_status', candidates)[0],
+        ).toBe('orders_status');
+    });
+
+    it('returns every candidate that shares a token, ranked', () => {
+        // "status" matches both *_status fields; nothing else.
+        expect(suggestClosestFieldIds('status', candidates)).toEqual([
+            'customers_status',
+            'orders_status',
+        ]);
+    });
+
+    it('respects the limit', () => {
+        expect(
+            suggestClosestFieldIds('orders_status', candidates, 1),
+        ).toHaveLength(1);
+    });
+
+    it('returns [] when nothing overlaps', () => {
+        expect(suggestClosestFieldIds('foo_bar', candidates)).toEqual([]);
+    });
+
+    it('is deterministic for equal scores (alphabetical)', () => {
+        // Both share exactly the "status" token → tie → alphabetical order.
+        expect(suggestClosestFieldIds('status', candidates)).toEqual([
+            'customers_status',
+            'orders_status',
+        ]);
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/suggestClosestFieldIds.ts
+++ b/packages/backend/src/ee/services/ai/utils/suggestClosestFieldIds.ts
@@ -1,0 +1,30 @@
+/**
+ * Suggest the field ids closest to `target` from `candidateIds`, ranked by how
+ * many `_`-delimited tokens they share. Deterministic (ties broken
+ * alphabetically) and pure, so it can be dropped into validation error messages
+ * to help the agent repair a filter that references an unknown field.
+ *
+ * Returns at most `limit` ids, and only ones that share at least one token.
+ */
+export const suggestClosestFieldIds = (
+    target: string,
+    candidateIds: string[],
+    limit = 5,
+): string[] => {
+    const targetTokens = new Set(
+        target.toLowerCase().split('_').filter(Boolean),
+    );
+    return candidateIds
+        .map((id) => ({
+            id,
+            shared: id
+                .toLowerCase()
+                .split('_')
+                .filter(Boolean)
+                .filter((token) => targetTokens.has(token)).length,
+        }))
+        .filter((candidate) => candidate.shared > 0)
+        .sort((a, b) => b.shared - a.shared || a.id.localeCompare(b.id))
+        .slice(0, limit)
+        .map((candidate) => candidate.id);
+};

--- a/packages/backend/src/ee/services/ai/utils/validateFilterRules.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateFilterRules.test.ts
@@ -1,0 +1,40 @@
+import { FilterOperator, type FilterRule } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { mockOrdersExplore } from './validationExplore.mock';
+import { validateFilterRules } from './validators';
+
+const filterOn = (fieldId: string): FilterRule =>
+    ({
+        id: 'rule-1',
+        target: { fieldId },
+        operator: FilterOperator.EQUALS,
+        values: ['x'],
+    }) as FilterRule;
+
+describe('validateFilterRules — unknown field suggestions', () => {
+    it('names the closest existing field when a filter targets an unknown one', () => {
+        // "orders_revenue_total" does not exist; the real field is
+        // "orders_total_revenue" (same tokens, reordered).
+        expect(() =>
+            validateFilterRules(mockOrdersExplore, [
+                filterOn('orders_revenue_total'),
+            ]),
+        ).toThrowError(/orders_total_revenue/);
+    });
+
+    it('still reports the field does not exist', () => {
+        expect(() =>
+            validateFilterRules(mockOrdersExplore, [
+                filterOn('orders_revenue_total'),
+            ]),
+        ).toThrowError(/does not exist/);
+    });
+
+    it('accepts a valid filter field without throwing', () => {
+        expect(() =>
+            validateFilterRules(mockOrdersExplore, [
+                filterOn('orders_customer_name'),
+            ]),
+        ).not.toThrow();
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -46,6 +46,7 @@ import {
 import Logger from '../../../../logging/logger';
 import { populateCustomMetricsSQL } from './populateCustomMetricsSQL';
 import { serializeData } from './serializeData';
+import { suggestClosestFieldIds } from './suggestClosestFieldIds';
 /**
  * Validate that all selected fields exist in the explore, custom metrics or table calculations
  * @param explore
@@ -396,10 +397,20 @@ export function validateFilterRules(
         const field = allFields[fieldIndex];
 
         if (!field) {
+            const suggestions = suggestClosestFieldIds(
+                rule.target.fieldId,
+                allFieldIds,
+            );
+            const suggestionText =
+                suggestions.length > 0
+                    ? `\nDid you mean one of these existing fields? ${suggestions.join(
+                          ', ',
+                      )}`
+                    : '';
             filterRuleErrors.push(
                 `Error: the field with id "${
                     rule.target.fieldId
-                }" does not exist.
+                }" does not exist.${suggestionText}
 FilterRule:
 ${serializeData(rule, 'json')}`,
             );


### PR DESCRIPTION
## What

When the agent builds a filter whose `target.fieldId` doesn't exist, `validateFilterRules` rejected it with just:

> `Error: the field with id "X" does not exist.` (+ the rule JSON)

…and **no hint of which fields it could filter on** — so the model guesses again (retry loop) or gives up. This enriches that error with the **closest existing filterable field ids**, so the model repairs the filter in one shot.

- `suggestClosestFieldIds(target, candidateIds, limit)` — pure, deterministic ranking by shared `_`-delimited name tokens (ties broken alphabetically); returns only real overlaps.
- Wired into the unknown-field branch of `validateFilterRules`, drawing suggestions from the fields already enumerated there.

## Why

Filter errors are the largest `generateVisualization` failure category; a bare "field does not exist" gives the model nothing to correct against. A short "did you mean …" list turns a dead-end into a one-retry fix.

## Scope

This is the deterministic half of ZAP-573. The other reading — detecting a filter the model *claims* it applied but silently omitted — needs intent inference / an LLM self-check and is a separate follow-up on the ticket.

## Testing

- New unit tests (vitest) for `suggestClosestFieldIds` (ranking, limit, no-overlap, determinism) and for `validateFilterRules` (unknown field → error names the closest real field; valid field → no throw) — TDD'd red → green.
- `typecheck:fast` + lint clean; all 119 `ee/services/ai/utils` tests pass.

_Context / metrics motivating this live in Linear ZAP-573 (kept out of this repo)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)