### PR TITLE
fix(apps): prevent clearing mandatory 'Send key as' select

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -162,6 +162,8 @@ const AuthStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({ form }) => {
                         {...form.getInputProps('apiKeyName')}
                     />
                     <Select
+                        required
+                        allowDeselect={false}
                         label="Send key as"
                         data={[
                             { value: 'header', label: 'Request header' },


### PR DESCRIPTION
### Description:
Mantine v8's Select defaults allowDeselect to true, so clicking the already-selected option cleared the mandatory apiKeyLocation value in the data app connection wizard. Disable deselection and mark the field required.
