### PR TITLE
fix(ai): hide trial alert in collapsed AI agents sidebar

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -229,7 +229,7 @@ export const AgentSidebar: FC<AgentSidebarProps> = ({
                     agentUuid={agent.uuid}
                 />
             )}
-            {isTrial && <TrialAlert />}
+            {isTrial && !isAgentSidebarCollapsed && <TrialAlert />}
         </Stack>
     );
 };
@@ -279,7 +279,7 @@ export const AutoModeSidebar: FC<AutoModeSidebarProps> = ({
                 />
             )}
 
-            {isTrial && <TrialAlert />}
+            {isTrial && !isAgentSidebarCollapsed && <TrialAlert />}
         </Stack>
     );
 };


### PR DESCRIPTION
The Trial Alert was rendered in the AI agents sidebar even when collapsed, spilling into the narrow rail. This gates it on the sidebar being expanded in both `AgentSidebar` and `AutoModeSidebar`.