### PR TITLE
feat(filters): source filter-autocomplete labels from a dimension

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3991,6 +3991,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                labelDimension: { dataType: 'string' },
                 fetchFromWarehouse: { dataType: 'boolean', required: true },
                 values: {
                     dataType: 'array',
@@ -9351,6 +9352,13 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 refreshedAt: { dataType: 'datetime', required: true },
                 cached: { dataType: 'boolean', required: true },
+                resultsWithLabels: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'FilterAutocompleteValue',
+                    },
+                },
                 results: {
                     dataType: 'array',
                     array: { dataType: 'any' },
@@ -40559,6 +40567,15 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                labelFieldId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                valueFieldId: { dataType: 'string', required: true },
                 cacheMetadata: { ref: 'CacheMetadata', required: true },
                 queryUuid: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4095,6 +4095,9 @@
             },
             "FilterAutocompleteConfig": {
                 "properties": {
+                    "labelDimension": {
+                        "type": "string"
+                    },
                     "fetchFromWarehouse": {
                         "type": "boolean"
                     },
@@ -10661,9 +10664,16 @@
                     "cached": {
                         "type": "boolean"
                     },
+                    "resultsWithLabels": {
+                        "items": {
+                            "$ref": "#/components/schemas/FilterAutocompleteValue"
+                        },
+                        "type": "array"
+                    },
                     "results": {
                         "items": {},
-                        "type": "array"
+                        "type": "array",
+                        "deprecated": true
                     },
                     "search": {
                         "type": "string"
@@ -40792,6 +40802,13 @@
             },
             "ApiExecuteAsyncFieldValueSearchResults": {
                 "properties": {
+                    "labelFieldId": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "valueFieldId": {
+                        "type": "string"
+                    },
                     "cacheMetadata": {
                         "$ref": "#/components/schemas/CacheMetadata"
                     },
@@ -40799,7 +40816,12 @@
                         "type": "string"
                     }
                 },
-                "required": ["cacheMetadata", "queryUuid"],
+                "required": [
+                    "labelFieldId",
+                    "valueFieldId",
+                    "cacheMetadata",
+                    "queryUuid"
+                ],
                 "type": "object"
             },
             "ApiSuccess_ApiExecuteAsyncFieldValueSearchResults_": {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4510,7 +4510,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         );
 
-        const { metricQuery, explore, fieldId } =
+        const { metricQuery, explore, fieldId, labelFieldId } =
             await getFieldValuesMetricQuery({
                 projectUuid,
                 table,
@@ -4617,6 +4617,8 @@ export class AsyncQueryService extends ProjectService {
         return {
             queryUuid,
             cacheMetadata,
+            valueFieldId: fieldId,
+            labelFieldId,
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -3,6 +3,7 @@ import {
     DbtProjectType,
     DbtVersionOptionLatest,
     defineUserAbility,
+    DimensionType,
     FeatureFlags,
     FilterOperator,
     ForbiddenError,
@@ -1770,6 +1771,69 @@ describe('ProjectService', () => {
                                    ORDER BY "a_dim1"
                                    LIMIT 10`),
             );
+        });
+        test('returns resultsWithLabels deduped by value for a label dimension', async () => {
+            const exploreWithLabelDimension: Explore = {
+                ...validExplore,
+                tables: {
+                    ...validExplore.tables,
+                    a: {
+                        ...validExplore.tables.a,
+                        dimensions: {
+                            ...validExplore.tables.a.dimensions,
+                            dim1: {
+                                ...validExplore.tables.a.dimensions.dim1,
+                                filterAutocomplete: {
+                                    fetchFromWarehouse: true,
+                                    labelDimension: 'label_dim',
+                                },
+                            },
+                            label_dim: {
+                                ...validExplore.tables.a.dimensions.dim1,
+                                name: 'label_dim',
+                                label: 'label_dim',
+                            },
+                        },
+                    },
+                },
+            };
+            (
+                projectModel.findExploreByTableName as import('vitest').Mock
+            ).mockResolvedValueOnce(exploreWithLabelDimension);
+
+            const runQueryMock = vi.fn(async () => ({
+                fields: {
+                    a_dim1: { type: DimensionType.STRING },
+                    a_label_dim: { type: DimensionType.STRING },
+                },
+                rows: [
+                    { a_dim1: 'u1', a_label_dim: 'Alice' },
+                    { a_dim1: 'u1', a_label_dim: 'Alice dup' },
+                    { a_dim1: 'u2', a_label_dim: null },
+                ],
+            }));
+            (
+                projectModel.getWarehouseClientFromCredentials as import('vitest').Mock
+            ).mockImplementation(() => ({
+                ...warehouseClientMock,
+                runQuery: runQueryMock,
+            }));
+
+            const result = await service.searchFieldUniqueValues(
+                user,
+                projectUuid,
+                'a',
+                'a_dim1',
+                '',
+                10,
+                undefined,
+            );
+
+            expect(result.results).toEqual(['u1', 'u2']);
+            expect(result.resultsWithLabels).toEqual([
+                { value: 'u1', label: 'Alice' },
+                { value: 'u2', label: 'u2' },
+            ]);
         });
         test('should query unique values with valid filters', async () => {
             const runQueryMock = vi.fn(async (_sql: string) => resultsWith1Row);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -71,6 +71,7 @@ import {
     ExploreType,
     FeatureFlags,
     FilterableDimension,
+    FilterAutocompleteValue,
     findReplaceableCustomMetrics,
     ForbiddenError,
     formatRows,
@@ -5970,7 +5971,7 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const { metricQuery, explore, field } =
+        const { metricQuery, explore, field, labelFieldId } =
             await this._getFieldValuesMetricQuery({
                 projectUuid,
                 table,
@@ -6080,18 +6081,38 @@ export class ProjectService extends BaseService {
         };
 
         const { rows } = await warehouseClient.runQuery(query, queryTags);
+        const valueFieldId = getItemId(field);
         const allResults: Set<string | number | boolean> = new Set();
+        const resultsWithLabels: FilterAutocompleteValue[] = [];
+        const seenLabeledValues = new Set<string>();
         for (const row of rows) {
-            const value = row[getItemId(field)];
+            const value = row[valueFieldId];
             if (value !== null && value !== undefined) {
                 allResults.add(value);
+                if (labelFieldId) {
+                    const valueKey = String(value);
+                    if (!seenLabeledValues.has(valueKey)) {
+                        seenLabeledValues.add(valueKey);
+                        const rawLabel = row[labelFieldId];
+                        resultsWithLabels.push({
+                            value: valueKey,
+                            label:
+                                rawLabel !== null && rawLabel !== undefined
+                                    ? String(rawLabel)
+                                    : valueKey,
+                        });
+                    }
+                }
             }
         }
+
+        const resultsArray = Array.from(allResults);
 
         if (isUserCacheEnabled) {
             const searchResults = {
                 search,
-                results: Array.from(allResults),
+                results: resultsArray,
+                ...(labelFieldId ? { resultsWithLabels } : {}),
                 refreshedAt: new Date(),
                 cached: true,
             };
@@ -6103,14 +6124,12 @@ export class ProjectService extends BaseService {
 
         await sshTunnel.disconnect();
 
-        const resultsArray = Array.from(allResults);
-
         this.analytics.track({
             event: 'field_value.search',
             userId: user.userUuid,
             properties: {
                 projectId: projectUuid,
-                fieldId: getItemId(field),
+                fieldId: valueFieldId,
                 searchCharCount: search.length,
                 resultsCount: resultsArray.length,
                 searchLimit: metricQuery.limit,
@@ -6120,6 +6139,7 @@ export class ProjectService extends BaseService {
         return {
             search,
             results: resultsArray,
+            ...(labelFieldId ? { resultsWithLabels } : {}),
             refreshedAt: new Date(),
             cached: false,
         };

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -1,4 +1,6 @@
 import {
+    DimensionType,
+    FieldType,
     FilterOperator,
     NotFoundError,
     ParameterError,
@@ -7,6 +9,38 @@ import {
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
 import { validExplore } from './ProjectService.mock';
+
+const exploreWithLabelDimension = (labelDimension: string): Explore => ({
+    ...validExplore,
+    tables: {
+        ...validExplore.tables,
+        a: {
+            ...validExplore.tables.a,
+            dimensions: {
+                ...validExplore.tables.a.dimensions,
+                dim1: {
+                    ...validExplore.tables.a.dimensions.dim1,
+                    filterAutocomplete: {
+                        fetchFromWarehouse: true,
+                        labelDimension,
+                    },
+                },
+                label_dim: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'label_dim',
+                    label: 'label_dim',
+                    table: 'a',
+                    tableLabel: '',
+                    sql: '',
+                    hidden: false,
+                    compiledSql: '',
+                    tablesReferences: ['a'],
+                },
+            },
+        },
+    },
+});
 
 const mockExploreResolver = {
     findExploreByTableName: vi.fn(),
@@ -215,6 +249,112 @@ describe('getFieldValuesMetricQuery', () => {
             getFieldValuesMetricQuery({
                 projectUuid: 'project-uuid',
                 table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('adds label dimension as a second column and searches/sorts by it', async () => {
+        mockExploreResolver.findExploreByTableName.mockResolvedValue(
+            exploreWithLabelDimension('label_dim'),
+        );
+
+        const result = await getFieldValuesMetricQuery({
+            projectUuid: 'project-uuid',
+            table: 'a',
+            initialFieldId: 'a_dim1',
+            search: 'test',
+            limit: 10,
+            maxLimit: 5000,
+            filters: undefined,
+            exploreResolver: mockExploreResolver,
+        });
+
+        expect(result.metricQuery.dimensions).toEqual([
+            'a_dim1',
+            'a_label_dim',
+        ]);
+        expect(result.metricQuery.sorts).toEqual([
+            { fieldId: 'a_label_dim', descending: false },
+        ]);
+        expect(result.labelFieldId).toBe('a_label_dim');
+
+        const dims = result.metricQuery.filters?.dimensions;
+        const filterRules = dims && 'and' in dims ? dims.and : [];
+        const searchGroup = filterRules?.[0];
+        const orRules =
+            searchGroup && 'or' in searchGroup ? searchGroup.or : [];
+        expect(orRules).toMatchObject([
+            {
+                operator: FilterOperator.INCLUDE,
+                values: ['test'],
+                target: { fieldId: 'a_label_dim' },
+            },
+            {
+                operator: FilterOperator.INCLUDE,
+                values: ['test'],
+                target: { fieldId: 'a_dim1' },
+            },
+        ]);
+        expect(filterRules?.[1]).toMatchObject({
+            operator: FilterOperator.NOT_NULL,
+            target: { fieldId: 'a_dim1' },
+        });
+    });
+
+    test('ignores label dimension that references the value field itself', async () => {
+        mockExploreResolver.findExploreByTableName.mockResolvedValue(
+            exploreWithLabelDimension('dim1'),
+        );
+
+        const result = await getFieldValuesMetricQuery({
+            projectUuid: 'project-uuid',
+            table: 'a',
+            initialFieldId: 'a_dim1',
+            search: '',
+            limit: 10,
+            maxLimit: 5000,
+            filters: undefined,
+            exploreResolver: mockExploreResolver,
+        });
+
+        expect(result.labelFieldId).toBeNull();
+        expect(result.metricQuery.dimensions).toEqual(['a_dim1']);
+    });
+
+    test('throws NotFoundError when label dimension does not exist', async () => {
+        mockExploreResolver.findExploreByTableName.mockResolvedValue(
+            exploreWithLabelDimension('missing_dim'),
+        );
+
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    test('throws ParameterError when label dimension is a metric', async () => {
+        mockExploreResolver.findExploreByTableName.mockResolvedValue(
+            exploreWithLabelDimension('met1'),
+        );
+
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
                 initialFieldId: 'a_dim1',
                 search: '',
                 limit: 10,

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -66,6 +66,7 @@ export async function getFieldValuesMetricQuery({
     explore: Explore;
     field: Dimension;
     fieldId: string;
+    labelFieldId: string | null;
 }> {
     const parsedLimit = parseFieldValuesLimit(limit, maxLimit);
 
@@ -108,17 +109,63 @@ export async function getFieldValuesMetricQuery({
         );
     }
 
+    let labelFieldId: string | null = null;
+    const labelDimension = field.filterAutocomplete?.labelDimension;
+    if (labelDimension) {
+        const candidateLabelFieldId = getItemId({
+            table: field.table,
+            name: labelDimension,
+        });
+        if (candidateLabelFieldId !== getItemId(field)) {
+            const resolvedLabelField = findFieldByIdInExplore(
+                explore,
+                candidateLabelFieldId,
+            );
+            if (!resolvedLabelField) {
+                throw new NotFoundError(
+                    `Can't find label dimension '${labelDimension}' in table '${field.table}'`,
+                );
+            }
+            if (!isDimension(resolvedLabelField)) {
+                throw new ParameterError(
+                    `Label field must be a dimension, but ${candidateLabelFieldId} is a ${resolvedLabelField.type}`,
+                );
+            }
+            labelFieldId = candidateLabelFieldId;
+        }
+    }
+
+    // Autocomplete ignores the field's caseSensitive setting.
+    const searchFilter: FilterGroupItem = labelFieldId
+        ? {
+              id: uuidv4(),
+              or: [
+                  {
+                      id: uuidv4(),
+                      target: { fieldId: labelFieldId },
+                      operator: FilterOperator.INCLUDE,
+                      values: [search],
+                      caseSensitive: false,
+                  },
+                  {
+                      id: uuidv4(),
+                      target: { fieldId },
+                      operator: FilterOperator.INCLUDE,
+                      values: [search],
+                      caseSensitive: false,
+                  },
+              ],
+          }
+        : {
+              id: uuidv4(),
+              target: { fieldId },
+              operator: FilterOperator.INCLUDE,
+              values: [search],
+              caseSensitive: false,
+          };
+    const sortFieldId = labelFieldId ?? getItemId(field);
     const autocompleteDimensionFilters: FilterGroupItem[] = [
-        {
-            id: uuidv4(),
-            target: {
-                fieldId,
-            },
-            operator: FilterOperator.INCLUDE,
-            values: [search],
-            // Autocomplete ignores the field's caseSensitive setting.
-            caseSensitive: false,
-        },
+        searchFilter,
         {
             id: uuidv4(),
             target: {
@@ -147,7 +194,9 @@ export async function getFieldValuesMetricQuery({
 
     const metricQuery: MetricQuery = {
         exploreName: explore.name,
-        dimensions: [getItemId(field)],
+        dimensions: labelFieldId
+            ? [getItemId(field), labelFieldId]
+            : [getItemId(field)],
         metrics: [],
         filters: {
             dimensions: {
@@ -158,12 +207,12 @@ export async function getFieldValuesMetricQuery({
         tableCalculations: [],
         sorts: [
             {
-                fieldId: getItemId(field),
+                fieldId: sortFieldId,
                 descending: false,
             },
         ],
         limit: parsedLimit,
     };
 
-    return { metricQuery, explore, field, fieldId };
+    return { metricQuery, explore, field, fieldId, labelFieldId };
 }

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -599,6 +599,34 @@ describe('convert tables from dbt models', () => {
         });
     });
 
+    it('should convert dimension filter autocomplete label_dimension', () => {
+        const table = convertTable(
+            SupportedDbtAdapter.BIGQUERY,
+            {
+                ...MODEL_WITH_NO_METRICS,
+                columns: {
+                    user_id: {
+                        ...MODEL_WITH_NO_METRICS.columns.user_id,
+                        meta: {
+                            dimension: {
+                                filter_autocomplete: {
+                                    label_dimension: 'user_name',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(table.dimensions.user_id.filterAutocomplete).toEqual({
+            fetchFromWarehouse: true,
+            labelDimension: 'user_name',
+        });
+    });
+
     it('should warn and keep the first duplicate dimension filter autocomplete value', () => {
         const table = convertTable(
             SupportedDbtAdapter.BIGQUERY,

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -168,6 +168,9 @@ const convertFilterAutocomplete = (
         filterAutocomplete: {
             ...(uniqueValues ? { values: uniqueValues } : {}),
             fetchFromWarehouse: filterAutocomplete.fetch_from_warehouse ?? true,
+            ...(filterAutocomplete.label_dimension
+                ? { labelDimension: filterAutocomplete.label_dimension }
+                : {}),
         },
         warnings,
     };

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -54,6 +54,10 @@
                 },
                 "fetch_from_warehouse": {
                     "type": "boolean"
+                },
+                "label_dimension": {
+                    "type": "string",
+                    "description": "Name of another dimension in the same table whose value is shown as the display label for each warehouse-fetched value."
                 }
             }
         },

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -1664,6 +1664,10 @@
                                 "fetch_from_warehouse": {
                                     "type": "boolean",
                                     "description": "When false, filter autocomplete will not fetch values from the warehouse for this dimension. Defaults to true."
+                                },
+                                "label_dimension": {
+                                    "type": "string",
+                                    "description": "Name of another dimension in the same table whose value is shown as the display label for each warehouse-fetched value."
                                 }
                             }
                         }
@@ -1907,6 +1911,10 @@
                                         "fetch_from_warehouse": {
                                             "type": "boolean",
                                             "description": "When false, filter autocomplete will not fetch values from the warehouse for this dimension. Defaults to true."
+                                        },
+                                        "label_dimension": {
+                                            "type": "string",
+                                            "description": "Name of another dimension in the same table whose value is shown as the display label for each warehouse-fetched value."
                                         }
                                     }
                                 }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -779,6 +779,8 @@ export type ApiExecuteAsyncDashboardSqlChartQueryResults =
 export type ApiExecuteAsyncFieldValueSearchResults = {
     queryUuid: string;
     cacheMetadata: CacheMetadata;
+    valueFieldId: string;
+    labelFieldId: string | null;
 };
 
 export type QueryResultsPerformance = {

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -222,6 +222,7 @@ type DbtColumnLightdashConfig = {
 export type DbtFilterAutocompleteConfig = {
     values?: FilterAutocompleteValue[];
     fetch_from_warehouse?: boolean;
+    label_dimension?: string;
 };
 
 export type DbtColumnLightdashDimension = {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -686,6 +686,7 @@ export type FilterAutocompleteValue = {
 export type FilterAutocompleteConfig = {
     values?: FilterAutocompleteValue[];
     fetchFromWarehouse: boolean;
+    labelDimension?: string;
 };
 
 /**

--- a/packages/common/src/types/fieldMatch.ts
+++ b/packages/common/src/types/fieldMatch.ts
@@ -1,6 +1,10 @@
+import { type FilterAutocompleteValue } from './field';
+
 export type FieldValueSearchResult<T = unknown> = {
     search: string;
+    /** @deprecated Kept for API/MCP compatibility; prefer `resultsWithLabels`. */
     results: T[];
+    resultsWithLabels?: FilterAutocompleteValue[];
     cached: boolean;
     refreshedAt: Date;
 };

--- a/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
+++ b/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
@@ -5,6 +5,7 @@ import {
     getResultValueArray,
     getVisibleFields,
     isCustomSqlDimension,
+    isDimension,
     isFilterableField,
     type AdditionalMetric,
     type CustomDimension,
@@ -69,7 +70,15 @@ export const useFieldsWithSuggestions = ({
                         const type = isCustomSqlDimension(field)
                             ? field.dimensionType
                             : field.type;
-                        if (type === DimensionType.STRING) {
+                        // A label dimension must always fetch labelled values from
+                        // the warehouse; harvesting raw result values masks the labels.
+                        const hasLabelDimension =
+                            isDimension(field) &&
+                            !!field.filterAutocomplete?.labelDimension;
+                        if (
+                            type === DimensionType.STRING &&
+                            !hasLabelDimension
+                        ) {
                             const currentSuggestions =
                                 prev[getItemId(field)]?.suggestions || [];
                             const newSuggestions: string[] =

--- a/packages/frontend/src/features/parameters/components/ParameterInput.tsx
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.tsx
@@ -137,6 +137,16 @@ export const ParameterInput: FC<ParameterInputProps> = ({
         [results, shouldFetch],
     );
 
+    const fetchedLabelMap = useMemo(() => {
+        const map = new Map<string, string>();
+        if (shouldFetch && results) {
+            results.forEach(({ value: resultValue, label }) => {
+                if (label !== undefined) map.set(resultValue, label);
+            });
+        }
+        return map;
+    }, [results, shouldFetch]);
+
     const placeholder = useMemo(() => {
         const defaultValues = parameter.default
             ? Array.isArray(parameter.default)
@@ -305,10 +315,16 @@ export const ParameterInput: FC<ParameterInputProps> = ({
                       {
                           group: 'Dimension values',
                           items: [...fetchedResults] // Create a copy to avoid mutating Redux state
-                              .sort((a, b) => a.localeCompare(b))
+                              .sort((a, b) => {
+                                  const aLabel = fetchedLabelMap.get(a) ?? a;
+                                  const bLabel = fetchedLabelMap.get(b) ?? b;
+                                  return aLabel.localeCompare(bLabel);
+                              })
                               .map((option) => ({
                                   value: option,
-                                  label: formatDisplayValue(option),
+                                  label:
+                                      fetchedLabelMap.get(option) ??
+                                      formatDisplayValue(option),
                               })),
                       } satisfies ComboboxItemGroup,
                   ]
@@ -346,6 +362,7 @@ export const ParameterInput: FC<ParameterInputProps> = ({
         return [...regularItems, ...fetchedItems, ...specialItems];
     }, [
         fetchedResults,
+        fetchedLabelMap,
         shouldFetch,
         optionsData,
         parameter.allow_custom_values,

--- a/packages/frontend/src/hooks/useFieldValues.test.ts
+++ b/packages/frontend/src/hooks/useFieldValues.test.ts
@@ -235,6 +235,59 @@ describe('getFieldValuesAsync', () => {
 
         expect(result.results).toEqual(['completed']);
     });
+
+    it('builds resultsWithLabels from the value and label columns and dedups by value', async () => {
+        const executeResultWithLabel = {
+            queryUuid: 'query-uuid',
+            cacheMetadata: { cacheHit: false },
+            valueFieldId: 'users_user_id',
+            labelFieldId: 'users_user_name',
+        };
+        const readyResult = {
+            status: QueryHistoryStatus.READY,
+            queryUuid: 'query-uuid',
+            rows: [
+                {
+                    users_user_id: { value: { raw: 'u1', formatted: 'u1' } },
+                    users_user_name: {
+                        value: { raw: 'Alice', formatted: 'Alice' },
+                    },
+                },
+                {
+                    users_user_id: { value: { raw: 'u1', formatted: 'u1' } },
+                    users_user_name: {
+                        value: { raw: 'Alice dup', formatted: 'Alice dup' },
+                    },
+                },
+                {
+                    users_user_id: { value: { raw: 'u2', formatted: 'u2' } },
+                    users_user_name: { value: { raw: null, formatted: '' } },
+                },
+            ],
+            columns: {},
+            metadata: { performance: {} },
+            pivotDetails: null,
+        };
+
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce(executeResultWithLabel as never)
+            .mockResolvedValueOnce(readyResult as never);
+
+        const result = await getFieldValuesAsync(
+            'project-uuid',
+            'users',
+            'users_user_id',
+            '',
+            false,
+            undefined,
+        );
+
+        expect(result.results).toEqual(['u1', 'u2']);
+        expect(result.resultsWithLabels).toEqual([
+            { value: 'u1', label: 'Alice' },
+            { value: 'u2', label: 'u2' },
+        ]);
+    });
 });
 
 describe('useFieldValues', () => {

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -239,22 +239,44 @@ export const getFieldValuesAsync = async (
     }
 
     // The backend may rewrite the fieldId (e.g. aliased joins), so read the
-    // single result column key from the response instead
-    const resultColumn = Object.keys(queryResult.columns)[0] ?? fieldId;
+    // value/label column keys from the execute response instead
+    const valueColumn =
+        executeResult.valueFieldId ??
+        Object.keys(queryResult.columns)[0] ??
+        fieldId;
+    const labelColumn = executeResult.labelFieldId;
 
-    const results: string[] = queryResult.rows
-        .map((row) => {
-            const cell = row[resultColumn];
-            if (!cell?.value) return undefined;
-            const { raw } = cell.value;
-            if (raw === null || raw === undefined) return undefined;
-            return String(raw);
-        })
-        .filter((v): v is string => v !== undefined);
+    const readCell = (
+        row: (typeof queryResult.rows)[number],
+        column: string,
+    ): string | undefined => {
+        const cell = row[column];
+        if (!cell?.value) return undefined;
+        const { raw } = cell.value;
+        if (raw === null || raw === undefined) return undefined;
+        return String(raw);
+    };
+
+    const results: string[] = [];
+    const resultsWithLabels: FilterAutocompleteValue[] = [];
+    const seenValues = new Set<string>();
+    queryResult.rows.forEach((row) => {
+        const value = readCell(row, valueColumn);
+        if (value === undefined || seenValues.has(value)) return;
+        seenValues.add(value);
+        results.push(value);
+        if (labelColumn) {
+            resultsWithLabels.push({
+                value,
+                label: readCell(row, labelColumn) ?? value,
+            });
+        }
+    });
 
     return {
         search,
         results,
+        ...(labelColumn ? { resultsWithLabels } : {}),
         cached: executeResult.cacheMetadata.cacheHit,
         refreshedAt: executeResult.cacheMetadata.cacheUpdatedTime
             ? new Date(executeResult.cacheMetadata.cacheUpdatedTime)
@@ -407,7 +429,8 @@ export const useFieldValues = (
                 useQueryOptions?.enabled !== false,
             staleTime: 0,
             onSuccess: (data) => {
-                const { results: newResults, search: newSearch } = data;
+                const { search: newSearch } = data;
+                const newResults = data.resultsWithLabels ?? data.results;
 
                 const normalizedNewResults = newResults.flatMap((result) => {
                     const normalizedResult = normalizeSearchResult(result);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Thanks for maintaining Lightdash! This builds on the `FilterAutocompleteValue { value, label }` model that recently landed, so I'd appreciate a review when you have a moment.

Closes: #24931

### Description:

Today, filter autocomplete can only attach custom labels through a hard-coded static `values` list. When a dimension holds opaque values (`user_id`, `account_id`, status codes), the dropdown shows raw values, and there's no way to attach human-readable labels to the **warehouse-fetched** suggestions short of manually maintaining a static list — which doesn't scale to high-cardinality fields and goes stale.

This PR lets a dimension's `filter_autocomplete` point at another dimension in the same table to use as the source of the labels shown for each fetched value:

```yaml
dimensions:
  user_id:
    type: string
    sql: ${TABLE}.user_id
    filter_autocomplete:
      label_dimension: user_name   # show the user's name as the label for each id
```

When `label_dimension` is set, Lightdash selects both the value and the label dimension when fetching autocomplete suggestions, searches/sorts by the label, and returns `{ value, label }` pairs. The dropdown then displays the label while filtering still uses the underlying value.

Because parameter `options_from_dimension` reuses the same field-value search, a parameter that sources options from a labelled dimension picks up the labels automatically too.

**Backwards compatibility:** the existing `FieldValueSearchResult.results` scalar array is left unchanged (and marked deprecated); labels are carried in a new optional `resultsWithLabels` field, so the public `field/search` endpoint and other consumers are unaffected. Both the sync (v1) and async (v2) field-value paths are covered.
