### PR TITLE
feat: data apps as code — upload safety, docs & verification [GLITCH-570]

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -887,6 +887,50 @@ Opt-in flags on the existing `lightdash download` / `lightdash upload` commands 
 - **Semantic-layer coupling:** a moved app's queries run against the **target project's** fields *by name*; fields missing in the target surface as in-app query errors, not upload failures.
 - **Security:** because the server only ever builds source in its trusted, network-locked sandbox and never serves client-supplied *built* code, the runtime trust model is unchanged from AI-generated apps. See [Security Model](#security-model). (Follow-up: the query bridge runs as the *viewing* user — a pre-existing consideration for any app, generated or uploaded.)
 
+### Local authoring (Phase 2)
+
+Phase 1 makes apps [downloadable and uploadable from source](#cli); Phase 2 makes the downloaded tree **locally buildable**, so you can verify changes compile before uploading.
+
+#### What `lightdash download --apps` now includes
+
+The download folder adds to the Phase 1 output (`src/` + `lightdash-app.yml`):
+
+- **Build scaffolding:** `package.json` (Lightdash App SDK pinned to the same published version the server uses), `vite.config.js`, `tailwind.config.js`, `postcss.config.js`, `tsconfig.json`, `index.html`
+- **Agent skills:** `.claude/skills/lightdash-data-app` (SDK reference) and `.claude/skills/developing-data-apps-locally` (local authoring workflow)
+- **Project files:** `AGENTS.md`, `README.md`, `.gitignore`
+- **Context snapshot** (`.lightdash/context/`): `semantic-layer.yml`, `parameters.yml` (if the app uses parameters), `prompt-history.md`, and `theme/`
+
+All scaffolding and context files are read-only reference — see [Upload is source-only](#upload-is-source-only) below.
+
+#### The local loop
+
+```sh
+edit src/  →  pnpm install && pnpm build  →  lightdash upload --apps  →  server rebuilds
+```
+
+1. Edit files under `src/`.
+2. Run `pnpm install && pnpm build` as a pre-flight compile check against the downloaded scaffolding.
+3. Upload with `lightdash upload --apps` (fire-and-forget, as in Phase 1). The server rebuilds in its trusted sandbox.
+
+**The server's build is authoritative.** Your local build is a compile check only; the deployed app is always the server's output.
+
+#### Upload is source-only
+
+Only `src/` is sent on upload. Scaffolding files and `.lightdash/context/` are local reference; the server ignores them and rebuilds against its own trusted template. Editing a local config file has **no effect** on the deployed app. The [Phase 1 trust model](#security-model) is unchanged — no new security surface.
+
+#### Context is a point-in-time snapshot
+
+`.lightdash/context/` reflects the **source project's** semantic layer at download time. On a cross-project or cross-instance upload, the target project's semantic layer may differ — queries referencing renamed or absent fields will fail in-app after upload (the existing [semantic-layer coupling caveat](#constraints--notes)). Re-download from the source project to refresh the snapshot.
+
+#### Theme asset cap
+
+If the org design linked to the app has more than **30 asset files**, the theme assets are skipped during download and a warning is printed; the theme instruction markdown is still written to `.lightdash/context/theme/`. An app whose theme was skipped may not build locally without those assets — the server-side rebuild is unaffected.
+
+#### Out of scope (Phase 3)
+
+- **Local preview against real data** — `pnpm build` is a compile check only, not a live data preview.
+- **Bring-your-own libraries** — running `pnpm add` locally has no effect on the server's sandbox. This is the "future bring your own libraries" path noted in [Constraints & notes](#constraints--notes).
+
 ---
 
 ## Frontend Architecture

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -4,6 +4,7 @@ import {
     type DataAppCode,
     type ImportAppCodeRequestBody,
 } from '@lightdash/common';
+import { extract as tarExtract } from 'tar-stream';
 import { AppGenerateService } from './AppGenerateService';
 
 vi.mock('e2b', () => ({
@@ -309,5 +310,48 @@ describe('AppGenerateService.importAppCode', () => {
         expect(result.action).toBe('create');
         expect(appModel.createWithVersion).toHaveBeenCalledOnce();
         expect(schedulerClient.appBuildFromSource).toHaveBeenCalledOnce();
+    });
+
+    it('create mode: source.tar contains only src/ entries when bundle has mixed files', async () => {
+        const { service, appModel } = buildService();
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        const mixedCode = makeCode([
+            {
+                path: 'src/App.jsx',
+                contentBase64: Buffer.from('// app').toString('base64'),
+            },
+            {
+                path: 'vite.config.js',
+                contentBase64: Buffer.from('// vite').toString('base64'),
+            },
+            {
+                path: '.lightdash/context/semantic-layer.yml',
+                contentBase64: Buffer.from('# context').toString('base64'),
+            },
+        ]);
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: mixedCode,
+        } as ImportAppCodeRequestBody);
+
+        const putArg = s3SendSpy.mock.calls[0][0];
+        const tarBuffer = putArg.input.Body as Buffer;
+
+        const entryNames = await new Promise<string[]>((resolve, reject) => {
+            const names: string[] = [];
+            const extractor = tarExtract();
+            extractor.on('entry', (header, stream, next) => {
+                names.push(header.name);
+                stream.resume();
+                stream.on('end', next);
+            });
+            extractor.on('finish', () => resolve(names));
+            extractor.on('error', reject);
+            extractor.end(tarBuffer);
+        });
+
+        expect(entryNames).toEqual(['src/App.jsx']);
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -355,6 +355,53 @@ describe('AppGenerateService.getAppCode', () => {
         ).rejects.toThrow(ForbiddenError);
     });
 
+    it('resolves with manifest and files intact when semanticLayer fetch fails (degraded context)', async () => {
+        const fakeS3 = makeFakeS3(sourceTarBuffer);
+
+        const appModel = {
+            getApp: vi.fn().mockResolvedValue(fakeApp),
+            getLatestReadyVersion: vi.fn().mockResolvedValue(fakeAppVersion),
+            getAppWithVersions: vi
+                .fn()
+                .mockResolvedValue({ versions: [], hasMore: false }),
+        };
+
+        const svc = buildService({
+            appModel,
+            s3ClientOverride: fakeS3,
+            projectModel: {
+                getAllExploresFromCache: vi
+                    .fn()
+                    .mockRejectedValue(new Error('cache miss')),
+            },
+            projectParametersModel: {
+                find: vi.fn().mockResolvedValue([]),
+            },
+            organizationDesignModel: {
+                findInOrganization: vi.fn().mockResolvedValue(null),
+            },
+        });
+
+        // Should not throw even though semanticLayer fetch fails
+        const result = await svc.getAppCode(fakeUser, PROJECT_UUID, APP_UUID);
+
+        // Core deliverables are intact
+        expect(result.manifest.appUuid).toBe(APP_UUID);
+        expect(result.manifest.version).toBe(VERSION);
+        expect(result.files).toHaveLength(2);
+
+        // Semantic layer is degraded placeholder, not absent
+        expect(result.context.semanticLayer).toBeDefined();
+        expect(result.context.semanticLayer.path).toBe(
+            '.lightdash/context/semantic-layer.yml',
+        );
+        const semanticContent = Buffer.from(
+            result.context.semanticLayer.contentBase64,
+            'base64',
+        ).toString('utf8');
+        expect(semanticContent).toContain('# Semantic layer unavailable');
+    });
+
     it('assembles context: semantic layer, null parameters (empty), prompt history, and empty theme', async () => {
         const fakeS3 = makeFakeS3(sourceTarBuffer);
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -75,6 +75,7 @@ const fakeApp = {
     name: 'My App',
     description: 'A test app',
     template: null,
+    design_uuid: null,
 };
 
 const fakeAppVersion = {
@@ -147,8 +148,40 @@ function makeFakeS3(tarBuffer: Buffer, expectedVersion: number = VERSION) {
 function buildService(overrides: {
     appModel?: Record<string, unknown>;
     s3ClientOverride?: { client: never; bucket: string };
+    projectModel?: Record<string, unknown>;
+    projectParametersModel?: Record<string, unknown>;
+    organizationDesignModel?: Record<string, unknown>;
 }): AppGenerateService {
-    const { appModel = {}, s3ClientOverride } = overrides;
+    const {
+        appModel = {},
+        s3ClientOverride,
+        projectModel = {},
+        projectParametersModel = {},
+        organizationDesignModel = {},
+    } = overrides;
+
+    // Default mocks for context-assembly methods so existing tests don't break
+    const fullAppModel = {
+        getAppWithVersions: vi
+            .fn()
+            .mockResolvedValue({ versions: [], hasMore: false }),
+        ...appModel,
+    };
+
+    const fullProjectModel = {
+        getAllExploresFromCache: vi.fn().mockResolvedValue({}),
+        ...projectModel,
+    };
+
+    const fullProjectParametersModel = {
+        find: vi.fn().mockResolvedValue([]),
+        ...projectParametersModel,
+    };
+
+    const fullOrganizationDesignModel = {
+        findInOrganization: vi.fn().mockResolvedValue(null),
+        ...organizationDesignModel,
+    };
 
     const featureFlagModel = {
         get: vi.fn().mockResolvedValue({ enabled: true }),
@@ -162,12 +195,12 @@ function buildService(overrides: {
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
-        appModel: appModel as never,
+        appModel: fullAppModel as never,
         featureFlagModel: featureFlagModel as never,
-        organizationDesignModel: {} as never,
+        organizationDesignModel: fullOrganizationDesignModel as never,
         pinnedListModel: {} as never,
-        projectModel: {} as never,
-        projectParametersModel: {} as never,
+        projectModel: fullProjectModel as never,
+        projectParametersModel: fullProjectParametersModel as never,
         spaceModel: {} as never,
         schedulerClient: {} as never,
         savedChartService: {} as never,
@@ -320,5 +353,89 @@ describe('AppGenerateService.getAppCode', () => {
         await expect(
             svc.getAppCode(fakeUser, PROJECT_UUID, APP_UUID),
         ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('assembles context: semantic layer, null parameters (empty), prompt history, and empty theme', async () => {
+        const fakeS3 = makeFakeS3(sourceTarBuffer);
+
+        const versions = [
+            {
+                app_version_id: 'v1-id',
+                app_id: APP_UUID,
+                version: 1,
+                prompt: 'Build a sales dashboard',
+                status: 'ready' as const,
+                error: null,
+                status_message: null,
+                status_updated_at: null,
+                resources: null,
+                viz_schema: null,
+                created_at: new Date('2024-01-01T10:00:00Z'),
+                created_by_user_uuid: 'user-uuid',
+                created_by_user_first_name: 'Test',
+                created_by_user_last_name: 'User',
+            },
+            {
+                app_version_id: 'v2-id',
+                app_id: APP_UUID,
+                version: 2,
+                prompt: 'Add a bar chart for revenue',
+                status: 'ready' as const,
+                error: null,
+                status_message: null,
+                status_updated_at: null,
+                resources: null,
+                viz_schema: null,
+                created_at: new Date('2024-01-02T10:00:00Z'),
+                created_by_user_uuid: 'user-uuid',
+                created_by_user_first_name: 'Test',
+                created_by_user_last_name: 'User',
+            },
+        ];
+
+        const appModel = {
+            getApp: vi.fn().mockResolvedValue({ ...fakeApp, version: VERSION }),
+            getLatestReadyVersion: vi.fn().mockResolvedValue(fakeAppVersion),
+            getAppWithVersions: vi
+                .fn()
+                .mockResolvedValue({ versions, hasMore: false }),
+        };
+
+        const svc = buildService({
+            appModel,
+            s3ClientOverride: fakeS3,
+            projectModel: {
+                getAllExploresFromCache: vi.fn().mockResolvedValue({}),
+            },
+            projectParametersModel: {
+                find: vi.fn().mockResolvedValue([]),
+            },
+            organizationDesignModel: {
+                findInOrganization: vi.fn().mockResolvedValue(null),
+            },
+        });
+
+        const result = await svc.getAppCode(fakeUser, PROJECT_UUID, APP_UUID);
+
+        // semantic layer context file is always present
+        expect(result.context.semanticLayer.path).toBe(
+            '.lightdash/context/semantic-layer.yml',
+        );
+
+        // empty parameters → null
+        expect(result.context.parameters).toBeNull();
+
+        // prompt history includes both prompts (newest-first ordering)
+        const promptHistoryContent = Buffer.from(
+            result.context.promptHistory.contentBase64,
+            'base64',
+        ).toString('utf8');
+        expect(promptHistoryContent).toContain('Build a sales dashboard');
+        expect(promptHistoryContent).toContain('Add a bar chart for revenue');
+
+        // no theme (design_uuid is null) → empty theme with skippedAssetCount 0
+        expect(result.context.theme.skippedAssetCount).toBe(0);
+        expect(result.context.theme.assets).toHaveLength(0);
+        expect(result.context.theme.instructions).toBeNull();
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -47,6 +47,8 @@ import {
     type CompiledTable,
     type DataAppClaudeModel,
     type DataAppCode,
+    type DataAppCodeDownload,
+    type DataAppContext,
     type DataAppTemplate,
     type DataAppViz,
     type DataAppVizSchema,
@@ -120,6 +122,7 @@ import {
     s3KeyToRelPath,
     versionPrefix,
 } from './appCode';
+import { contextFile, promptHistoryToMarkdown } from './appContext';
 import {
     classifyClaudeCliFailure,
     ClaudeGenerationError,
@@ -139,6 +142,7 @@ import {
     copyDesignIntoSandbox,
     type DesignSandboxCopyResult,
 } from './designSandboxCopy';
+import { readDesignForDownload } from './readDesignForDownload';
 import { getTemplateInstructions } from './templates';
 
 /**
@@ -6713,7 +6717,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         projectUuid: string,
         appUuid: string,
         version?: number,
-    ): Promise<DataAppCode> {
+    ): Promise<DataAppCodeDownload> {
         const app = await this.appModel.getApp(appUuid, projectUuid);
         await this.assertCanViewApp(user, app);
 
@@ -6814,7 +6818,62 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             downloadedAt: new Date().toISOString(),
         });
 
-        return { manifest, files };
+        const context = await this.assembleAppContext(
+            app,
+            projectUuid,
+            app.organization_uuid,
+        );
+
+        return { manifest, files, context };
+    }
+
+    private async assembleAppContext(
+        app: { app_id: string; design_uuid: string | null },
+        projectUuid: string,
+        organizationUuid: string,
+    ): Promise<DataAppContext> {
+        const exploresByUuid =
+            await this.projectModel.getAllExploresFromCache(projectUuid);
+        const explores = Object.values(exploresByUuid).filter(
+            (e): e is Explore => !isExploreError(e),
+        );
+        const { yaml: modelYaml } = AppGenerateService.exploresToYaml(explores);
+
+        const globalParameters =
+            await this.projectParametersModel.find(projectUuid);
+        const configYaml =
+            AppGenerateService.projectParametersToConfigYaml(globalParameters);
+
+        const withVersions = await this.appModel.getAppWithVersions(
+            app.app_id,
+            projectUuid,
+        );
+        const promptMd = promptHistoryToMarkdown(
+            withVersions.versions.map((v) => ({
+                version: v.version,
+                prompt: v.prompt ?? '',
+                createdAt: v.created_at.toISOString(),
+            })),
+        );
+
+        const { client: s3Client, bucket } = this.getS3Client();
+        const theme = await readDesignForDownload({
+            s3Client,
+            bucket,
+            organizationDesignModel: this.organizationDesignModel,
+            organizationUuid,
+            designUuid: app.design_uuid,
+            logger: this.logger,
+        });
+
+        return {
+            semanticLayer: contextFile('semantic-layer.yml', modelYaml),
+            parameters: configYaml
+                ? contextFile('parameters.yml', configYaml)
+                : null,
+            promptHistory: contextFile('prompt-history.md', promptMd),
+            theme,
+        };
     }
 
     async importAppCode(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -6832,48 +6832,103 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         projectUuid: string,
         organizationUuid: string,
     ): Promise<DataAppContext> {
-        const exploresByUuid =
-            await this.projectModel.getAllExploresFromCache(projectUuid);
-        const explores = Object.values(exploresByUuid).filter(
-            (e): e is Explore => !isExploreError(e),
-        );
-        const { yaml: modelYaml } = AppGenerateService.exploresToYaml(explores);
+        // Each piece is fetched independently — a failure in one degrades only
+        // that piece and never blocks the download of manifest + files.
 
-        const globalParameters =
-            await this.projectParametersModel.find(projectUuid);
-        const configYaml =
-            AppGenerateService.projectParametersToConfigYaml(globalParameters);
+        const semanticLayer = await (async () => {
+            try {
+                const exploresByUuid =
+                    await this.projectModel.getAllExploresFromCache(
+                        projectUuid,
+                    );
+                const explores = Object.values(exploresByUuid).filter(
+                    (e): e is Explore => !isExploreError(e),
+                );
+                const { yaml: modelYaml } =
+                    AppGenerateService.exploresToYaml(explores);
+                return contextFile('semantic-layer.yml', modelYaml);
+            } catch (err) {
+                this.logger.warn(
+                    `assembleAppContext: semantic layer unavailable for project ${projectUuid}`,
+                    err,
+                );
+                return contextFile(
+                    'semantic-layer.yml',
+                    '# Semantic layer unavailable\n',
+                );
+            }
+        })();
 
-        const withVersions = await this.appModel.getAppWithVersions(
-            app.app_id,
-            projectUuid,
-        );
-        const promptMd = promptHistoryToMarkdown(
-            withVersions.versions.map((v) => ({
-                version: v.version,
-                prompt: v.prompt ?? '',
-                createdAt: v.created_at.toISOString(),
-            })),
-        );
+        const parameters = await (async () => {
+            try {
+                const globalParameters =
+                    await this.projectParametersModel.find(projectUuid);
+                const configYaml =
+                    AppGenerateService.projectParametersToConfigYaml(
+                        globalParameters,
+                    );
+                return configYaml
+                    ? contextFile('parameters.yml', configYaml)
+                    : null;
+            } catch (err) {
+                this.logger.warn(
+                    `assembleAppContext: parameters unavailable for project ${projectUuid}`,
+                    err,
+                );
+                return null;
+            }
+        })();
 
-        const { client: s3Client, bucket } = this.getS3Client();
-        const theme = await readDesignForDownload({
-            s3Client,
-            bucket,
-            organizationDesignModel: this.organizationDesignModel,
-            organizationUuid,
-            designUuid: app.design_uuid,
-            logger: this.logger,
-        });
+        const promptHistory = await (async () => {
+            try {
+                const withVersions = await this.appModel.getAppWithVersions(
+                    app.app_id,
+                    projectUuid,
+                );
+                const promptMd = promptHistoryToMarkdown(
+                    withVersions.versions.map((v) => ({
+                        version: v.version,
+                        prompt: v.prompt ?? '',
+                        createdAt:
+                            v.created_at instanceof Date
+                                ? v.created_at.toISOString()
+                                : String(v.created_at),
+                    })),
+                );
+                return contextFile('prompt-history.md', promptMd);
+            } catch (err) {
+                this.logger.warn(
+                    `assembleAppContext: prompt history unavailable for app ${app.app_id}`,
+                    err,
+                );
+                return contextFile(
+                    'prompt-history.md',
+                    '# Prompt history\n\n_Unavailable._\n',
+                );
+            }
+        })();
 
-        return {
-            semanticLayer: contextFile('semantic-layer.yml', modelYaml),
-            parameters: configYaml
-                ? contextFile('parameters.yml', configYaml)
-                : null,
-            promptHistory: contextFile('prompt-history.md', promptMd),
-            theme,
-        };
+        const theme = await (async () => {
+            try {
+                const { client: s3Client, bucket } = this.getS3Client();
+                return await readDesignForDownload({
+                    s3Client,
+                    bucket,
+                    organizationDesignModel: this.organizationDesignModel,
+                    organizationUuid,
+                    designUuid: app.design_uuid,
+                    logger: this.logger,
+                });
+            } catch (err) {
+                this.logger.warn(
+                    `assembleAppContext: theme unavailable for org ${organizationUuid}`,
+                    err,
+                );
+                return { instructions: null, assets: [], skippedAssetCount: 0 };
+            }
+        })();
+
+        return { semanticLayer, parameters, promptHistory, theme };
     }
 
     async importAppCode(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -6943,8 +6943,11 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         await this.assertDataAppsEnabled(user);
 
         const code = validateDataAppCode(body.code);
-        if (!code.files.some((f) => f.path.startsWith('src/'))) {
-            throw new ParameterError('bundle has no src/ files to build');
+        const sourceFiles = code.files.filter((f) => f.path.startsWith('src/'));
+        if (sourceFiles.length === 0) {
+            throw new ParameterError(
+                'Uploaded bundle has no src/ files to build',
+            );
         }
 
         // Determine mode: append to existing app or create new one
@@ -7039,11 +7042,11 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             packer.on('error', reject);
 
             const addNext = (index: number): void => {
-                if (index >= code.files.length) {
+                if (index >= sourceFiles.length) {
                     packer.finalize();
                     return;
                 }
-                const file = code.files[index];
+                const file = sourceFiles[index];
                 const content = Buffer.from(file.contentBase64, 'base64');
                 packer.entry({ name: file.path }, content, (err) => {
                     if (err) {

--- a/packages/backend/src/ee/services/AppGenerateService/appContext.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appContext.test.ts
@@ -1,0 +1,35 @@
+import {
+    CONTEXT_PREFIX,
+    contextFile,
+    promptHistoryToMarkdown,
+    THEME_ASSET_CAP,
+} from './appContext';
+
+describe('appContext helpers', () => {
+    it('caps theme assets at 30', () => {
+        expect(THEME_ASSET_CAP).toBe(30);
+    });
+    it('prefixes and base64-encodes a context file', () => {
+        const f = contextFile('semantic-layer.yml', 'models: []');
+        expect(f.path).toBe(`${CONTEXT_PREFIX}semantic-layer.yml`);
+        expect(Buffer.from(f.contentBase64, 'base64').toString('utf-8')).toBe(
+            'models: []',
+        );
+    });
+    it('renders prompt history newest first', () => {
+        const md = promptHistoryToMarkdown([
+            {
+                version: 1,
+                prompt: 'first',
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+            {
+                version: 2,
+                prompt: 'second',
+                createdAt: '2026-01-02T00:00:00.000Z',
+            },
+        ]);
+        expect(md.indexOf('Version 2')).toBeLessThan(md.indexOf('Version 1'));
+        expect(md).toContain('second');
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/appContext.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appContext.ts
@@ -1,0 +1,27 @@
+import { type DataAppContextFile } from '@lightdash/common';
+
+export const CONTEXT_PREFIX = '.lightdash/context/';
+export const THEME_ASSET_CAP = 30;
+
+export const contextFile = (
+    relPath: string,
+    content: string | Buffer,
+): DataAppContextFile => ({
+    path: `${CONTEXT_PREFIX}${relPath}`,
+    contentBase64: Buffer.isBuffer(content)
+        ? content.toString('base64')
+        : Buffer.from(content, 'utf-8').toString('base64'),
+});
+
+export const promptHistoryToMarkdown = (
+    versions: { version: number; prompt: string; createdAt: string }[],
+): string => {
+    const sorted = [...versions].sort((a, b) => b.version - a.version);
+    const body = sorted
+        .map(
+            (v) =>
+                `## Version ${v.version} — ${v.createdAt}\n\n${v.prompt.trim() || '_(no prompt)_'}`,
+        )
+        .join('\n\n');
+    return `# Prompt history\n\nThe prompts used to generate each version of this app, newest first.\n\n${body}\n`;
+};

--- a/packages/backend/src/ee/services/AppGenerateService/designSandboxCopy.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/designSandboxCopy.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { type S3Client } from '@aws-sdk/client-s3';
 import {
     type AppVersionDesignSnapshot,
     type OrganizationDesignFileKind,
@@ -7,6 +7,7 @@ import type { Logger } from 'winston';
 import type { OrganizationDesignModel } from '../../../models/OrganizationDesignModel';
 import { designS3Key } from '../../../services/OrganizationDesignService/OrganizationDesignService';
 import { type SandboxHandle } from '../SandboxRuntime';
+import { readS3ObjectAsBuffer } from './s3Utils';
 
 /**
  * Sandbox layout the agent sees when a theme is applied. Subdirectories are
@@ -39,25 +40,6 @@ const EMPTY_RESULT: DesignSandboxCopyResult = {
     fontPaths: [],
     instructionMarkdown: '',
     designSnapshot: null,
-};
-
-const readS3ObjectAsBuffer = async (
-    s3Client: S3Client,
-    bucket: string,
-    key: string,
-): Promise<Buffer> => {
-    const response = await s3Client.send(
-        new GetObjectCommand({ Bucket: bucket, Key: key }),
-    );
-    const body = response.Body;
-    if (!body || typeof (body as NodeJS.ReadableStream).on !== 'function') {
-        throw new Error(`Unexpected S3 response body type for key=${key}`);
-    }
-    const chunks: Uint8Array[] = [];
-    for await (const chunk of body as AsyncIterable<Uint8Array>) {
-        chunks.push(chunk);
-    }
-    return Buffer.concat(chunks);
 };
 
 /**

--- a/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.test.ts
@@ -128,6 +128,9 @@ describe('readDesignForDownload', () => {
         expect(result.instructions?.path).toBe(
             '.lightdash/context/theme/instructions.md',
         );
+        expect(result.assets[0].path).toBe(
+            '.lightdash/context/theme/assets/css-1.css',
+        );
         // All 3 files fetched from S3 (2 assets + 1 instruction)
         expect(s3Client.send).toHaveBeenCalledTimes(3);
     });

--- a/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.test.ts
@@ -1,0 +1,168 @@
+import { Readable } from 'stream';
+
+// A minimal helper that builds a fake S3 response body from a Buffer.
+// readS3ObjectAsBuffer checks for `.on` (stream-like) then iterates as async iterable.
+// Node's Readable satisfies both requirements.
+const makeS3Body = (buf: Buffer) => Readable.from(buf);
+
+// Build a fake S3 client whose send() always returns a body containing the
+// given buffer content. In real usage different keys return different files;
+// here we give every call the same small buffer — enough to verify the
+// plumbing without caring about content.
+const makeS3Client = (content: Buffer = Buffer.from('file-content')) => ({
+    send: vi
+        .fn()
+        .mockImplementation(() =>
+            Promise.resolve({ Body: makeS3Body(content) }),
+        ),
+});
+
+const KIND_EXTENSIONS: Record<
+    'css' | 'font' | 'image' | 'instruction',
+    string
+> = {
+    css: 'css',
+    font: 'woff2',
+    image: 'png',
+    instruction: 'md',
+};
+
+const makeDesignFile = (
+    kind: 'css' | 'font' | 'image' | 'instruction',
+    n: number,
+) => ({
+    fileUuid: `file-uuid-${kind}-${n}`,
+    kind,
+    filename: `${kind}-${n}.${KIND_EXTENSIONS[kind]}`,
+    contentType: 'application/octet-stream',
+    sizeBytes: 100,
+    createdAt: new Date('2024-01-01'),
+});
+
+const makeDesign = (
+    files: ReturnType<typeof makeDesignFile>[],
+    extraInstructions: string | null = null,
+) => ({
+    designUuid: 'design-uuid-1',
+    organizationUuid: 'org-uuid-1',
+    name: 'Test Design',
+    description: null,
+    extraInstructions,
+    isDefault: false,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    createdByUserUuid: null,
+    files,
+});
+
+const makeOrganizationDesignModel = (
+    design: ReturnType<typeof makeDesign> | undefined,
+) => ({
+    findInOrganization: vi.fn().mockResolvedValue(design),
+});
+
+const makeLogger = () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+});
+
+describe('readDesignForDownload', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('(a) returns empty context when designUuid is null', async () => {
+        const { readDesignForDownload } =
+            await import('./readDesignForDownload');
+        const s3Client = makeS3Client();
+        const organizationDesignModel = makeOrganizationDesignModel(undefined);
+        const logger = makeLogger();
+
+        const result = await readDesignForDownload({
+            s3Client: s3Client as never,
+            bucket: 'test-bucket',
+            organizationDesignModel: organizationDesignModel as never,
+            organizationUuid: 'org-uuid-1',
+            designUuid: null,
+            logger: logger as never,
+        });
+
+        expect(result).toEqual({
+            instructions: null,
+            assets: [],
+            skippedAssetCount: 0,
+        });
+        expect(
+            organizationDesignModel.findInOrganization,
+        ).not.toHaveBeenCalled();
+        expect(s3Client.send).not.toHaveBeenCalled();
+    });
+
+    it('(b) returns 2 assets and instructions when design has 2 assets + 1 instruction file', async () => {
+        const { readDesignForDownload } =
+            await import('./readDesignForDownload');
+        const files = [
+            makeDesignFile('css', 1),
+            makeDesignFile('image', 1),
+            makeDesignFile('instruction', 1),
+        ];
+        const design = makeDesign(files);
+        const organizationDesignModel = makeOrganizationDesignModel(design);
+        const s3Client = makeS3Client(Buffer.from('# My instructions'));
+        const logger = makeLogger();
+
+        const result = await readDesignForDownload({
+            s3Client: s3Client as never,
+            bucket: 'test-bucket',
+            organizationDesignModel: organizationDesignModel as never,
+            organizationUuid: 'org-uuid-1',
+            designUuid: 'design-uuid-1',
+            logger: logger as never,
+        });
+
+        expect(result.assets).toHaveLength(2);
+        expect(result.skippedAssetCount).toBe(0);
+        expect(result.instructions).not.toBeNull();
+        expect(result.instructions?.path).toBe(
+            '.lightdash/context/theme/instructions.md',
+        );
+        // All 3 files fetched from S3 (2 assets + 1 instruction)
+        expect(s3Client.send).toHaveBeenCalledTimes(3);
+    });
+
+    it('(c) returns 0 assets and skippedAssetCount=31 when design has 31 assets, with instructions still present', async () => {
+        const { readDesignForDownload } =
+            await import('./readDesignForDownload');
+        const assetFiles = Array.from({ length: 31 }, (_, i) =>
+            makeDesignFile('css', i),
+        );
+        const instructionFile = makeDesignFile('instruction', 1);
+        const files = [...assetFiles, instructionFile];
+        const design = makeDesign(files);
+        const organizationDesignModel = makeOrganizationDesignModel(design);
+        const s3Client = makeS3Client(Buffer.from('# Theme instructions'));
+        const logger = makeLogger();
+
+        const result = await readDesignForDownload({
+            s3Client: s3Client as never,
+            bucket: 'test-bucket',
+            organizationDesignModel: organizationDesignModel as never,
+            organizationUuid: 'org-uuid-1',
+            designUuid: 'design-uuid-1',
+            logger: logger as never,
+        });
+
+        expect(result.assets).toHaveLength(0);
+        expect(result.skippedAssetCount).toBe(31);
+        // Instructions should still be present (instruction file was read + cap note appended)
+        expect(result.instructions).not.toBeNull();
+        expect(result.instructions?.path).toBe(
+            '.lightdash/context/theme/instructions.md',
+        );
+        // Only the 1 instruction file is fetched from S3 (assets are skipped)
+        expect(s3Client.send).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.ts
@@ -1,0 +1,133 @@
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { type DataAppThemeContext } from '@lightdash/common';
+import type { Logger } from 'winston';
+import type { OrganizationDesignModel } from '../../../models/OrganizationDesignModel';
+import { designS3Key } from '../../../services/OrganizationDesignService/OrganizationDesignService';
+import { contextFile, THEME_ASSET_CAP } from './appContext';
+
+const readS3ObjectAsBuffer = async (
+    s3Client: S3Client,
+    bucket: string,
+    key: string,
+): Promise<Buffer> => {
+    const response = await s3Client.send(
+        new GetObjectCommand({ Bucket: bucket, Key: key }),
+    );
+    const body = response.Body;
+    if (!body || typeof (body as NodeJS.ReadableStream).on !== 'function') {
+        throw new Error(`Unexpected S3 response body type for key=${key}`);
+    }
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of body as AsyncIterable<Uint8Array>) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+};
+
+const EMPTY_THEME: DataAppThemeContext = {
+    instructions: null,
+    assets: [],
+    skippedAssetCount: 0,
+};
+
+export async function readDesignForDownload(args: {
+    s3Client: S3Client;
+    bucket: string;
+    organizationDesignModel: OrganizationDesignModel;
+    organizationUuid: string;
+    designUuid: string | null;
+    logger: Logger;
+}): Promise<DataAppThemeContext> {
+    const {
+        s3Client,
+        bucket,
+        organizationDesignModel,
+        organizationUuid,
+        designUuid,
+        logger,
+    } = args;
+
+    if (!designUuid) {
+        return EMPTY_THEME;
+    }
+
+    const design = await organizationDesignModel.findInOrganization(
+        organizationUuid,
+        designUuid,
+    );
+    if (!design) {
+        logger.warn(
+            `Theme ${designUuid} not found during download context build; returning empty theme`,
+        );
+        return EMPTY_THEME;
+    }
+
+    const instructionFiles = design.files.filter(
+        (f) => f.kind === 'instruction',
+    );
+    const assetFiles = design.files.filter((f) => f.kind !== 'instruction');
+
+    // Read instruction files first — always fetched regardless of asset cap
+    const instructionParts: string[] = [];
+    /* eslint-disable no-await-in-loop */
+    for (const file of instructionFiles) {
+        const key = designS3Key(
+            organizationUuid,
+            design.designUuid,
+            file.fileUuid,
+            file.filename,
+        );
+        const buffer = await readS3ObjectAsBuffer(s3Client, bucket, key);
+        instructionParts.push(buffer.toString('utf8'));
+    }
+    /* eslint-enable no-await-in-loop */
+
+    if (design.extraInstructions) {
+        instructionParts.push(design.extraInstructions);
+    }
+
+    const assetCount = assetFiles.length;
+    if (assetCount > THEME_ASSET_CAP) {
+        logger.warn(
+            `Theme ${design.designUuid}: ${assetCount} assets exceed cap of ${THEME_ASSET_CAP}; skipping all assets`,
+        );
+        instructionParts.push(
+            `> **Note**: ${assetCount} theme asset(s) were skipped because they exceed the download cap of ${THEME_ASSET_CAP}.`,
+        );
+        const instructionText = instructionParts.join('\n\n---\n\n');
+        return {
+            instructions: contextFile('theme/instructions.md', instructionText),
+            assets: [],
+            skippedAssetCount: assetCount,
+        };
+    }
+
+    // Read all asset buffers
+    const assets = [];
+    /* eslint-disable no-await-in-loop */
+    for (const file of assetFiles) {
+        const key = designS3Key(
+            organizationUuid,
+            design.designUuid,
+            file.fileUuid,
+            file.filename,
+        );
+        const buffer = await readS3ObjectAsBuffer(s3Client, bucket, key);
+        assets.push(contextFile(`theme/assets/${file.filename}`, buffer));
+    }
+    /* eslint-enable no-await-in-loop */
+
+    const instructions =
+        instructionParts.length > 0
+            ? contextFile(
+                  'theme/instructions.md',
+                  instructionParts.join('\n\n---\n\n'),
+              )
+            : null;
+
+    return {
+        instructions,
+        assets,
+        skippedAssetCount: 0,
+    };
+}

--- a/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.ts
@@ -1,34 +1,10 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { type S3Client } from '@aws-sdk/client-s3';
 import { type DataAppThemeContext } from '@lightdash/common';
 import type { Logger } from 'winston';
 import type { OrganizationDesignModel } from '../../../models/OrganizationDesignModel';
 import { designS3Key } from '../../../services/OrganizationDesignService/OrganizationDesignService';
 import { contextFile, THEME_ASSET_CAP } from './appContext';
-
-const readS3ObjectAsBuffer = async (
-    s3Client: S3Client,
-    bucket: string,
-    key: string,
-): Promise<Buffer> => {
-    const response = await s3Client.send(
-        new GetObjectCommand({ Bucket: bucket, Key: key }),
-    );
-    const body = response.Body;
-    if (!body || typeof (body as NodeJS.ReadableStream).on !== 'function') {
-        throw new Error(`Unexpected S3 response body type for key=${key}`);
-    }
-    const chunks: Uint8Array[] = [];
-    for await (const chunk of body as AsyncIterable<Uint8Array>) {
-        chunks.push(chunk);
-    }
-    return Buffer.concat(chunks);
-};
-
-const EMPTY_THEME: DataAppThemeContext = {
-    instructions: null,
-    assets: [],
-    skippedAssetCount: 0,
-};
+import { readS3ObjectAsBuffer } from './s3Utils';
 
 export async function readDesignForDownload(args: {
     s3Client: S3Client;
@@ -48,7 +24,7 @@ export async function readDesignForDownload(args: {
     } = args;
 
     if (!designUuid) {
-        return EMPTY_THEME;
+        return { instructions: null, assets: [], skippedAssetCount: 0 };
     }
 
     const design = await organizationDesignModel.findInOrganization(
@@ -59,7 +35,7 @@ export async function readDesignForDownload(args: {
         logger.warn(
             `Theme ${designUuid} not found during download context build; returning empty theme`,
         );
-        return EMPTY_THEME;
+        return { instructions: null, assets: [], skippedAssetCount: 0 };
     }
 
     const instructionFiles = design.files.filter(

--- a/packages/backend/src/ee/services/AppGenerateService/s3Utils.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/s3Utils.ts
@@ -1,0 +1,20 @@
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+
+export const readS3ObjectAsBuffer = async (
+    s3Client: S3Client,
+    bucket: string,
+    key: string,
+): Promise<Buffer> => {
+    const response = await s3Client.send(
+        new GetObjectCommand({ Bucket: bucket, Key: key }),
+    );
+    const body = response.Body;
+    if (!body || typeof (body as NodeJS.ReadableStream).on !== 'function') {
+        throw new Error(`Unexpected S3 response body type for key=${key}`);
+    }
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of body as AsyncIterable<Uint8Array>) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+};

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10353,12 +10353,86 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSuccess_DataAppCode_: {
+    DataAppContextFile: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                results: { ref: 'DataAppCode', required: true },
+                contentBase64: { dataType: 'string', required: true },
+                path: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppThemeContext: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                skippedAssetCount: { dataType: 'double', required: true },
+                assets: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DataAppContextFile' },
+                    required: true,
+                },
+                instructions: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DataAppContextFile' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppContext: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                theme: { ref: 'DataAppThemeContext', required: true },
+                promptHistory: { ref: 'DataAppContextFile', required: true },
+                parameters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DataAppContextFile' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                semanticLayer: { ref: 'DataAppContextFile', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppCodeDownload: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'DataAppCode' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        context: { ref: 'DataAppContext', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_DataAppCodeDownload_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'DataAppCodeDownload', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
@@ -10367,7 +10441,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiGetAppCodeResponse: {
         dataType: 'refAlias',
-        type: { ref: 'ApiSuccess_DataAppCode_', validators: {} },
+        type: { ref: 'ApiSuccess_DataAppCodeDownload_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__appUuid-string--version-number--action-create-or-append__': {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11736,10 +11736,90 @@
                 "required": ["files", "manifest"],
                 "type": "object"
             },
-            "ApiSuccess_DataAppCode_": {
+            "DataAppContextFile": {
+                "properties": {
+                    "contentBase64": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    }
+                },
+                "required": ["contentBase64", "path"],
+                "type": "object"
+            },
+            "DataAppThemeContext": {
+                "properties": {
+                    "skippedAssetCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "assets": {
+                        "items": {
+                            "$ref": "#/components/schemas/DataAppContextFile"
+                        },
+                        "type": "array"
+                    },
+                    "instructions": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DataAppContextFile"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "required": ["skippedAssetCount", "assets", "instructions"],
+                "type": "object"
+            },
+            "DataAppContext": {
+                "properties": {
+                    "theme": {
+                        "$ref": "#/components/schemas/DataAppThemeContext"
+                    },
+                    "promptHistory": {
+                        "$ref": "#/components/schemas/DataAppContextFile"
+                    },
+                    "parameters": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DataAppContextFile"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "semanticLayer": {
+                        "$ref": "#/components/schemas/DataAppContextFile"
+                    }
+                },
+                "required": [
+                    "theme",
+                    "promptHistory",
+                    "parameters",
+                    "semanticLayer"
+                ],
+                "type": "object"
+            },
+            "DataAppCodeDownload": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/DataAppCode"
+                    },
+                    {
+                        "properties": {
+                            "context": {
+                                "$ref": "#/components/schemas/DataAppContext"
+                            }
+                        },
+                        "required": ["context"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiSuccess_DataAppCodeDownload_": {
                 "properties": {
                     "results": {
-                        "$ref": "#/components/schemas/DataAppCode"
+                        "$ref": "#/components/schemas/DataAppCodeDownload"
                     },
                     "status": {
                         "type": "string",
@@ -11751,7 +11831,7 @@
                 "type": "object"
             },
             "ApiGetAppCodeResponse": {
-                "$ref": "#/components/schemas/ApiSuccess_DataAppCode_"
+                "$ref": "#/components/schemas/ApiSuccess_DataAppCodeDownload_"
             },
             "ApiSuccess__appUuid-string--version-number--action-create-or-append__": {
                 "properties": {

--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -7,6 +7,7 @@ import {
     buildImportBody,
     readBundleFromDir,
     writeBundleToDir,
+    writeContextToDir,
 } from './appCodeFiles';
 
 const makeCode = (appUuid: string, projectUuid: string): DataAppCode => ({
@@ -157,6 +158,44 @@ it('throws a clear error when the manifest is not valid YAML', async () => {
     await expect(readBundleFromDir(dir)).rejects.toThrow(
         /Could not parse lightdash-app\.yml/,
     );
+});
+
+it('writes context files under .lightdash/context and skips null parameters', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-ctx-'));
+    await writeContextToDir(dir, {
+        semanticLayer: {
+            path: '.lightdash/context/semantic-layer.yml',
+            contentBase64: Buffer.from('models: []').toString('base64'),
+        },
+        parameters: null,
+        promptHistory: {
+            path: '.lightdash/context/prompt-history.md',
+            contentBase64: Buffer.from('# prompts').toString('base64'),
+        },
+        theme: {
+            instructions: {
+                path: '.lightdash/context/theme/instructions.md',
+                contentBase64: Buffer.from('# theme').toString('base64'),
+            },
+            assets: [],
+            skippedAssetCount: 0,
+        },
+    });
+    expect(
+        await fs.readFile(
+            path.join(dir, '.lightdash/context/semantic-layer.yml'),
+            'utf-8',
+        ),
+    ).toBe('models: []');
+    expect(
+        await fs.readFile(
+            path.join(dir, '.lightdash/context/theme/instructions.md'),
+            'utf-8',
+        ),
+    ).toBe('# theme');
+    await expect(
+        fs.access(path.join(dir, '.lightdash/context/parameters.yml')),
+    ).rejects.toThrow();
 });
 
 describe('appFolderName', () => {

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -4,6 +4,8 @@ import {
     validateDataAppCode,
     type DataAppCode,
     type DataAppCodeFile,
+    type DataAppContext,
+    type DataAppContextFile,
     type DataAppManifest,
     type ImportAppCodeRequestBody,
 } from '@lightdash/common';
@@ -56,6 +58,20 @@ export const writeFilesToDir = async (
             );
         }),
     );
+};
+
+export const writeContextToDir = async (
+    dir: string,
+    context: DataAppContext,
+): Promise<void> => {
+    const files: DataAppContextFile[] = [
+        context.semanticLayer,
+        ...(context.parameters ? [context.parameters] : []),
+        context.promptHistory,
+        ...(context.theme.instructions ? [context.theme.instructions] : []),
+        ...context.theme.assets,
+    ];
+    await writeFilesToDir(dir, files);
 };
 
 export const writeBundleToDir = async (

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -23,7 +23,7 @@ import {
     PromotionChanges,
     removePivotedSeriesValuesFromChartConfig,
     SqlChartAsCode,
-    type DataAppCode,
+    type DataAppCodeDownload,
     type SpaceAsCode,
 } from '@lightdash/common';
 import { Dirent, promises as fs, type Stats } from 'fs';
@@ -41,6 +41,7 @@ import {
     buildImportBody,
     readBundleFromDir,
     writeBundleToDir,
+    writeContextToDir,
     writeFilesToDir,
 } from './apps/appCodeFiles';
 import { buildStaticAuthoringFiles } from './apps/scaffolding';
@@ -1057,7 +1058,7 @@ export const downloadHandler = async (
                 for (const appUuid of appUuidsToDownload) {
                     try {
                         // eslint-disable-next-line no-await-in-loop
-                        const code = await lightdashApi<DataAppCode>({
+                        const code = await lightdashApi<DataAppCodeDownload>({
                             method: 'GET',
                             url: `/api/v1/ee/projects/${projectId}/apps/${appUuid}/download`,
                             body: undefined,
@@ -1085,6 +1086,8 @@ export const downloadHandler = async (
                                 sdkVersion: CLI_VERSION,
                             }),
                         );
+                        // eslint-disable-next-line no-await-in-loop
+                        await writeContextToDir(appDir, code.context);
                         appSuccessCount += 1;
                     } catch (appErr) {
                         if (

--- a/packages/common/src/ee/apps/code.test.ts
+++ b/packages/common/src/ee/apps/code.test.ts
@@ -2,6 +2,7 @@ import {
     currentDataAppCodeVersion,
     validateDataAppCode,
     type DataAppCode,
+    type DataAppCodeDownload,
 } from './code';
 
 const valid: DataAppCode = {
@@ -88,4 +89,23 @@ describe('validateDataAppCode', () => {
         };
         expect(validateDataAppCode(withVersion)).toEqual(withVersion);
     });
+});
+
+it('DataAppCodeDownload carries manifest, files, and context', () => {
+    const dl: DataAppCodeDownload = {
+        ...valid,
+        context: {
+            semanticLayer: {
+                path: '.lightdash/context/semantic-layer.yml',
+                contentBase64: '',
+            },
+            parameters: null,
+            promptHistory: {
+                path: '.lightdash/context/prompt-history.md',
+                contentBase64: '',
+            },
+            theme: { instructions: null, assets: [], skippedAssetCount: 0 },
+        },
+    };
+    expect(dl.context.theme.skippedAssetCount).toBe(0);
 });

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -27,7 +27,27 @@ export type DataAppCode = {
     files: DataAppCodeFile[];
 };
 
-export type ApiGetAppCodeResponse = ApiSuccess<DataAppCode>;
+export type DataAppContextFile = {
+    path: string; // relative to the bundle root, e.g. `.lightdash/context/semantic-layer.yml`
+    contentBase64: string;
+};
+
+export type DataAppThemeContext = {
+    instructions: DataAppContextFile | null;
+    assets: DataAppContextFile[];
+    skippedAssetCount: number; // > 0 when assets were dropped by the cap
+};
+
+export type DataAppContext = {
+    semanticLayer: DataAppContextFile;
+    parameters: DataAppContextFile | null;
+    promptHistory: DataAppContextFile;
+    theme: DataAppThemeContext;
+};
+
+export type DataAppCodeDownload = DataAppCode & { context: DataAppContext };
+
+export type ApiGetAppCodeResponse = ApiSuccess<DataAppCodeDownload>;
 
 export type ImportAppCodeRequestBody = {
     code: DataAppCode;


### PR DESCRIPTION
Part of **Data Apps as Code — Phase 2** (GLITCH-557). Slice **2c** of 3 (stacked on 2b / #25017). Final slice.

Linear: https://linear.app/lightdash/issue/GLITCH-570

## What
Safety, docs, and verification for the local authoring loop.

- **Defensive server-side guard:** `importAppCode` now builds the `source.tar` from **only** `src/` entries and rejects a bundle with no `src/` files. Belt-and-braces with the CLI's source-only upload filter (2a) — even a hand-crafted upload cannot get scaffolding or `.lightdash/context/` into the server build. The server rebuilds against its trusted template, so the Phase-1 trust model is unchanged.
- **Docs:** a "Local authoring (Phase 2)" section in `docs/data-apps.md` — the download contents, the edit → `pnpm build` → `upload --apps` → server-rebuild loop, source-only upload, the context snapshot caveat, and the 30-asset theme cap.
- **Verification:** confirmed offline that an assembled bundle runs `pnpm install && pnpm build` cleanly (dist/ produced, SDK resolves from npm). Server-rebuild / themed / cross-instance e2e steps are documented for a live-stack run.

## Notes
- No new security surface — the server still only ever rebuilds trusted source.
- Draft; top of the Phase 2 stack (2a #25010 → 2b #25017 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
