### PR TITLE
feat: trino headers - send query metadata to trino in header X-Trino-Client-Tags

### DIFF
--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -83,7 +83,7 @@ describe('TrinoWarehouseClient', () => {
         it('sends X-Trino-Client-Tags header as comma-separated key=value pairs when tags are provided', async () => {
             const warehouse = new TrinoWarehouseClient(credentials);
             queryResultMock.mockReturnValue({
-                next: jest
+                next: vi
                     .fn()
                     .mockResolvedValue({ done: true, value: queryResponse }),
             });
@@ -106,7 +106,7 @@ describe('TrinoWarehouseClient', () => {
         it('sanitizes tag values that are unsafe for the header', async () => {
             const warehouse = new TrinoWarehouseClient(credentials);
             queryResultMock.mockReturnValue({
-                next: jest
+                next: vi
                     .fn()
                     .mockResolvedValue({ done: true, value: queryResponse }),
             });
@@ -129,7 +129,7 @@ describe('TrinoWarehouseClient', () => {
         it('sends query as plain string (no extraHeaders) when no tags are provided', async () => {
             const warehouse = new TrinoWarehouseClient(credentials);
             queryResultMock.mockReturnValue({
-                next: jest
+                next: vi
                     .fn()
                     .mockResolvedValue({ done: true, value: queryResponse }),
             });

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { AnyType, QueryExecutionContext,} from '@lightdash/common';
+import { AnyType, QueryExecutionContext } from '@lightdash/common';
 import { Columns, Iterator, QueryData, QueryResult, Trino } from 'trino-client';
 import { TrinoTypes, TrinoWarehouseClient } from './TrinoWarehouseClient';
 import {
@@ -79,28 +79,8 @@ describe('TrinoWarehouseClient', () => {
         );
     });
 
-    it('sends query context as Trino client tag', async () => {
-        const warehouse = new TrinoWarehouseClient(credentials);
-        queryResultMock.mockReturnValue({
-            next: jest
-                .fn()
-                .mockResolvedValue({ done: true, value: queryResponse }),
-        });
-
-        await warehouse.runQuery('fake sql', {
-            query_context: QueryExecutionContext.SCHEDULED_DELIVERY,
-        });
-
-        expect(queryResultMock).toHaveBeenCalledWith({
-            query: expect.stringContaining('fake sql'),
-            extraHeaders: {
-                'X-Trino-Client-Tags': QueryExecutionContext.SCHEDULED_DELIVERY,
-            },
-        });
-    });
-    
     describe('streamQuery client tag headers', () => {
-        it('sends X-Trino-Client-Tags header as comma-separated key:value pairs when tags are provided', async () => {
+        it('sends X-Trino-Client-Tags header as comma-separated key=value pairs when tags are provided', async () => {
             const warehouse = new TrinoWarehouseClient(credentials);
             queryResultMock.mockReturnValue({
                 next: jest
@@ -119,6 +99,29 @@ describe('TrinoWarehouseClient', () => {
                         'X-Trino-Client-Tags':
                             'dashboard_uuid=abc-123,chart_uuid=def-456',
                     }),
+                }),
+            );
+        });
+
+        it('sanitizes tag values that are unsafe for the header', async () => {
+            const warehouse = new TrinoWarehouseClient(credentials);
+            queryResultMock.mockReturnValue({
+                next: jest
+                    .fn()
+                    .mockResolvedValue({ done: true, value: queryResponse }),
+            });
+
+            await warehouse.runQuery('SELECT 1', {
+                scheduler_name: 'Weekly report, EMEA 📊',
+                query_context: QueryExecutionContext.SCHEDULED_DELIVERY,
+            });
+
+            expect(queryResultMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    extraHeaders: {
+                        'X-Trino-Client-Tags':
+                            'scheduler_name=Weekly_report__EMEA___,query_context=scheduledDelivery',
+                    },
                 }),
             );
         });

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { AnyType, DimensionType } from '@lightdash/common';
+import { AnyType, QueryExecutionContext,} from '@lightdash/common';
 import { Columns, Iterator, QueryData, QueryResult, Trino } from 'trino-client';
 import { TrinoTypes, TrinoWarehouseClient } from './TrinoWarehouseClient';
 import {
@@ -77,5 +77,63 @@ describe('TrinoWarehouseClient', () => {
         expect(warehouse.getCatalog(wharehouseClient.config)).resolves.toEqual(
             wharehouseClient.expectedWarehouseSchema,
         );
+    });
+
+    it('sends query context as Trino client tag', async () => {
+        const warehouse = new TrinoWarehouseClient(credentials);
+        queryResultMock.mockReturnValue({
+            next: jest
+                .fn()
+                .mockResolvedValue({ done: true, value: queryResponse }),
+        });
+
+        await warehouse.runQuery('fake sql', {
+            query_context: QueryExecutionContext.SCHEDULED_DELIVERY,
+        });
+
+        expect(queryResultMock).toHaveBeenCalledWith({
+            query: expect.stringContaining('fake sql'),
+            extraHeaders: {
+                'X-Trino-Client-Tags': QueryExecutionContext.SCHEDULED_DELIVERY,
+            },
+        });
+    });
+    
+    describe('streamQuery client tag headers', () => {
+        it('sends X-Trino-Client-Tags header as comma-separated key:value pairs when tags are provided', async () => {
+            const warehouse = new TrinoWarehouseClient(credentials);
+            queryResultMock.mockReturnValue({
+                next: jest
+                    .fn()
+                    .mockResolvedValue({ done: true, value: queryResponse }),
+            });
+
+            await warehouse.runQuery('SELECT 1', {
+                dashboard_uuid: 'abc-123',
+                chart_uuid: 'def-456',
+            });
+
+            expect(queryResultMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    extraHeaders: expect.objectContaining({
+                        'X-Trino-Client-Tags':
+                            'dashboard_uuid=abc-123,chart_uuid=def-456',
+                    }),
+                }),
+            );
+        });
+
+        it('sends query as plain string (no extraHeaders) when no tags are provided', async () => {
+            const warehouse = new TrinoWarehouseClient(credentials);
+            queryResultMock.mockReturnValue({
+                next: jest
+                    .fn()
+                    .mockResolvedValue({ done: true, value: queryResponse }),
+            });
+
+            await warehouse.runQuery('SELECT 1');
+
+            expect(queryResultMock).toHaveBeenCalledWith('SELECT 1');
+        });
     });
 });

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -29,6 +29,8 @@ import { normalizeUnicode } from '../utils/sql';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 
+const TRINO_CLIENT_TAGS_HEADER = 'X-Trino-Client-Tags';
+
 export enum TrinoTypes {
     BOOLEAN = 'boolean',
     TINYINT = 'tinyint',
@@ -281,18 +283,32 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
     ): Promise<void> {
         const { session, close } = await this.getSession();
         let query: Iterator<QueryResult>;
+        let clientTagHeaders: Record<string, string> = {};
         try {
             let alteredQuery = sql;
             if (options?.tags) {
                 alteredQuery = `${alteredQuery}\n-- ${JSON.stringify(
                     options?.tags,
                 )}`;
+                clientTagHeaders = {
+                    [TRINO_CLIENT_TAGS_HEADER]: Object.entries(options.tags)
+                        .map(([k, v]) => `${k}=${v}`)
+                        .join(','),
+                };
             }
             if (options?.timezone) {
                 console.debug(`Setting Trino timezone to ${options?.timezone}`);
                 await session.query(`SET TIME ZONE '${options?.timezone}'`);
             }
-            query = await session.query(alteredQuery);
+
+            query = await session.query(
+                options?.tags
+                    ? {
+                          query: alteredQuery,
+                          extraHeaders: clientTagHeaders,
+                      }
+                    : alteredQuery,
+            );
 
             let queryResult = await query.next();
 

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -31,6 +31,11 @@ import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 
 const TRINO_CLIENT_TAGS_HEADER = 'X-Trino-Client-Tags';
 
+// Trino splits the header on commas and Node rejects non-latin1 header values,
+// so tag keys/values are restricted to a safe charset
+const sanitizeClientTag = (tag: string): string =>
+    tag.replace(/[^a-zA-Z0-9_-]/g, '_').substring(0, 60);
+
 export enum TrinoTypes {
     BOOLEAN = 'boolean',
     TINYINT = 'tinyint',
@@ -283,18 +288,12 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
     ): Promise<void> {
         const { session, close } = await this.getSession();
         let query: Iterator<QueryResult>;
-        let clientTagHeaders: Record<string, string> = {};
         try {
             let alteredQuery = sql;
             if (options?.tags) {
                 alteredQuery = `${alteredQuery}\n-- ${JSON.stringify(
                     options?.tags,
                 )}`;
-                clientTagHeaders = {
-                    [TRINO_CLIENT_TAGS_HEADER]: Object.entries(options.tags)
-                        .map(([k, v]) => `${k}=${v}`)
-                        .join(','),
-                };
             }
             if (options?.timezone) {
                 console.debug(`Setting Trino timezone to ${options?.timezone}`);
@@ -305,7 +304,18 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
                 options?.tags
                     ? {
                           query: alteredQuery,
-                          extraHeaders: clientTagHeaders,
+                          extraHeaders: {
+                              [TRINO_CLIENT_TAGS_HEADER]: Object.entries(
+                                  options.tags,
+                              )
+                                  .map(
+                                      ([key, value]) =>
+                                          `${sanitizeClientTag(
+                                              key,
+                                          )}=${sanitizeClientTag(value)}`,
+                                  )
+                                  .join(','),
+                          },
                       }
                     : alteredQuery,
             );


### PR DESCRIPTION
Closes: #18148

### Description:
Send all the query context details to trino in header `X-Trino-Client-Tags`. On trino side, we can use these tags to setup routing rules or resource groups.

<!-- Even better add a screenshot / gif / loom -->
