### PR TITLE
fix(backend): fall back to S3 bucket for chunks missing after deploy

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -126,10 +126,10 @@ jobs:
   # Job 2: Push static assets to the Cloud retention buckets
   #
   # Stale browser tabs request hashed chunks that a new deploy no longer
-  # ships; the backend falls back to these buckets (StaticAssetsS3Client).
-  # Cloud pods run with ASSETS_S3_SYNC_ENABLED=false, so this job is the
-  # only writer. Assets are extracted from the published image (never
-  # rebuilt here) so uploaded hashes always match what the image serves.
+  # ships; the backend falls back to these buckets (StaticAssetsS3Client,
+  # read-only — this job is the only writer). Assets are extracted from the
+  # published image (never rebuilt here) so uploaded hashes always match
+  # what the image serves.
   # `gsutil cp` is deliberately unconditional: rewriting unchanged objects
   # resets their lifecycle age, which keeps long-lived chunks (e.g. vendor
   # bundles) alive while superseded ones expire.

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -123,7 +123,60 @@ jobs:
             SENTRY_ENVIRONMENT=cloud_beta
 
   # ============================================================================
-  # Job 2: QA Blast Radius
+  # Job 2: Push static assets to the Cloud retention buckets
+  #
+  # Stale browser tabs request hashed chunks that a new deploy no longer
+  # ships; the backend falls back to these buckets (StaticAssetsS3Client).
+  # Cloud pods run with ASSETS_S3_SYNC_ENABLED=false, so this job is the
+  # only writer. Assets are extracted from the published image (never
+  # rebuilt here) so uploaded hashes always match what the image serves.
+  # `gsutil cp` is deliberately unconditional: rewriting unchanged objects
+  # resets their lifecycle age, which keeps long-lived chunks (e.g. vendor
+  # bundles) alive while superseded ones expire.
+  # ============================================================================
+  push-static-assets:
+    name: Push Static Assets to GCS
+    runs-on: ubuntu-latest
+    needs: build-and-push-images
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - id: 'auth'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS_IMAGE_DEPLOY }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+        with:
+          version: '>= 381.0.0'
+
+      - name: Extract assets from the published image
+        run: |
+          gcloud auth configure-docker us-docker.pkg.dev --quiet
+          IMAGE="us-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ github.event.release.tag_name }}-commercial"
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker create "$IMAGE")
+          docker cp "$CONTAINER_ID":/usr/app/packages/frontend/build/assets ./assets
+          docker rm "$CONTAINER_ID"
+          # Sourcemaps and precompressed companions are never served from
+          # the bucket (see StaticAssetsS3Client.syncLocalAssets)
+          find ./assets -name '*.map' -delete
+          find ./assets -name '*.gzip' -delete
+          echo "Extracted $(find ./assets -type f | wc -l) asset files"
+
+      - name: Upload assets to retention buckets
+        run: |
+          for BUCKET in lightdash-static-assets-us lightdash-static-assets-eu lightdash-static-assets-staging; do
+            echo "Uploading to gs://$BUCKET/assets/"
+            gsutil -m -h "Cache-Control:public, max-age=31536000, immutable" \
+              cp -r ./assets/* "gs://$BUCKET/assets/"
+          done
+
+  # ============================================================================
+  # Job 3: QA Blast Radius
   # ============================================================================
   qa-blast-radius:
     name: Generate QA Blast Radius
@@ -177,7 +230,7 @@ jobs:
             --clobber
 
   # ============================================================================
-  # Job 3: CLI Release Binaries
+  # Job 4: CLI Release Binaries
   # ============================================================================
   check-cli-changes:
     name: Check if CLI files changed
@@ -477,7 +530,7 @@ jobs:
           git push origin main
 
   # ============================================================================
-  # Job 4: Data App E2B template — publish a tag matching this release
+  # Job 5: Data App E2B template — publish a tag matching this release
   # ============================================================================
   # Two paths:
   #   build  — full E2B template rebuild when sandboxes/data-apps/** or
@@ -623,7 +676,7 @@ jobs:
         run: pnpm exec tsx assign-tag.ts
 
   # ============================================================================
-  # Job 5: AI Writeback E2B template — publish a tag matching this release
+  # Job 6: AI Writeback E2B template — publish a tag matching this release
   # ============================================================================
   # Mirrors the data-app template jobs above. Two paths:
   #   build  — full E2B template rebuild when sandboxes/ai-writeback/**

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -729,9 +729,10 @@ export default class App {
         );
 
         // Chunks from recent builds that this image no longer ships are
-        // retained in a bucket for ~24h, so stale tabs survive a deploy.
+        // retained in a bucket for ~3 days, so stale tabs survive a deploy.
         // No-op (falls through to the 404 below) when the bucket is not
-        // configured.
+        // configured. Constructed directly rather than via ClientRepository:
+        // it is HTTP wiring only, nothing in the service layer needs it.
         const staticAssetsClient = new StaticAssetsS3Client({
             lightdashConfig: this.lightdashConfig,
         });

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -814,10 +814,14 @@ export default class App {
 
         // Populate the assets bucket with this build's chunks; the bucket
         // lifecycle rule ages out chunks no build re-uploads anymore.
-        // syncLocalAssets never throws, it logs failures instead.
-        void staticAssetsClient.syncLocalAssets(
-            path.join(__dirname, '../../frontend/build/assets'),
-        );
+        // syncLocalAssets never throws, it logs failures instead. Disabled
+        // (ASSETS_S3_SYNC_ENABLED=false) when a release pipeline populates
+        // the bucket at publish time and pods must stay read-only.
+        if (this.lightdashConfig.staticAssets.syncEnabled) {
+            void staticAssetsClient.syncLocalAssets(
+                path.join(__dirname, '../../frontend/build/assets'),
+            );
+        }
 
         // Errors
         Sentry.setupExpressErrorHandler(expressApp);

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -729,10 +729,11 @@ export default class App {
         );
 
         // Chunks from recent builds that this image no longer ships are
-        // retained in a bucket for ~3 days, so stale tabs survive a deploy.
-        // No-op (falls through to the 404 below) when the bucket is not
-        // configured. Constructed directly rather than via ClientRepository:
-        // it is HTTP wiring only, nothing in the service layer needs it.
+        // retained in a bucket populated at release time, so stale tabs
+        // survive a deploy. Read-only here; no-op (falls through to the 404
+        // below) when the bucket is not configured. Constructed directly
+        // rather than via ClientRepository: it is HTTP wiring only, nothing
+        // in the service layer needs it.
         const staticAssetsClient = new StaticAssetsS3Client({
             lightdashConfig: this.lightdashConfig,
         });
@@ -811,17 +812,6 @@ export default class App {
                 );
             }
         });
-
-        // Populate the assets bucket with this build's chunks; the bucket
-        // lifecycle rule ages out chunks no build re-uploads anymore.
-        // syncLocalAssets never throws, it logs failures instead. Disabled
-        // (ASSETS_S3_SYNC_ENABLED=false) when a release pipeline populates
-        // the bucket at publish time and pods must stay read-only.
-        if (this.lightdashConfig.staticAssets.syncEnabled) {
-            void staticAssetsClient.syncLocalAssets(
-                path.join(__dirname, '../../frontend/build/assets'),
-            );
-        }
 
         // Errors
         Sentry.setupExpressErrorHandler(expressApp);

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -35,6 +35,8 @@ import {
 } from './clients/ClientRepository';
 import { setGithubRateLimitObserver } from './clients/github/Github';
 import { SlackClient } from './clients/Slack/SlackClient';
+import { createStaticAssetsFallbackHandler } from './clients/StaticAssets/staticAssetsFallbackMiddleware';
+import { StaticAssetsS3Client } from './clients/StaticAssets/StaticAssetsS3Client';
 import { LightdashConfig } from './config/parseConfig';
 import {
     apiKeyPassportStrategy,
@@ -726,6 +728,18 @@ export default class App {
             ),
         );
 
+        // Chunks from recent builds that this image no longer ships are
+        // retained in a bucket for ~24h, so stale tabs survive a deploy.
+        // No-op (falls through to the 404 below) when the bucket is not
+        // configured.
+        const staticAssetsClient = new StaticAssetsS3Client({
+            lightdashConfig: this.lightdashConfig,
+        });
+        expressApp.get(
+            '/assets/*',
+            createStaticAssetsFallbackHandler(staticAssetsClient),
+        );
+
         // Return 404 for missing assets (don't fall through index.html)
         // This ensures chunks are not serving the index.html file.
         expressApp.use('/assets/*', (req, res) => {
@@ -796,6 +810,13 @@ export default class App {
                 );
             }
         });
+
+        // Populate the assets bucket with this build's chunks; the bucket
+        // lifecycle rule ages out chunks no build re-uploads anymore.
+        // syncLocalAssets never throws, it logs failures instead.
+        void staticAssetsClient.syncLocalAssets(
+            path.join(__dirname, '../../frontend/build/assets'),
+        );
 
         // Errors
         Sentry.setupExpressErrorHandler(expressApp);

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
@@ -93,35 +93,28 @@ describe('StaticAssetsS3Client', () => {
             });
         });
 
-        it('treats NoSuchKey as a silent miss', async () => {
+        it('treats a missing object (NoSuchKey, or 403 on AWS S3 without ListBucket) as a silent miss', async () => {
             s3Mocks.send.mockRejectedValueOnce(
                 new s3Mocks.FakeNoSuchKey('missing'),
             );
-
             expect(await createClient().getAsset('chunk.js')).toBeNull();
+
+            s3Mocks.send.mockRejectedValueOnce(forbiddenError(403));
+            expect(await createClient().getAsset('chunk.js')).toBeNull();
+
             expect(Logger.warn).not.toHaveBeenCalled();
             expect(Logger.error).not.toHaveBeenCalled();
         });
 
-        it('treats a 403 (AWS S3 without ListBucket) as a silent miss', async () => {
-            s3Mocks.send.mockRejectedValueOnce(forbiddenError(403));
-
-            expect(await createClient().getAsset('chunk.js')).toBeNull();
-            expect(Logger.warn).not.toHaveBeenCalled();
-        });
-
-        it('logs and returns null on unexpected errors', async () => {
+        it('degrades unexpected errors and the 5s time-box to a logged miss', async () => {
+            // Never throw into the request path; a slow bucket must produce
+            // a fast 404, not hang every /assets request behind SDK retries.
             s3Mocks.send.mockRejectedValueOnce(new Error('socket timeout'));
-
             expect(await createClient().getAsset('chunk.js')).toBeNull();
             expect(Logger.warn).toHaveBeenCalledWith(
                 expect.stringContaining('socket timeout'),
             );
-        });
 
-        it('degrades to a fast miss when the bucket exceeds the 5s time-box', async () => {
-            // A slow bucket must produce a 404, not hang every /assets
-            // request behind SDK retries.
             vi.useFakeTimers();
             try {
                 s3Mocks.send.mockImplementationOnce(

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
@@ -1,6 +1,3 @@
-import * as fs from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
 import { Readable } from 'stream';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -43,7 +40,6 @@ const s3Mocks = vi.hoisted(() => {
 vi.mock('@aws-sdk/client-s3', () => ({
     S3: s3Mocks.FakeS3,
     GetObjectCommand: class extends s3Mocks.FakeCommand {},
-    PutObjectCommand: class extends s3Mocks.FakeCommand {},
     NoSuchKey: s3Mocks.FakeNoSuchKey,
     NotFound: s3Mocks.FakeNotFound,
     S3ServiceException: s3Mocks.FakeS3ServiceException,
@@ -59,7 +55,6 @@ const configWithAssets: LightdashConfig = {
             accessKey: 'access',
             secretKey: 'secret',
         },
-        syncEnabled: true,
     },
 };
 
@@ -82,7 +77,6 @@ describe('StaticAssetsS3Client', () => {
 
         expect(client.isEnabled).toBe(false);
         expect(await client.getAsset('chunk.js')).toBeNull();
-        await client.syncLocalAssets('/nonexistent/assets');
         expect(s3Mocks.send).not.toHaveBeenCalled();
     });
 
@@ -127,83 +121,6 @@ describe('StaticAssetsS3Client', () => {
             expect(await createClient().getAsset('chunk.js')).toBeNull();
             expect(Logger.warn).toHaveBeenCalledWith(
                 expect.stringContaining('socket timeout'),
-            );
-        });
-    });
-
-    describe('syncLocalAssets', () => {
-        let assetsDir: string;
-
-        beforeEach(async () => {
-            assetsDir = await fs.mkdtemp(
-                path.join(os.tmpdir(), 'static-assets-test-'),
-            );
-            await fs.writeFile(path.join(assetsDir, 'index-abc.js'), 'js');
-            await fs.writeFile(path.join(assetsDir, 'style.css'), 'css');
-            await fs.writeFile(path.join(assetsDir, 'index-abc.js.map'), '{}');
-            await fs.writeFile(path.join(assetsDir, 'index-abc.js.gzip'), 'gz');
-            await fs.mkdir(path.join(assetsDir, 'fonts'));
-            await fs.writeFile(
-                path.join(assetsDir, 'fonts', 'inter.woff2'),
-                'font',
-            );
-        });
-
-        afterEach(async () => {
-            await fs.rm(assetsDir, { recursive: true, force: true });
-        });
-
-        it('uploads assets with content types, skipping .gzip and .map files', async () => {
-            s3Mocks.send.mockResolvedValue({});
-
-            await createClient().syncLocalAssets(assetsDir);
-
-            const inputs = s3Mocks.send.mock.calls.map(
-                ([command]) => command.input,
-            );
-            expect(inputs.map((input) => input.Key).sort()).toEqual([
-                'assets/fonts/inter.woff2',
-                'assets/index-abc.js',
-                'assets/style.css',
-            ]);
-            const jsUpload = inputs.find(
-                (input) => input.Key === 'assets/index-abc.js',
-            );
-            expect(jsUpload).toMatchObject({
-                Bucket: 'assets-bucket',
-                ContentType: 'application/javascript; charset=UTF-8',
-                ContentLength: 2,
-                CacheControl: 'public, max-age=31536000, immutable',
-            });
-            expect(Logger.info).toHaveBeenCalledWith(
-                expect.stringContaining('Uploaded 3/3 static assets'),
-            );
-        });
-
-        it('never rejects and reports partial upload failures', async () => {
-            s3Mocks.send
-                .mockRejectedValueOnce(new Error('put failed'))
-                .mockResolvedValue({});
-
-            await expect(
-                createClient().syncLocalAssets(assetsDir),
-            ).resolves.toBeUndefined();
-
-            expect(Logger.error).toHaveBeenCalledWith(
-                expect.stringContaining('put failed'),
-            );
-            expect(Logger.info).toHaveBeenCalledWith(
-                expect.stringContaining('Uploaded 2/3 static assets'),
-            );
-        });
-
-        it('never rejects when the assets directory is unreadable', async () => {
-            await expect(
-                createClient().syncLocalAssets('/nonexistent/assets'),
-            ).resolves.toBeUndefined();
-
-            expect(Logger.error).toHaveBeenCalledWith(
-                expect.stringContaining('Failed to sync static assets'),
             );
         });
     });

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
@@ -72,11 +72,14 @@ describe('StaticAssetsS3Client', () => {
         vi.clearAllMocks();
     });
 
-    // "No bucket configured → no-op" is pinned at the config layer
-    // (parseConfig.test.ts) and the middleware layer (isEnabled gate);
-    // this file only covers the configured client.
+    // "No bucket configured → no-op" is pinned at the middleware layer
+    // (isEnabled gate); this file only covers the configured client.
     describe('getAsset', () => {
-        it('fetches the object under the assets/ prefix', async () => {
+        it('fetches under the assets/ prefix and treats a missing object as a silent miss', async () => {
+            // The assets/ key prefix is the contract with the release
+            // pipeline's upload job — if it drifts, every lookup misses
+            // silently. Missing objects (NoSuchKey, or a bare 403 on AWS S3
+            // without ListBucket) resolve to null without log spam.
             const body = Readable.from(['x']);
             s3Mocks.send.mockResolvedValueOnce({
                 Body: body,
@@ -91,9 +94,7 @@ describe('StaticAssetsS3Client', () => {
                 Bucket: 'assets-bucket',
                 Key: 'assets/chunk.js',
             });
-        });
 
-        it('treats a missing object (NoSuchKey, or 403 on AWS S3 without ListBucket) as a silent miss', async () => {
             s3Mocks.send.mockRejectedValueOnce(
                 new s3Mocks.FakeNoSuchKey('missing'),
             );
@@ -104,41 +105,6 @@ describe('StaticAssetsS3Client', () => {
 
             expect(Logger.warn).not.toHaveBeenCalled();
             expect(Logger.error).not.toHaveBeenCalled();
-        });
-
-        it('degrades unexpected errors and the 5s time-box to a logged miss', async () => {
-            // Never throw into the request path; a slow bucket must produce
-            // a fast 404, not hang every /assets request behind SDK retries.
-            s3Mocks.send.mockRejectedValueOnce(new Error('socket timeout'));
-            expect(await createClient().getAsset('chunk.js')).toBeNull();
-            expect(Logger.warn).toHaveBeenCalledWith(
-                expect.stringContaining('socket timeout'),
-            );
-
-            vi.useFakeTimers();
-            try {
-                s3Mocks.send.mockImplementationOnce(
-                    (
-                        _command: unknown,
-                        options: { abortSignal: AbortSignal },
-                    ) =>
-                        new Promise((_resolve, reject) => {
-                            options.abortSignal.addEventListener('abort', () =>
-                                reject(new Error('Request aborted')),
-                            );
-                        }),
-                );
-
-                const assetPromise = createClient().getAsset('chunk.js');
-                await vi.advanceTimersByTimeAsync(5_000);
-
-                expect(await assetPromise).toBeNull();
-                expect(Logger.warn).toHaveBeenCalledWith(
-                    expect.stringContaining('aborted'),
-                );
-            } finally {
-                vi.useRealTimers();
-            }
         });
     });
 });

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
@@ -59,6 +59,7 @@ const configWithAssets: LightdashConfig = {
             accessKey: 'access',
             secretKey: 'secret',
         },
+        syncEnabled: true,
     },
 };
 

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
@@ -1,0 +1,209 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Readable } from 'stream';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+import { StaticAssetsS3Client } from './StaticAssetsS3Client';
+
+vi.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const s3Mocks = vi.hoisted(() => {
+    const send = vi.fn();
+    class FakeS3 {
+        send = send;
+    }
+    class FakeCommand {
+        constructor(readonly input: Record<string, unknown>) {}
+    }
+    class FakeNoSuchKey extends Error {}
+    class FakeNotFound extends Error {}
+    class FakeS3ServiceException extends Error {
+        $metadata: { httpStatusCode?: number } = {};
+    }
+    return {
+        send,
+        FakeS3,
+        FakeCommand,
+        FakeNoSuchKey,
+        FakeNotFound,
+        FakeS3ServiceException,
+    };
+});
+
+vi.mock('@aws-sdk/client-s3', () => ({
+    S3: s3Mocks.FakeS3,
+    GetObjectCommand: class extends s3Mocks.FakeCommand {},
+    PutObjectCommand: class extends s3Mocks.FakeCommand {},
+    NoSuchKey: s3Mocks.FakeNoSuchKey,
+    NotFound: s3Mocks.FakeNotFound,
+    S3ServiceException: s3Mocks.FakeS3ServiceException,
+}));
+
+const configWithAssets: LightdashConfig = {
+    ...lightdashConfigMock,
+    staticAssets: {
+        s3: {
+            endpoint: 'https://storage.example.com',
+            region: 'us-east-1',
+            bucket: 'assets-bucket',
+            accessKey: 'access',
+            secretKey: 'secret',
+        },
+    },
+};
+
+const createClient = (lightdashConfig: LightdashConfig = configWithAssets) =>
+    new StaticAssetsS3Client({ lightdashConfig });
+
+const forbiddenError = (statusCode: number) => {
+    const error = new s3Mocks.FakeS3ServiceException('denied');
+    error.$metadata = { httpStatusCode: statusCode };
+    return error;
+};
+
+describe('StaticAssetsS3Client', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('is disabled and inert without configuration', async () => {
+        const client = createClient(lightdashConfigMock);
+
+        expect(client.isEnabled).toBe(false);
+        expect(await client.getAsset('chunk.js')).toBeNull();
+        await client.syncLocalAssets('/nonexistent/assets');
+        expect(s3Mocks.send).not.toHaveBeenCalled();
+    });
+
+    describe('getAsset', () => {
+        it('fetches the object under the assets/ prefix', async () => {
+            const body = Readable.from(['x']);
+            s3Mocks.send.mockResolvedValueOnce({
+                Body: body,
+                ContentLength: 7,
+            });
+
+            const asset = await createClient().getAsset('chunk.js');
+
+            expect(asset).toEqual({ body, contentLength: 7 });
+            const command = s3Mocks.send.mock.calls[0][0];
+            expect(command.input).toEqual({
+                Bucket: 'assets-bucket',
+                Key: 'assets/chunk.js',
+            });
+        });
+
+        it('treats NoSuchKey as a silent miss', async () => {
+            s3Mocks.send.mockRejectedValueOnce(
+                new s3Mocks.FakeNoSuchKey('missing'),
+            );
+
+            expect(await createClient().getAsset('chunk.js')).toBeNull();
+            expect(Logger.warn).not.toHaveBeenCalled();
+            expect(Logger.error).not.toHaveBeenCalled();
+        });
+
+        it('treats a 403 (AWS S3 without ListBucket) as a silent miss', async () => {
+            s3Mocks.send.mockRejectedValueOnce(forbiddenError(403));
+
+            expect(await createClient().getAsset('chunk.js')).toBeNull();
+            expect(Logger.warn).not.toHaveBeenCalled();
+        });
+
+        it('logs and returns null on unexpected errors', async () => {
+            s3Mocks.send.mockRejectedValueOnce(new Error('socket timeout'));
+
+            expect(await createClient().getAsset('chunk.js')).toBeNull();
+            expect(Logger.warn).toHaveBeenCalledWith(
+                expect.stringContaining('socket timeout'),
+            );
+        });
+    });
+
+    describe('syncLocalAssets', () => {
+        let assetsDir: string;
+
+        beforeEach(async () => {
+            assetsDir = await fs.mkdtemp(
+                path.join(os.tmpdir(), 'static-assets-test-'),
+            );
+            await fs.writeFile(path.join(assetsDir, 'index-abc.js'), 'js');
+            await fs.writeFile(path.join(assetsDir, 'style.css'), 'css');
+            await fs.writeFile(path.join(assetsDir, 'index-abc.js.map'), '{}');
+            await fs.writeFile(path.join(assetsDir, 'index-abc.js.gzip'), 'gz');
+            await fs.mkdir(path.join(assetsDir, 'fonts'));
+            await fs.writeFile(
+                path.join(assetsDir, 'fonts', 'inter.woff2'),
+                'font',
+            );
+        });
+
+        afterEach(async () => {
+            await fs.rm(assetsDir, { recursive: true, force: true });
+        });
+
+        it('uploads assets with content types, skipping .gzip and .map files', async () => {
+            s3Mocks.send.mockResolvedValue({});
+
+            await createClient().syncLocalAssets(assetsDir);
+
+            const inputs = s3Mocks.send.mock.calls.map(
+                ([command]) => command.input,
+            );
+            expect(inputs.map((input) => input.Key).sort()).toEqual([
+                'assets/fonts/inter.woff2',
+                'assets/index-abc.js',
+                'assets/style.css',
+            ]);
+            const jsUpload = inputs.find(
+                (input) => input.Key === 'assets/index-abc.js',
+            );
+            expect(jsUpload).toMatchObject({
+                Bucket: 'assets-bucket',
+                ContentType: 'application/javascript; charset=UTF-8',
+                ContentLength: 2,
+                CacheControl: 'public, max-age=31536000, immutable',
+            });
+            expect(Logger.info).toHaveBeenCalledWith(
+                expect.stringContaining('Uploaded 3/3 static assets'),
+            );
+        });
+
+        it('never rejects and reports partial upload failures', async () => {
+            s3Mocks.send
+                .mockRejectedValueOnce(new Error('put failed'))
+                .mockResolvedValue({});
+
+            await expect(
+                createClient().syncLocalAssets(assetsDir),
+            ).resolves.toBeUndefined();
+
+            expect(Logger.error).toHaveBeenCalledWith(
+                expect.stringContaining('put failed'),
+            );
+            expect(Logger.info).toHaveBeenCalledWith(
+                expect.stringContaining('Uploaded 2/3 static assets'),
+            );
+        });
+
+        it('never rejects when the assets directory is unreadable', async () => {
+            await expect(
+                createClient().syncLocalAssets('/nonexistent/assets'),
+            ).resolves.toBeUndefined();
+
+            expect(Logger.error).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to sync static assets'),
+            );
+        });
+    });
+});

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.test.ts
@@ -72,14 +72,9 @@ describe('StaticAssetsS3Client', () => {
         vi.clearAllMocks();
     });
 
-    it('is disabled and inert without configuration', async () => {
-        const client = createClient(lightdashConfigMock);
-
-        expect(client.isEnabled).toBe(false);
-        expect(await client.getAsset('chunk.js')).toBeNull();
-        expect(s3Mocks.send).not.toHaveBeenCalled();
-    });
-
+    // "No bucket configured → no-op" is pinned at the config layer
+    // (parseConfig.test.ts) and the middleware layer (isEnabled gate);
+    // this file only covers the configured client.
     describe('getAsset', () => {
         it('fetches the object under the assets/ prefix', async () => {
             const body = Readable.from(['x']);
@@ -122,6 +117,35 @@ describe('StaticAssetsS3Client', () => {
             expect(Logger.warn).toHaveBeenCalledWith(
                 expect.stringContaining('socket timeout'),
             );
+        });
+
+        it('degrades to a fast miss when the bucket exceeds the 5s time-box', async () => {
+            // A slow bucket must produce a 404, not hang every /assets
+            // request behind SDK retries.
+            vi.useFakeTimers();
+            try {
+                s3Mocks.send.mockImplementationOnce(
+                    (
+                        _command: unknown,
+                        options: { abortSignal: AbortSignal },
+                    ) =>
+                        new Promise((_resolve, reject) => {
+                            options.abortSignal.addEventListener('abort', () =>
+                                reject(new Error('Request aborted')),
+                            );
+                        }),
+                );
+
+                const assetPromise = createClient().getAsset('chunk.js');
+                await vi.advanceTimersByTimeAsync(5_000);
+
+                expect(await assetPromise).toBeNull();
+                expect(Logger.warn).toHaveBeenCalledWith(
+                    expect.stringContaining('aborted'),
+                );
+            } finally {
+                vi.useRealTimers();
+            }
         });
     });
 });

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.ts
@@ -1,0 +1,163 @@
+import {
+    GetObjectCommand,
+    NoSuchKey,
+    NotFound,
+    PutObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getErrorMessage } from '@lightdash/common';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { Readable } from 'stream';
+import { LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+import { S3BaseClient } from '../Aws/S3BaseClient';
+
+const KEY_PREFIX = 'assets/';
+
+const CONTENT_TYPES: Record<string, string> = {
+    '.js': 'text/javascript; charset=utf-8',
+    '.mjs': 'text/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.map': 'application/json',
+    '.json': 'application/json',
+    '.svg': 'image/svg+xml',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.ico': 'image/x-icon',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+    '.ttf': 'font/ttf',
+    '.txt': 'text/plain; charset=utf-8',
+    '.wasm': 'application/wasm',
+};
+
+export type StaticAsset = {
+    body: Readable;
+    contentType: string;
+    contentLength: number | undefined;
+};
+
+const listFilesRecursively = async (dir: string): Promise<string[]> => {
+    const entries = await fs.readdir(dir, {
+        recursive: true,
+        withFileTypes: true,
+    });
+    return entries
+        .filter((entry) => entry.isFile())
+        .map((entry) =>
+            path
+                .relative(dir, path.join(entry.parentPath, entry.name))
+                .split(path.sep)
+                .join('/'),
+        );
+};
+
+/**
+ * Retains hashed frontend assets across deploys. Every pod uploads its
+ * bundled assets on startup; a bucket lifecycle rule ages out chunks once
+ * they are no longer part of any running build, so stale browser tabs can
+ * still load chunks the latest image no longer ships.
+ */
+export class StaticAssetsS3Client extends S3BaseClient {
+    private readonly configuration: LightdashConfig['staticAssets']['s3'];
+
+    constructor({ lightdashConfig }: { lightdashConfig: LightdashConfig }) {
+        super(lightdashConfig.staticAssets.s3);
+        this.configuration = lightdashConfig.staticAssets.s3;
+
+        if (this.s3 && this.configuration) {
+            Logger.info(
+                `Static assets bucket fallback enabled: ${this.configuration.bucket}`,
+            );
+        }
+    }
+
+    get isEnabled(): boolean {
+        return this.s3 !== undefined && this.configuration !== undefined;
+    }
+
+    async getAsset(relativePath: string): Promise<StaticAsset | null> {
+        if (!this.s3 || !this.configuration) {
+            return null;
+        }
+
+        try {
+            const response = await this.s3.send(
+                new GetObjectCommand({
+                    Bucket: this.configuration.bucket,
+                    Key: `${KEY_PREFIX}${relativePath}`,
+                }),
+            );
+            if (!response.Body) {
+                return null;
+            }
+            return {
+                body: response.Body as Readable,
+                contentType: response.ContentType ?? 'application/octet-stream',
+                contentLength: response.ContentLength,
+            };
+        } catch (error) {
+            if (error instanceof NoSuchKey || error instanceof NotFound) {
+                return null;
+            }
+            Logger.error(
+                `Failed to fetch static asset '${relativePath}' from bucket: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Uploads are unconditional: rewriting an unchanged object resets its
+     * lifecycle age in GCS/S3, which is what keeps the current build's
+     * chunks from expiring while superseded ones age out.
+     */
+    async syncLocalAssets(localAssetsDir: string): Promise<void> {
+        if (!this.s3 || !this.configuration) {
+            return;
+        }
+        const { s3, configuration } = this;
+
+        try {
+            const relativePaths = await listFilesRecursively(localAssetsDir);
+            const uploadable = relativePaths.filter(
+                // .gzip files are precompressed companions served only by
+                // expressStaticGzip from local disk
+                (relativePath) => !relativePath.endsWith('.gzip'),
+            );
+
+            const upload = async (relativePath: string) => {
+                const extension = path.extname(relativePath).toLowerCase();
+                await s3.send(
+                    new PutObjectCommand({
+                        Bucket: configuration.bucket,
+                        Key: `${KEY_PREFIX}${relativePath}`,
+                        Body: await fs.readFile(
+                            path.join(localAssetsDir, relativePath),
+                        ),
+                        ContentType:
+                            CONTENT_TYPES[extension] ??
+                            'application/octet-stream',
+                        CacheControl: 'public, max-age=31536000, immutable',
+                    }),
+                );
+            };
+
+            await Promise.all(uploadable.map(upload));
+            Logger.info(
+                `Uploaded ${uploadable.length} static assets to bucket ${configuration.bucket}`,
+            );
+        } catch (error) {
+            Logger.error(
+                `Failed to sync static assets to bucket: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+        }
+    }
+}

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.ts
@@ -3,40 +3,24 @@ import {
     NoSuchKey,
     NotFound,
     PutObjectCommand,
+    S3ServiceException,
 } from '@aws-sdk/client-s3';
 import { getErrorMessage } from '@lightdash/common';
+import { createReadStream } from 'fs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { Readable } from 'stream';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { S3BaseClient } from '../Aws/S3BaseClient';
+import { getAssetContentType } from './assetContentType';
 
 const KEY_PREFIX = 'assets/';
-
-const CONTENT_TYPES: Record<string, string> = {
-    '.js': 'text/javascript; charset=utf-8',
-    '.mjs': 'text/javascript; charset=utf-8',
-    '.css': 'text/css; charset=utf-8',
-    '.map': 'application/json',
-    '.json': 'application/json',
-    '.svg': 'image/svg+xml',
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.gif': 'image/gif',
-    '.webp': 'image/webp',
-    '.ico': 'image/x-icon',
-    '.woff': 'font/woff',
-    '.woff2': 'font/woff2',
-    '.ttf': 'font/ttf',
-    '.txt': 'text/plain; charset=utf-8',
-    '.wasm': 'application/wasm',
-};
+const GET_ASSET_TIMEOUT_MS = 5_000;
+const UPLOAD_BATCH_SIZE = 10;
 
 export type StaticAsset = {
     body: Readable;
-    contentType: string;
     contentLength: number | undefined;
 };
 
@@ -53,6 +37,19 @@ const listFilesRecursively = async (dir: string): Promise<string[]> => {
                 .split(path.sep)
                 .join('/'),
         );
+};
+
+// A missing object is 404 (NoSuchKey/NotFound) on GCS/MinIO but can be a
+// bare 403 on AWS S3 without s3:ListBucket — all are a miss, not an error
+const isMissingObjectError = (error: unknown): boolean => {
+    if (error instanceof NoSuchKey || error instanceof NotFound) {
+        return true;
+    }
+    return (
+        error instanceof S3ServiceException &&
+        (error.$metadata.httpStatusCode === 403 ||
+            error.$metadata.httpStatusCode === 404)
+    );
 };
 
 /**
@@ -84,38 +81,49 @@ export class StaticAssetsS3Client extends S3BaseClient {
             return null;
         }
 
+        // Bound time-to-response so a slow bucket degrades to the fast 404
+        // instead of hanging /assets requests through SDK retries. Cleared
+        // once headers arrive — body streaming is backpressure-driven and
+        // must not be cut off for slow clients.
+        const abortController = new AbortController();
+        const timeoutHandle = setTimeout(
+            () => abortController.abort(),
+            GET_ASSET_TIMEOUT_MS,
+        );
         try {
             const response = await this.s3.send(
                 new GetObjectCommand({
                     Bucket: this.configuration.bucket,
                     Key: `${KEY_PREFIX}${relativePath}`,
                 }),
+                { abortSignal: abortController.signal },
             );
             if (!response.Body) {
                 return null;
             }
             return {
                 body: response.Body as Readable,
-                contentType: response.ContentType ?? 'application/octet-stream',
                 contentLength: response.ContentLength,
             };
         } catch (error) {
-            if (error instanceof NoSuchKey || error instanceof NotFound) {
-                return null;
+            if (!isMissingObjectError(error)) {
+                Logger.warn(
+                    `Failed to fetch static asset '${relativePath}' from bucket: ${getErrorMessage(
+                        error,
+                    )}`,
+                );
             }
-            Logger.error(
-                `Failed to fetch static asset '${relativePath}' from bucket: ${getErrorMessage(
-                    error,
-                )}`,
-            );
             return null;
+        } finally {
+            clearTimeout(timeoutHandle);
         }
     }
 
     /**
      * Uploads are unconditional: rewriting an unchanged object resets its
      * lifecycle age in GCS/S3, which is what keeps the current build's
-     * chunks from expiring while superseded ones age out.
+     * chunks from expiring while superseded ones age out. Never throws —
+     * callers fire-and-forget at startup.
      */
     async syncLocalAssets(localAssetsDir: string): Promise<void> {
         if (!this.s3 || !this.configuration) {
@@ -126,31 +134,59 @@ export class StaticAssetsS3Client extends S3BaseClient {
         try {
             const relativePaths = await listFilesRecursively(localAssetsDir);
             const uploadable = relativePaths.filter(
-                // .gzip files are precompressed companions served only by
-                // expressStaticGzip from local disk
-                (relativePath) => !relativePath.endsWith('.gzip'),
+                // .gzip files are precompressed companions served only from
+                // local disk; .map sourcemaps are the bulk of the build and
+                // only fetched with devtools open — a 404 there is harmless
+                (relativePath) =>
+                    !relativePath.endsWith('.gzip') &&
+                    !relativePath.endsWith('.map'),
             );
 
             const upload = async (relativePath: string) => {
-                const extension = path.extname(relativePath).toLowerCase();
+                const absolutePath = path.join(localAssetsDir, relativePath);
+                const { size } = await fs.stat(absolutePath);
                 await s3.send(
                     new PutObjectCommand({
                         Bucket: configuration.bucket,
                         Key: `${KEY_PREFIX}${relativePath}`,
-                        Body: await fs.readFile(
-                            path.join(localAssetsDir, relativePath),
-                        ),
+                        Body: createReadStream(absolutePath),
+                        ContentLength: size,
                         ContentType:
-                            CONTENT_TYPES[extension] ??
+                            getAssetContentType(relativePath) ??
                             'application/octet-stream',
                         CacheControl: 'public, max-age=31536000, immutable',
                     }),
                 );
             };
 
-            await Promise.all(uploadable.map(upload));
+            // Bounded batches: firing every PUT at once would hold the whole
+            // build in flight on a pod that is already serving traffic
+            const results: PromiseSettledResult<void>[] = [];
+            for (let i = 0; i < uploadable.length; i += UPLOAD_BATCH_SIZE) {
+                // eslint-disable-next-line no-await-in-loop
+                const batchResults = await Promise.allSettled(
+                    uploadable.slice(i, i + UPLOAD_BATCH_SIZE).map(upload),
+                );
+                results.push(...batchResults);
+            }
+
+            const failed = results.filter(
+                (result): result is PromiseRejectedResult =>
+                    result.status === 'rejected',
+            );
+            if (failed.length > 0) {
+                Logger.error(
+                    `Failed to upload ${failed.length}/${
+                        uploadable.length
+                    } static assets to bucket ${
+                        configuration.bucket
+                    }: ${getErrorMessage(failed[0].reason)}`,
+                );
+            }
             Logger.info(
-                `Uploaded ${uploadable.length} static assets to bucket ${configuration.bucket}`,
+                `Uploaded ${uploadable.length - failed.length}/${
+                    uploadable.length
+                } static assets to bucket ${configuration.bucket}`,
             );
         } catch (error) {
             Logger.error(

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.ts
@@ -53,10 +53,13 @@ const isMissingObjectError = (error: unknown): boolean => {
 };
 
 /**
- * Retains hashed frontend assets across deploys. Every pod uploads its
- * bundled assets on startup; a bucket lifecycle rule ages out chunks once
- * they are no longer part of any running build, so stale browser tabs can
- * still load chunks the latest image no longer ships.
+ * Retains hashed frontend assets across deploys so stale browser tabs can
+ * still load chunks the latest image no longer ships. The bucket is filled
+ * either by each pod on startup (syncLocalAssets, the default) or by the
+ * release pipeline at image-publish time (see push-static-assets in
+ * .github/workflows/post-release.yml) with pod sync disabled via
+ * ASSETS_S3_SYNC_ENABLED=false. A bucket lifecycle rule ages out chunks
+ * that no release re-uploads anymore.
  */
 export class StaticAssetsS3Client extends S3BaseClient {
     private readonly configuration: LightdashConfig['staticAssets']['s3'];

--- a/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.ts
+++ b/packages/backend/src/clients/StaticAssets/StaticAssetsS3Client.ts
@@ -2,41 +2,20 @@ import {
     GetObjectCommand,
     NoSuchKey,
     NotFound,
-    PutObjectCommand,
     S3ServiceException,
 } from '@aws-sdk/client-s3';
 import { getErrorMessage } from '@lightdash/common';
-import { createReadStream } from 'fs';
-import * as fs from 'fs/promises';
-import * as path from 'path';
 import { Readable } from 'stream';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { S3BaseClient } from '../Aws/S3BaseClient';
-import { getAssetContentType } from './assetContentType';
 
 const KEY_PREFIX = 'assets/';
 const GET_ASSET_TIMEOUT_MS = 5_000;
-const UPLOAD_BATCH_SIZE = 10;
 
 export type StaticAsset = {
     body: Readable;
     contentLength: number | undefined;
-};
-
-const listFilesRecursively = async (dir: string): Promise<string[]> => {
-    const entries = await fs.readdir(dir, {
-        recursive: true,
-        withFileTypes: true,
-    });
-    return entries
-        .filter((entry) => entry.isFile())
-        .map((entry) =>
-            path
-                .relative(dir, path.join(entry.parentPath, entry.name))
-                .split(path.sep)
-                .join('/'),
-        );
 };
 
 // A missing object is 404 (NoSuchKey/NotFound) on GCS/MinIO but can be a
@@ -53,13 +32,13 @@ const isMissingObjectError = (error: unknown): boolean => {
 };
 
 /**
- * Retains hashed frontend assets across deploys so stale browser tabs can
- * still load chunks the latest image no longer ships. The bucket is filled
- * either by each pod on startup (syncLocalAssets, the default) or by the
- * release pipeline at image-publish time (see push-static-assets in
- * .github/workflows/post-release.yml) with pod sync disabled via
- * ASSETS_S3_SYNC_ENABLED=false. A bucket lifecycle rule ages out chunks
- * that no release re-uploads anymore.
+ * Read-only client for the bucket retaining hashed frontend assets across
+ * deploys, so stale browser tabs can still load chunks the latest image no
+ * longer ships. The backend never writes: the bucket is populated at
+ * release time (see push-static-assets in
+ * .github/workflows/post-release.yml, or your own deploy pipeline when
+ * self-hosting), and a lifecycle rule ages out chunks no release
+ * re-uploads anymore.
  */
 export class StaticAssetsS3Client extends S3BaseClient {
     private readonly configuration: LightdashConfig['staticAssets']['s3'];
@@ -119,84 +98,6 @@ export class StaticAssetsS3Client extends S3BaseClient {
             return null;
         } finally {
             clearTimeout(timeoutHandle);
-        }
-    }
-
-    /**
-     * Uploads are unconditional: rewriting an unchanged object resets its
-     * lifecycle age in GCS/S3, which is what keeps the current build's
-     * chunks from expiring while superseded ones age out. Never throws —
-     * callers fire-and-forget at startup.
-     */
-    async syncLocalAssets(localAssetsDir: string): Promise<void> {
-        if (!this.s3 || !this.configuration) {
-            return;
-        }
-        const { s3, configuration } = this;
-
-        try {
-            const relativePaths = await listFilesRecursively(localAssetsDir);
-            const uploadable = relativePaths.filter(
-                // .gzip files are precompressed companions served only from
-                // local disk; .map sourcemaps are the bulk of the build and
-                // only fetched with devtools open — a 404 there is harmless
-                (relativePath) =>
-                    !relativePath.endsWith('.gzip') &&
-                    !relativePath.endsWith('.map'),
-            );
-
-            const upload = async (relativePath: string) => {
-                const absolutePath = path.join(localAssetsDir, relativePath);
-                const { size } = await fs.stat(absolutePath);
-                await s3.send(
-                    new PutObjectCommand({
-                        Bucket: configuration.bucket,
-                        Key: `${KEY_PREFIX}${relativePath}`,
-                        Body: createReadStream(absolutePath),
-                        ContentLength: size,
-                        ContentType:
-                            getAssetContentType(relativePath) ??
-                            'application/octet-stream',
-                        CacheControl: 'public, max-age=31536000, immutable',
-                    }),
-                );
-            };
-
-            // Bounded batches: firing every PUT at once would hold the whole
-            // build in flight on a pod that is already serving traffic
-            const results: PromiseSettledResult<void>[] = [];
-            for (let i = 0; i < uploadable.length; i += UPLOAD_BATCH_SIZE) {
-                // eslint-disable-next-line no-await-in-loop
-                const batchResults = await Promise.allSettled(
-                    uploadable.slice(i, i + UPLOAD_BATCH_SIZE).map(upload),
-                );
-                results.push(...batchResults);
-            }
-
-            const failed = results.filter(
-                (result): result is PromiseRejectedResult =>
-                    result.status === 'rejected',
-            );
-            if (failed.length > 0) {
-                Logger.error(
-                    `Failed to upload ${failed.length}/${
-                        uploadable.length
-                    } static assets to bucket ${
-                        configuration.bucket
-                    }: ${getErrorMessage(failed[0].reason)}`,
-                );
-            }
-            Logger.info(
-                `Uploaded ${uploadable.length - failed.length}/${
-                    uploadable.length
-                } static assets to bucket ${configuration.bucket}`,
-            );
-        } catch (error) {
-            Logger.error(
-                `Failed to sync static assets to bucket: ${getErrorMessage(
-                    error,
-                )}`,
-            );
         }
     }
 }

--- a/packages/backend/src/clients/StaticAssets/assetContentType.ts
+++ b/packages/backend/src/clients/StaticAssets/assetContentType.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+
+/**
+ * Resolves Content-Type from serve-static's mime db — the same resolver
+ * expressStaticGzip uses for disk-served assets — so bucket-served fallback
+ * responses can't drift from disk responses (helmet's nosniff makes a
+ * mismatched type a hard failure for module scripts). Returns undefined
+ * for extensions the db doesn't know, which vite builds never emit.
+ */
+export const getAssetContentType = (
+    relativePath: string,
+): string | undefined => {
+    const contentType = express.static.mime.lookup(relativePath);
+    if (contentType === 'application/octet-stream') {
+        return undefined;
+    }
+    const charset = express.static.mime.charsets.lookup(contentType, '');
+    return charset ? `${contentType}; charset=${charset}` : contentType;
+};

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
@@ -27,8 +27,8 @@ const createClientStub = (overrides?: Partial<ClientStub>): ClientStub => ({
     ...overrides,
 });
 
-const createRequest = (assetPath: string): Request =>
-    ({ params: { 0: assetPath } }) as unknown as Request;
+const createRequest = (assetPath: string, method = 'GET'): Request =>
+    ({ params: { 0: assetPath }, method }) as unknown as Request;
 
 const createResponse = (): Response =>
     ({ setHeader: vi.fn() }) as unknown as Response;
@@ -56,14 +56,16 @@ const createWritableResponse = (): WritableResponse => {
 };
 
 const runHandler = async (
-    client: ClientStub,
+    handler: ReturnType<typeof createStaticAssetsFallbackHandler>,
     req: Request,
     res: Response,
     next: NextFunction,
-) =>
+) => handler(req, res, next);
+
+const createHandler = (client: ClientStub) =>
     createStaticAssetsFallbackHandler(
         client as unknown as StaticAssetsS3Client,
-    )(req, res, next);
+    );
 
 describe('isSafeAssetPath', () => {
     it('accepts hashed chunk filenames and nested paths', () => {
@@ -71,7 +73,7 @@ describe('isSafeAssetPath', () => {
         expect(isSafeAssetPath('fonts/inter-Bold.woff2')).toBe(true);
     });
 
-    it('rejects traversal and empty segments', () => {
+    it('rejects traversal, empty segments, and oversized paths', () => {
         expect(isSafeAssetPath('../secrets.env')).toBe(false);
         expect(isSafeAssetPath('foo/../../etc/passwd')).toBe(false);
         expect(isSafeAssetPath('..%2Fsecrets.env')).toBe(false);
@@ -80,6 +82,7 @@ describe('isSafeAssetPath', () => {
         expect(isSafeAssetPath('foo bar.js')).toBe(false);
         expect(isSafeAssetPath('foo\\bar.js')).toBe(false);
         expect(isSafeAssetPath('foo\0.js')).toBe(false);
+        expect(isSafeAssetPath(`${'a'.repeat(600)}.js`)).toBe(false);
     });
 });
 
@@ -89,7 +92,7 @@ describe('createStaticAssetsFallbackHandler', () => {
         const next = vi.fn();
 
         await runHandler(
-            client,
+            createHandler(client),
             createRequest('chunk.js'),
             createResponse(),
             next,
@@ -104,8 +107,23 @@ describe('createStaticAssetsFallbackHandler', () => {
         const next = vi.fn();
 
         await runHandler(
-            client,
+            createHandler(client),
             createRequest('../index.html'),
+            createResponse(),
+            next,
+        );
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(client.getAsset).not.toHaveBeenCalled();
+    });
+
+    it('falls through without hitting the bucket for unknown extensions', async () => {
+        const client = createClientStub();
+        const next = vi.fn();
+
+        await runHandler(
+            createHandler(client),
+            createRequest('probe.zzz9'),
             createResponse(),
             next,
         );
@@ -119,7 +137,7 @@ describe('createStaticAssetsFallbackHandler', () => {
         const next = vi.fn();
 
         await runHandler(
-            client,
+            createHandler(client),
             createRequest('chunk.js'),
             createResponse(),
             next,
@@ -129,10 +147,31 @@ describe('createStaticAssetsFallbackHandler', () => {
         expect(next).toHaveBeenCalledTimes(1);
     });
 
+    it('does not re-hit the bucket for a recently missed path', async () => {
+        const client = createClientStub();
+        const handler = createHandler(client);
+        const next = vi.fn();
+
+        await runHandler(
+            handler,
+            createRequest('chunk.js'),
+            createResponse(),
+            next,
+        );
+        await runHandler(
+            handler,
+            createRequest('chunk.js'),
+            createResponse(),
+            next,
+        );
+
+        expect(client.getAsset).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledTimes(2);
+    });
+
     it('streams a bucket hit with immutable caching headers', async () => {
         const asset: StaticAsset = {
             body: Readable.from(['chunk contents']),
-            contentType: 'text/javascript; charset=utf-8',
             contentLength: 123,
         };
         const client = createClientStub({
@@ -142,7 +181,7 @@ describe('createStaticAssetsFallbackHandler', () => {
         const next = vi.fn();
 
         await runHandler(
-            client,
+            createHandler(client),
             createRequest('chunk.js'),
             res as unknown as Response,
             next,
@@ -158,20 +197,70 @@ describe('createStaticAssetsFallbackHandler', () => {
         );
         expect(res.setHeader).toHaveBeenCalledWith(
             'Content-Type',
-            'text/javascript; charset=utf-8',
+            'application/javascript; charset=UTF-8',
         );
         expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 123);
         expect(res.writtenBody()).toBe('chunk contents');
     });
 
-    it('ends the response with a 500 when the stream errors before any data', async () => {
+    it('omits Content-Length when the bucket does not report one', async () => {
+        const asset: StaticAsset = {
+            body: Readable.from(['x']),
+            contentLength: undefined,
+        };
+        const client = createClientStub({
+            getAsset: vi.fn().mockResolvedValue(asset),
+        });
+        const res = createWritableResponse();
+
+        await runHandler(
+            createHandler(client),
+            createRequest('chunk.js'),
+            res as unknown as Response,
+            vi.fn(),
+        );
+        await new Promise((resolve) => {
+            res.on('finish', resolve);
+        });
+
+        expect(res.setHeader).not.toHaveBeenCalledWith(
+            'Content-Length',
+            expect.anything(),
+        );
+    });
+
+    it('answers HEAD requests with headers only and discards the body', async () => {
+        const body = Readable.from(['chunk contents']);
+        const asset: StaticAsset = { body, contentLength: 123 };
+        const client = createClientStub({
+            getAsset: vi.fn().mockResolvedValue(asset),
+        });
+        const res = createWritableResponse();
+        const next = vi.fn();
+
+        await runHandler(
+            createHandler(client),
+            createRequest('chunk.js', 'HEAD'),
+            res as unknown as Response,
+            next,
+        );
+        await new Promise((resolve) => {
+            res.on('finish', resolve);
+        });
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 123);
+        expect(res.writtenBody()).toBe('');
+        expect(body.destroyed).toBe(true);
+    });
+
+    it('tears the response down without a late status write when the stream errors', async () => {
         const asset: StaticAsset = {
             body: new Readable({
                 read() {
                     this.destroy(new Error('connection reset'));
                 },
             }),
-            contentType: 'text/javascript; charset=utf-8',
             contentLength: 123,
         };
         const client = createClientStub({
@@ -181,7 +270,7 @@ describe('createStaticAssetsFallbackHandler', () => {
         const next = vi.fn();
 
         await runHandler(
-            client,
+            createHandler(client),
             createRequest('chunk.js'),
             res as unknown as Response,
             next,
@@ -190,7 +279,8 @@ describe('createStaticAssetsFallbackHandler', () => {
             res.on('close', resolve);
         });
 
-        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.destroyed).toBe(true);
+        expect(res.status).not.toHaveBeenCalled();
         expect(next).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
@@ -67,12 +67,9 @@ const createHandler = (client: ClientStub) =>
         client as unknown as StaticAssetsS3Client,
     );
 
+// The accept path of isSafeAssetPath is exercised by every handler test
+// below that reaches the bucket (they run the real predicate, unmocked).
 describe('isSafeAssetPath', () => {
-    it('accepts hashed chunk filenames and nested paths', () => {
-        expect(isSafeAssetPath('index-DhQ0k3aF.js')).toBe(true);
-        expect(isSafeAssetPath('fonts/inter-Bold.woff2')).toBe(true);
-    });
-
     it('rejects traversal, empty segments, and oversized paths', () => {
         expect(isSafeAssetPath('../secrets.env')).toBe(false);
         expect(isSafeAssetPath('foo/../../etc/passwd')).toBe(false);
@@ -169,6 +166,38 @@ describe('createStaticAssetsFallbackHandler', () => {
         expect(next).toHaveBeenCalledTimes(2);
     });
 
+    it('re-hits the bucket once the miss-cache TTL lapses', async () => {
+        // If expiry ever breaks, a pod that misses a chunk once would 404 it
+        // forever — even after a release uploads it. This is the recovery
+        // half of the negative-cache contract.
+        vi.useFakeTimers();
+        try {
+            const client = createClientStub();
+            const handler = createHandler(client);
+            const next = vi.fn();
+
+            await runHandler(
+                handler,
+                createRequest('chunk.js'),
+                createResponse(),
+                next,
+            );
+            expect(client.getAsset).toHaveBeenCalledTimes(1);
+
+            vi.advanceTimersByTime(61_000);
+
+            await runHandler(
+                handler,
+                createRequest('chunk.js'),
+                createResponse(),
+                next,
+            );
+            expect(client.getAsset).toHaveBeenCalledTimes(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it('streams a bucket hit with immutable caching headers', async () => {
         const asset: StaticAsset = {
             body: Readable.from(['chunk contents']),
@@ -201,29 +230,25 @@ describe('createStaticAssetsFallbackHandler', () => {
         );
         expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 123);
         expect(res.writtenBody()).toBe('chunk contents');
-    });
 
-    it('omits Content-Length when the bucket does not report one', async () => {
-        const asset: StaticAsset = {
-            body: Readable.from(['x']),
-            contentLength: undefined,
-        };
-        const client = createClientStub({
-            getAsset: vi.fn().mockResolvedValue(asset),
+        // Same path with an unknown length: header omitted, not sent as 0
+        const noLengthClient = createClientStub({
+            getAsset: vi.fn().mockResolvedValue({
+                body: Readable.from(['x']),
+                contentLength: undefined,
+            } satisfies StaticAsset),
         });
-        const res = createWritableResponse();
-
+        const noLengthRes = createWritableResponse();
         await runHandler(
-            createHandler(client),
-            createRequest('chunk.js'),
-            res as unknown as Response,
+            createHandler(noLengthClient),
+            createRequest('other.js'),
+            noLengthRes as unknown as Response,
             vi.fn(),
         );
         await new Promise((resolve) => {
-            res.on('finish', resolve);
+            noLengthRes.on('finish', resolve);
         });
-
-        expect(res.setHeader).not.toHaveBeenCalledWith(
+        expect(noLengthRes.setHeader).not.toHaveBeenCalledWith(
             'Content-Length',
             expect.anything(),
         );

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
@@ -1,9 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import { Readable, Writable } from 'stream';
-import {
-    createStaticAssetsFallbackHandler,
-    isSafeAssetPath,
-} from './staticAssetsFallbackMiddleware';
+import { createStaticAssetsFallbackHandler } from './staticAssetsFallbackMiddleware';
 import type { StaticAsset, StaticAssetsS3Client } from './StaticAssetsS3Client';
 
 vi.mock('../../logging/logger', () => ({
@@ -67,36 +64,26 @@ const createHandler = (client: ClientStub) =>
         client as unknown as StaticAssetsS3Client,
     );
 
-// The accept path of isSafeAssetPath is exercised by every handler test
-// below that reaches the bucket (they run the real predicate, unmocked).
-describe('isSafeAssetPath', () => {
-    it('rejects traversal, empty segments, and oversized paths', () => {
-        expect(isSafeAssetPath('../secrets.env')).toBe(false);
-        expect(isSafeAssetPath('foo/../../etc/passwd')).toBe(false);
-        expect(isSafeAssetPath('..%2Fsecrets.env')).toBe(false);
-        expect(isSafeAssetPath('foo//bar.js')).toBe(false);
-        expect(isSafeAssetPath('.')).toBe(false);
-        expect(isSafeAssetPath('foo bar.js')).toBe(false);
-        expect(isSafeAssetPath('foo\\bar.js')).toBe(false);
-        expect(isSafeAssetPath('foo\0.js')).toBe(false);
-        expect(isSafeAssetPath(`${'a'.repeat(600)}.js`)).toBe(false);
-    });
-});
-
 describe('createStaticAssetsFallbackHandler', () => {
-    it('falls through without a bucket round-trip when disabled, path is unsafe, or extension is unknown', async () => {
-        // All three gates must fall through to the 404 handler without a
-        // billed bucket GET.
-        const cases: Array<{ client: ClientStub; assetPath: string }> = [
+    it('falls through to the 404 on every non-hit: disabled, unsafe path, unknown extension, bucket miss', async () => {
+        // The safety contract: whatever happens, /assets behavior degrades
+        // to today's 404 — and the three gates never cost a bucket GET.
+        // (Unsafe paths run the real isSafeAssetPath predicate.)
+        const gatedCases: Array<{ client: ClientStub; assetPath: string }> = [
             {
                 client: createClientStub({ isEnabled: false }),
                 assetPath: 'chunk.js',
             },
             { client: createClientStub(), assetPath: '../index.html' },
+            { client: createClientStub(), assetPath: 'foo/../../etc/passwd' },
+            {
+                client: createClientStub(),
+                assetPath: `${'a'.repeat(600)}.js`,
+            },
             { client: createClientStub(), assetPath: 'probe.zzz9' },
         ];
 
-        for (const { client, assetPath } of cases) {
+        for (const { client, assetPath } of gatedCases) {
             const next = vi.fn();
             // eslint-disable-next-line no-await-in-loop
             await runHandler(
@@ -108,20 +95,17 @@ describe('createStaticAssetsFallbackHandler', () => {
             expect(next).toHaveBeenCalledTimes(1);
             expect(client.getAsset).not.toHaveBeenCalled();
         }
-    });
 
-    it('falls through when the bucket does not have the asset', async () => {
-        const client = createClientStub();
+        // Safe path but the bucket doesn't have it: one GET, then the 404
+        const missClient = createClientStub();
         const next = vi.fn();
-
         await runHandler(
-            createHandler(client),
+            createHandler(missClient),
             createRequest('chunk.js'),
             createResponse(),
             next,
         );
-
-        expect(client.getAsset).toHaveBeenCalledWith('chunk.js');
+        expect(missClient.getAsset).toHaveBeenCalledWith('chunk.js');
         expect(next).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
@@ -1,9 +1,20 @@
 import type { NextFunction, Request, Response } from 'express';
+import { Readable, Writable } from 'stream';
 import {
     createStaticAssetsFallbackHandler,
     isSafeAssetPath,
 } from './staticAssetsFallbackMiddleware';
 import type { StaticAsset, StaticAssetsS3Client } from './StaticAssetsS3Client';
+
+vi.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
 
 type ClientStub = {
     isEnabled: boolean;
@@ -21,6 +32,28 @@ const createRequest = (assetPath: string): Request =>
 
 const createResponse = (): Response =>
     ({ setHeader: vi.fn() }) as unknown as Response;
+
+type WritableResponse = Writable & {
+    setHeader: ReturnType<typeof vi.fn>;
+    status: ReturnType<typeof vi.fn>;
+    headersSent: boolean;
+    writtenBody: () => string;
+};
+
+const createWritableResponse = (): WritableResponse => {
+    const chunks: Buffer[] = [];
+    const res = new Writable({
+        write(chunk, _encoding, callback) {
+            chunks.push(Buffer.from(chunk));
+            callback();
+        },
+    }) as WritableResponse;
+    res.setHeader = vi.fn();
+    res.status = vi.fn(() => res);
+    res.headersSent = false;
+    res.writtenBody = () => Buffer.concat(chunks).toString();
+    return res;
+};
 
 const runHandler = async (
     client: ClientStub,
@@ -41,9 +74,12 @@ describe('isSafeAssetPath', () => {
     it('rejects traversal and empty segments', () => {
         expect(isSafeAssetPath('../secrets.env')).toBe(false);
         expect(isSafeAssetPath('foo/../../etc/passwd')).toBe(false);
+        expect(isSafeAssetPath('..%2Fsecrets.env')).toBe(false);
         expect(isSafeAssetPath('foo//bar.js')).toBe(false);
         expect(isSafeAssetPath('.')).toBe(false);
         expect(isSafeAssetPath('foo bar.js')).toBe(false);
+        expect(isSafeAssetPath('foo\\bar.js')).toBe(false);
+        expect(isSafeAssetPath('foo\0.js')).toBe(false);
     });
 });
 
@@ -95,17 +131,25 @@ describe('createStaticAssetsFallbackHandler', () => {
 
     it('streams a bucket hit with immutable caching headers', async () => {
         const asset: StaticAsset = {
-            body: { pipe: vi.fn() } as unknown as StaticAsset['body'],
+            body: Readable.from(['chunk contents']),
             contentType: 'text/javascript; charset=utf-8',
             contentLength: 123,
         };
         const client = createClientStub({
             getAsset: vi.fn().mockResolvedValue(asset),
         });
-        const res = createResponse();
+        const res = createWritableResponse();
         const next = vi.fn();
 
-        await runHandler(client, createRequest('chunk.js'), res, next);
+        await runHandler(
+            client,
+            createRequest('chunk.js'),
+            res as unknown as Response,
+            next,
+        );
+        await new Promise((resolve) => {
+            res.on('finish', resolve);
+        });
 
         expect(next).not.toHaveBeenCalled();
         expect(res.setHeader).toHaveBeenCalledWith(
@@ -117,6 +161,36 @@ describe('createStaticAssetsFallbackHandler', () => {
             'text/javascript; charset=utf-8',
         );
         expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 123);
-        expect(asset.body.pipe).toHaveBeenCalledWith(res);
+        expect(res.writtenBody()).toBe('chunk contents');
+    });
+
+    it('ends the response with a 500 when the stream errors before any data', async () => {
+        const asset: StaticAsset = {
+            body: new Readable({
+                read() {
+                    this.destroy(new Error('connection reset'));
+                },
+            }),
+            contentType: 'text/javascript; charset=utf-8',
+            contentLength: 123,
+        };
+        const client = createClientStub({
+            getAsset: vi.fn().mockResolvedValue(asset),
+        });
+        const res = createWritableResponse();
+        const next = vi.fn();
+
+        await runHandler(
+            client,
+            createRequest('chunk.js'),
+            res as unknown as Response,
+            next,
+        );
+        await new Promise((resolve) => {
+            res.on('close', resolve);
+        });
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(next).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
@@ -84,49 +84,30 @@ describe('isSafeAssetPath', () => {
 });
 
 describe('createStaticAssetsFallbackHandler', () => {
-    it('falls through when the client is not configured', async () => {
-        const client = createClientStub({ isEnabled: false });
-        const next = vi.fn();
+    it('falls through without a bucket round-trip when disabled, path is unsafe, or extension is unknown', async () => {
+        // All three gates must fall through to the 404 handler without a
+        // billed bucket GET.
+        const cases: Array<{ client: ClientStub; assetPath: string }> = [
+            {
+                client: createClientStub({ isEnabled: false }),
+                assetPath: 'chunk.js',
+            },
+            { client: createClientStub(), assetPath: '../index.html' },
+            { client: createClientStub(), assetPath: 'probe.zzz9' },
+        ];
 
-        await runHandler(
-            createHandler(client),
-            createRequest('chunk.js'),
-            createResponse(),
-            next,
-        );
-
-        expect(next).toHaveBeenCalledTimes(1);
-        expect(client.getAsset).not.toHaveBeenCalled();
-    });
-
-    it('falls through without hitting the bucket for unsafe paths', async () => {
-        const client = createClientStub();
-        const next = vi.fn();
-
-        await runHandler(
-            createHandler(client),
-            createRequest('../index.html'),
-            createResponse(),
-            next,
-        );
-
-        expect(next).toHaveBeenCalledTimes(1);
-        expect(client.getAsset).not.toHaveBeenCalled();
-    });
-
-    it('falls through without hitting the bucket for unknown extensions', async () => {
-        const client = createClientStub();
-        const next = vi.fn();
-
-        await runHandler(
-            createHandler(client),
-            createRequest('probe.zzz9'),
-            createResponse(),
-            next,
-        );
-
-        expect(next).toHaveBeenCalledTimes(1);
-        expect(client.getAsset).not.toHaveBeenCalled();
+        for (const { client, assetPath } of cases) {
+            const next = vi.fn();
+            // eslint-disable-next-line no-await-in-loop
+            await runHandler(
+                createHandler(client),
+                createRequest(assetPath),
+                createResponse(),
+                next,
+            );
+            expect(next).toHaveBeenCalledTimes(1);
+            expect(client.getAsset).not.toHaveBeenCalled();
+        }
     });
 
     it('falls through when the bucket does not have the asset', async () => {
@@ -144,32 +125,11 @@ describe('createStaticAssetsFallbackHandler', () => {
         expect(next).toHaveBeenCalledTimes(1);
     });
 
-    it('does not re-hit the bucket for a recently missed path', async () => {
-        const client = createClientStub();
-        const handler = createHandler(client);
-        const next = vi.fn();
-
-        await runHandler(
-            handler,
-            createRequest('chunk.js'),
-            createResponse(),
-            next,
-        );
-        await runHandler(
-            handler,
-            createRequest('chunk.js'),
-            createResponse(),
-            next,
-        );
-
-        expect(client.getAsset).toHaveBeenCalledTimes(1);
-        expect(next).toHaveBeenCalledTimes(2);
-    });
-
-    it('re-hits the bucket once the miss-cache TTL lapses', async () => {
-        // If expiry ever breaks, a pod that misses a chunk once would 404 it
-        // forever — even after a release uploads it. This is the recovery
-        // half of the negative-cache contract.
+    it('caches a miss within the TTL and re-hits the bucket once it lapses', async () => {
+        // Both halves of the negative-cache contract: repeated misses cost
+        // one bucket GET (probe protection), and expiry recovers — if it
+        // ever broke, a pod that missed a chunk once would 404 it forever,
+        // even after a release uploads it.
         vi.useFakeTimers();
         try {
             const client = createClientStub();
@@ -182,7 +142,14 @@ describe('createStaticAssetsFallbackHandler', () => {
                 createResponse(),
                 next,
             );
+            await runHandler(
+                handler,
+                createRequest('chunk.js'),
+                createResponse(),
+                next,
+            );
             expect(client.getAsset).toHaveBeenCalledTimes(1);
+            expect(next).toHaveBeenCalledTimes(2);
 
             vi.advanceTimersByTime(61_000);
 
@@ -198,7 +165,7 @@ describe('createStaticAssetsFallbackHandler', () => {
         }
     });
 
-    it('streams a bucket hit with immutable caching headers', async () => {
+    it('serves a bucket hit: streamed GET with immutable headers, no Content-Length when unknown, headers-only HEAD', async () => {
         const asset: StaticAsset = {
             body: Readable.from(['chunk contents']),
             contentLength: 123,
@@ -252,31 +219,29 @@ describe('createStaticAssetsFallbackHandler', () => {
             'Content-Length',
             expect.anything(),
         );
-    });
 
-    it('answers HEAD requests with headers only and discards the body', async () => {
-        const body = Readable.from(['chunk contents']);
-        const asset: StaticAsset = { body, contentLength: 123 };
-        const client = createClientStub({
-            getAsset: vi.fn().mockResolvedValue(asset),
+        // HEAD (express routes it to GET handlers): headers only, and the
+        // bucket stream must be destroyed, not leaked
+        const headBody = Readable.from(['chunk contents']);
+        const headClient = createClientStub({
+            getAsset: vi.fn().mockResolvedValue({
+                body: headBody,
+                contentLength: 123,
+            } satisfies StaticAsset),
         });
-        const res = createWritableResponse();
-        const next = vi.fn();
-
+        const headRes = createWritableResponse();
         await runHandler(
-            createHandler(client),
+            createHandler(headClient),
             createRequest('chunk.js', 'HEAD'),
-            res as unknown as Response,
-            next,
+            headRes as unknown as Response,
+            vi.fn(),
         );
         await new Promise((resolve) => {
-            res.on('finish', resolve);
+            headRes.on('finish', resolve);
         });
-
-        expect(next).not.toHaveBeenCalled();
-        expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 123);
-        expect(res.writtenBody()).toBe('');
-        expect(body.destroyed).toBe(true);
+        expect(headRes.setHeader).toHaveBeenCalledWith('Content-Length', 123);
+        expect(headRes.writtenBody()).toBe('');
+        expect(headBody.destroyed).toBe(true);
     });
 
     it('tears the response down without a late status write when the stream errors', async () => {

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.test.ts
@@ -1,0 +1,122 @@
+import type { NextFunction, Request, Response } from 'express';
+import {
+    createStaticAssetsFallbackHandler,
+    isSafeAssetPath,
+} from './staticAssetsFallbackMiddleware';
+import type { StaticAsset, StaticAssetsS3Client } from './StaticAssetsS3Client';
+
+type ClientStub = {
+    isEnabled: boolean;
+    getAsset: ReturnType<typeof vi.fn>;
+};
+
+const createClientStub = (overrides?: Partial<ClientStub>): ClientStub => ({
+    isEnabled: true,
+    getAsset: vi.fn().mockResolvedValue(null),
+    ...overrides,
+});
+
+const createRequest = (assetPath: string): Request =>
+    ({ params: { 0: assetPath } }) as unknown as Request;
+
+const createResponse = (): Response =>
+    ({ setHeader: vi.fn() }) as unknown as Response;
+
+const runHandler = async (
+    client: ClientStub,
+    req: Request,
+    res: Response,
+    next: NextFunction,
+) =>
+    createStaticAssetsFallbackHandler(
+        client as unknown as StaticAssetsS3Client,
+    )(req, res, next);
+
+describe('isSafeAssetPath', () => {
+    it('accepts hashed chunk filenames and nested paths', () => {
+        expect(isSafeAssetPath('index-DhQ0k3aF.js')).toBe(true);
+        expect(isSafeAssetPath('fonts/inter-Bold.woff2')).toBe(true);
+    });
+
+    it('rejects traversal and empty segments', () => {
+        expect(isSafeAssetPath('../secrets.env')).toBe(false);
+        expect(isSafeAssetPath('foo/../../etc/passwd')).toBe(false);
+        expect(isSafeAssetPath('foo//bar.js')).toBe(false);
+        expect(isSafeAssetPath('.')).toBe(false);
+        expect(isSafeAssetPath('foo bar.js')).toBe(false);
+    });
+});
+
+describe('createStaticAssetsFallbackHandler', () => {
+    it('falls through when the client is not configured', async () => {
+        const client = createClientStub({ isEnabled: false });
+        const next = vi.fn();
+
+        await runHandler(
+            client,
+            createRequest('chunk.js'),
+            createResponse(),
+            next,
+        );
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(client.getAsset).not.toHaveBeenCalled();
+    });
+
+    it('falls through without hitting the bucket for unsafe paths', async () => {
+        const client = createClientStub();
+        const next = vi.fn();
+
+        await runHandler(
+            client,
+            createRequest('../index.html'),
+            createResponse(),
+            next,
+        );
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(client.getAsset).not.toHaveBeenCalled();
+    });
+
+    it('falls through when the bucket does not have the asset', async () => {
+        const client = createClientStub();
+        const next = vi.fn();
+
+        await runHandler(
+            client,
+            createRequest('chunk.js'),
+            createResponse(),
+            next,
+        );
+
+        expect(client.getAsset).toHaveBeenCalledWith('chunk.js');
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('streams a bucket hit with immutable caching headers', async () => {
+        const asset: StaticAsset = {
+            body: { pipe: vi.fn() } as unknown as StaticAsset['body'],
+            contentType: 'text/javascript; charset=utf-8',
+            contentLength: 123,
+        };
+        const client = createClientStub({
+            getAsset: vi.fn().mockResolvedValue(asset),
+        });
+        const res = createResponse();
+        const next = vi.fn();
+
+        await runHandler(client, createRequest('chunk.js'), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.setHeader).toHaveBeenCalledWith(
+            'Cache-Control',
+            'public, max-age=31536000, immutable',
+        );
+        expect(res.setHeader).toHaveBeenCalledWith(
+            'Content-Type',
+            'text/javascript; charset=utf-8',
+        );
+        expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 123);
+        expect(asset.body.pipe).toHaveBeenCalledWith(res);
+    });
+});

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.ts
@@ -1,4 +1,7 @@
+import { getErrorMessage } from '@lightdash/common';
 import { RequestHandler } from 'express';
+import { pipeline } from 'stream';
+import Logger from '../../logging/logger';
 import { StaticAssetsS3Client } from './StaticAssetsS3Client';
 
 export const isSafeAssetPath = (relativePath: string): boolean =>
@@ -41,5 +44,18 @@ export const createStaticAssetsFallbackHandler =
         if (asset.contentLength !== undefined) {
             res.setHeader('Content-Length', asset.contentLength);
         }
-        asset.body.pipe(res);
+        // pipeline (unlike pipe) destroys both streams if the bucket read
+        // fails mid-transfer instead of emitting an unhandled 'error'
+        pipeline(asset.body, res, (error) => {
+            if (error) {
+                Logger.warn(
+                    `Streaming static asset '${relativePath}' failed: ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+                if (!res.headersSent) {
+                    res.status(500).end();
+                }
+            }
+        });
     };

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.ts
@@ -2,9 +2,17 @@ import { getErrorMessage } from '@lightdash/common';
 import { RequestHandler } from 'express';
 import { pipeline } from 'stream';
 import Logger from '../../logging/logger';
+import { getAssetContentType } from './assetContentType';
 import { StaticAssetsS3Client } from './StaticAssetsS3Client';
 
+const MAX_ASSET_PATH_LENGTH = 512;
+const MISS_CACHE_TTL_MS = 60_000;
+const MISS_CACHE_MAX_ENTRIES = 10_000;
+
+type StaticAssetsReader = Pick<StaticAssetsS3Client, 'isEnabled' | 'getAsset'>;
+
 export const isSafeAssetPath = (relativePath: string): boolean =>
+    relativePath.length <= MAX_ASSET_PATH_LENGTH &&
     relativePath
         .split('/')
         .every(
@@ -16,46 +24,101 @@ export const isSafeAssetPath = (relativePath: string): boolean =>
 
 /**
  * Serves hashed assets that a deploy removed from the pod image but the
- * bucket still retains. Falls through to the next handler (the hard 404)
- * on any miss, so behavior is unchanged when the bucket is not configured.
+ * bucket still retains. Every gate falls through to the next handler (the
+ * hard 404), so behavior is unchanged when the bucket is not configured.
  */
-export const createStaticAssetsFallbackHandler =
-    (staticAssetsClient: StaticAssetsS3Client): RequestHandler =>
-    async (req, res, next) => {
-        if (!staticAssetsClient.isEnabled) {
-            next();
-            return;
-        }
+export const createStaticAssetsFallbackHandler = (
+    staticAssetsClient: StaticAssetsReader,
+): RequestHandler => {
+    // Misses are remembered briefly so unauthenticated probing of /assets/*
+    // can't turn every request into a billed bucket GET (the CDN in front
+    // has negative caching disabled, so 404s are never cached at the edge)
+    const missedAt = new Map<string, number>();
 
-        const relativePath = req.params[0];
-        if (!relativePath || !isSafeAssetPath(relativePath)) {
-            next();
-            return;
+    const isRecentMiss = (relativePath: string): boolean => {
+        const missTime = missedAt.get(relativePath);
+        if (missTime === undefined) {
+            return false;
         }
-
-        const asset = await staticAssetsClient.getAsset(relativePath);
-        if (!asset) {
-            next();
-            return;
+        if (Date.now() - missTime > MISS_CACHE_TTL_MS) {
+            missedAt.delete(relativePath);
+            return false;
         }
-
-        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-        res.setHeader('Content-Type', asset.contentType);
-        if (asset.contentLength !== undefined) {
-            res.setHeader('Content-Length', asset.contentLength);
-        }
-        // pipeline (unlike pipe) destroys both streams if the bucket read
-        // fails mid-transfer instead of emitting an unhandled 'error'
-        pipeline(asset.body, res, (error) => {
-            if (error) {
-                Logger.warn(
-                    `Streaming static asset '${relativePath}' failed: ${getErrorMessage(
-                        error,
-                    )}`,
-                );
-                if (!res.headersSent) {
-                    res.status(500).end();
-                }
-            }
-        });
+        return true;
     };
+
+    const recordMiss = (relativePath: string) => {
+        if (missedAt.size >= MISS_CACHE_MAX_ENTRIES) {
+            missedAt.clear();
+        }
+        missedAt.set(relativePath, Date.now());
+    };
+
+    return async (req, res, next) => {
+        try {
+            if (!staticAssetsClient.isEnabled) {
+                next();
+                return;
+            }
+
+            const relativePath = req.params[0];
+            if (!relativePath || !isSafeAssetPath(relativePath)) {
+                next();
+                return;
+            }
+
+            // Vite only emits extensions the mime db knows; anything else
+            // is a probe not worth a bucket round-trip
+            const contentType = getAssetContentType(relativePath);
+            if (!contentType) {
+                next();
+                return;
+            }
+
+            if (isRecentMiss(relativePath)) {
+                next();
+                return;
+            }
+
+            const asset = await staticAssetsClient.getAsset(relativePath);
+            if (!asset) {
+                recordMiss(relativePath);
+                next();
+                return;
+            }
+
+            res.setHeader(
+                'Cache-Control',
+                'public, max-age=31536000, immutable',
+            );
+            res.setHeader('Content-Type', contentType);
+            if (asset.contentLength !== undefined) {
+                res.setHeader('Content-Length', asset.contentLength);
+            }
+
+            // Express routes HEAD to GET handlers; skip the body transfer
+            if (req.method === 'HEAD') {
+                asset.body.destroy();
+                res.end();
+                return;
+            }
+
+            // pipeline (unlike pipe) destroys both streams if the bucket
+            // read fails mid-transfer. The torn-down socket is the correct
+            // client signal — a late status write would be swallowed on the
+            // destroyed response, and could be CDN-cached as immutable if
+            // it ever were delivered
+            pipeline(asset.body, res, (error) => {
+                if (error) {
+                    Logger.warn(
+                        `Streaming static asset '${relativePath}' failed: ${getErrorMessage(
+                            error,
+                        )}`,
+                    );
+                }
+            });
+        } catch (error) {
+            next(error);
+        }
+    };
+};

--- a/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.ts
+++ b/packages/backend/src/clients/StaticAssets/staticAssetsFallbackMiddleware.ts
@@ -1,0 +1,45 @@
+import { RequestHandler } from 'express';
+import { StaticAssetsS3Client } from './StaticAssetsS3Client';
+
+export const isSafeAssetPath = (relativePath: string): boolean =>
+    relativePath
+        .split('/')
+        .every(
+            (segment) =>
+                /^[\w.-]+$/.test(segment) &&
+                segment !== '.' &&
+                segment !== '..',
+        );
+
+/**
+ * Serves hashed assets that a deploy removed from the pod image but the
+ * bucket still retains. Falls through to the next handler (the hard 404)
+ * on any miss, so behavior is unchanged when the bucket is not configured.
+ */
+export const createStaticAssetsFallbackHandler =
+    (staticAssetsClient: StaticAssetsS3Client): RequestHandler =>
+    async (req, res, next) => {
+        if (!staticAssetsClient.isEnabled) {
+            next();
+            return;
+        }
+
+        const relativePath = req.params[0];
+        if (!relativePath || !isSafeAssetPath(relativePath)) {
+            next();
+            return;
+        }
+
+        const asset = await staticAssetsClient.getAsset(relativePath);
+        if (!asset) {
+            next();
+            return;
+        }
+
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        res.setHeader('Content-Type', asset.contentType);
+        if (asset.contentLength !== undefined) {
+            res.setHeader('Content-Length', asset.contentLength);
+        }
+        asset.body.pipe(res);
+    };

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -152,6 +152,7 @@ export const lightdashConfigMock: LightdashConfig = {
             region: 'mock_region',
         },
     },
+    staticAssets: {},
     natsWorker: {
         enabled: false,
         url: undefined,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -152,7 +152,9 @@ export const lightdashConfigMock: LightdashConfig = {
             region: 'mock_region',
         },
     },
-    staticAssets: {},
+    staticAssets: {
+        syncEnabled: true,
+    },
     natsWorker: {
         enabled: false,
         url: undefined,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -152,9 +152,7 @@ export const lightdashConfigMock: LightdashConfig = {
             region: 'mock_region',
         },
     },
-    staticAssets: {
-        syncEnabled: true,
-    },
+    staticAssets: {},
     natsWorker: {
         enabled: false,
         url: undefined,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -126,6 +126,46 @@ test('Should use explicit pre-aggregate S3 credentials when set', () => {
     });
 });
 
+test('Should leave static assets S3 config undefined when no bucket is set', () => {
+    const config = parseConfig();
+    expect(config.staticAssets.s3).toBeUndefined();
+});
+
+test('Should fall back to base S3 region and credentials for static assets S3 config', () => {
+    process.env.S3_ACCESS_KEY = 'base_access_key';
+    process.env.S3_SECRET_KEY = 'base_secret_key';
+    process.env.ASSETS_S3_BUCKET = 'assets_bucket';
+
+    const config = parseConfig();
+    expect(config.staticAssets.s3).toEqual({
+        endpoint: 'mock_endpoint',
+        bucket: 'assets_bucket',
+        region: 'mock_region',
+        accessKey: 'base_access_key',
+        secretKey: 'base_secret_key',
+        forcePathStyle: false,
+    });
+});
+
+test('Should use explicit static assets S3 config when set', () => {
+    process.env.S3_ACCESS_KEY = 'base_access_key';
+    process.env.S3_SECRET_KEY = 'base_secret_key';
+    process.env.ASSETS_S3_BUCKET = 'assets_bucket';
+    process.env.ASSETS_S3_REGION = 'assets_region';
+    process.env.ASSETS_S3_ACCESS_KEY = 'assets_access_key';
+    process.env.ASSETS_S3_SECRET_KEY = 'assets_secret_key';
+
+    const config = parseConfig();
+    expect(config.staticAssets.s3).toEqual({
+        endpoint: 'mock_endpoint',
+        bucket: 'assets_bucket',
+        region: 'assets_region',
+        accessKey: 'assets_access_key',
+        secretKey: 'assets_secret_key',
+        forcePathStyle: false,
+    });
+});
+
 test('Should default apps S3 config to base S3 config', () => {
     process.env.S3_ACCESS_KEY = 'mock_access_key';
     process.env.S3_SECRET_KEY = 'mock_secret_key';

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -126,37 +126,6 @@ test('Should use explicit pre-aggregate S3 credentials when set', () => {
     });
 });
 
-test('Should parse static assets S3 config: unset is a no-op, base S3 creds by default, explicit values win', () => {
-    // No bucket set → feature disabled everywhere
-    expect(parseConfig().staticAssets.s3).toBeUndefined();
-
-    // Bucket set → inherit base S3 region and credentials
-    process.env.S3_ACCESS_KEY = 'base_access_key';
-    process.env.S3_SECRET_KEY = 'base_secret_key';
-    process.env.ASSETS_S3_BUCKET = 'assets_bucket';
-    expect(parseConfig().staticAssets.s3).toEqual({
-        endpoint: 'mock_endpoint',
-        bucket: 'assets_bucket',
-        region: 'mock_region',
-        accessKey: 'base_access_key',
-        secretKey: 'base_secret_key',
-        forcePathStyle: false,
-    });
-
-    // Explicit ASSETS_S3_* values take precedence over the base config
-    process.env.ASSETS_S3_REGION = 'assets_region';
-    process.env.ASSETS_S3_ACCESS_KEY = 'assets_access_key';
-    process.env.ASSETS_S3_SECRET_KEY = 'assets_secret_key';
-    expect(parseConfig().staticAssets.s3).toEqual({
-        endpoint: 'mock_endpoint',
-        bucket: 'assets_bucket',
-        region: 'assets_region',
-        accessKey: 'assets_access_key',
-        secretKey: 'assets_secret_key',
-        forcePathStyle: false,
-    });
-});
-
 test('Should default apps S3 config to base S3 config', () => {
     process.env.S3_ACCESS_KEY = 'mock_access_key';
     process.env.S3_SECRET_KEY = 'mock_secret_key';

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -147,17 +147,6 @@ test('Should fall back to base S3 region and credentials for static assets S3 co
     });
 });
 
-test('Should enable static assets startup sync by default', () => {
-    const config = parseConfig();
-    expect(config.staticAssets.syncEnabled).toBe(true);
-});
-
-test('Should disable static assets startup sync when ASSETS_S3_SYNC_ENABLED is false', () => {
-    process.env.ASSETS_S3_SYNC_ENABLED = 'false';
-    const config = parseConfig();
-    expect(config.staticAssets.syncEnabled).toBe(false);
-});
-
 test('Should use explicit static assets S3 config when set', () => {
     process.env.S3_ACCESS_KEY = 'base_access_key';
     process.env.S3_SECRET_KEY = 'base_secret_key';

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -147,6 +147,17 @@ test('Should fall back to base S3 region and credentials for static assets S3 co
     });
 });
 
+test('Should enable static assets startup sync by default', () => {
+    const config = parseConfig();
+    expect(config.staticAssets.syncEnabled).toBe(true);
+});
+
+test('Should disable static assets startup sync when ASSETS_S3_SYNC_ENABLED is false', () => {
+    process.env.ASSETS_S3_SYNC_ENABLED = 'false';
+    const config = parseConfig();
+    expect(config.staticAssets.syncEnabled).toBe(false);
+});
+
 test('Should use explicit static assets S3 config when set', () => {
     process.env.S3_ACCESS_KEY = 'base_access_key';
     process.env.S3_SECRET_KEY = 'base_secret_key';

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -126,18 +126,15 @@ test('Should use explicit pre-aggregate S3 credentials when set', () => {
     });
 });
 
-test('Should leave static assets S3 config undefined when no bucket is set', () => {
-    const config = parseConfig();
-    expect(config.staticAssets.s3).toBeUndefined();
-});
+test('Should parse static assets S3 config: unset is a no-op, base S3 creds by default, explicit values win', () => {
+    // No bucket set → feature disabled everywhere
+    expect(parseConfig().staticAssets.s3).toBeUndefined();
 
-test('Should fall back to base S3 region and credentials for static assets S3 config', () => {
+    // Bucket set → inherit base S3 region and credentials
     process.env.S3_ACCESS_KEY = 'base_access_key';
     process.env.S3_SECRET_KEY = 'base_secret_key';
     process.env.ASSETS_S3_BUCKET = 'assets_bucket';
-
-    const config = parseConfig();
-    expect(config.staticAssets.s3).toEqual({
+    expect(parseConfig().staticAssets.s3).toEqual({
         endpoint: 'mock_endpoint',
         bucket: 'assets_bucket',
         region: 'mock_region',
@@ -145,18 +142,12 @@ test('Should fall back to base S3 region and credentials for static assets S3 co
         secretKey: 'base_secret_key',
         forcePathStyle: false,
     });
-});
 
-test('Should use explicit static assets S3 config when set', () => {
-    process.env.S3_ACCESS_KEY = 'base_access_key';
-    process.env.S3_SECRET_KEY = 'base_secret_key';
-    process.env.ASSETS_S3_BUCKET = 'assets_bucket';
+    // Explicit ASSETS_S3_* values take precedence over the base config
     process.env.ASSETS_S3_REGION = 'assets_region';
     process.env.ASSETS_S3_ACCESS_KEY = 'assets_access_key';
     process.env.ASSETS_S3_SECRET_KEY = 'assets_secret_key';
-
-    const config = parseConfig();
-    expect(config.staticAssets.s3).toEqual({
+    expect(parseConfig().staticAssets.s3).toEqual({
         endpoint: 'mock_endpoint',
         bucket: 'assets_bucket',
         region: 'assets_region',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1343,18 +1343,12 @@ export type LightdashConfig = {
     staticAssets: {
         /**
          * Fallback origin for hashed frontend chunks that a deploy removed
-         * from the pod image but stale browser tabs still reference.
+         * from the pod image but stale browser tabs still reference. The
+         * backend only reads from this bucket; it is populated at release
+         * time (push-static-assets in post-release.yml, or your own deploy
+         * pipeline when self-hosting).
          */
         s3?: Omit<S3Config, 'expirationTime'>;
-        /**
-         * Whether each pod uploads its build's chunks to the bucket on
-         * startup. Default on so any deployment gets retention with no
-         * pipeline work. Disable (ASSETS_S3_SYNC_ENABLED=false) when a
-         * release pipeline populates the bucket instead — required when the
-         * bucket is shared across tenants, where pods must be read-only so
-         * one compromised tenant cannot overwrite chunks served to others.
-         */
-        syncEnabled: boolean;
     };
     natsWorker: {
         enabled: boolean;
@@ -2537,7 +2531,6 @@ export const parseConfig = (): LightdashConfig => {
         },
         staticAssets: {
             s3: parseStaticAssetsS3Config(),
-            syncEnabled: process.env.ASSETS_S3_SYNC_ENABLED !== 'false',
         },
         natsWorker: {
             enabled: natsWorkerEnabled,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -940,6 +940,37 @@ export const parsePreAggregateResultsS3Config = ():
     };
 };
 
+export const parseStaticAssetsS3Config = ():
+    | Omit<S3Config, 'expirationTime'>
+    | undefined => {
+    const bucket = process.env.ASSETS_S3_BUCKET;
+
+    if (!bucket) {
+        return undefined;
+    }
+
+    const baseS3Config = parseBaseS3Config();
+    const endpoint = baseS3Config?.endpoint;
+    const region = process.env.ASSETS_S3_REGION || baseS3Config?.region;
+
+    if (!endpoint || !region) {
+        throw new ParseError(
+            'ASSETS_S3_REGION and S3_ENDPOINT must be set when ASSETS_S3_BUCKET is configured.',
+            {},
+        );
+    }
+
+    return {
+        endpoint,
+        forcePathStyle: baseS3Config?.forcePathStyle,
+        bucket,
+        region,
+        accessKey: process.env.ASSETS_S3_ACCESS_KEY || baseS3Config?.accessKey,
+        secretKey: process.env.ASSETS_S3_SECRET_KEY || baseS3Config?.secretKey,
+        useCredentialsFrom: baseS3Config?.useCredentialsFrom,
+    };
+};
+
 const validateTaskList = (tasks: string[], envVarName: string) => {
     const validTasks: SchedulerTaskName[] = [];
     const invalidTasks: string[] = [];
@@ -1310,6 +1341,13 @@ export type LightdashConfig = {
         cacheEnabled: boolean;
         autocompleteEnabled: boolean;
         cacheStateTimeSeconds: number;
+        s3?: Omit<S3Config, 'expirationTime'>;
+    };
+    staticAssets: {
+        /**
+         * Fallback origin for hashed frontend chunks that a deploy removed
+         * from the pod image but stale browser tabs still reference.
+         */
         s3?: Omit<S3Config, 'expirationTime'>;
     };
     natsWorker: {
@@ -2490,6 +2528,9 @@ export const parseConfig = (): LightdashConfig => {
                 10,
             ),
             s3: parseResultsS3Config(),
+        },
+        staticAssets: {
+            s3: parseStaticAssetsS3Config(),
         },
         natsWorker: {
             enabled: natsWorkerEnabled,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1346,6 +1346,15 @@ export type LightdashConfig = {
          * from the pod image but stale browser tabs still reference.
          */
         s3?: Omit<S3Config, 'expirationTime'>;
+        /**
+         * Whether each pod uploads its build's chunks to the bucket on
+         * startup. Default on so any deployment gets retention with no
+         * pipeline work. Disable (ASSETS_S3_SYNC_ENABLED=false) when a
+         * release pipeline populates the bucket instead — required when the
+         * bucket is shared across tenants, where pods must be read-only so
+         * one compromised tenant cannot overwrite chunks served to others.
+         */
+        syncEnabled: boolean;
     };
     natsWorker: {
         enabled: boolean;
@@ -2528,6 +2537,7 @@ export const parseConfig = (): LightdashConfig => {
         },
         staticAssets: {
             s3: parseStaticAssetsS3Config(),
+            syncEnabled: process.env.ASSETS_S3_SYNC_ENABLED !== 'false',
         },
         natsWorker: {
             enabled: natsWorkerEnabled,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -949,25 +949,22 @@ export const parseStaticAssetsS3Config = ():
         return undefined;
     }
 
+    // parseBaseS3Config throws its own ParseError when S3_ENDPOINT /
+    // S3_BUCKET / S3_REGION are missing, so no endpoint/region check is
+    // needed here
     const baseS3Config = parseBaseS3Config();
-    const endpoint = baseS3Config?.endpoint;
-    const region = process.env.ASSETS_S3_REGION || baseS3Config?.region;
-
-    if (!endpoint || !region) {
-        throw new ParseError(
-            'ASSETS_S3_REGION and S3_ENDPOINT must be set when ASSETS_S3_BUCKET is configured.',
-            {},
-        );
+    if (!baseS3Config) {
+        return undefined;
     }
 
     return {
-        endpoint,
-        forcePathStyle: baseS3Config?.forcePathStyle,
+        endpoint: baseS3Config.endpoint,
+        forcePathStyle: baseS3Config.forcePathStyle,
         bucket,
-        region,
-        accessKey: process.env.ASSETS_S3_ACCESS_KEY || baseS3Config?.accessKey,
-        secretKey: process.env.ASSETS_S3_SECRET_KEY || baseS3Config?.secretKey,
-        useCredentialsFrom: baseS3Config?.useCredentialsFrom,
+        region: process.env.ASSETS_S3_REGION || baseS3Config.region,
+        accessKey: process.env.ASSETS_S3_ACCESS_KEY || baseS3Config.accessKey,
+        secretKey: process.env.ASSETS_S3_SECRET_KEY || baseS3Config.secretKey,
+        useCredentialsFrom: baseS3Config.useCredentialsFrom,
     };
 };
 


### PR DESCRIPTION
## Summary

After a deploy, a browser tab holding a stale `index.html` requests hashed chunks (`/assets/index-<hash>.js`) that the new pod image no longer contains. The request 404s and the app crashes with `Failed to fetch dynamically imported module`.

Affects any tab left open across a release on deployments that serve assets from the backend image (Lightdash Cloud). Complementary to #25015, which softens the failure by surfacing a refresh prompt; this PR removes the failure by keeping the old chunks servable.

## Root cause

The backend serves `/assets/*` straight from its container image, and each image only ships the chunks of its own build. Nothing accumulates chunks across deploys, so once old pods roll away, an old chunk has no origin anywhere — the CDN miss falls through to a new pod, which hard-404s:

```ts
// App.ts — anything not in this image's frontend/build/assets is a hard 404
expressApp.use('/assets/*', (req, res) => {
    res.status(404).send('Not found');
});
```

Cloud CDN cannot paper over this (`serveWhileStale: 0`, and evicted entries re-fetch from an origin that no longer has the file).

## Fix

Chunks from recent builds are retained in a bucket and served from there when the local image misses. **The backend is read-only against the bucket** — it is populated once per release by the pipeline. Env-gated by `ASSETS_S3_BUCKET` (plus the existing base `S3_*` config); when unset — everywhere today, including self-hosted — every code path is a no-op and behavior is byte-identical.

```
release published                          request path (backend)
  └─ push-static-assets job                 GET /assets/index-<hash>.js
     extracts /assets from the               1. expressStaticGzip (pod image)  hit → 200
     published image, gsutil-cp's            2. bucket fallback (read-only)    hit → 200
     to the per-region buckets               3. hard 404  (unchanged; always when env unset)
```

Writing only from the release pipeline (rather than from pods) matters for three reasons:

1. **Security** — the Cloud bucket is shared across tenants; read-only pods mean no compromised tenant can overwrite a chunk served to every other tenant (enforced by IAM in the companion cloud PR, and by the backend simply having no write path).
2. **No deploy race** — assets land in the bucket at image-publish time, hours before any pod rolls, so an old pod can never miss a chunk of a build that is already serving HTML.
3. **One writer, one contract** — uploads are deliberately unconditional (`gsutil cp`, not `rsync`): rewriting unchanged objects resets their lifecycle age, so long-lived chunks (vendor bundles that don't change for months) stay alive while superseded ones expire.

Self-hosters who opt in populate the bucket from their own deploy pipeline the same way (copy the image's `assets/` dir on each release; rewrite unchanged objects so the lifecycle rule doesn't expire live chunks).

- `clients/StaticAssets/StaticAssetsS3Client.ts` — read-only client: single-asset fetch with a 5s time-box, treating 404/403 as silent misses; failures log and degrade to today's behavior, never crash.
- `clients/StaticAssets/staticAssetsFallbackMiddleware.ts` — the fallback handler, registered between the static handler and the 404. Gates before any bucket round-trip: path allowlist + length cap, known-extension check, and a short negative cache so unauthenticated probing of `/assets/*` can't turn every miss into a billed bucket GET. Streams via `stream.pipeline` so a mid-transfer bucket failure tears the response down; HEAD answers headers-only.
- `clients/StaticAssets/assetContentType.ts` — content types resolved from serve-static's mime db (the same resolver disk serving uses), so fallback responses can't drift from disk responses under helmet's `nosniff`.
- `config/parseConfig.ts` — `ASSETS_S3_BUCKET/REGION/ACCESS_KEY/SECRET_KEY` parsing with base `S3_*` fallbacks.
- `.github/workflows/post-release.yml` — `push-static-assets` job: pulls the just-published commercial image (never rebuilds, so uploaded hashes always match what the image serves), strips `.map`/`.gzip`, `gsutil cp`s to `lightdash-static-assets-{us,eu,staging}`.

## Test plan

- [x] `pnpm -F backend typecheck:fast`; eslint clean on touched files
- [x] `vitest run src/clients/StaticAssets` — 5 scenario tests, one per production failure mode: every non-hit falls through to the 404 (disabled / traversal / oversized / unknown-extension gates without a bucket GET, and a genuine bucket miss); negative cache protects within the TTL **and** recovers after it lapses (the branch whose regression would make a pod 404 a chunk forever); a hit serves with disk-parity headers (streamed GET, unknown length, headers-only HEAD); a mid-stream error tears the response down without a late status write that the CDN could cache as immutable; and the assets/ key prefix — the upload-job contract — with missing objects (NoSuchKey/403) as silent misses
- [x] Local end-to-end against MinIO with two real production builds: stale tab from build N navigated after deploying build N+1 → v1-only chunk served 200 from the bucket, no reload, page renders; byte/header parity with disk serving verified; misconfig (missing bucket, bad creds) degrades to today's 404
- [ ] Staging (after cloud PR applies): release twice, keep a tab from build N open, verify chunks load from bucket on build N+1

## Notes

- Customers pinned to old versions get status-quo behavior once their chunks age out of the bucket (their pods still serve their own build from disk).
- Follow-up: a structural release gate (cloud `generate-release` verifying assets landed before pinning a version) — today the guarantee is temporal (assets push at publish, rollout is the next daily release).



