### PR TITLE
fix(apps): prevent Add data app connection modal from closing on outside click

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -382,6 +382,7 @@ export const AddConnectionWizard: FC<Props> = ({
             title="Add data app connection"
             icon={IconPlugConnected}
             size="lg"
+            modalRootProps={{ closeOnClickOutside: false }}
             {...footerProps}
         >
             <Stepper


### PR DESCRIPTION
### Description:
The Add data app connection wizard is a multi-step modal. Clicking outside the modal dismissed it and dropped the user's progress. Disable closeOnClickOutside so the modal can only be dismissed via the close button or Cancel.
