### PR TITLE
fix(apps): hide data app viz from the app template picker

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import AppTemplatePicker from './AppTemplatePicker';
 
 const setup = (
-    selected: 'dashboard' | 'slideshow' | 'pdf' | 'data_app_viz' | null,
+    selected: 'dashboard' | 'slideshow' | 'pdf' | 'custom' | null,
     onSelectedChange = vi.fn(),
 ) => {
     render(
@@ -31,7 +31,7 @@ describe('AppTemplatePicker', () => {
             screen.getByRole('button', { name: /PDF Report/i }),
         ).toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: /Data app visualization/i }),
+            screen.getByRole('button', { name: /From scratch/i }),
         ).toBeInTheDocument();
         expect(
             screen.queryByRole('button', { name: /Let's go/i }),

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -2,8 +2,8 @@ import { type DataAppTemplate } from '@lightdash/common';
 import {
     IconFileText,
     IconLayoutDashboard,
+    IconPencil,
     IconPresentation,
-    IconPuzzle,
     type Icon as TablerIcon,
 } from '@tabler/icons-react';
 
@@ -36,11 +36,10 @@ export const TEMPLATES: TemplateDefinition[] = [
         icon: IconFileText,
     },
     {
-        id: 'data_app_viz',
-        title: 'Data app visualization',
-        description:
-            'A reusable single-tile chart you can apply to any query like a chart type.',
-        icon: IconPuzzle,
+        id: 'custom',
+        title: 'From scratch',
+        description: 'Start from scratch and describe whatever you want.',
+        icon: IconPencil,
     },
 ];
 


### PR DESCRIPTION
## What

Removes the **Data app visualization** starter from the app generate template picker, restoring the **From scratch** (`custom`) starter in its place. Frontend-only, single file plus its test.

## Why

The data app viz *consumption* path (picking a generated viz as a chart type and feeding it live query data) is not shipped yet — it lands with the GLITCH-553 → 555 render stack.