### PR TITLE
fix(data-apps): announce lineage availability only when the app has query stamps (GLITCH-575)

### DIFF
--- a/packages/query-sdk/src/lineage.test.ts
+++ b/packages/query-sdk/src/lineage.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, beforeEach } from 'vitest';
-import { resolveLineageTarget, applyHighlight, clearHighlight } from './lineage';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+    resolveLineageTarget,
+    applyHighlight,
+    clearHighlight,
+} from './lineage';
 
 beforeEach(() => {
     document.body.innerHTML = '';
@@ -15,7 +19,9 @@ describe('resolveLineageTarget', () => {
 
     it('returns null when no stamped ancestor exists', () => {
         document.body.innerHTML = '<div><span id="cell">x</span></div>';
-        expect(resolveLineageTarget(document.getElementById('cell'))).toBeNull();
+        expect(
+            resolveLineageTarget(document.getElementById('cell')),
+        ).toBeNull();
     });
 
     it('returns null for a null element', () => {
@@ -42,5 +48,82 @@ describe('applyHighlight / clearHighlight', () => {
         applyHighlight('q-1');
         applyHighlight(null);
         expect(document.getElementById('a')!.style.outline).toBe('');
+    });
+});
+
+describe('mountLineage availability announcement', () => {
+    // mountLineage keeps module-level mount state, so each test gets a fresh
+    // module instance via dynamic import.
+    const loadMountLineage = async () => {
+        vi.resetModules();
+        const { mountLineage } = await import('./lineage');
+        return mountLineage;
+    };
+
+    // MutationObserver callbacks are delivered async; flush them.
+    const flushObservers = () => new Promise((r) => setTimeout(r, 0));
+
+    const availableMessages = (parent: {
+        postMessage: ReturnType<typeof vi.fn>;
+    }) =>
+        parent.postMessage.mock.calls.filter(
+            ([msg]) => msg?.type === 'lightdash:lineage:available',
+        );
+
+    const makeParent = () => ({ postMessage: vi.fn() });
+
+    it('does not announce when the app has no [data-ld-query] elements', async () => {
+        const mountLineage = await loadMountLineage();
+        const parent = makeParent();
+        mountLineage(parent as unknown as Window);
+        await flushObservers();
+        expect(availableMessages(parent)).toHaveLength(0);
+    });
+
+    it('announces immediately when a stamped element already exists', async () => {
+        const mountLineage = await loadMountLineage();
+        document.body.innerHTML = '<div data-ld-query="q-1"></div>';
+        const parent = makeParent();
+        mountLineage(parent as unknown as Window);
+        expect(availableMessages(parent)).toHaveLength(1);
+    });
+
+    it('announces when a stamped element is added after mount', async () => {
+        const mountLineage = await loadMountLineage();
+        const parent = makeParent();
+        mountLineage(parent as unknown as Window);
+        expect(availableMessages(parent)).toHaveLength(0);
+
+        const el = document.createElement('div');
+        el.setAttribute('data-ld-query', 'q-1');
+        document.body.appendChild(el);
+        await flushObservers();
+        expect(availableMessages(parent)).toHaveLength(1);
+    });
+
+    it('announces when data-ld-query is set on an existing element after mount', async () => {
+        const mountLineage = await loadMountLineage();
+        document.body.innerHTML = '<div id="late"></div>';
+        const parent = makeParent();
+        mountLineage(parent as unknown as Window);
+        expect(availableMessages(parent)).toHaveLength(0);
+
+        document.getElementById('late')!.setAttribute('data-ld-query', 'q-1');
+        await flushObservers();
+        expect(availableMessages(parent)).toHaveLength(1);
+    });
+
+    it('announces only once even when more stamps appear later', async () => {
+        const mountLineage = await loadMountLineage();
+        const parent = makeParent();
+        mountLineage(parent as unknown as Window);
+
+        for (const uuid of ['q-1', 'q-2']) {
+            const el = document.createElement('div');
+            el.setAttribute('data-ld-query', uuid);
+            document.body.appendChild(el);
+            await flushObservers();
+        }
+        expect(availableMessages(parent)).toHaveLength(1);
     });
 });

--- a/packages/query-sdk/src/lineage.ts
+++ b/packages/query-sdk/src/lineage.ts
@@ -6,7 +6,7 @@
  * `data-ld-query` stamp) and can highlight where a given query renders.
  *
  * Protocol (parent <-> iframe), all over postMessage:
- *   iframe -> parent : lightdash:lineage:available           (on mount)
+ *   iframe -> parent : lightdash:lineage:available           (once the app has [data-ld-query] stamps)
  *   parent -> iframe : lightdash:lineage:enable | :disable    (click-select mode)
  *   iframe -> parent : lightdash:lineage:selected {queryUuid} (on click, while enabled)
  *   parent -> iframe : lightdash:lineage:highlight {queryUuid|null}  (hover, any time)
@@ -64,6 +64,24 @@ let enabled = false;
 let parentWindow: Window | null = null;
 let clickListenerAttached = false;
 let messageListenerAttached = false;
+let availabilityAnnounced = false;
+let stampObserver: MutationObserver | null = null;
+
+// Only announce once the app actually has stamped elements — an unconditional
+// announce enables the parent's Inspect-data toggle even when the generated
+// app never spread `{...lineage}`, leaving a toggle that does nothing.
+function announceIfStamped(): boolean {
+    if (availabilityAnnounced) return true;
+    if (!document.querySelector('[data-ld-query]')) return false;
+    availabilityAnnounced = true;
+    parentWindow?.postMessage(
+        {
+            type: 'lightdash:lineage:available',
+        } satisfies LineageAvailableMessage,
+        '*',
+    );
+    return true;
+}
 
 function onClick(e: MouseEvent) {
     if (!enabled) return;
@@ -98,10 +116,24 @@ export function mountLineage(parent: Window): void {
         window.addEventListener('click', onClick, true);
     }
 
-    parent.postMessage(
-        { type: 'lightdash:lineage:available' } satisfies LineageAvailableMessage,
-        '*',
-    );
+    // Stamps render after data loads, so a one-shot check at mount isn't
+    // enough — watch for the first stamp, then disconnect.
+    if (!announceIfStamped() && !stampObserver) {
+        stampObserver = new MutationObserver(() => {
+            if (announceIfStamped()) {
+                stampObserver?.disconnect();
+                stampObserver = null;
+            }
+        });
+        // documentElement (not body): body may not exist yet if the app's
+        // module code runs before the parser reaches <body>.
+        stampObserver.observe(document.documentElement, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['data-ld-query'],
+        });
+    }
 
     if (messageListenerAttached) return;
     messageListenerAttached = true;


### PR DESCRIPTION
## Problem

The Query Inspector's **Inspect data** toggle enables whenever the sandbox SDK announces `lightdash:lineage:available` — which `mountLineage` posted **unconditionally** on mount. But the lineage interaction (click element → reveal query, hover query row → highlight element) only works if the generated app actually spread `{...lineage}` on its elements, emitting the `data-ld-query` stamps the feature targets.

The agent doesn't reliably apply those stamps, so apps without them showed an **enabled toggle that does nothing**.

## Solution

Make availability honest: `mountLineage` now announces `lightdash:lineage:available` only once the document actually contains a `[data-ld-query]` element.

- Check at mount (covers stamps already rendered).
- Otherwise a `MutationObserver` (`childList` + `subtree` + `attributeFilter: ['data-ld-query']`) announces on the first stamp and disconnects.
- Observes `document.documentElement` rather than `document.body` so mounting before `<body>` exists can't throw.

No parent-side change needed — the existing `disabled={!lineageAvailable}` gate in `AppInspectorPanel` now reflects real inspectability.

## Notes

- `query-sdk` change → needs an E2B template rebuild; only affects newly generated apps (existing apps keep their baked SDK, so their toggle stays enabled-but-dead until regenerated).
- v1 only flips availability **on**; it won't flip off if a later view renders no stamps (rare, harmless — hover/click just no-op).

## Testing

- New unit tests for the announce behavior: no stamps → no announce; stamp at mount → immediate announce; stamp added later / attribute set later → announce; announces only once.
- `pnpm -F @lightdash/query-sdk test` (31 passed), `typecheck:fast`, `build` all green.

Closes: GLITCH-575

🤖 Generated with [Claude Code](https://claude.com/claude-code)
