### PR TITLE
feat(metrics): split warehouse query duration into per-phase timings

### DIFF
--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -3,6 +3,7 @@ import {
     PreAggregateMissReason,
     QueryExecutionContext,
     QueryHistoryStatus,
+    type WarehousePhaseTimings,
 } from '@lightdash/common';
 import { EventEmitter } from 'events';
 import express from 'express';
@@ -206,6 +207,8 @@ export default class PrometheusMetrics {
 
     private warehouseDurationHistogram: prometheus.Histogram | null = null;
 
+    private warehousePhaseDurationHistogram: prometheus.Histogram | null = null;
+
     private overheadDurationHistogram: prometheus.Histogram | null = null;
 
     private httpServerRequestsDurationSeconds: prometheus.Histogram<
@@ -297,6 +300,18 @@ export default class PrometheusMetrics {
                     buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
                     ...rest,
                 });
+
+                this.warehousePhaseDurationHistogram = new prometheus.Histogram(
+                    {
+                        name: 'lightdash_query_warehouse_phase_duration_seconds',
+                        help: 'Warehouse query duration split by phase (connect/session/query/fetch)',
+                        labelNames: ['phase', 'warehouse_type', 'context'],
+                        buckets: [
+                            0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120,
+                        ],
+                        ...rest,
+                    },
+                );
 
                 this.overheadDurationHistogram = new prometheus.Histogram({
                     name: 'lightdash_query_overhead_duration_seconds',
@@ -1127,6 +1142,24 @@ export default class PrometheusMetrics {
             },
             durationMs / 1000,
         );
+    }
+
+    public observeWarehousePhaseDurations(
+        phaseTimings: WarehousePhaseTimings,
+        warehouseType: string,
+        context: string,
+    ) {
+        const contextLabel = getQueryContextLabel(context);
+        Object.entries(phaseTimings).forEach(([phase, durationMs]) => {
+            this.warehousePhaseDurationHistogram?.observe(
+                {
+                    phase,
+                    warehouse_type: warehouseType,
+                    context: contextLabel,
+                },
+                durationMs / 1000,
+            );
+        });
     }
 
     public observeOverheadDuration(durationMs: number, context: string) {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3144,6 +3144,7 @@ describe('AsyncQueryService', () => {
                 service._getWarehouseClient = vi.fn(async () => ({
                     warehouseClient: mockWarehouseClient,
                     sshTunnel: mockSshTunnel,
+                    tunnelConnectMs: null,
                 }));
 
                 await service.executeAsyncSqlQuery({
@@ -3232,6 +3233,7 @@ describe('AsyncQueryService', () => {
                 service._getWarehouseClient = vi.fn(async () => ({
                     warehouseClient: mockWarehouseClient,
                     sshTunnel: mockSshTunnel,
+                    tunnelConnectMs: null,
                 }));
 
                 // WHEN: executeAsyncSqlQuery is called with SQL containing user attributes
@@ -3381,6 +3383,7 @@ describe('AsyncQueryService', () => {
                         streamQuery,
                     },
                     sshTunnel: mockSshTunnel,
+                    tunnelConnectMs: null,
                 }));
 
                 return { service, streamQuery };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -117,6 +117,7 @@ import {
     type SessionUser,
     type SpaceSummaryBase,
     type WarehouseExecuteAsyncQuery,
+    type WarehousePhaseTimings,
     type WarehouseResults,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
@@ -2524,6 +2525,7 @@ export class AsyncQueryService extends ProjectService {
             | CreateWarehouseCredentials['type']
             | undefined;
         let warehouseClient: WarehouseClient;
+        let tunnelConnectMs: number | null = null;
 
         const analyticsIdentity = isRegisteredUser
             ? { userId: userUuid }
@@ -2565,6 +2567,7 @@ export class AsyncQueryService extends ProjectService {
                 );
                 warehouseClient = warehouseConnection.warehouseClient;
                 sshTunnel = warehouseConnection.sshTunnel;
+                tunnelConnectMs = warehouseConnection.tunnelConnectMs;
             }
 
             const isTimezoneSupportEnabled =
@@ -2653,6 +2656,7 @@ export class AsyncQueryService extends ProjectService {
                     totalRows,
                     queryMetadata,
                     queryId,
+                    phaseTimings,
                 },
                 pivotDetails,
                 columns,
@@ -2681,10 +2685,21 @@ export class AsyncQueryService extends ProjectService {
                     }),
             );
 
+            const warehousePhaseTimings: WarehousePhaseTimings =
+                tunnelConnectMs !== null
+                    ? { ssh_tunnel: tunnelConnectMs, ...phaseTimings }
+                    : phaseTimings;
+
             this.prometheusMetrics?.observeWarehouseDuration(
                 durationMs,
-                warehouseCredentialsType || 'unknown',
-                queryTags.query_context || 'unknown',
+                warehouseCredentialsType,
+                queryTags.query_context,
+            );
+
+            this.prometheusMetrics?.observeWarehousePhaseDurations(
+                warehousePhaseTimings,
+                warehouseCredentialsType,
+                queryTags.query_context,
             );
 
             this.analytics.track({
@@ -2804,8 +2819,13 @@ export class AsyncQueryService extends ProjectService {
             const streamMetricsStr = streamMetrics
                 ? ` stream_bytes=${streamMetrics.totalBytesWritten} stream_rows=${streamMetrics.totalRowsWritten} write_calls=${streamMetrics.writeCalls}`
                 : '';
+            const phasesStr = Object.keys(warehousePhaseTimings).length
+                ? ` phases=[${Object.entries(warehousePhaseTimings)
+                      .map(([phase, ms]) => `${phase}=${Math.round(ms)}ms`)
+                      .join(' ')}]`
+                : '';
             this.logger.info(
-                `Query ${queryUuid} completed: source=${executionSource} s3_stream_create=${s3StreamCreatedMs}ms query_exec=${queryExecMs}ms s3_upload_close=${s3UploadCloseMs}ms db_update=${dbUpdateMs}ms total=${totalMs}ms rows=${pivotDetails?.totalRows ?? totalRows}${streamMetricsStr}`,
+                `Query ${queryUuid} completed: source=${executionSource} s3_stream_create=${s3StreamCreatedMs}ms query_exec=${queryExecMs}ms s3_upload_close=${s3UploadCloseMs}ms db_update=${dbUpdateMs}ms total=${totalMs}ms rows=${pivotDetails?.totalRows ?? totalRows}${streamMetricsStr}${phasesStr}`,
             );
 
             // Track successful query in Prometheus

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1697,11 +1697,18 @@ export class ProjectService extends BaseService {
     ): Promise<{
         warehouseClient: WarehouseClient;
         sshTunnel: SshTunnel<CreateWarehouseCredentials>;
+        tunnelConnectMs: number | null;
     }> {
         Sentry.setTag('warehouse.type', credentials.type);
         // Setup SSH tunnel for client (user needs to close this)
         const sshTunnel = new SshTunnel(credentials);
+        const usedSshTunnel =
+            'useSshTunnel' in credentials && !!credentials.useSshTunnel;
+        const tunnelStart = performance.now();
         const warehouseSshCredentials = await sshTunnel.connect();
+        const tunnelConnectMs = usedSshTunnel
+            ? performance.now() - tunnelStart
+            : null;
 
         const { snowflakeVirtualWarehouse, databricksCompute } =
             overrides || {};
@@ -1718,7 +1725,11 @@ export class ProjectService extends BaseService {
             deepEqual(existingClient.credentials, warehouseSshCredentials)
         ) {
             // if existing client uses identical credentials, use it
-            return { warehouseClient: existingClient, sshTunnel };
+            return {
+                warehouseClient: existingClient,
+                sshTunnel,
+                tunnelConnectMs,
+            };
         }
         // otherwise create a new client and cache for future use
         const getSnowflakeWarehouse = (
@@ -1782,7 +1793,7 @@ export class ProjectService extends BaseService {
             credentialsWithOverrides,
         );
         this.warehouseClients[cacheKey] = client;
-        return { warehouseClient: client, sshTunnel };
+        return { warehouseClient: client, sshTunnel, tunnelConnectMs };
     }
 
     private async syncPreAggregateDefinitionsRegistry(

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -57,6 +57,7 @@ export const warehouseClientMock: WarehouseClient = {
             queryMetadata: null,
             totalRows: 0,
             durationMs: 0,
+            phaseTimings: {},
         };
     },
     runQuery: () =>
@@ -162,6 +163,7 @@ export const bigqueryClientMock: WarehouseClient = {
         queryMetadata: null,
         totalRows: 0,
         durationMs: 0,
+        phaseTimings: {},
     }),
     runQuery: () =>
         Promise.resolve({

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -44,6 +44,7 @@ export const warehouseClientMock: WarehouseClient = {
         queryMetadata: null,
         totalRows: 0,
         durationMs: 0,
+        phaseTimings: {},
     }),
     runQuery: () =>
         Promise.resolve({

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -61,11 +61,24 @@ export type WarehouseExecuteAsyncQueryArgs = {
     sql: string;
 };
 
+// `query` is execution up to the first row; `fetch` is streaming the rest.
+export type WarehouseQueryPhase =
+    | 'ssh_tunnel'
+    | 'connect'
+    | 'session'
+    | 'query'
+    | 'fetch';
+
+export type WarehousePhaseTimings = Partial<
+    Record<WarehouseQueryPhase, number>
+>;
+
 export type WarehouseExecuteAsyncQuery = {
     queryId: string | null;
     queryMetadata: WarehouseQueryMetadata | null;
     totalRows: number;
     durationMs: number;
+    phaseTimings: WarehousePhaseTimings;
 };
 
 export enum TimeIntervalUnit {

--- a/packages/common/src/utils/virtualView.test.ts
+++ b/packages/common/src/utils/virtualView.test.ts
@@ -29,6 +29,7 @@ const fakeWarehouseClient: WarehouseClient = {
         queryMetadata: null,
         totalRows: 0,
         durationMs: 0,
+        phaseTimings: {},
     }),
     runQuery: async () => ({ fields: {}, rows: [] }),
     test: async () => {},

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -107,6 +107,7 @@ export const createTemporaryVirtualView = (
             queryMetadata: null,
             totalRows: 0,
             durationMs: 0,
+            phaseTimings: {},
         }),
         runQuery: async () => ({ fields: {}, rows: [] }),
         test: async () => {},

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -680,6 +680,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         ) => void,
     ): Promise<WarehouseExecuteAsyncQuery> {
         try {
+            const queryPhaseStart = performance.now();
             const [job] = await this.createJob(sql, {
                 tags,
             });
@@ -699,6 +700,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             await this.awaitJobCompletion(job);
 
             const resultsMetadata = await this.getJobResultsMetadata(job);
+            const queryMs = performance.now() - queryPhaseStart;
             const startTime = job.metadata?.statistics?.startTime;
             const endTime = job.metadata?.statistics?.endTime;
             const totalRows: number = resultsMetadata?.totalRows
@@ -708,10 +710,13 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 BigqueryWarehouseClient.getFieldsFromResponse(resultsMetadata);
 
             // If a callback is provided, stream the results to the callback
+            let fetchMs = 0;
             if (resultsStreamCallback) {
+                const fetchPhaseStart = performance.now();
                 await this.streamResults(job, (row) =>
                     resultsStreamCallback([row], fields),
                 );
+                fetchMs = performance.now() - fetchPhaseStart;
             }
 
             return {
@@ -722,6 +727,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 },
                 totalRows,
                 durationMs: startTime && endTime ? endTime - startTime : 0,
+                phaseTimings: { query: queryMs, fetch: fetchMs },
             };
         } catch (e: unknown) {
             if (BigqueryWarehouseClient.isBigqueryError(e)) {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -18,6 +18,7 @@ import {
     WarehouseCatalog,
     WarehouseResults,
     WarehouseTypes,
+    type WarehouseQueryPhase,
 } from '@lightdash/common';
 import { createHash } from 'crypto';
 import fs from 'fs/promises';
@@ -1528,9 +1529,15 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             queryParams?: Record<string, AnyType>;
             tags?: Record<string, string>;
             timezone?: string;
+            onPhaseTiming?: (
+                phase: WarehouseQueryPhase,
+                durationMs: number,
+            ) => void;
         },
     ): Promise<void> {
+        const reportPhase = options?.onPhaseTiming;
         await this.withSession(async (db) => {
+            const sessionStart = performance.now();
             if (options?.timezone) {
                 await db.run(
                     `SET TimeZone = '${this.escapeString(options.timezone)}';`,
@@ -1550,7 +1557,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             }
 
             await this.validateUserSql(db, sql);
+            reportPhase?.('session', performance.now() - sessionStart);
 
+            const queryStart = performance.now();
             const result = await db.stream(
                 this.getSQLWithMetadata(sql, options?.tags),
                 this.getBindValues(options),
@@ -1558,9 +1567,20 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             const fields =
                 DuckdbWarehouseClient.getFieldsFromStreamResult(result);
 
+            let fetchStart: number | undefined;
             // eslint-disable-next-line no-restricted-syntax
             for await (const rows of result.yieldRowObjectJson()) {
+                if (fetchStart === undefined) {
+                    reportPhase?.('query', performance.now() - queryStart);
+                    fetchStart = performance.now();
+                }
                 await streamCallback({ fields, rows });
+            }
+            if (fetchStart === undefined) {
+                reportPhase?.('query', performance.now() - queryStart);
+                reportPhase?.('fetch', 0);
+            } else {
+                reportPhase?.('fetch', performance.now() - fetchStart);
             }
 
             if (profilePath) {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -12,6 +12,7 @@ import {
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type WarehouseQueryPhase,
 } from '@lightdash/common';
 import { readFileSync } from 'fs';
 import path from 'path';
@@ -254,12 +255,18 @@ export class PostgresClient<
             values?: AnyType[];
             tags?: Record<string, string>;
             timezone?: string;
+            onPhaseTiming?: (
+                phase: WarehouseQueryPhase,
+                durationMs: number,
+            ) => void;
         },
     ): Promise<void> {
         let pool: pg.Pool | undefined;
         let closeClient: (() => void) | undefined;
         let activeStream: QueryStream | undefined;
         let queryTimeout: ReturnType<typeof setTimeout> | undefined;
+
+        const reportPhase = options.onPhaseTiming;
 
         // The pool's `query_timeout` does not fire on the cursor (pg-cursor)
         // path, so we enforce the ceiling ourselves: a server-side
@@ -306,6 +313,7 @@ export class PostgresClient<
                 });
             });
 
+            const connectStart = performance.now();
             pool.connect((err, client, done) => {
                 // Store references so we can clean up properly
                 closeClient = done;
@@ -318,6 +326,7 @@ export class PostgresClient<
                     reject(new Error('client undefined'));
                     return;
                 }
+                reportPhase?.('connect', performance.now() - connectStart);
 
                 client.on('error', (e) => {
                     console.error(
@@ -337,6 +346,8 @@ export class PostgresClient<
                 });
 
                 const runQuery = () => {
+                    const queryStart = performance.now();
+                    let fetchStart: number | undefined;
                     // CodeQL: This will raise a security warning because user defined raw SQL is being passed into the database module.
                     //         In this case this is exactly what we want to do. We're hitting the user's warehouse not the application's database.
                     activeStream = client.query(
@@ -376,6 +387,11 @@ export class PostgresClient<
                                         PostgresClient.convertQueryResultFields(
                                             chunk.fields,
                                         );
+                                    reportPhase?.(
+                                        'query',
+                                        performance.now() - queryStart,
+                                    );
+                                    fetchStart = performance.now();
                                 }
                                 await streamCallback({
                                     fields: cachedFields,
@@ -395,6 +411,18 @@ export class PostgresClient<
                     // Wait for writable to finish processing all async callbacks
                     // (not 'end' on readable - async write callbacks may still be in flight)
                     writable.on('finish', () => {
+                        if (fetchStart === undefined) {
+                            reportPhase?.(
+                                'query',
+                                performance.now() - queryStart,
+                            );
+                            reportPhase?.('fetch', 0);
+                        } else {
+                            reportPhase?.(
+                                'fetch',
+                                performance.now() - fetchStart,
+                            );
+                        }
                         resolve();
                     });
                     writable.on('error', (err2) => {
@@ -412,6 +440,7 @@ export class PostgresClient<
                 // query_timeout is ineffective on the cursor path. Issued as
                 // its own single statement (followed by the optional timezone)
                 // to stay portable across Postgres and Redshift.
+                const sessionStart = performance.now();
                 client
                     .query(`SET statement_timeout = ${statementTimeoutMs}`)
                     .then(() => {
@@ -426,6 +455,10 @@ export class PostgresClient<
                         return undefined;
                     })
                     .then(() => {
+                        reportPhase?.(
+                            'session',
+                            performance.now() - sessionStart,
+                        );
                         runQuery();
                     })
                     .catch((sessionError) => {

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -601,15 +601,19 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             fields: WarehouseResults['fields'],
         ) => void | Promise<void>,
     ): Promise<WarehouseExecuteAsyncQuery> {
+        const connectStart = performance.now();
         const connection = await this.getConnection();
+        const connectMs = performance.now() - connectStart;
 
         try {
+            const sessionStart = performance.now();
             await this.prepareWarehouse(connection, {
                 timezone,
                 tags,
             });
+            const sessionMs = performance.now() - sessionStart;
 
-            const { queryId, durationMs, totalRows } =
+            const { queryId, durationMs, totalRows, queryMs, fetchMs } =
                 await this.executeAsyncStatement(
                     connection,
                     sql,
@@ -624,6 +628,12 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 queryMetadata: null,
                 totalRows,
                 durationMs,
+                phaseTimings: {
+                    connect: connectMs,
+                    session: sessionMs,
+                    query: queryMs,
+                    fetch: fetchMs,
+                },
             };
         } finally {
             await this.destroyConnection(
@@ -652,6 +662,8 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 queryMetadata: null;
                 totalRows: number;
                 durationMs: number;
+                queryMs: number;
+                fetchMs: number;
             }>((resolve, reject) => {
                 connection.execute({
                     sqlText: sql,
@@ -665,6 +677,8 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
 
                         const fields = this.getFieldsFromStatement(stmt);
                         let rowCount = 0;
+                        const queryMs = performance.now() - startTime;
+                        const fetchStart = performance.now();
 
                         pipeline(
                             stmt.streamRows(),
@@ -707,6 +721,8 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                                         totalRows: rowCount,
                                         durationMs:
                                             performance.now() - startTime,
+                                        queryMs,
+                                        fetchMs: performance.now() - fetchStart,
                                     });
                                 }
                             },
@@ -761,6 +777,8 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             queryMetadata: null,
             totalRows,
             durationMs,
+            queryMs: durationMs,
+            fetchMs: 0,
         };
     }
 

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -12,6 +12,8 @@ import {
     WeekDay,
     type WarehouseExecuteAsyncQuery,
     type WarehouseExecuteAsyncQueryArgs,
+    type WarehousePhaseTimings,
+    type WarehouseQueryPhase,
 } from '@lightdash/common';
 import { type WarehouseClient } from '../types';
 
@@ -79,6 +81,10 @@ export default abstract class WarehouseBaseClient<
             queryParams?: Record<string, AnyType>;
             tags?: Record<string, string>;
             timezone?: string;
+            onPhaseTiming?: (
+                phase: WarehouseQueryPhase,
+                durationMs: number,
+            ) => void;
         },
     ): Promise<void>;
 
@@ -97,6 +103,7 @@ export default abstract class WarehouseBaseClient<
     ): Promise<WarehouseExecuteAsyncQuery> {
         let rowCount = 0;
 
+        const phaseTimings: WarehousePhaseTimings = {};
         const startTime = performance.now();
         await this.streamQuery(
             sql,
@@ -109,6 +116,10 @@ export default abstract class WarehouseBaseClient<
                 queryParams,
                 tags,
                 timezone,
+                onPhaseTiming: (phase, durationMs) => {
+                    phaseTimings[phase] =
+                        (phaseTimings[phase] ?? 0) + durationMs;
+                },
             },
         );
 
@@ -118,6 +129,7 @@ export default abstract class WarehouseBaseClient<
             queryMetadata: null,
             durationMs: performance.now() - startTime,
             totalRows: rowCount,
+            phaseTimings,
         };
     }
 


### PR DESCRIPTION
## What

Adds a Prometheus histogram `lightdash_query_warehouse_phase_duration_seconds` that breaks a single warehouse query's execution into phases:

| phase | meaning |
|---|---|
| `ssh_tunnel` | SSH handshake/auth to the bastion (only for SSH-tunnelled warehouses) |
| `connect` | warehouse driver connection — TCP/TLS/auth, through the tunnel if present |
| `session` | per-connection session setup (e.g. `SET statement_timeout` / timezone) |
| `query` | execution up to the first row |
| `fetch` | streaming the remaining rows |

Labels: `phase`, `warehouse_type`, `context` (the scrape target adds `namespace` etc.). The phases decompose the existing `lightdash_query_warehouse_duration_seconds`, so `sum by (phase)` ≈ the warehouse total.

## Why

`lightdash_query_warehouse_duration_seconds` is a single opaque number. When a warehouse query is slow, metrics can't currently say whether the time is connection/session setup, execution, or result streaming. This split makes that visible, unsampled.

## How

- `WarehouseQueryPhase` union + required `phaseTimings` on `WarehouseExecuteAsyncQuery` (common).
- `streamQuery` gains an optional `onPhaseTiming` hook; `WarehouseBaseClient.executeAsyncQuery` accumulates the phases and returns them. Postgres/Redshift and DuckDB report through this path. Snowflake and BigQuery override `executeAsyncQuery`, so they build `phaseTimings` directly (BigQuery is stateless HTTP → `query` / `fetch` only).
- SSH tunnel connect is timed in `ProjectService._getWarehouseClient` and merged into the timings at the recording site.
- Recorded via `PrometheusMetrics.observeWarehousePhaseDurations`; the query-completion log line now includes `phases=[…]`.

### Coverage

| warehouse | ssh_tunnel | connect | session | query | fetch |
|---|:---:|:---:|:---:|:---:|:---:|
| Postgres/Redshift | ✅ (tunnelled) | ✅ | ✅ | ✅ | ✅ |
| Snowflake | — | ✅ | ✅ | ✅ | ✅ |
| BigQuery | — | — | — | ✅ | ✅ |
| DuckDB | — | — | ✅ | ✅ | ✅ |

## Notes

- Recorded in the worker that runs the async query (same place as `warehouse_duration`); no new config flag — registered whenever `LIGHTDASH_PROMETHEUS_ENABLED` is on.
- `query` / `fetch` split at first-row arrival (no distinct "execution done" event on a streaming cursor); `fetch` includes downstream per-row processing.
- Also standardizes timing on `performance.now()` and removes dead `|| 'unknown'` fallbacks next to the recording call.

## Testing

- `typecheck:fast` green for `common`, `warehouses`, `backend`.
- Verified locally: an uncached warehouse query produces `connect` / `session` / `query` / `fetch` samples on the worker `/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
