### PR TITLE
feat(ai): hide explore names by default in rendered tables

### DIFF
--- a/packages/backend/src/ee/services/McpService/buildMcpExploreConfigState.test.ts
+++ b/packages/backend/src/ee/services/McpService/buildMcpExploreConfigState.test.ts
@@ -107,6 +107,9 @@ describe('buildMcpExploreConfigState', () => {
             columnOrder: ['enrollments_campus', 'enrollments_count'],
         });
 
-        expect(configState.chartConfig).toEqual({ type: ChartType.TABLE });
+        expect(configState.chartConfig).toEqual({
+            type: ChartType.TABLE,
+            config: { showTableNames: false },
+        });
     });
 });

--- a/packages/common/src/ee/AiAgent/chartConfig/web/generateTableVizConfigTool/getTableChartConfig.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/generateTableVizConfigTool/getTableChartConfig.ts
@@ -5,4 +5,8 @@ import {
 
 export const getTableChartConfig = (): TableChartConfig => ({
     type: ChartType.TABLE,
+    // Hide explore name prefixes in column headers by default
+    config: {
+        showTableNames: false,
+    },
 });

--- a/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/getRunQueryChartConfig.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/getRunQueryChartConfig.ts
@@ -1,7 +1,8 @@
 import { type ItemsMap } from '../../../../../types/field';
 import { type MetricQuery } from '../../../../../types/metricQuery';
-import { ChartType, type ChartConfig } from '../../../../../types/savedCharts';
+import { type ChartConfig } from '../../../../../types/savedCharts';
 import { type ToolRunQueryArgsTransformed } from '../../../schemas';
+import { getTableChartConfig } from '../generateTableVizConfigTool/getTableChartConfig';
 import { canRenderAsChart } from '../shared/canRenderAsChart';
 import { type AiAgentChartTypeOption } from '../types';
 import { getBarChartConfig } from './viz/bar';
@@ -31,7 +32,7 @@ export const getRunQueryChartConfig = ({
 
     if (!canRenderAsChart(chartType, metricQuery)) {
         // Fallback to table if chart type is not valid
-        return { type: ChartType.TABLE };
+        return getTableChartConfig();
     }
 
     const { chartConfig } = queryTool;
@@ -42,7 +43,7 @@ export const getRunQueryChartConfig = ({
 
     switch (chartType) {
         case 'table':
-            return { type: ChartType.TABLE };
+            return getTableChartConfig();
 
         case 'bar':
             return getBarChartConfig({


### PR DESCRIPTION
Rendered table columns in AI agent artifacts were prefixed with the explore name. Because the AI web table config didn't set `showTableNames`, the table view's auto-detection enabled the prefix whenever fields came from a table, making headers unnecessarily long.

This sets `showTableNames: false` explicitly in the AI web table config (`getTableChartConfig`, reused by the runQuery table path) so prefixes are hidden by default. Users can still re-enable them via the "Show table names" table config, matching the normal table view.

Only affects AI agent artifact rendering — Slack and MCP paths are unchanged.