### PR TITLE
feat(apps): re-add data app viz to the app template picker (GLITCH-571)

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import AppTemplatePicker from './AppTemplatePicker';
 
 const setup = (
-    selected: 'dashboard' | 'slideshow' | 'pdf' | 'custom' | null,
+    selected: 'dashboard' | 'slideshow' | 'pdf' | 'data_app_viz' | null,
     onSelectedChange = vi.fn(),
 ) => {
     render(
@@ -31,7 +31,7 @@ describe('AppTemplatePicker', () => {
             screen.getByRole('button', { name: /PDF Report/i }),
         ).toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: /From scratch/i }),
+            screen.getByRole('button', { name: /Data app visualization/i }),
         ).toBeInTheDocument();
         expect(
             screen.queryByRole('button', { name: /Let's go/i }),

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -2,8 +2,8 @@ import { type DataAppTemplate } from '@lightdash/common';
 import {
     IconFileText,
     IconLayoutDashboard,
-    IconPencil,
     IconPresentation,
+    IconPuzzle,
     type Icon as TablerIcon,
 } from '@tabler/icons-react';
 
@@ -36,10 +36,11 @@ export const TEMPLATES: TemplateDefinition[] = [
         icon: IconFileText,
     },
     {
-        id: 'custom',
-        title: 'From scratch',
-        description: 'Start from scratch and describe whatever you want.',
-        icon: IconPencil,
+        id: 'data_app_viz',
+        title: 'Data app visualization',
+        description:
+            'A reusable single-tile chart you can apply to any query like a chart type.',
+        icon: IconPuzzle,
     },
 ];
 


### PR DESCRIPTION
Re-enables the **Data app visualization** starter in the app generate template picker (replacing the temporary **From scratch** entry added in #25021), now that the render stack (GLITCH-553 → 554 → 555) is landing.

This is the exact inverse of #25021: restores the `data_app_viz` entry in `TEMPLATES` and the matching `AppTemplatePicker` test assertion.

Linear: GLITCH-571