### PR TITLE
fix(ai-copilot): skip AI agents probe when Copilot is disabled

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts
@@ -15,7 +15,9 @@ export const useDefaultAiAgent = (projectUuid: string | undefined) => {
         options: {
             enabled:
                 aiOrganizationSettingsQuery.isSuccess &&
-                aiOrganizationSettingsQuery.data?.aiAgentsVisible,
+                !!aiOrganizationSettingsQuery.data?.aiAgentsVisible &&
+                (aiOrganizationSettingsQuery.data.isCopilotEnabled ||
+                    aiOrganizationSettingsQuery.data.isTrial),
         },
         redirectOnUnauthorized: false,
     });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
@@ -21,7 +21,9 @@ export const useAiAgentButtonVisibility = () => {
         options: {
             enabled:
                 aiOrganizationSettingsQuery.isSuccess &&
-                aiOrganizationSettingsQuery.data?.aiAgentsVisible,
+                !!aiOrganizationSettingsQuery.data?.aiAgentsVisible &&
+                (aiOrganizationSettingsQuery.data.isCopilotEnabled ||
+                    aiOrganizationSettingsQuery.data.isTrial),
         },
         redirectOnUnauthorized: false,
     });


### PR DESCRIPTION
### Description:

**Problem:** On every page load the frontend probes the AI agents list endpoint (`GET /api/v1/projects/{uuid}/aiAgents`). When AI Copilot isn't enabled for the org, the backend rejects this with a `403 ForbiddenError('Copilot is not enabled')`, producing benign-but-noisy errors in logs/Sentry and the network tab. The probe fired because it was gated only on `aiAgentsVisible`, which defaults to `true` independently of whether Copilot is actually enabled.

**Fix:** Gate the two `useProjectAiAgents` call sites (`useAiAgentsButtonVisibility` and `useDefaultAiAgent`) on the `isCopilotEnabled`/`isTrial` fields already returned by the `/aiAgents/admin/settings` response, so the request is only made when Copilot is usable.

**Why these fields:** the backend already performs the same check server-side before allowing the request — `AiAgentService.getIsCopilotEnabled` returns `true` when the Copilot flag is enabled **or** the org is trial-eligible:

```ts
// packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
private async getIsCopilotEnabled(user) {
    const aiCopilotFlag = await this.featureFlagService.get({
        user,
        featureFlagId: CommercialFeatureFlags.AiCopilot,
    });
    if (aiCopilotFlag.enabled) {
        return true;
    }
    // ...
    const isEligibleForTrial =
        await this.aiOrganizationSettingsService.isEligibleForTrial(
            aiCopilotFlag.enabled,
            user.organizationUuid,
        );
    return isEligibleForTrial;
}
```

`listAgents` throws `Copilot is not enabled` whenever this returns `false`. The `/aiAgents/admin/settings` response surfaces those same two inputs as `isCopilotEnabled` (the flag) and `isTrial` (trial eligibility), so gating the frontend probe on `isCopilotEnabled || isTrial` mirrors the backend precondition exactly — no extra request, and no risk of hiding the button when Copilot *is* available.

No functional change when Copilot is enabled or the org is on trial.