### PR TITLE
fix(apps): copy external connection links when duplicating a data app

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -802,6 +802,8 @@ External connections let a project admin register a third-party HTTP API (base U
 
 A connection lives on the `external_connections` table (`packages/backend/src/ee/database/entities/externalConnections.ts`), scoped to a project. It stores a human-readable **alias**, a **base URL** (origin), the auth method, and an **encrypted secret** (never returned to the client — stripped on read, only decrypted server-side for an actual fetch). Apps opt into a connection by linking it (`app_external_connections`); an app can reference a connection's data only after the admin links it.
 
+Runtime fetches resolve the alias against `app_external_connections` (`resolveAppAlias`), so the link rows — not the version `resources` snapshot — are what grant an app access. When an app is **duplicated** (`AppGenerateService.duplicateApp`), its live links are copied onto the new app so the duplicate can make the same external fetches; both apps share a project, so the connection UUIDs stay valid. (Cross-project copies — `promoteApp`, `duplicateAppsForPreview` — deliberately don't copy link rows, since the target project's connections are different entities.)
+
 ### Proxy security model
 
 The sandboxed preview iframe has no network access of its own (`default-src 'none'` CSP, opaque origin). External fetches therefore route through the same parent → backend proxy path as metric queries:

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -4939,9 +4939,22 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             );
         }
 
-        const resources = AppGenerateService.buildCopiedResources(
-            sourceVersion.resources ?? null,
+        const sourceLinks = await this.externalConnectionModel.listAppLinks(
+            sourceApp.app_id,
         );
+        const externalConnectionResources: AppVersionExternalConnectionResource[] =
+            sourceLinks.map((link) => ({
+                externalConnectionUuid: link.connection.externalConnectionUuid,
+                name: link.connection.name,
+                alias: link.alias,
+            }));
+
+        const resources: AppVersionResources = {
+            ...AppGenerateService.buildCopiedResources(
+                sourceVersion.resources ?? null,
+            ),
+            externalConnections: externalConnectionResources,
+        };
 
         const newAppUuid = uuidv4();
         const newVersion = 1;
@@ -4977,6 +4990,10 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 { version: newVersion, prompt: duplicatePrompt },
                 'ready',
                 resources,
+            );
+            await this.linkResolvedExternalConnections(
+                newAppUuid,
+                externalConnectionResources,
             );
             await this.appModel.updateStatusMessage(
                 newAppUuid,


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-548/duplicating-apps-not-considering-external-connections

### Description:
duplicateApp copied the version resources.externalConnections snapshot but never re-created the app_external_connections link rows. Those rows are what runtime fetches resolve against (resolveAppAlias) and what the connections panel lists (listAppLinks), so a duplicated app showed no connections and every external fetch failed with "not linked to the requested connection".

Read the source app's live links and re-link them onto the duplicate (same project, so the connection UUIDs stay valid), deriving the version snapshot from the same links so chat chips match. Cross-project copies (promoteApp, duplicateAppsForPreview) intentionally still don't copy link rows.
