### PR TITLE
fix(ai): hide explore names by default in rendered tables

### DIFF
--- a/packages/common/src/ee/AiAgent/chartConfig/web/generateTableVizConfigTool/getTableChartConfig.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/generateTableVizConfigTool/getTableChartConfig.ts
@@ -5,4 +5,8 @@ import {
 
 export const getTableChartConfig = (): TableChartConfig => ({
     type: ChartType.TABLE,
+    config: {
+        // Hide explore name prefixes on column headers by default in AI artifacts
+        showTableNames: false,
+    },
 });

--- a/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/getRunQueryChartConfig.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/getRunQueryChartConfig.ts
@@ -1,7 +1,8 @@
 import { type ItemsMap } from '../../../../../types/field';
 import { type MetricQuery } from '../../../../../types/metricQuery';
-import { ChartType, type ChartConfig } from '../../../../../types/savedCharts';
+import { type ChartConfig } from '../../../../../types/savedCharts';
 import { type ToolRunQueryArgsTransformed } from '../../../schemas';
+import { getTableChartConfig } from '../generateTableVizConfigTool/getTableChartConfig';
 import { canRenderAsChart } from '../shared/canRenderAsChart';
 import { type AiAgentChartTypeOption } from '../types';
 import { getBarChartConfig } from './viz/bar';
@@ -31,7 +32,7 @@ export const getRunQueryChartConfig = ({
 
     if (!canRenderAsChart(chartType, metricQuery)) {
         // Fallback to table if chart type is not valid
-        return { type: ChartType.TABLE };
+        return getTableChartConfig();
     }
 
     const { chartConfig } = queryTool;
@@ -42,7 +43,7 @@ export const getRunQueryChartConfig = ({
 
     switch (chartType) {
         case 'table':
-            return { type: ChartType.TABLE };
+            return getTableChartConfig();
 
         case 'bar':
             return getBarChartConfig({


### PR DESCRIPTION
Rendered table columns in AI agent artifacts were prefixed with the explore name (e.g. `Orders`), which can get long.

In the normal table view this is controlled by the "Show table names" chart config, which auto-enables when the config is left `undefined`. AI artifacts never set it, so the prefix showed by default.

This explicitly defaults `showTableNames: false` in the AI table chart configs (`getTableChartConfig`, and the `table`/fallback paths of `getRunQueryChartConfig`), so the prefix is hidden by default. Users can still toggle it on via chart config since it's a normal config value, not a hardcoded override.