### PR TITLE
feat(ai): grep-filter loadProjectContext (ZAP-579)

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/filterProjectContext.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/filterProjectContext.test.ts
@@ -1,0 +1,58 @@
+import type { ProjectContextEntry } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { filterProjectContext } from './filterProjectContext';
+
+const entry = (over: Partial<ProjectContextEntry>): ProjectContextEntry => ({
+    id: 'e',
+    kind: 'context',
+    content: '',
+    terms: [],
+    objects: [],
+    ...over,
+});
+
+const entries: ProjectContextEntry[] = [
+    entry({
+        id: 'arr-def',
+        content: 'ARR means annual recurring revenue in AUD',
+        terms: ['arr', 'revenue'],
+    }),
+    entry({
+        id: 'sao-def',
+        content: 'A sales accepted opportunity',
+        terms: ['sao'],
+        objects: ['rpt_gtm_mission_control'],
+    }),
+    entry({ id: 'unrelated', content: 'onboarding checklist steps' }),
+];
+
+describe('filterProjectContext', () => {
+    it('returns all entries when no patterns are given', () => {
+        expect(filterProjectContext(entries, [])).toEqual(entries);
+    });
+
+    it('matches on content', () => {
+        expect(
+            filterProjectContext(entries, ['revenue']).map((e) => e.id),
+        ).toEqual(['arr-def']);
+    });
+
+    it('matches on terms and objects', () => {
+        expect(
+            filterProjectContext(entries, ['mission_control']).map((e) => e.id),
+        ).toEqual(['sao-def']);
+    });
+
+    it('ORs across patterns and ranks multi-pattern hits first', () => {
+        // arr-def hits both "arr" and "revenue"; sao-def hits only "sao".
+        expect(
+            filterProjectContext(entries, ['sao', 'arr|revenue']).map(
+                (e) => e.id,
+            ),
+        ).toEqual(['arr-def', 'sao-def']);
+    });
+
+    it('returns [] when nothing matches', () => {
+        expect(filterProjectContext(entries, ['nonexistent_xyz'])).toEqual([]);
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/filterProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/filterProjectContext.ts
@@ -1,0 +1,36 @@
+import type { ProjectContextEntry } from '@lightdash/common';
+import { compileMatcher } from './grepFieldsIndex';
+
+/**
+ * Grep-filter project context entries so the agent loads only what's relevant
+ * instead of the whole context. Reuses grepFields' `compileMatcher` (substring
+ * AND/OR, ReDoS-safe) over a per-entry haystack (id + kind + terms + objects +
+ * content). An entry matches if it hits ANY pattern; results are ranked by how
+ * many patterns they hit (matched-first). Empty patterns → all entries.
+ */
+export const filterProjectContext = (
+    entries: ProjectContextEntry[],
+    patterns: string[],
+): ProjectContextEntry[] => {
+    if (patterns.length === 0) return entries;
+    const matchers = patterns.map(compileMatcher);
+    return entries
+        .map((entry) => {
+            const haystack = [
+                entry.id,
+                entry.kind,
+                ...entry.terms,
+                ...entry.objects,
+                entry.content,
+            ]
+                .join('\n')
+                .toLowerCase();
+            const score = matchers.filter((matches) =>
+                matches(haystack),
+            ).length;
+            return { entry, score };
+        })
+        .filter((scored) => scored.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .map((scored) => scored.entry);
+};

--- a/packages/backend/src/ee/services/ai/tools/loadProjectContext.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/loadProjectContext.test.ts
@@ -30,7 +30,7 @@ const run = (patterns?: string[]) => {
     const tool = getLoadProjectContext({ getDocument: async () => entries });
     // Tool.execute is (args, options); options is unused here.
     return (
-        tool.execute as (
+        tool.execute as unknown as (
             a: unknown,
             o: unknown,
         ) => Promise<{

--- a/packages/backend/src/ee/services/ai/tools/loadProjectContext.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/loadProjectContext.test.ts
@@ -1,0 +1,67 @@
+import type { ProjectContextEntry } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getLoadProjectContext } from './loadProjectContext';
+
+const entries: ProjectContextEntry[] = [
+    {
+        id: 'arr-def',
+        kind: 'context',
+        content: 'ARR means annual recurring revenue',
+        terms: ['arr', 'revenue'],
+        objects: [],
+    },
+    {
+        id: 'sao-def',
+        kind: 'context',
+        content: 'A sales accepted opportunity',
+        terms: ['sao'],
+        objects: [],
+    },
+    {
+        id: 'unrelated',
+        kind: 'context',
+        content: 'onboarding',
+        terms: [],
+        objects: [],
+    },
+];
+
+const run = (patterns?: string[]) => {
+    const tool = getLoadProjectContext({ getDocument: async () => entries });
+    // Tool.execute is (args, options); options is unused here.
+    return (
+        tool.execute as (
+            a: unknown,
+            o: unknown,
+        ) => Promise<{
+            result: string;
+            metadata: { entryIds?: string[] };
+        }>
+    )({ patterns }, {});
+};
+
+describe('loadProjectContext tool', () => {
+    it('loads all entries when no patterns are given', async () => {
+        const res = await run();
+        expect(res.metadata.entryIds).toEqual([
+            'arr-def',
+            'sao-def',
+            'unrelated',
+        ]);
+    });
+
+    it('loads only matching entries when patterns are given', async () => {
+        const res = await run(['revenue']);
+        expect(res.metadata.entryIds).toEqual(['arr-def']);
+        expect(res.result).toContain('ARR means annual recurring revenue');
+        expect(res.result).not.toContain('onboarding');
+    });
+
+    it('lists available entries when nothing matches', async () => {
+        const res = await run(['nonexistent_xyz']);
+        expect(res.metadata.entryIds).toEqual([]);
+        expect(res.result).toContain('No context entry matched');
+        expect(res.result).toContain('arr-def');
+        expect(res.result).toContain('sao-def');
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/loadProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/loadProjectContext.ts
@@ -6,6 +6,7 @@ import { tool } from 'ai';
 import Logger from '../../../../logging/logger';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
+import { filterProjectContext } from './filterProjectContext';
 
 const renderEntries = (entries: ProjectContextEntry[]): string => {
     if (entries.length === 0) {
@@ -27,6 +28,22 @@ const renderEntries = (entries: ProjectContextEntry[]): string => {
         .join('\n');
 };
 
+// When patterns match nothing, list the available entries (id/kind/terms) so
+// the agent can re-grep with broader keywords or load everything — cheaper than
+// silently dumping the whole context.
+const renderNoMatch = (all: ProjectContextEntry[]): string => {
+    const lines = all
+        .map((entry) => {
+            const terms =
+                entry.terms.length > 0
+                    ? ` terms: ${entry.terms.join(', ')};`
+                    : '';
+            return `- id: ${entry.id}; kind: ${entry.kind};${terms}`;
+        })
+        .join('\n');
+    return `No context entry matched your patterns. ${all.length} entries exist — re-grep with broader keywords, or call again without patterns to load all:\n${lines}`;
+};
+
 export const getLoadProjectContext = ({
     getDocument,
 }: {
@@ -34,12 +51,28 @@ export const getLoadProjectContext = ({
 }) =>
     tool({
         ...loadProjectContextToolDefinition.for('agent'),
-        execute: async () => {
+        execute: async ({ patterns }) => {
             try {
                 const entries = await getDocument();
+                const selected = patterns?.length
+                    ? filterProjectContext(entries, patterns)
+                    : entries;
+
+                // Patterns given but nothing matched: surface the available
+                // entries instead of an empty result.
+                if (patterns?.length && selected.length === 0) {
+                    return {
+                        result: renderNoMatch(entries),
+                        metadata: {
+                            status: 'success' as const,
+                            entryIds: [],
+                            approxTokens: 0,
+                        },
+                    };
+                }
 
                 const approxTokens = Math.ceil(
-                    entries.reduce(
+                    selected.reduce(
                         (sum, e) =>
                             sum +
                             e.content.length +
@@ -50,14 +83,18 @@ export const getLoadProjectContext = ({
                         0,
                     ) / 4,
                 );
-                const entryIds = entries.map((e) => e.id);
+                const entryIds = selected.map((e) => e.id);
                 // Budget metric: what the agent actually loads per turn.
                 Logger.info(
-                    `[ProjectContext] count=${entries.length} approxTokens=${approxTokens} ids=${entryIds.join(',')}`,
+                    `[ProjectContext] loaded=${selected.length}/${
+                        entries.length
+                    } approxTokens=${approxTokens} patterns=${
+                        patterns?.join('|') ?? '(all)'
+                    } ids=${entryIds.join(',')}`,
                 );
 
                 return {
-                    result: renderEntries(entries),
+                    result: renderEntries(selected),
                     metadata: {
                         status: 'success' as const,
                         entryIds,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolLoadProjectContextArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolLoadProjectContextArgs.ts
@@ -2,10 +2,17 @@ import { z } from 'zod';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 
 export const TOOL_LOAD_PROJECT_CONTEXT_DESCRIPTION =
-    'Load the project business context: curated acronyms, definitions, rules and conventions that are NOT in the field metadata. Call this BEFORE findExplores/findFields/discoverFields — it can change which explore, field, or filter value you should use. Treat what it returns as authoritative over your own assumptions.';
+    'Load the project business context: curated acronyms, definitions, rules and conventions that are NOT in the field metadata. Call this BEFORE findExplores/findFields/discoverFields — it can change which explore, field, or filter value you should use. Treat what it returns as authoritative over your own assumptions. Pass `patterns` to load only the entries relevant to your question (recommended); omit to load the entire context.';
 
-// The whole project context is loaded wholesale, so the tool takes no args.
-export const toolLoadProjectContextArgsSchema = z.object({});
+export const toolLoadProjectContextArgsSchema = z.object({
+    patterns: z
+        .array(z.string().min(1))
+        .max(5)
+        .optional()
+        .describe(
+            "Up to 5 case-insensitive keyword patterns; only context entries matching them are loaded. Use `|` to OR synonyms and a space or `.*` between words to require all of them; matched against each entry's id, terms, referenced objects and content. Omit to load the entire project context.",
+        ),
+});
 
 export const toolLoadProjectContextOutputSchema = z.object({
     result: z.string(),


### PR DESCRIPTION
## What

`loadProjectContext` loaded **every** context entry (id/kind/terms/objects/content) into the turn — token-heavy on large project contexts (the tool already logs `approxTokens` because the cost is real). This gives it the grepFields treatment.

Adds an optional **`patterns?: string[]`** (max 5) to the existing tool — backwards compatible:
- **with patterns** → return only the entries matching them;
- **without** → today's whole-load, unchanged.

## How

- `filterProjectContext(entries, patterns)` — pure, **reuses grepFields' `compileMatcher`** (substring AND/OR, ReDoS-safe) over a per-entry haystack (`id + kind + terms + objects + content`). An entry matches if it hits **any** pattern; results are ranked matched-first (by # patterns hit).
- **No matches** → returns a lean list of the available entry ids/kinds/terms so the model can re-grep broader or call again without patterns — no silent whole-load fallback (that would defeat the token win).
- Keeps the `approxTokens` telemetry, now logged as `loaded=N/total`.

## Scope / follow-on

Just project context. Knowledge-doc grep (search across docs, return relevant **snippets** rather than whole documents — needs chunk/window design) is a separate follow-on.

## Testing

- 8 unit tests (vitest), TDD'd red→green: `filterProjectContext` (matches content/terms/objects; OR across patterns; matched-first; empty→all; no-match→[]) and tool-level (patterns filter / no-patterns=all / no-match lists ids).
- Lint clean. (Typecheck runs in CI; a local worktree had unrelated pre-existing type noise from an install drift — verified 0 new errors from this change.)

Closes: ZAP-579

🤖 Generated with [Claude Code](https://claude.com/claude-code)