### PR TITLE
fix(apps): copy external connections into preview projects

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -354,6 +354,15 @@ Orchestration lives in `AppGenerateService.duplicateAppsForPreview`, called once
 - **Spaces.** `ProjectModel.duplicateContent` now returns the source→preview space-uuid mapping; each app lands in the
   preview's mirror of its source space (ancestors already created by the content copy). Personal apps
   (`space_uuid IS NULL`) stay personal.
+- **External connections.** Because connections are project-scoped and runtime fetches resolve against
+  `app_external_connections` (`resolveAppAlias`), the preview needs its own connections or the copied apps' external
+  fetches would dangle. Before copying apps, `ExternalConnectionModel.copyConnectionsToProject` clones every non-deleted
+  upstream connection — with its secret and saved samples — into the preview project, returning a source→preview
+  connection-uuid map. The secret ciphertext is copied verbatim (`EncryptionUtil` is instance-wide, so the payload is
+  portable). Each app's live links are then translated through that map onto the preview's own connections, and the
+  version snapshot's `externalConnections` is rebuilt from the same translated set. Project deletion cascades
+  (`external_connections.project_uuid ON DELETE CASCADE`) clean the copies up when the preview is torn down. This copy is
+  best-effort: if it fails, apps are still copied (just without working connections).
 - **The round trip — `upstream_app_uuid`.** Each preview copy's `upstream_app_uuid` is set back to the production app it
   was copied from. That is the same link `promoteApp` writes on first promotion, so iterating on the copy inside the
   preview and then promoting **updates the original production app** rather than creating a duplicate. Preview
@@ -802,7 +811,7 @@ External connections let a project admin register a third-party HTTP API (base U
 
 A connection lives on the `external_connections` table (`packages/backend/src/ee/database/entities/externalConnections.ts`), scoped to a project. It stores a human-readable **alias**, a **base URL** (origin), the auth method, and an **encrypted secret** (never returned to the client — stripped on read, only decrypted server-side for an actual fetch). Apps opt into a connection by linking it (`app_external_connections`); an app can reference a connection's data only after the admin links it.
 
-Runtime fetches resolve the alias against `app_external_connections` (`resolveAppAlias`), so the link rows — not the version `resources` snapshot — are what grant an app access. When an app is **duplicated** (`AppGenerateService.duplicateApp`), its live links are copied onto the new app so the duplicate can make the same external fetches; both apps share a project, so the connection UUIDs stay valid. (Cross-project copies — `promoteApp`, `duplicateAppsForPreview` — deliberately don't copy link rows, since the target project's connections are different entities.)
+Runtime fetches resolve the alias against `app_external_connections` (`resolveAppAlias`), so the link rows — not the version `resources` snapshot — are what grant an app access. When an app is **duplicated** (`AppGenerateService.duplicateApp`), its live links are copied onto the new app so the duplicate can make the same external fetches; both apps share a project, so the connection UUIDs stay valid. **Preview duplication** is the cross-project case: the target preview project has none of the source's connections, so it first clones the connections themselves (see [Preview environments](#preview-environments-copy-on-preview)) and re-links the copied apps onto those clones. **Promotion** (`promoteApp`, preview → upstream) still does **not** carry links across today — the upstream project's connections are separate entities and would need identity mapping to re-link.
 
 ### Proxy security model
 

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -148,6 +148,98 @@ export class ExternalConnectionModel {
         });
     }
 
+    /**
+     * Copy every (non-deleted) connection in `sourceProjectUuid` into
+     * `targetProjectUuid` — with its secret and saved samples — and return a
+     * source→target connection-uuid map. Used when a preview project is
+     * created: the copied data apps re-link to the preview's own connections
+     * instead of the upstream project's (which are separate, project-scoped
+     * entities the preview can't reference). The secret ciphertext is copied
+     * verbatim — `EncryptionUtil` is instance-wide, so the payload is portable
+     * across projects on the same instance (no decrypt/re-encrypt).
+     */
+    async copyConnectionsToProject(
+        sourceProjectUuid: string,
+        targetProjectUuid: string,
+    ): Promise<Map<string, string>> {
+        return this.database.transaction(async (trx) => {
+            const sources = await trx(ExternalConnectionsTableName)
+                .where('project_uuid', sourceProjectUuid)
+                .whereNull('deleted_at')
+                .select<DbExternalConnection[]>('*');
+
+            const map = new Map<string, string>();
+            /* eslint-disable no-await-in-loop */
+            for (const src of sources) {
+                const [row] = await trx(ExternalConnectionsTableName)
+                    .insert({
+                        project_uuid: targetProjectUuid,
+                        organization_uuid: src.organization_uuid,
+                        name: src.name,
+                        type: src.type,
+                        origin: src.origin,
+                        allowed_path_prefixes: JSON.stringify(
+                            src.allowed_path_prefixes,
+                        ),
+                        allowed_methods: JSON.stringify(src.allowed_methods),
+                        allowed_content_types: JSON.stringify(
+                            src.allowed_content_types,
+                        ),
+                        response_max_bytes: src.response_max_bytes,
+                        request_max_bytes: src.request_max_bytes,
+                        timeout_ms: src.timeout_ms,
+                        rate_limit_per_minute: src.rate_limit_per_minute,
+                        api_key_name: src.api_key_name,
+                        api_key_location: src.api_key_location,
+                        created_by_user_uuid: src.created_by_user_uuid,
+                        updated_by_user_uuid: src.updated_by_user_uuid,
+                    })
+                    .returning<{ external_connection_uuid: string }[]>(
+                        'external_connection_uuid',
+                    );
+                const targetUuid = row.external_connection_uuid;
+                map.set(src.external_connection_uuid, targetUuid);
+
+                const secret = await trx(ExternalConnectionSecretsTableName)
+                    .where(
+                        'external_connection_uuid',
+                        src.external_connection_uuid,
+                    )
+                    .first<{ encrypted_payload: Buffer } | undefined>(
+                        'encrypted_payload',
+                    );
+                if (secret) {
+                    await trx(ExternalConnectionSecretsTableName).insert({
+                        external_connection_uuid: targetUuid,
+                        encrypted_payload: secret.encrypted_payload,
+                    });
+                }
+
+                // Carry saved samples so in-preview iteration keeps the same
+                // code-gen grounding as upstream.
+                const samples = await trx(ExternalConnectionSamplesTableName)
+                    .where(
+                        'external_connection_uuid',
+                        src.external_connection_uuid,
+                    )
+                    .select<DbExternalConnectionSample[]>('*');
+                if (samples.length > 0) {
+                    await trx(ExternalConnectionSamplesTableName).insert(
+                        samples.map((sample) => ({
+                            external_connection_uuid: targetUuid,
+                            label: sample.label,
+                            request: JSON.stringify(sample.request),
+                            response: JSON.stringify(sample.response),
+                            created_by_user_uuid: sample.created_by_user_uuid,
+                        })),
+                    );
+                }
+            }
+            /* eslint-enable no-await-in-loop */
+            return map;
+        });
+    }
+
     async list(
         projectUuid: string,
         organizationUuid: string,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -5125,6 +5125,21 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         );
         const { client: s3Client, bucket } = this.getS3Client();
 
+        let connectionUuidMap = new Map<string, string>();
+        try {
+            connectionUuidMap =
+                await this.externalConnectionModel.copyConnectionsToProject(
+                    sourceProjectUuid,
+                    previewProjectUuid,
+                );
+        } catch (error) {
+            this.logger.error(
+                `Preview duplication: failed to copy external connections from ${sourceProjectUuid} into preview ${previewProjectUuid}: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+        }
+
         const mappings: { sourceAppUuid: string; previewAppUuid: string }[] =
             [];
 
@@ -5136,6 +5151,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 previewProjectUuid,
                 previewProject.organizationUuid,
                 previewSpaceBySource,
+                connectionUuidMap,
                 s3Client,
                 bucket,
             );
@@ -5172,6 +5188,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         previewProjectUuid: string,
         previewOrganizationUuid: string,
         previewSpaceBySource: Map<string, string>,
+        connectionUuidMap: Map<string, string>,
         s3Client: S3Client,
         bucket: string,
     ): Promise<string | null> {
@@ -5183,6 +5200,25 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             // The tile (if any) keeps its read-through reference.
             return null;
         }
+
+        const sourceLinks = await this.externalConnectionModel.listAppLinks(
+            sourceApp.app_id,
+        );
+        const externalConnectionResources: AppVersionExternalConnectionResource[] =
+            sourceLinks.flatMap((link) => {
+                const previewConnectionUuid = connectionUuidMap.get(
+                    link.connection.externalConnectionUuid,
+                );
+                return previewConnectionUuid
+                    ? [
+                          {
+                              externalConnectionUuid: previewConnectionUuid,
+                              name: link.connection.name,
+                              alias: link.alias,
+                          },
+                      ]
+                    : [];
+            });
 
         // Place the copy in the preview's mirror of the source space. Spaceless
         // (personal) apps stay personal. A source space missing from the map
@@ -5208,9 +5244,12 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 ? sourceApp.design_uuid
                 : null;
 
-        const resources = AppGenerateService.buildCopiedResources(
-            sourceVersion.resources ?? null,
-        );
+        const resources: AppVersionResources = {
+            ...AppGenerateService.buildCopiedResources(
+                sourceVersion.resources ?? null,
+            ),
+            externalConnections: externalConnectionResources,
+        };
 
         const newAppUuid = uuidv4();
         const newVersion = 1;
@@ -5253,6 +5292,10 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             await this.appModel.setUpstreamAppUuid(
                 newAppUuid,
                 sourceApp.app_id,
+            );
+            await this.linkResolvedExternalConnections(
+                newAppUuid,
+                externalConnectionResources,
             );
             await this.appModel.updateStatusMessage(
                 newAppUuid,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-548/duplicating-apps-not-considering-external-connections

### Description:
When a preview project is created, every data app is duplicated into it, but the app's external-connection links pointed at the upstream project's connections, which the preview can't reference — so the copied apps' runtime external fetches would dangle (resolveAppAlias finds no link).

Before copying apps, ExternalConnectionModel.copyConnectionsToProject now clones every non-deleted upstream connection — with its secret (ciphertext copied verbatim, since EncryptionUtil is instance-wide) and saved samples — into the preview project, returning a source->preview connection-uuid map. copyAppForPreview translates each app's live links through that map onto the preview's own connections and rebuilds the version snapshot's externalConnections from the same set. Best-effort: a connection-copy failure logs and lets apps copy without connections. Preview teardown cleans the clones up via the existing project ON DELETE CASCADE.
