### PR TITLE
fix(cli): resolve Redshift IAM credentials from the local AWS chain for preview

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@actions/core": "1.11.1",
+    "@aws-sdk/credential-providers": "3.995.0",
     "@casl/ability": "6.8.0",
     "@lightdash/common": "workspace:*",
     "@lightdash/warehouses": "workspace:*",

--- a/packages/cli/src/dbt/targets/redshift.test.ts
+++ b/packages/cli/src/dbt/targets/redshift.test.ts
@@ -1,3 +1,4 @@
+import { fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import {
     ParseError,
     RedshiftAuthenticationType,
@@ -5,21 +6,34 @@ import {
 } from '@lightdash/common';
 import { convertRedshiftSchema } from './redshift';
 
+vi.mock('@aws-sdk/credential-providers', () => ({
+    fromIni: vi.fn(),
+    fromNodeProviderChain: vi.fn(),
+}));
+
+const mockedFromIni = vi.mocked(fromIni);
+const mockedFromNodeProviderChain = vi.mocked(fromNodeProviderChain);
+
+// Build a credential provider (the thunk fromIni/fromNodeProviderChain return)
+// that resolves to the given AWS credentials.
+const providerResolving = (credentials: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+    expiration?: Date;
+}) => vi.fn().mockResolvedValue(credentials);
+
+// ...or rejects, the way the SDK does when nothing in the chain resolves
+// (e.g. an expired SSO session, or no credentials at all).
+const providerRejecting = (message: string) =>
+    vi.fn().mockRejectedValue(new Error(message));
+
 describe('convertRedshiftSchema', () => {
-    const originalEnv = process.env;
-
     beforeEach(() => {
-        process.env = { ...originalEnv };
-        delete process.env.AWS_ACCESS_KEY_ID;
-        delete process.env.AWS_SECRET_ACCESS_KEY;
-        delete process.env.AWS_SESSION_TOKEN;
+        vi.resetAllMocks();
     });
 
-    afterAll(() => {
-        process.env = originalEnv;
-    });
-
-    test('should parse password authentication', () => {
+    test('should parse password authentication', async () => {
         const target = {
             type: 'redshift',
             host: 'cluster.abc.us-east-1.redshift.amazonaws.com',
@@ -30,7 +44,7 @@ describe('convertRedshiftSchema', () => {
             schema: 'public',
         };
 
-        expect(convertRedshiftSchema(target)).toEqual({
+        expect(await convertRedshiftSchema(target)).toEqual({
             type: WarehouseTypes.REDSHIFT,
             host: 'cluster.abc.us-east-1.redshift.amazonaws.com',
             user: 'analytics',
@@ -43,9 +57,13 @@ describe('convertRedshiftSchema', () => {
         });
     });
 
-    test('should parse IAM authentication for a provisioned cluster', () => {
-        process.env.AWS_ACCESS_KEY_ID = 'test-access-key-id-value';
-        process.env.AWS_SECRET_ACCESS_KEY = 'super-secret-access-key';
+    test('should resolve IAM credentials from the default AWS chain for a provisioned cluster', async () => {
+        mockedFromNodeProviderChain.mockReturnValue(
+            providerResolving({
+                accessKeyId: 'test-access-key-id-value',
+                secretAccessKey: 'super-secret-access-key',
+            }),
+        );
 
         const target = {
             type: 'redshift',
@@ -60,7 +78,7 @@ describe('convertRedshiftSchema', () => {
             autocreate: true,
         };
 
-        expect(convertRedshiftSchema(target)).toEqual({
+        expect(await convertRedshiftSchema(target)).toEqual({
             type: WarehouseTypes.REDSHIFT,
             host: 'cluster.abc.us-east-1.redshift.amazonaws.com',
             user: 'analytics',
@@ -77,24 +95,32 @@ describe('convertRedshiftSchema', () => {
             secretAccessKey: 'super-secret-access-key',
             autoCreate: true,
         });
+        // No named profile -> resolve via the default provider chain.
+        expect(mockedFromNodeProviderChain).toHaveBeenCalledTimes(1);
+        expect(mockedFromIni).not.toHaveBeenCalled();
     });
 
-    test('should parse IAM authentication for serverless (derived from host), forwarding a session token when present', () => {
-        process.env.AWS_ACCESS_KEY_ID = 'test-access-key-id-value';
-        process.env.AWS_SECRET_ACCESS_KEY = 'super-secret-access-key';
-        process.env.AWS_SESSION_TOKEN = 'temporary-session-token';
+    test('should resolve a named iam_profile via fromIni and forward a session token for serverless (derived from host)', async () => {
+        mockedFromIni.mockReturnValue(
+            providerResolving({
+                accessKeyId: 'test-access-key-id-value',
+                secretAccessKey: 'super-secret-access-key',
+                sessionToken: 'temporary-session-token',
+            }),
+        );
 
         const target = {
             type: 'redshift',
             method: 'iam',
             host: 'my-wg.123.us-east-1.redshift-serverless.amazonaws.com',
+            iam_profile: 'my-sso-profile',
             region: 'us-east-1',
             port: 5439,
             dbname: 'dev',
             schema: 'public',
         };
 
-        expect(convertRedshiftSchema(target)).toEqual({
+        expect(await convertRedshiftSchema(target)).toEqual({
             type: WarehouseTypes.REDSHIFT,
             host: 'my-wg.123.us-east-1.redshift-serverless.amazonaws.com',
             user: '',
@@ -112,10 +138,47 @@ describe('convertRedshiftSchema', () => {
             sessionToken: 'temporary-session-token',
             autoCreate: undefined,
         });
+        // The dbt "iam_profile" is passed straight through to fromIni so we
+        // resolve the exact identity dbt would use (matching its precedence).
+        expect(mockedFromIni).toHaveBeenCalledWith({
+            profile: 'my-sso-profile',
+        });
+        expect(mockedFromNodeProviderChain).not.toHaveBeenCalled();
     });
 
-    test('should throw when IAM target is missing a region', () => {
-        expect(() =>
+    test('should warn when forwarding temporary (expiring) credentials', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const expiration = new Date('2026-07-07T12:00:00.000Z');
+        mockedFromNodeProviderChain.mockReturnValue(
+            providerResolving({
+                accessKeyId: 'test-access-key-id-value',
+                secretAccessKey: 'super-secret-access-key',
+                sessionToken: 'temporary-session-token',
+                expiration,
+            }),
+        );
+
+        await convertRedshiftSchema({
+            type: 'redshift',
+            method: 'iam',
+            host: 'cluster.abc.us-east-1.redshift.amazonaws.com',
+            cluster_id: 'my-cluster',
+            user: 'analytics',
+            region: 'us-east-1',
+            port: 5439,
+            dbname: 'dev',
+            schema: 'public',
+        });
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining(expiration.toISOString()),
+        );
+        warnSpy.mockRestore();
+    });
+
+    test('should throw when IAM target is missing a region', async () => {
+        await expect(
             convertRedshiftSchema({
                 type: 'redshift',
                 method: 'iam',
@@ -126,11 +189,15 @@ describe('convertRedshiftSchema', () => {
                 dbname: 'dev',
                 schema: 'public',
             }),
-        ).toThrow(ParseError);
+        ).rejects.toThrow(ParseError);
     });
 
-    test('should throw when IAM target has no AWS credentials available', () => {
-        expect(() =>
+    test('should throw a clear error when the default AWS credential chain resolves nothing', async () => {
+        mockedFromNodeProviderChain.mockReturnValue(
+            providerRejecting('Could not load credentials from any providers'),
+        );
+
+        await expect(
             convertRedshiftSchema({
                 type: 'redshift',
                 method: 'iam',
@@ -142,11 +209,17 @@ describe('convertRedshiftSchema', () => {
                 dbname: 'dev',
                 schema: 'public',
             }),
-        ).toThrow(ParseError);
+        ).rejects.toThrow(ParseError);
     });
 
-    test('should throw a clear error when IAM target only has a local named profile', () => {
-        expect(() =>
+    test('should throw an error naming the profile and "aws sso login" when a named profile cannot be resolved', async () => {
+        mockedFromIni.mockReturnValue(
+            providerRejecting(
+                'Token for sso-session shared-aws-profile is expired',
+            ),
+        );
+
+        await expect(
             convertRedshiftSchema({
                 type: 'redshift',
                 method: 'iam',
@@ -159,11 +232,11 @@ describe('convertRedshiftSchema', () => {
                 dbname: 'dev',
                 schema: 'public',
             }),
-        ).toThrow(/iam_profile: shared-aws-profile/);
+        ).rejects.toThrow(/aws sso login --profile shared-aws-profile/);
     });
 
-    test('should throw when password target has no password', () => {
-        expect(() =>
+    test('should throw when password target has no password', async () => {
+        await expect(
             convertRedshiftSchema({
                 type: 'redshift',
                 host: 'cluster.abc.us-east-1.redshift.amazonaws.com',
@@ -172,6 +245,6 @@ describe('convertRedshiftSchema', () => {
                 dbname: 'dev',
                 schema: 'public',
             }),
-        ).toThrow(ParseError);
+        ).rejects.toThrow(ParseError);
     });
 });

--- a/packages/cli/src/dbt/targets/redshift.test.ts
+++ b/packages/cli/src/dbt/targets/redshift.test.ts
@@ -6,6 +6,19 @@ import {
 import { convertRedshiftSchema } from './redshift';
 
 describe('convertRedshiftSchema', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.AWS_ACCESS_KEY_ID;
+        delete process.env.AWS_SECRET_ACCESS_KEY;
+        delete process.env.AWS_SESSION_TOKEN;
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
     test('should parse password authentication', () => {
         const target = {
             type: 'redshift',
@@ -31,6 +44,9 @@ describe('convertRedshiftSchema', () => {
     });
 
     test('should parse IAM authentication for a provisioned cluster', () => {
+        process.env.AWS_ACCESS_KEY_ID = 'test-access-key-id-value';
+        process.env.AWS_SECRET_ACCESS_KEY = 'super-secret-access-key';
+
         const target = {
             type: 'redshift',
             method: 'iam',
@@ -57,11 +73,17 @@ describe('convertRedshiftSchema', () => {
             region: 'us-east-1',
             isServerless: false,
             clusterIdentifier: 'my-cluster',
+            accessKeyId: 'test-access-key-id-value',
+            secretAccessKey: 'super-secret-access-key',
             autoCreate: true,
         });
     });
 
-    test('should parse IAM authentication for serverless (derived from host)', () => {
+    test('should parse IAM authentication for serverless (derived from host), forwarding a session token when present', () => {
+        process.env.AWS_ACCESS_KEY_ID = 'test-access-key-id-value';
+        process.env.AWS_SECRET_ACCESS_KEY = 'super-secret-access-key';
+        process.env.AWS_SESSION_TOKEN = 'temporary-session-token';
+
         const target = {
             type: 'redshift',
             method: 'iam',
@@ -85,6 +107,9 @@ describe('convertRedshiftSchema', () => {
             region: 'us-east-1',
             isServerless: true,
             workgroupName: 'my-wg',
+            accessKeyId: 'test-access-key-id-value',
+            secretAccessKey: 'super-secret-access-key',
+            sessionToken: 'temporary-session-token',
             autoCreate: undefined,
         });
     });
@@ -102,6 +127,39 @@ describe('convertRedshiftSchema', () => {
                 schema: 'public',
             }),
         ).toThrow(ParseError);
+    });
+
+    test('should throw when IAM target has no AWS credentials available', () => {
+        expect(() =>
+            convertRedshiftSchema({
+                type: 'redshift',
+                method: 'iam',
+                host: 'cluster.abc.us-east-1.redshift.amazonaws.com',
+                cluster_id: 'my-cluster',
+                user: 'analytics',
+                region: 'us-east-1',
+                port: 5439,
+                dbname: 'dev',
+                schema: 'public',
+            }),
+        ).toThrow(ParseError);
+    });
+
+    test('should throw a clear error when IAM target only has a local named profile', () => {
+        expect(() =>
+            convertRedshiftSchema({
+                type: 'redshift',
+                method: 'iam',
+                host: 'cluster.abc.us-east-1.redshift.amazonaws.com',
+                cluster_id: 'my-cluster',
+                user: 'analytics',
+                region: 'us-east-1',
+                iam_profile: 'shared-aws-profile',
+                port: 5439,
+                dbname: 'dev',
+                schema: 'public',
+            }),
+        ).toThrow(/iam_profile: shared-aws-profile/);
     });
 
     test('should throw when password target has no password', () => {

--- a/packages/cli/src/dbt/targets/redshift.ts
+++ b/packages/cli/src/dbt/targets/redshift.ts
@@ -1,5 +1,7 @@
+import { fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import {
     CreateRedshiftCredentials,
+    getErrorMessage,
     ParseError,
     RedshiftAuthenticationType,
     WarehouseTypes,
@@ -7,6 +9,7 @@ import {
 import { JSONSchemaType } from 'ajv';
 import betterAjvErrors from 'better-ajv-errors';
 import { ajv } from '../../ajv';
+import * as styles from '../../styles';
 import { Target } from '../types';
 
 export type RedshiftTarget = {
@@ -116,9 +119,9 @@ export const redshiftSchema: JSONSchemaType<RedshiftTarget> = {
     required: ['type', 'host', 'port', 'schema'],
 };
 
-export const convertRedshiftSchema = (
+export const convertRedshiftSchema = async (
     target: Target,
-): CreateRedshiftCredentials => {
+): Promise<CreateRedshiftCredentials> => {
     const validate = ajv.compile<RedshiftTarget>(redshiftSchema);
     if (validate(target)) {
         const dbname = target.dbname || target.database;
@@ -136,26 +139,52 @@ export const convertRedshiftSchema = (
                     `Redshift IAM target requires a region: "region"`,
                 );
             }
-            // dbt-redshift resolves IAM credentials locally via boto3's
-            // credential chain (env vars, a named profile via
-            // "iam_profile", or an EC2/ECS/EKS role). Only the standard AWS
-            // env vars are portable to the Lightdash backend - a local
-            // named profile or role-based identity has no meaning outside
-            // this machine, so if that's all we have we can't forward a
-            // working identity. Fail fast here instead of creating a
-            // connection that will fail to mint credentials on every query.
-            const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
-            const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
-            const sessionToken = process.env.AWS_SESSION_TOKEN;
-            if (!accessKeyId || !secretAccessKey) {
+            // dbt-redshift resolves an AWS identity locally via boto3's
+            // credential chain (env vars, a named profile via "iam_profile"
+            // - including AWS SSO profiles - or an EC2/ECS/EKS role). None of
+            // those local references (a profile name, an instance role) mean
+            // anything on the Lightdash backend, so we resolve the chain here
+            // and forward the concrete credentials it produces. For SSO or a
+            // role these are short-lived session credentials, which is what a
+            // "sign in with SSO, then lightdash preview" workflow wants. This
+            // mirrors how the BigQuery "oauth" target resolves local ADC
+            // before uploading a preview project's credentials.
+            const credentialProvider = target.iam_profile
+                ? fromIni({ profile: target.iam_profile })
+                : fromNodeProviderChain();
+
+            let awsCredentials: Awaited<ReturnType<typeof credentialProvider>>;
+            try {
+                awsCredentials = await credentialProvider();
+            } catch (e) {
+                const source = target.iam_profile
+                    ? `AWS profile "${target.iam_profile}"`
+                    : 'the default AWS credential chain (environment variables, the default profile, SSO, or an instance role)';
                 throw new ParseError(
-                    `Redshift IAM target ("method: iam") requires AWS credentials that can be forwarded to the Lightdash backend. Set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables (and AWS_SESSION_TOKEN if using temporary credentials) before running this command${
+                    `Redshift IAM target ("method: iam") requires AWS credentials that "lightdash preview" can resolve locally and forward to the Lightdash backend, but none could be resolved from ${source}: ${getErrorMessage(
+                        e,
+                    )}. If you authenticate with AWS SSO, run "aws sso login${
                         target.iam_profile
-                            ? ` - a local named AWS profile ("iam_profile: ${target.iam_profile}") cannot be forwarded to the Lightdash backend`
+                            ? ` --profile ${target.iam_profile}`
                             : ''
-                    }.`,
+                    }" and try again, or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (plus AWS_SESSION_TOKEN for temporary credentials).`,
                 );
             }
+            const { accessKeyId, secretAccessKey, sessionToken, expiration } =
+                awsCredentials;
+
+            // SSO/role credentials are temporary. The preview project keeps
+            // using these forwarded credentials to mint Redshift credentials
+            // per query, so warn that queries will start failing once they
+            // expire rather than letting it surface as an opaque runtime error.
+            if (expiration) {
+                console.warn(
+                    styles.warning(
+                        `Forwarding temporary AWS credentials for this Redshift IAM preview that expire at ${expiration.toISOString()}. Queries in the preview project will stop working after that - re-run "lightdash preview" (re-authenticating with AWS if needed) to refresh them.`,
+                    ),
+                );
+            }
+
             // dbt-redshift represents serverless purely via the host endpoint
             // (no cluster_id); derive the workgroup from it so the connection
             // round-trips to the runtime client correctly.

--- a/packages/cli/src/dbt/targets/redshift.ts
+++ b/packages/cli/src/dbt/targets/redshift.ts
@@ -136,6 +136,26 @@ export const convertRedshiftSchema = (
                     `Redshift IAM target requires a region: "region"`,
                 );
             }
+            // dbt-redshift resolves IAM credentials locally via boto3's
+            // credential chain (env vars, a named profile via
+            // "iam_profile", or an EC2/ECS/EKS role). Only the standard AWS
+            // env vars are portable to the Lightdash backend - a local
+            // named profile or role-based identity has no meaning outside
+            // this machine, so if that's all we have we can't forward a
+            // working identity. Fail fast here instead of creating a
+            // connection that will fail to mint credentials on every query.
+            const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+            const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+            const sessionToken = process.env.AWS_SESSION_TOKEN;
+            if (!accessKeyId || !secretAccessKey) {
+                throw new ParseError(
+                    `Redshift IAM target ("method: iam") requires AWS credentials that can be forwarded to the Lightdash backend. Set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables (and AWS_SESSION_TOKEN if using temporary credentials) before running this command${
+                        target.iam_profile
+                            ? ` - a local named AWS profile ("iam_profile: ${target.iam_profile}") cannot be forwarded to the Lightdash backend`
+                            : ''
+                    }.`,
+                );
+            }
             // dbt-redshift represents serverless purely via the host endpoint
             // (no cluster_id); derive the workgroup from it so the connection
             // round-trips to the runtime client correctly.
@@ -157,6 +177,9 @@ export const convertRedshiftSchema = (
                 ...(isServerless
                     ? { workgroupName: target.host.split('.')[0] }
                     : { clusterIdentifier: target.cluster_id }),
+                accessKeyId,
+                secretAccessKey,
+                ...(sessionToken ? { sessionToken } : {}),
                 autoCreate: target.autocreate,
             };
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,6 +716,9 @@ importers:
       '@actions/core':
         specifier: 1.11.1
         version: 1.11.1
+      '@aws-sdk/credential-providers':
+        specifier: 3.995.0
+        version: 3.995.0
       '@casl/ability':
         specifier: 6.8.0
         version: 6.8.0


### PR DESCRIPTION
## Summary

`lightdash preview` builds a Redshift warehouse connection from a dbt `method: iam` target, but it forwarded no AWS identity the backend could use. `RedshiftWarehouseClient` then failed to mint IAM credentials on every query against the resulting preview project:

```
Failed to mint Redshift IAM credentials: Could not load credentials from any providers
```

dbt's `method: iam` resolves an AWS identity locally (env vars, a named profile via `iam_profile` including AWS SSO profiles, or an EC2/ECS/EKS role). None of those local references mean anything on the Lightdash backend, so the uploaded connection had nothing to authenticate with.

### What changed

`convertRedshiftSchema` now resolves AWS credentials from the local credential chain and forwards the concrete result:

- `fromIni({ profile })` when the target sets `iam_profile` (matches dbt's own precedence, and covers AWS SSO profiles)
- `fromNodeProviderChain()` otherwise (env vars, default profile, SSO, instance role)

It forwards the resolved `accessKeyId` / `secretAccessKey` / `sessionToken` to the backend, which already consumes them in `getRedshiftAwsCredentials`. These fields are already in `sensitiveCredentialsFieldNames`, so they are redacted on read and excluded from the preview/parent credential merge. No backend change is needed.

This mirrors how the BigQuery `oauth` target resolves local ADC before uploading a preview project, and it supports the common "sign in with AWS SSO, then `lightdash preview`" workflow with no long-lived per-user keys.

Because SSO and role credentials are short-lived, the CLI warns when it forwards temporary credentials (the preview stops working once the session expires, and the user re-runs `aws sso login` + `lightdash preview` to refresh). It fails fast with an actionable error pointing at `aws sso login` only when the chain resolves nothing.

Fixes #25028

### Out of scope / follow-up

This makes ephemeral `lightdash preview` connections work under per-user SSO. It is not intended for durable, persistent project connections, which should instead use a role the backend assumes (`assumeRoleArn`, already supported) - the AWS-recommended pattern for hosted cross-account Redshift access.

## Test plan

- [x] Rewrote unit tests in `packages/cli/src/dbt/targets/redshift.test.ts` (mocking `@aws-sdk/credential-providers`): resolution via `fromNodeProviderChain` (provisioned cluster) and `fromIni` (serverless, with `iam_profile` and a forwarded session token), the expiring-credentials warning, the "chain resolves nothing" error, the named-profile `aws sso login` error, plus the existing password-auth and missing-region cases
- [x] `pnpm exec vitest run src/dbt/targets/redshift.test.ts` on `packages/cli` - 8 passed
- [x] `pnpm run build` on `packages/common` and `packages/cli` - no type errors
- [x] `pnpm run linter` + `oxfmt --check` on the changed files - clean
- [x] Verified `@aws-sdk/credential-providers@3.995.0` resolves modern reusable `[sso-session]` profiles correctly via both `fromIni` and `fromNodeProviderChain` (the known SDK sso-session resolution bugs are fixed in this version)

Note: adds `@aws-sdk/credential-providers` to `packages/cli` (already a dependency of `packages/warehouses`, so it is already in the CLI's transitive tree).
