### PR TITLE
fix(frontend): never auto-reload on stale chunks to protect unsaved edits

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -9,7 +9,6 @@ import {
 } from './ee/CommercialRoutes';
 import { AiAgentsGlobalProvider } from './ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider';
 import { parseEmbedThemeParams } from './ee/providers/Embed/parseEmbedThemeParams';
-import { installChunkLoadErrorHandler } from './features/chunkErrorHandler';
 import ChunkErrorRouteBoundary from './features/errorBoundary/ChunkErrorRouteBoundary';
 import ErrorBoundary from './features/errorBoundary/ErrorBoundary';
 import { SourceCodeEditorProvider } from './features/sourceCodeEditor';
@@ -26,8 +25,6 @@ import SchedulerJobsProvider from './providers/SchedulerJobs/SchedulerJobsProvid
 import ThirdPartyProvider from './providers/ThirdPartyServicesProvider';
 import TrackingProvider from './providers/Tracking/TrackingProvider';
 import Routes from './Routes';
-
-installChunkLoadErrorHandler();
 
 // const isMobile =
 //     /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -2,10 +2,7 @@ import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
-import {
-    isChunkLoadError,
-    triggerChunkErrorReload,
-} from '../../features/chunkErrorHandler';
+import { isChunkLoadError } from '../../features/chunkErrorHandler';
 import { computeLimitedRowCount, sliceRows } from '../../utils/sliceRows';
 import LoadingChart from '../common/LoadingChart';
 import PivotTable from '../common/PivotTable';
@@ -264,7 +261,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                             variant="default"
                             size={'xs'}
                             leftIcon={<IconRefresh size={16} />}
-                            onClick={triggerChunkErrorReload}
+                            onClick={() => window.location.reload()}
                         >
                             Refresh page
                         </Button>

--- a/packages/frontend/src/features/chunkErrorHandler/CLAUDE.md
+++ b/packages/frontend/src/features/chunkErrorHandler/CLAUDE.md
@@ -1,7 +1,8 @@
 # Chunk Error Handler
 
 <summary>
-Handles automatic recovery when users encounter stale JavaScript chunks after a deployment.
+Detects stale JavaScript/CSS chunk load failures so the UI can show a clear
+"file not found, please refresh" message.
 
 When Lightdash deploys a new version:
 
@@ -10,50 +11,35 @@ When Lightdash deploys a new version:
 3. Users with cached HTML still reference old chunk URLs
 4. When React.lazy() tries to load the old chunk → 404 → error
 
-This module detects these "Failed to fetch dynamically imported module" errors and auto-reloads
-the page to fetch fresh HTML with correct chunk references.
+This module only provides detection helpers (`isChunkLoadError`,
+`isChunkLoadErrorObject`). The error boundaries use them to render a
+manual-refresh fallback.
 
 </summary>
 
-<howToUse>
-This module is already integrated into:
-- `@/features/errorBoundary/ErrorBoundary.tsx` - Auto-reload on chunk errors
-- `@/hooks/thirdPartyServices/useSentry.ts` - Filters chunk errors from Sentry until auto-reload fails
-- `@/components/SimpleTable/index.tsx` - Manual refresh UI for pivot table worker errors (no auto-reload)
-
-You typically don't need to use this directly unless handling chunk errors in a new location.
-</howToUse>
-
-<codeExample>
-
-```typescript
-import {
-    isChunkLoadErrorObject,
-    hasRecentChunkReload,
-    triggerChunkErrorReload,
-} from '../chunkErrorHandler';
-
-// In an error boundary fallback:
-if (isChunkLoadErrorObject(error)) {
-    if (!hasRecentChunkReload()) {
-        triggerChunkErrorReload(); // Auto-reload once
-        return null;
-    }
-    // Show manual refresh UI (auto-reload already failed)
-}
-```
-
-</codeExample>
-
 <importantToKnow>
-- Uses sessionStorage to prevent infinite reload loops (60s cooldown)
+- **We never reload automatically.** A programmatic `window.location.reload()`
+  bypasses the editors' unsaved-changes guards and silently discards in-progress
+  chart/dashboard work (see PROD-8618). Instead, the error boundaries show
+  `ChunkErrorFallback` with a "Refresh page" button the user clicks themselves,
+  so the `beforeunload` guard can warn them and they can save first.
 - `isChunkLoadError(message: string)` - checks error message strings
 - `isChunkLoadErrorObject(error: unknown)` - checks Error objects
-- Sentry integration: errors are only reported if auto-reload fails
+- Sentry integration (`useSentry.ts`) drops chunk load errors — they're benign
+  stale-deploy artifacts resolved by refreshing.
 </importantToKnow>
 
+<howToUse>
+This module is integrated into:
+- `@/features/errorBoundary/ErrorBoundary.tsx` - shows the refresh fallback on chunk errors
+- `@/features/errorBoundary/ChunkErrorRouteBoundary.tsx` - same, for react-router lazy-route failures
+- `@/hooks/thirdPartyServices/useSentry.ts` - filters chunk errors from Sentry
+- `@/components/SimpleTable/index.tsx` - manual refresh UI for pivot table worker errors
+</howToUse>
+
 <links>
-- @/features/errorBoundary/ErrorBoundary.tsx - Primary integration point
-- @/hooks/thirdPartyServices/useSentry.ts - Sentry filtering logic
-- @/components/SimpleTable/index.tsx - Manual refresh UI for pivot table worker errors
+- @/features/errorBoundary/ErrorBoundary.tsx
+- @/features/errorBoundary/ChunkErrorRouteBoundary.tsx
+- @/features/errorBoundary/ErrorFallbacks.tsx - the ChunkErrorFallback UI
+- @/hooks/thirdPartyServices/useSentry.ts
 </links>

--- a/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
@@ -1,6 +1,3 @@
-const CHUNK_ERROR_RELOAD_KEY = 'lightdash-chunk-error-reload';
-const RELOAD_COOLDOWN_MS = 60_000; // 60 seconds before allowing another auto-reload
-
 const CHUNK_ERROR_MESSAGES = [
     'Failed to fetch dynamically imported module',
     'error loading dynamically imported module',
@@ -8,8 +5,6 @@ const CHUNK_ERROR_MESSAGES = [
     'Failed to load module script',
     'Unable to preload CSS',
 ];
-
-let isChunkLoadErrorHandlerInstalled = false;
 
 export const isChunkLoadError = (message: string): boolean => {
     const normalizedMessage = message.toLowerCase();
@@ -23,77 +18,4 @@ export const isChunkLoadErrorObject = (error: unknown): boolean => {
         return isChunkLoadError(error.message);
     }
     return false;
-};
-
-/**
- * Check if we've recently attempted an auto-reload for chunk errors.
- * Used by ErrorBoundary to decide whether to auto-reload or show manual refresh UI.
- */
-export const hasRecentChunkReload = (): boolean => {
-    try {
-        const reloadTimestamp = sessionStorage.getItem(CHUNK_ERROR_RELOAD_KEY);
-        if (!reloadTimestamp) {
-            return false;
-        }
-
-        const reloadTime = parseInt(reloadTimestamp, 10);
-
-        if (isNaN(reloadTime) || Date.now() - reloadTime > RELOAD_COOLDOWN_MS) {
-            sessionStorage.removeItem(CHUNK_ERROR_RELOAD_KEY);
-            return false;
-        }
-
-        return true;
-    } catch {
-        // sessionStorage may throw in private browsing or when storage is disabled.
-        // Return true to skip auto-reload and show manual refresh UI (avoids infinite loop).
-        return true;
-    }
-};
-
-/**
- * Trigger an auto-reload for a chunk error.
- * Sets sessionStorage flag to prevent infinite loops.
- */
-export const triggerChunkErrorReload = (): void => {
-    try {
-        sessionStorage.setItem(CHUNK_ERROR_RELOAD_KEY, Date.now().toString());
-    } catch {
-        // sessionStorage may throw in private browsing or when storage is disabled.
-        // Proceed with reload anyway - worst case user sees manual refresh UI.
-    }
-    window.location.reload();
-};
-
-const reloadOnceForChunkError = (): boolean => {
-    if (hasRecentChunkReload()) {
-        return false;
-    }
-
-    triggerChunkErrorReload();
-    return true;
-};
-
-export const installChunkLoadErrorHandler = (): void => {
-    if (typeof window === 'undefined' || isChunkLoadErrorHandlerInstalled) {
-        return;
-    }
-
-    isChunkLoadErrorHandlerInstalled = true;
-
-    window.addEventListener('vite:preloadError', (event) => {
-        if (reloadOnceForChunkError()) {
-            event.preventDefault();
-        }
-    });
-
-    window.addEventListener('unhandledrejection', (event) => {
-        if (!isChunkLoadErrorObject(event.reason)) {
-            return;
-        }
-
-        if (reloadOnceForChunkError()) {
-            event.preventDefault();
-        }
-    });
 };

--- a/packages/frontend/src/features/chunkErrorHandler/index.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/index.ts
@@ -1,7 +1,1 @@
-export {
-    hasRecentChunkReload,
-    installChunkLoadErrorHandler,
-    isChunkLoadError,
-    isChunkLoadErrorObject,
-    triggerChunkErrorReload,
-} from './chunkErrorHandler';
+export { isChunkLoadError, isChunkLoadErrorObject } from './chunkErrorHandler';

--- a/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.tsx
@@ -3,25 +3,24 @@ import { Flex } from '@mantine/core';
 import * as Sentry from '@sentry/react';
 import { useEffect, useState, type FC } from 'react';
 import { useRouteError } from 'react-router';
-import {
-    hasRecentChunkReload,
-    isChunkLoadErrorObject,
-    triggerChunkErrorReload,
-} from '../chunkErrorHandler';
+import { isChunkLoadErrorObject } from '../chunkErrorHandler';
 import { ChunkErrorFallback, GeneralErrorFallback } from './ErrorFallbacks';
 
 /**
  * Route `errorElement` for react-router. Route-level `lazy` chunk failures are
- * caught by react-router itself and never reach the React ErrorBoundary or the
- * window `unhandledrejection` listener, so they need chunk-aware handling here.
+ * caught by react-router itself and never reach the React ErrorBoundary, so they
+ * need chunk-aware handling here. We never reload automatically (that would
+ * silently discard unsaved editing work); instead we show a manual-refresh
+ * fallback and let the user reload on their own terms.
  */
 const ChunkErrorRouteBoundary: FC = () => {
     const error = useRouteError();
     const isChunkError = isChunkLoadErrorObject(error);
     const [eventId, setEventId] = useState<string>('');
 
-    // Chunk errors are kept out of Sentry until auto-reload fails; capture in an
-    // effect so we don't report a side effect (or duplicates) on every render.
+    // Chunk errors are benign stale-deploy artifacts, so they're kept out of
+    // Sentry; capture other errors in an effect so we don't report a side
+    // effect (or duplicates) on every render.
     useEffect(() => {
         if (!isChunkError) {
             setEventId(Sentry.captureException(error));
@@ -29,10 +28,6 @@ const ChunkErrorRouteBoundary: FC = () => {
     }, [error, isChunkError]);
 
     if (isChunkError) {
-        if (!hasRecentChunkReload()) {
-            triggerChunkErrorReload();
-            return null;
-        }
         return (
             <Flex
                 id={ERROR_BOUNDARY_ID}

--- a/packages/frontend/src/features/errorBoundary/ErrorBoundary.test.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorBoundary.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { type ReactElement } from 'react';
 import {
     afterAll,
     afterEach,
@@ -8,21 +9,26 @@ import {
     it,
     vi,
 } from 'vitest';
-import ChunkErrorRouteBoundary from './ChunkErrorRouteBoundary';
+import ErrorBoundary from './ErrorBoundary';
 
-const mockUseRouteError = vi.fn();
 const mockIsChunkLoadErrorObject = vi.fn();
 const mockCaptureException = vi.fn((_error: unknown) => 'event-123');
 
-vi.mock('react-router', () => ({
-    useRouteError: () => mockUseRouteError(),
-}));
+// Drive the fallback directly with a controlled error, bypassing the need for a
+// child that actually throws.
+let boundaryError: unknown = null;
 
 vi.mock('../chunkErrorHandler', () => ({
     isChunkLoadErrorObject: (e: unknown) => mockIsChunkLoadErrorObject(e),
 }));
 
 vi.mock('@sentry/react', () => ({
+    ErrorBoundary: ({
+        fallback,
+    }: {
+        fallback: (props: { eventId: string; error: unknown }) => ReactElement;
+        children: unknown;
+    }) => fallback({ eventId: 'event-123', error: boundaryError }),
     captureException: (e: unknown) => mockCaptureException(e),
 }));
 
@@ -33,7 +39,7 @@ vi.mock('./ErrorFallbacks', () => ({
     ),
 }));
 
-describe('ChunkErrorRouteBoundary', () => {
+describe('ErrorBoundary', () => {
     const reloadSpy = vi.fn();
     const originalLocation = window.location;
 
@@ -53,29 +59,36 @@ describe('ChunkErrorRouteBoundary', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+        boundaryError = null;
     });
 
     it('shows the chunk fallback and never reloads on a chunk error', () => {
-        mockUseRouteError.mockReturnValue(new Error('Failed to fetch'));
+        boundaryError = new Error('Failed to fetch');
         mockIsChunkLoadErrorObject.mockReturnValue(true);
 
-        render(<ChunkErrorRouteBoundary />);
+        render(
+            <ErrorBoundary>
+                <div>child</div>
+            </ErrorBoundary>,
+        );
 
         expect(screen.getByText('chunk-fallback')).toBeInTheDocument();
         expect(reloadSpy).not.toHaveBeenCalled();
-        expect(mockCaptureException).not.toHaveBeenCalled();
     });
 
-    it('captures non-chunk errors to Sentry and shows the general fallback', () => {
-        mockUseRouteError.mockReturnValue(new Error('boom'));
+    it('shows the general fallback on a non-chunk error', () => {
+        boundaryError = new Error('boom');
         mockIsChunkLoadErrorObject.mockReturnValue(false);
 
-        render(<ChunkErrorRouteBoundary />);
+        render(
+            <ErrorBoundary>
+                <div>child</div>
+            </ErrorBoundary>,
+        );
 
-        expect(mockCaptureException).toHaveBeenCalledTimes(1);
-        expect(reloadSpy).not.toHaveBeenCalled();
         expect(
             screen.getByText('general-fallback:event-123'),
         ).toBeInTheDocument();
+        expect(reloadSpy).not.toHaveBeenCalled();
     });
 });

--- a/packages/frontend/src/features/errorBoundary/ErrorBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorBoundary.tsx
@@ -2,16 +2,13 @@ import { ERROR_BOUNDARY_ID } from '@lightdash/common';
 import { Flex, type FlexProps } from '@mantine/core';
 import * as Sentry from '@sentry/react';
 import { type FC, type PropsWithChildren } from 'react';
-import {
-    hasRecentChunkReload,
-    isChunkLoadErrorObject,
-    triggerChunkErrorReload,
-} from '../chunkErrorHandler';
+import { isChunkLoadErrorObject } from '../chunkErrorHandler';
 import { ChunkErrorFallback, GeneralErrorFallback } from './ErrorFallbacks';
 
 /**
  * Renders the appropriate fallback based on error type.
- * For chunk errors: auto-reload once, then show manual refresh UI.
+ * For chunk errors: show a manual refresh UI (never reload automatically, as
+ * that would silently discard unsaved editing work).
  * For other errors: show error details with Sentry event ID.
  */
 const ErrorFallback: FC<{
@@ -19,21 +16,15 @@ const ErrorFallback: FC<{
     error: unknown;
     wrapper?: FlexProps;
 }> = ({ eventId, error, wrapper }) => {
-    const errorMessage = isChunkLoadErrorObject(error)
+    const isChunkError = isChunkLoadErrorObject(error);
+    const errorMessage = isChunkError
         ? 'Application update required (chunk load error)'
         : error instanceof Error
           ? error.message
           : String(error);
 
-    // Check if this is a chunk load error
-    if (isChunkLoadErrorObject(error)) {
-        // If we haven't recently reloaded, auto-reload now
-        if (!hasRecentChunkReload()) {
-            triggerChunkErrorReload();
-            // Return null while reloading - page will refresh
-            return null;
-        }
-        // Auto-reload already attempted, show manual refresh UI
+    // Chunk load errors get a manual refresh UI; we never reload automatically.
+    if (isChunkError) {
         return (
             <Flex
                 id={ERROR_BOUNDARY_ID}

--- a/packages/frontend/src/features/errorBoundary/ErrorFallbacks.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorFallbacks.tsx
@@ -3,21 +3,23 @@ import { Prism } from '@mantine/prism';
 import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
 import { type FC } from 'react';
 import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
-import { triggerChunkErrorReload } from '../chunkErrorHandler';
 
 /**
- * Fallback UI shown when a chunk load error occurs after auto-reload has failed.
- * This happens when the browser cache is aggressive or there are network issues.
+ * Fallback UI shown when a file (JS/CSS chunk) fails to load, usually because a
+ * new version has been deployed and the old chunk is gone. We never reload
+ * automatically, so the user refreshes on their own terms once their work is
+ * saved.
  */
 export const ChunkErrorFallback: FC = () => (
     <SuboptimalState
         icon={IconAlertCircle}
-        title="Application update required"
+        title="File not found, please refresh the page"
         description={
             <Box>
                 <Text mb="xs">
-                    A new version of Lightdash is available. Please refresh your
-                    browser to load the latest version.
+                    A new version of Lightdash is available. Save any unsaved
+                    changes, then refresh your browser to load the latest
+                    version.
                 </Text>
                 <Text size="sm" c="dimmed">
                     If this persists after refreshing, try clearing your browser
@@ -30,7 +32,7 @@ export const ChunkErrorFallback: FC = () => (
                 variant="default"
                 size="xs"
                 leftSection={<IconRefresh size={16} />}
-                onClick={triggerChunkErrorReload}
+                onClick={() => window.location.reload()}
             >
                 Refresh page
             </Button>

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -16,10 +16,7 @@ import {
     useNavigationType,
     useParams,
 } from 'react-router';
-import {
-    hasRecentChunkReload,
-    isChunkLoadErrorObject,
-} from '../../features/chunkErrorHandler';
+import { isChunkLoadErrorObject } from '../../features/chunkErrorHandler';
 
 const sentrySpotlightEnabled =
     import.meta.env.DEV && import.meta.env.VITE_SENTRY_SPOTLIGHT;
@@ -86,11 +83,9 @@ const useSentry = (
                 replaysOnErrorSampleRate: 1.0,
                 beforeSend(event, hint) {
                     const error = hint.originalException;
-                    // For chunk load errors, only send to Sentry if auto-reload already failed
-                    if (
-                        isChunkLoadErrorObject(error) &&
-                        !hasRecentChunkReload()
-                    ) {
+                    // Chunk load errors are benign stale-deploy artifacts that
+                    // the user resolves by refreshing, so keep them out of Sentry.
+                    if (isChunkLoadErrorObject(error)) {
                         return null;
                     }
 


### PR DESCRIPTION
Closes #25011

## Bug

After a frontend deploy, an old browser tab requests a lazily-loaded JS chunk whose hashed filename the deploy already purged → 404 → `Failed to fetch dynamically imported module`. To self-heal, the app called `window.location.reload()` automatically. That programmatic reload bypasses the editors' unsaved-changes guards, so in-progress chart/dashboard edits are silently discarded. In dashboard view mode the reload happened with no warning at all.

## Root cause

`triggerChunkErrorReload()` called `window.location.reload()` from a global window listener and from both error boundaries, with no check for unsaved editing state. `useBlocker` doesn't intercept a full-page reload, and nothing persists editor state across it.

## Fix

Never reload automatically. A stale chunk now surfaces as a normal error boundary state — "File not found, please refresh the page" — with a **Refresh page** button the user clicks themselves. A user-initiated reload still triggers the editors' `beforeunload` guard, so the user is warned and can save first.

```
Before:  stale chunk 404 → window.location.reload()   → unsaved edits gone
After:   stale chunk 404 → ChunkErrorFallback UI       → user saves, then clicks Refresh
```

- Removed the global `vite:preloadError` / `unhandledrejection` auto-reload listeners (`installChunkLoadErrorHandler`) and the reload/cooldown machinery; kept only the detection helpers `isChunkLoadError` / `isChunkLoadErrorObject`.
- `ErrorBoundary` and `ChunkErrorRouteBoundary` always render `ChunkErrorFallback` on a chunk error.
- The fallback + the pivot-worker refresh button call `window.location.reload()` directly (user-initiated).
- Chunk errors are dropped from Sentry — they're now a handled, benign UX state.

## Test plan

- `pnpm -F frontend typecheck:fast`, `oxlint`, `vitest src/features/errorBoundary` (4 tests) — all green.
- New/updated regression tests: `ChunkErrorRouteBoundary.test.tsx` and `ErrorBoundary.test.tsx` assert a chunk error renders the fallback and **never** calls `window.location.reload()`; non-chunk errors still capture to Sentry + show the general fallback. Both verified red against the old auto-reload code.
- Manual (dev instance): dashboard in edit mode with an unsaved tile, dispatched the real stale-chunk events. Before: page reloaded, tile lost (`navigation.type: reload`). After: no reload (`navigation.type: navigate`), unsaved tile and dirty state preserved.

## Notes

- Trade-off vs PROD-8474 (recurring stale-chunk errors), which proposed *more* aggressive guarded auto-reload — this deliberately goes the other way (safety over auto-healing) and drops the Sentry signal for chunk errors. Intentional; PROD-8474 can add deploy-health monitoring separately.
- Known gaps (low risk): a dynamic-import failure that rejects outside React render (worker/event-handler) now gets neither reload nor fallback UI; the manual Refresh button isn't unit-tested (Mantine v6/v8 + CSS-module render is brittle).
