### PR TITLE
feat(data-apps): save an app query to Lightdash

### DIFF
--- a/packages/frontend/src/features/apps/AppInspector.module.css
+++ b/packages/frontend/src/features/apps/AppInspector.module.css
@@ -198,12 +198,6 @@
     min-width: 0;
 }
 
-.openInExplore {
-    position: absolute;
-    top: var(--mantine-spacing-xs);
-    right: var(--mantine-spacing-sm);
-}
-
 .rawJsonPanel {
     padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
     flex-shrink: 0;

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -329,11 +329,10 @@ const QueryRow: FC<{
                     )}
                 </Group>
             </Collapse>
-            {query.exploreName && query.rawMetricQuery && (
+            {saveOpen && query.rawMetricQuery && (
                 <SaveQueryToLightdashModal
                     query={query}
                     projectUuid={projectUuid}
-                    opened={saveOpen}
                     onClose={() => setSaveOpen(false)}
                 />
             )}

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -77,6 +77,10 @@ const QueryRow: FC<{
         }
     }, [focused]);
 
+    const exploreUrl = query.exploreName
+        ? buildExploreUrl(projectUuid, query)
+        : null;
+
     return (
         <Box
             ref={rowRef}
@@ -132,28 +136,22 @@ const QueryRow: FC<{
                     <Box className={classes.queryDetails}>
                         {query.exploreName && (
                             <Group gap="md" wrap="nowrap">
-                                {(() => {
-                                    const exploreUrl = buildExploreUrl(
-                                        projectUuid,
-                                        query,
-                                    );
-                                    return exploreUrl ? (
-                                        <Anchor
-                                            href={exploreUrl}
-                                            target="_blank"
-                                            size="xs"
-                                            onClick={(e) => e.stopPropagation()}
-                                        >
-                                            <Group gap={4} wrap="nowrap">
-                                                <MantineIcon
-                                                    icon={IconExternalLink}
-                                                    size={12}
-                                                />
-                                                Open in Explore
-                                            </Group>
-                                        </Anchor>
-                                    ) : null;
-                                })()}
+                                {exploreUrl && (
+                                    <Anchor
+                                        href={exploreUrl}
+                                        target="_blank"
+                                        size="xs"
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        <Group gap={4} wrap="nowrap">
+                                            <MantineIcon
+                                                icon={IconExternalLink}
+                                                size={12}
+                                            />
+                                            Open in Explore
+                                        </Group>
+                                    </Anchor>
+                                )}
                                 {query.rawMetricQuery && (
                                     <Anchor
                                         component="button"

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -154,23 +154,25 @@ const QueryRow: FC<{
                                         </Anchor>
                                     ) : null;
                                 })()}
-                                <Anchor
-                                    component="button"
-                                    type="button"
-                                    size="xs"
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        setSaveOpen(true);
-                                    }}
-                                >
-                                    <Group gap={4} wrap="nowrap">
-                                        <MantineIcon
-                                            icon={IconDeviceFloppy}
-                                            size={12}
-                                        />
-                                        Save to Lightdash
-                                    </Group>
-                                </Anchor>
+                                {query.rawMetricQuery && (
+                                    <Anchor
+                                        component="button"
+                                        type="button"
+                                        size="xs"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            setSaveOpen(true);
+                                        }}
+                                    >
+                                        <Group gap={4} wrap="nowrap">
+                                            <MantineIcon
+                                                icon={IconDeviceFloppy}
+                                                size={12}
+                                            />
+                                            Save to Lightdash
+                                        </Group>
+                                    </Anchor>
+                                )}
                             </Group>
                         )}
                         {query.exploreName && (
@@ -327,7 +329,7 @@ const QueryRow: FC<{
                     )}
                 </Group>
             </Collapse>
-            {query.exploreName && (
+            {query.exploreName && query.rawMetricQuery && (
                 <SaveQueryToLightdashModal
                     query={query}
                     projectUuid={projectUuid}

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -142,7 +142,6 @@ const QueryRow: FC<{
                                             href={exploreUrl}
                                             target="_blank"
                                             size="xs"
-                                            className={classes.openInExplore}
                                             onClick={(e) => e.stopPropagation()}
                                         >
                                             <Group gap={4} wrap="nowrap">
@@ -159,7 +158,6 @@ const QueryRow: FC<{
                                     component="button"
                                     type="button"
                                     size="xs"
-                                    className={classes.openInExplore}
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         setSaveOpen(true);

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -1,4 +1,3 @@
-import { ChartType, type CreateSavedChartVersion } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -15,6 +14,7 @@ import {
     IconChevronDown,
     IconChevronRight,
     IconCopy,
+    IconDeviceFloppy,
     IconExternalLink,
 } from '@tabler/icons-react';
 import { useEffect, useRef, useState, type FC } from 'react';
@@ -22,6 +22,8 @@ import MantineIcon from '../../components/common/MantineIcon';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import classes from './AppInspector.module.css';
 import type { QueryEvent } from './hooks/useAppSdkBridge';
+import SaveQueryToLightdashModal from './SaveQueryToLightdashModal';
+import { trackedQueryToChartVersion } from './utils/trackedQueryToChart';
 
 type TrackedQuery = QueryEvent & {
     /** Merged from the initial POST + subsequent poll results */
@@ -46,31 +48,7 @@ const buildExploreUrl = (
     query: TrackedQuery,
 ): string | null => {
     if (!query.exploreName) return null;
-    const chartVersion: CreateSavedChartVersion = {
-        tableName: query.exploreName,
-        metricQuery: {
-            exploreName: query.exploreName,
-            dimensions: query.dimensions,
-            metrics: query.metrics,
-            filters:
-                (query.filters as CreateSavedChartVersion['metricQuery']['filters']) ??
-                {},
-            sorts:
-                (query.sorts as CreateSavedChartVersion['metricQuery']['sorts']) ??
-                [],
-            limit: query.limit,
-            tableCalculations: query.tableCalculations.map((tc) => ({
-                name: tc.name,
-                displayName: tc.displayName,
-                sql: tc.sql,
-            })),
-        },
-        chartConfig: {
-            type: ChartType.TABLE,
-            config: {},
-        },
-        tableConfig: { columnOrder: [] },
-    };
+    const chartVersion = trackedQueryToChartVersion(query);
     const { pathname, search } = getExplorerUrlFromCreateSavedChartVersion(
         projectUuid,
         chartVersion,
@@ -86,6 +64,7 @@ const QueryRow: FC<{
 }> = ({ query, projectUuid, onHover, focused }) => {
     const [expanded, setExpanded] = useState(false);
     const [jsonExpanded, setJsonExpanded] = useState(false);
+    const [saveOpen, setSaveOpen] = useState(false);
     const rowRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -151,29 +130,51 @@ const QueryRow: FC<{
                     className={classes.queryDetailsRow}
                 >
                     <Box className={classes.queryDetails}>
-                        {(() => {
-                            const exploreUrl = buildExploreUrl(
-                                projectUuid,
-                                query,
-                            );
-                            return exploreUrl ? (
+                        {query.exploreName && (
+                            <Group gap="md" wrap="nowrap">
+                                {(() => {
+                                    const exploreUrl = buildExploreUrl(
+                                        projectUuid,
+                                        query,
+                                    );
+                                    return exploreUrl ? (
+                                        <Anchor
+                                            href={exploreUrl}
+                                            target="_blank"
+                                            size="xs"
+                                            className={classes.openInExplore}
+                                            onClick={(e) => e.stopPropagation()}
+                                        >
+                                            <Group gap={4} wrap="nowrap">
+                                                <MantineIcon
+                                                    icon={IconExternalLink}
+                                                    size={12}
+                                                />
+                                                Open in Explore
+                                            </Group>
+                                        </Anchor>
+                                    ) : null;
+                                })()}
                                 <Anchor
-                                    href={exploreUrl}
-                                    target="_blank"
+                                    component="button"
+                                    type="button"
                                     size="xs"
                                     className={classes.openInExplore}
-                                    onClick={(e) => e.stopPropagation()}
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        setSaveOpen(true);
+                                    }}
                                 >
-                                    <Group gap={4}>
+                                    <Group gap={4} wrap="nowrap">
                                         <MantineIcon
-                                            icon={IconExternalLink}
+                                            icon={IconDeviceFloppy}
                                             size={12}
                                         />
-                                        Open in Explore
+                                        Save to Lightdash
                                     </Group>
                                 </Anchor>
-                            ) : null;
-                        })()}
+                            </Group>
+                        )}
                         {query.exploreName && (
                             <Box>
                                 <Text size="xs" fw={600} c="dimmed">
@@ -328,6 +329,14 @@ const QueryRow: FC<{
                     )}
                 </Group>
             </Collapse>
+            {query.exploreName && (
+                <SaveQueryToLightdashModal
+                    query={query}
+                    projectUuid={projectUuid}
+                    opened={saveOpen}
+                    onClose={() => setSaveOpen(false)}
+                />
+            )}
         </Box>
     );
 };

--- a/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
+++ b/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
@@ -66,7 +66,7 @@ const SaveQueryToLightdashModal: FC<Props> = ({
             onConfirm={handleSave}
             confirmLabel="Save"
             confirmLoading={createChart.isLoading}
-            confirmDisabled={!name.trim()}
+            confirmDisabled={!name.trim() || !selectedSpace}
         >
             <Stack gap="sm">
                 <TextInput

--- a/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
+++ b/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
@@ -46,15 +46,16 @@ const SaveQueryToLightdashModal: FC<Props> = ({
 
     const handleSave = () => {
         if (!name.trim()) return;
-        createChart.mutate(
-            trackedQueryToCreateChart(query, {
-                name: name.trim(),
-                spaceUuid: selectedSpace ?? undefined,
-            }),
+        const payload = trackedQueryToCreateChart(query, {
+            name: name.trim(),
+            spaceUuid: selectedSpace ?? undefined,
+        });
+        if (!payload) return;
+        createChart.mutate(payload, {
             // The hook's own onSuccess shows the toast + "View chart" action;
             // this per-call handler just closes the modal.
-            { onSuccess: () => onClose() },
-        );
+            onSuccess: () => onClose(),
+        });
     };
 
     return (

--- a/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
+++ b/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
@@ -1,0 +1,98 @@
+import { Select, Stack, TextInput } from '@mantine-8/core';
+import { IconDeviceFloppy } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import MantineModal from '../../components/common/MantineModal';
+import { useCreateMutation } from '../../hooks/useSavedQuery';
+import { useSpaceSummaries } from '../../hooks/useSpaces';
+import type { QueryEvent } from './hooks/useAppSdkBridge';
+import { trackedQueryToCreateChart } from './utils/trackedQueryToChart';
+
+type Props = {
+    query: QueryEvent;
+    projectUuid: string;
+    opened: boolean;
+    onClose: () => void;
+};
+
+/**
+ * Saves a tracked app query as a governed Lightdash table chart. Lives in the
+ * Query Inspector (host chrome) — the sandboxed app never sees it. Reuses the
+ * standard create-chart mutation, which shows the success toast + "View chart"
+ * action and surfaces permission errors, so this modal only collects a name +
+ * target space.
+ */
+const SaveQueryToLightdashModal: FC<Props> = ({
+    query,
+    projectUuid,
+    opened,
+    onClose,
+}) => {
+    const { data: spaces, isLoading: spacesLoading } =
+        useSpaceSummaries(projectUuid);
+    const createChart = useCreateMutation({ redirectOnSuccess: false });
+
+    const [name, setName] = useState(
+        query.label || query.exploreName || 'Untitled query',
+    );
+    const [spaceUuid, setSpaceUuid] = useState<string | null>(null);
+
+    const spaceOptions = useMemo(
+        () => (spaces ?? []).map((s) => ({ value: s.uuid, label: s.name })),
+        [spaces],
+    );
+    // Derived (not synced state): default to the first accessible space until
+    // the user picks one.
+    const selectedSpace = spaceUuid ?? spaceOptions[0]?.value ?? null;
+
+    const handleSave = () => {
+        if (!name.trim()) return;
+        createChart.mutate(
+            trackedQueryToCreateChart(query, {
+                name: name.trim(),
+                spaceUuid: selectedSpace ?? undefined,
+            }),
+            // The hook's own onSuccess shows the toast + "View chart" action;
+            // this per-call handler just closes the modal.
+            { onSuccess: () => onClose() },
+        );
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Save to Lightdash"
+            icon={IconDeviceFloppy}
+            size="sm"
+            onConfirm={handleSave}
+            confirmLabel="Save"
+            confirmLoading={createChart.isLoading}
+            confirmDisabled={!name.trim()}
+        >
+            <Stack gap="sm">
+                <TextInput
+                    label="Chart name"
+                    placeholder="e.g. Weekly revenue"
+                    required
+                    value={name}
+                    onChange={(e) => setName(e.currentTarget.value)}
+                    data-autofocus
+                />
+                <Select
+                    label="Space"
+                    placeholder={
+                        spacesLoading ? 'Loading spaces…' : 'Select a space'
+                    }
+                    data={spaceOptions}
+                    value={selectedSpace}
+                    onChange={setSpaceUuid}
+                    disabled={spacesLoading}
+                    searchable
+                    nothingFoundMessage="No spaces found"
+                />
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export default SaveQueryToLightdashModal;

--- a/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
+++ b/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
@@ -10,7 +10,6 @@ import { trackedQueryToCreateChart } from './utils/trackedQueryToChart';
 type Props = {
     query: QueryEvent;
     projectUuid: string;
-    opened: boolean;
     onClose: () => void;
 };
 
@@ -24,7 +23,6 @@ type Props = {
 const SaveQueryToLightdashModal: FC<Props> = ({
     query,
     projectUuid,
-    opened,
     onClose,
 }) => {
     const { data: spaces, isLoading: spacesLoading } =
@@ -60,7 +58,7 @@ const SaveQueryToLightdashModal: FC<Props> = ({
 
     return (
         <MantineModal
-            opened={opened}
+            opened
             onClose={onClose}
             title="Save to Lightdash"
             icon={IconDeviceFloppy}

--- a/packages/frontend/src/features/apps/utils/trackedQueryToChart.test.ts
+++ b/packages/frontend/src/features/apps/utils/trackedQueryToChart.test.ts
@@ -1,0 +1,75 @@
+import { ChartType } from '@lightdash/common';
+import type { QueryEvent } from '../hooks/useAppSdkBridge';
+import {
+    trackedQueryToChartVersion,
+    trackedQueryToCreateChart,
+} from './trackedQueryToChart';
+
+const makeQuery = (overrides: Partial<QueryEvent> = {}): QueryEvent => ({
+    id: 'q1',
+    timestamp: 0,
+    label: 'Weekly revenue',
+    exploreName: 'orders',
+    dimensions: ['orders_order_date'],
+    metrics: ['orders_total_revenue'],
+    filters: { dimensions: { id: 'g', and: [] } },
+    sorts: [{ fieldId: 'orders_total_revenue', descending: true }],
+    tableCalculations: [{ name: 'growth', displayName: 'Growth', sql: '1' }],
+    additionalMetrics: [],
+    limit: 500,
+    queryUuid: 'uuid-1',
+    status: 'ready',
+    rowCount: 10,
+    durationMs: 5,
+    error: null,
+    rawMetricQuery: null,
+    ...overrides,
+});
+
+describe('trackedQueryToChartVersion', () => {
+    it('maps a plain table chart version with derived column order', () => {
+        const v = trackedQueryToChartVersion(makeQuery());
+        expect(v.tableName).toBe('orders');
+        expect(v.chartConfig).toEqual({ type: ChartType.TABLE, config: {} });
+        // dimensions, then metrics, then table-calc names
+        expect(v.tableConfig.columnOrder).toEqual([
+            'orders_order_date',
+            'orders_total_revenue',
+            'growth',
+        ]);
+        expect(v.metricQuery.exploreName).toBe('orders');
+        expect(v.metricQuery.limit).toBe(500);
+        expect(v.metricQuery.tableCalculations).toEqual([
+            { name: 'growth', displayName: 'Growth', sql: '1' },
+        ]);
+    });
+
+    it('defaults missing filters/sorts to empty', () => {
+        const v = trackedQueryToChartVersion(
+            makeQuery({
+                filters: undefined,
+                sorts: [],
+            }),
+        );
+        expect(v.metricQuery.filters).toEqual({});
+        expect(v.metricQuery.sorts).toEqual([]);
+    });
+});
+
+describe('trackedQueryToCreateChart', () => {
+    it('adds name + space and marks it a space chart (dashboardUuid null)', () => {
+        const c = trackedQueryToCreateChart(makeQuery(), {
+            name: 'My chart',
+            spaceUuid: 'space-1',
+        });
+        expect(c.name).toBe('My chart');
+        expect(c.spaceUuid).toBe('space-1');
+        expect(c.dashboardUuid).toBeNull();
+        expect(c.tableName).toBe('orders');
+    });
+
+    it('omits space when not provided (backend picks the default space)', () => {
+        const c = trackedQueryToCreateChart(makeQuery(), { name: 'X' });
+        expect(c.spaceUuid).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/features/apps/utils/trackedQueryToChart.test.ts
+++ b/packages/frontend/src/features/apps/utils/trackedQueryToChart.test.ts
@@ -57,19 +57,47 @@ describe('trackedQueryToChartVersion', () => {
 });
 
 describe('trackedQueryToCreateChart', () => {
-    it('adds name + space and marks it a space chart (dashboardUuid null)', () => {
-        const c = trackedQueryToCreateChart(makeQuery(), {
+    const rawMetricQuery = {
+        exploreName: 'orders',
+        dimensions: ['orders_order_date'],
+        metrics: ['orders_total_revenue'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [
+            { name: 'growth', displayName: 'Growth', sql: '1' },
+        ],
+        additionalMetrics: [{ name: 'adhoc' }],
+        customDimensions: [],
+    };
+
+    it('adds name + space and persists the exact raw metric query', () => {
+        const c = trackedQueryToCreateChart(makeQuery({ rawMetricQuery }), {
             name: 'My chart',
             spaceUuid: 'space-1',
         });
-        expect(c.name).toBe('My chart');
-        expect(c.spaceUuid).toBe('space-1');
-        expect(c.dashboardUuid).toBeNull();
-        expect(c.tableName).toBe('orders');
+        expect(c).not.toBeNull();
+        expect(c?.name).toBe('My chart');
+        expect(c?.description).toBe('');
+        expect(c?.spaceUuid).toBe('space-1');
+        expect(c?.dashboardUuid).toBeNull();
+        expect(c?.tableName).toBe('orders');
+        // faithful: the app's exact query, keeping additionalMetrics
+        expect(c?.metricQuery).toBe(rawMetricQuery);
     });
 
     it('omits space when not provided (backend picks the default space)', () => {
-        const c = trackedQueryToCreateChart(makeQuery(), { name: 'X' });
-        expect(c.spaceUuid).toBeUndefined();
+        const c = trackedQueryToCreateChart(makeQuery({ rawMetricQuery }), {
+            name: 'X',
+        });
+        expect(c?.spaceUuid).toBeUndefined();
+    });
+
+    it('returns null without a captured query (e.g. linked-chart rows)', () => {
+        expect(
+            trackedQueryToCreateChart(makeQuery({ rawMetricQuery: null }), {
+                name: 'X',
+            }),
+        ).toBeNull();
     });
 });

--- a/packages/frontend/src/features/apps/utils/trackedQueryToChart.ts
+++ b/packages/frontend/src/features/apps/utils/trackedQueryToChart.ts
@@ -51,13 +51,26 @@ export const trackedQueryToChartVersion = (
  * Build a full `CreateSavedChart` (a table chart) from a tracked app query,
  * adding a name and target space. Posted to `POST /projects/{uuid}/saved`.
  * Omit `spaceUuid` to let the backend pick the user's first viewable space.
+ *
+ * Returns `null` when the row has no `rawMetricQuery` — only inline app queries
+ * (POST /query/metric-query) capture one. Linked-chart rows (POST /query/chart)
+ * don't, and they're already governed charts, so they aren't savable here.
  */
 export const trackedQueryToCreateChart = (
     query: QueryEvent,
     opts: { name: string; spaceUuid?: string },
-): CreateSavedChart => ({
-    ...trackedQueryToChartVersion(query),
-    name: opts.name,
-    spaceUuid: opts.spaceUuid,
-    dashboardUuid: null,
-});
+): CreateSavedChart | null => {
+    if (!query.exploreName || !query.rawMetricQuery) return null;
+    return {
+        ...trackedQueryToChartVersion(query),
+        // Persist the EXACT query the app ran — this keeps additionalMetrics /
+        // customDimensions that the discrete inspector fields drop (a chart
+        // referencing an ad-hoc metric it doesn't define would be broken).
+        metricQuery:
+            query.rawMetricQuery as unknown as CreateSavedChartVersion['metricQuery'],
+        name: opts.name,
+        description: '',
+        spaceUuid: opts.spaceUuid,
+        dashboardUuid: null,
+    };
+};

--- a/packages/frontend/src/features/apps/utils/trackedQueryToChart.ts
+++ b/packages/frontend/src/features/apps/utils/trackedQueryToChart.ts
@@ -1,0 +1,63 @@
+import {
+    ChartType,
+    type CreateSavedChart,
+    type CreateSavedChartVersion,
+} from '@lightdash/common';
+import type { QueryEvent } from '../hooks/useAppSdkBridge';
+
+/**
+ * Build a table-chart *version* (viz config + metric query) from a tracked app
+ * query. Shared by the Query Inspector's "Open in Explore" link and its
+ * "Save to Lightdash" action so both map a query the same way.
+ *
+ * A tracked query's `filters`/`sorts`/field ids are already in backend
+ * `MetricQuery` shape (the SDK converts them before the bridge captures them),
+ * so no reconciliation is needed — the only synthesis is the viz defaults
+ * (a plain TABLE) and an explicit `columnOrder` derived from the query fields.
+ */
+export const trackedQueryToChartVersion = (
+    query: QueryEvent,
+): CreateSavedChartVersion => {
+    const columnOrder = [
+        ...query.dimensions,
+        ...query.metrics,
+        ...query.tableCalculations.map((tc) => tc.name),
+    ];
+    return {
+        tableName: query.exploreName,
+        metricQuery: {
+            exploreName: query.exploreName,
+            dimensions: query.dimensions,
+            metrics: query.metrics,
+            filters:
+                (query.filters as CreateSavedChartVersion['metricQuery']['filters']) ??
+                {},
+            sorts:
+                (query.sorts as CreateSavedChartVersion['metricQuery']['sorts']) ??
+                [],
+            limit: query.limit,
+            tableCalculations: query.tableCalculations.map((tc) => ({
+                name: tc.name,
+                displayName: tc.displayName,
+                sql: tc.sql,
+            })),
+        },
+        chartConfig: { type: ChartType.TABLE, config: {} },
+        tableConfig: { columnOrder },
+    };
+};
+
+/**
+ * Build a full `CreateSavedChart` (a table chart) from a tracked app query,
+ * adding a name and target space. Posted to `POST /projects/{uuid}/saved`.
+ * Omit `spaceUuid` to let the backend pick the user's first viewable space.
+ */
+export const trackedQueryToCreateChart = (
+    query: QueryEvent,
+    opts: { name: string; spaceUuid?: string },
+): CreateSavedChart => ({
+    ...trackedQueryToChartVersion(query),
+    name: opts.name,
+    spaceUuid: opts.spaceUuid,
+    dashboardUuid: null,
+});


### PR DESCRIPTION
## What

Adds a **"Save to Lightdash"** action to each row in the app **Query Inspector**, next to "Open in Explore". It opens a small modal (chart name + target space) and creates a governed **table** saved chart from the query the app ran.

## How

- **No backend / SDK / bridge change.** Host-side Lightdash UI using the normal authenticated API (`POST /projects/{uuid}/saved`); the sandboxed app gets no write access.
- `trackedQueryToChart` — shared mapping (`TrackedQuery` → table `CreateSavedChart`), now also backing the existing "Open in Explore" link. `columnOrder` derived from the query fields; the query's `filters`/`sorts` are already in backend `MetricQuery` shape (the SDK converts before the bridge captures them), so no reconciliation is needed.
- `SaveQueryToLightdashModal` — reuses the standard create-chart mutation (`useCreateMutation`: success toast + "View chart" action, permission errors) and `useSpaceSummaries` for the space picker (defaults to the first accessible space; `spaceUuid` optional → backend picks a default).

## Scope / follow-ups

Out of scope (per the ticket): the GLITCH-534 relink-after-save loop; an app-callable SDK writer; non-table viz; filter richness beyond what the SDK captured.

## Test plan

- Unit: `trackedQueryToChart` mapping (derived columnOrder, table config, name/space).
- Manual: run an app → Queries inspector → **Save to Lightdash** → chart opens as a table in Lightdash; save respects space create-permission.

Closes: GLITCH-533
Relates: PROD-7940
Relates: #23520
