### PR TITLE
feat(ai): flag competing metric definitions in grepFields (ZAP-572)

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/grepFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFields.ts
@@ -4,6 +4,7 @@ import type { FindExploresFn } from '../types/aiAgentDependencies';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
     buildFieldIndex,
+    buildMetricAmbiguityNote,
     compileMatcher,
     summarizeRequiredFilters,
     type FieldEntry,
@@ -108,9 +109,11 @@ const renderPattern = (
         hits.length > MAX_PER_PATTERN
             ? ` (showing ${MAX_PER_PATTERN} of ${hits.length})`
             : '';
+    const body = renderHits(hits, requiredFiltersByExplore);
+    const ambiguityNote = buildMetricAmbiguityNote(hits);
     return `/${pattern}/ — ${hits.length} match${
         hits.length === 1 ? '' : 'es'
-    }${capped}:\n${renderHits(hits, requiredFiltersByExplore)}`;
+    }${capped}:\n${body}${ambiguityNote ? `\n${ambiguityNote}` : ''}`;
 };
 
 /**

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.metricAmbiguity.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.metricAmbiguity.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildMetricAmbiguityNote, type FieldEntry } from './grepFieldsIndex';
+
+const entry = (over: Partial<FieldEntry>): FieldEntry => ({
+    exploreName: 'explore_a',
+    exploreLabel: 'Explore A',
+    path: 'explore_a/a_metric',
+    kind: 'metric',
+    type: 'number',
+    label: 'A metric',
+    description: '',
+    aiHint: '',
+    haystack: '',
+    verifiedUsage: 0,
+    ...over,
+});
+
+describe('buildMetricAmbiguityNote', () => {
+    it('flags competing metrics across ≥2 explores when none is verified', () => {
+        const note = buildMetricAmbiguityNote([
+            entry({ exploreName: 'rpt_conversion_events' }),
+            entry({ exploreName: 'fct_conversion_events' }),
+        ]);
+        expect(note).not.toBeNull();
+        expect(note).toMatch(/2 metrics/);
+        expect(note).toMatch(/which metric and explore/i);
+    });
+
+    it('does not flag when all metric hits are in one explore', () => {
+        expect(
+            buildMetricAmbiguityNote([
+                entry({ exploreName: 'rpt_x', path: 'rpt_x/m1' }),
+                entry({ exploreName: 'rpt_x', path: 'rpt_x/m2' }),
+            ]),
+        ).toBeNull();
+    });
+
+    it('does not flag when a verified metric is present', () => {
+        expect(
+            buildMetricAmbiguityNote([
+                entry({ exploreName: 'rpt_a', verifiedUsage: 3 }),
+                entry({ exploreName: 'fct_b' }),
+            ]),
+        ).toBeNull();
+    });
+
+    it('ignores dimensions (only metrics compete here)', () => {
+        expect(
+            buildMetricAmbiguityNote([
+                entry({ exploreName: 'rpt_a', kind: 'dimension' }),
+                entry({ exploreName: 'fct_b', kind: 'dimension' }),
+            ]),
+        ).toBeNull();
+    });
+
+    it('does not flag a single metric hit', () => {
+        expect(buildMetricAmbiguityNote([entry({})])).toBeNull();
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
@@ -243,3 +243,20 @@ export const renderCandidateBlock = (candidates: FieldEntry[]): string => {
         ...blocks,
     ].join('\n');
 };
+
+/**
+ * When a grep pattern surfaces several metric definitions of the same measure
+ * across explores and none is verified, the agent has no governance signal to
+ * pick between them and may silently choose the wrong one. Return a one-line
+ * note nudging it to prefer a verified / governed metric and to state which one
+ * it used. Additive — it does NOT reorder results, so it cannot make an
+ * otherwise-correct pick worse. Null when there is nothing ambiguous to flag.
+ */
+export const buildMetricAmbiguityNote = (hits: FieldEntry[]): string | null => {
+    const metricHits = hits.filter((h) => h.kind === 'metric');
+    if (metricHits.length < 2) return null;
+    if (metricHits.some((h) => h.verifiedUsage > 0)) return null;
+    const explores = new Set(metricHits.map((h) => h.exploreName));
+    if (explores.size < 2) return null;
+    return `⚠ ${metricHits.length} metrics across ${explores.size} explores match — likely competing definitions of the same measure, and none is ✓verified. Prefer a verified metric if one exists; otherwise pick the most governed explore (e.g. a reporting "rpt_" model) and state in your answer which metric and explore you used.`;
+};


### PR DESCRIPTION
## What

When one measure has several metric definitions spread across explores and **none is verified**, `grepFields` returned a flat (verified-first) ranked list and the model would silently pick one — often a different definition run-to-run.

This appends a **deterministic disambiguation note** to a grep pattern's output when its **metric** hits span **≥2 explores** and **none is `✓verified`**:

> ⚠ N metrics across M explores match — likely competing definitions of the same measure, and none is ✓verified. Prefer a verified metric if one exists; otherwise pick the most governed explore (e.g. a reporting `rpt_` model) and state in your answer which metric and explore you used.

## Why

The largest remaining accuracy gap is the agent confidently choosing between competing, ungoverned metric definitions. This nudges it toward the governed one **and** forces it to surface which definition it used — turning a silently-wrong answer into a transparent one.

## Safety

**Additive only** — it does not reorder or drop results, so it cannot make an otherwise-correct pick worse. Worst case the model ignores the note.

## Scope / follow-ups (on ZAP-572)

- **Usage-based ranking** (rank competing metrics by `chart_usage`, which works even without verified content) — deliberately left out here because it *reorders* results; it should ship **feature-flagged + eval-gated** so it's proven not to regress.
- `query_history`-based usage — stronger/broader signal but heavier and risks an AI-query feedback loop; later.
- A true certified-metric flag — product-level.

## Testing

- New unit tests (vitest) for `buildMetricAmbiguityNote` (flags ≥2 metrics/≥2 explores with none verified; null for single-explore, verified-present, dimensions-only, single-hit) — TDD'd red → green.
- `typecheck:fast` + lint clean; all `ee/services/ai/tools` tests pass.

_Context / metrics motivating this live in Linear ZAP-572 (kept out of this repo)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)