### PR TITLE
feat(analytics): buffered event stream writer for usage events raw zone

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -28,6 +28,8 @@ import path from 'path';
 import qs from 'qs';
 import reDoc from 'redoc-express';
 import { URL } from 'url';
+import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
+import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import {
     ClientProviderMap,
@@ -177,6 +179,8 @@ export default class App {
 
     private readonly prometheusMetrics: PrometheusMetrics;
 
+    private readonly eventStreamWriter: BufferedEventStreamWriter | null;
+
     private readonly customExpressMiddlewares: Array<(app: Express) => void>;
 
     private readonly analyticsEventEmitter: EventEmitter;
@@ -225,6 +229,10 @@ export default class App {
         });
         this.prometheusMetrics = new PrometheusMetrics(
             this.lightdashConfig.prometheus,
+        );
+        this.eventStreamWriter = createEventStreamWriter(
+            this.lightdashConfig,
+            this.prometheusMetrics,
         );
 
         this.serviceRepository = new ServiceRepository({
@@ -973,6 +981,10 @@ export default class App {
     }
 
     async stop() {
+        if (this.eventStreamWriter) {
+            await this.eventStreamWriter.close();
+            Logger.info('Flushed usage event stream writer');
+        }
         await this.prometheusMetrics.stop();
         await shutdownOtelTracing();
         if (this.schedulerWorker && this.schedulerWorker.runner) {
@@ -999,5 +1011,9 @@ export default class App {
 
     getDatabase() {
         return this.database;
+    }
+
+    getEventStreamWriter() {
+        return this.eventStreamWriter;
     }
 }

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -3,6 +3,8 @@ import * as Sentry from '@sentry/node';
 import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
+import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
+import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import { registerOAuthRefreshStrategies } from './auth/registerOAuthRefreshStrategies';
 import {
@@ -97,6 +99,8 @@ export default class NatsWorkerApp {
 
     private readonly prometheusMetrics: PrometheusMetrics;
 
+    private readonly eventStreamWriter: BufferedEventStreamWriter | null;
+
     constructor(args: NatsWorkerAppArguments) {
         this.lightdashConfig = args.lightdashConfig;
         this.port = args.port;
@@ -141,6 +145,10 @@ export default class NatsWorkerApp {
         });
         this.prometheusMetrics = new PrometheusMetrics(
             this.lightdashConfig.prometheus,
+        );
+        this.eventStreamWriter = createEventStreamWriter(
+            this.lightdashConfig,
+            this.prometheusMetrics,
         );
 
         this.clients = clients;
@@ -249,6 +257,10 @@ export default class NatsWorkerApp {
                 Logger.info('Shutting down NATS worker gracefully');
             },
             onSignal: async () => {
+                if (this.eventStreamWriter) {
+                    Logger.info('Flushing usage event stream writer');
+                    await this.eventStreamWriter.close();
+                }
                 Logger.info('Stopping Prometheus metrics');
                 await this.prometheusMetrics.stop();
                 await shutdownOtelTracing();
@@ -268,5 +280,9 @@ export default class NatsWorkerApp {
         });
 
         server.listen(this.port);
+    }
+
+    public getEventStreamWriter() {
+        return this.eventStreamWriter;
     }
 }

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -4,6 +4,8 @@ import { EventEmitter } from 'events';
 import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
+import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
+import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import { registerOAuthRefreshStrategies } from './auth/registerOAuthRefreshStrategies';
 import {
@@ -120,6 +122,8 @@ export default class SchedulerApp {
 
     private readonly prometheusMetrics: PrometheusMetrics;
 
+    private readonly eventStreamWriter: BufferedEventStreamWriter | null;
+
     private readonly models: ModelRepository;
 
     private readonly database: Knex;
@@ -175,6 +179,10 @@ export default class SchedulerApp {
         });
         this.prometheusMetrics = new PrometheusMetrics(
             this.lightdashConfig.prometheus,
+        );
+        this.eventStreamWriter = createEventStreamWriter(
+            this.lightdashConfig,
+            this.prometheusMetrics,
         );
         this.serviceRepository = new ServiceRepository({
             serviceProviders: args.serviceProviders,
@@ -290,6 +298,10 @@ export default class SchedulerApp {
                 Logger.info('Shutting down gracefully');
             },
             onSignal: async () => {
+                if (this.eventStreamWriter) {
+                    Logger.info('Flushing usage event stream writer');
+                    await this.eventStreamWriter.close();
+                }
                 Logger.info('Stopping Prometheus metrics');
                 await this.prometheusMetrics.stop();
                 await shutdownOtelTracing();
@@ -310,5 +322,9 @@ export default class SchedulerApp {
         });
 
         server.listen(this.port);
+    }
+
+    public getEventStreamWriter() {
+        return this.eventStreamWriter;
     }
 }

--- a/packages/backend/src/analytics/eventStream/BufferedEventStreamWriter.test.ts
+++ b/packages/backend/src/analytics/eventStream/BufferedEventStreamWriter.test.ts
@@ -1,0 +1,159 @@
+import { gunzipSync } from 'zlib';
+import PrometheusMetrics from '../../prometheus/PrometheusMetrics';
+import {
+    BufferedEventStreamWriter,
+    BufferedEventStreamWriterArgs,
+} from './BufferedEventStreamWriter';
+import { EventStreamRow } from './types';
+
+vi.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const s3Mocks = vi.hoisted(() => {
+    const putObject = vi.fn();
+    class FakeS3 {
+        putObject = putObject;
+    }
+    return { putObject, FakeS3 };
+});
+
+vi.mock('@aws-sdk/client-s3', () => ({
+    S3: s3Mocks.FakeS3,
+}));
+
+const s3Config = {
+    endpoint: 'https://s3.example.com',
+    region: 'us-east-1',
+    bucket: 'events-bucket',
+    accessKey: 'AKIA',
+    secretKey: 'SECRET',
+    forcePathStyle: true,
+};
+
+const createMetricsMock = () => ({
+    incrementUsageEventsPushed: vi.fn(),
+    incrementUsageEventsFlushed: vi.fn(),
+    incrementUsageEventsDropped: vi.fn(),
+    incrementUsageEventsPutFailure: vi.fn(),
+});
+
+type MetricsMock = ReturnType<typeof createMetricsMock>;
+
+const createWriter = (
+    metrics: MetricsMock,
+    overrides: Partial<BufferedEventStreamWriterArgs> = {},
+) =>
+    new BufferedEventStreamWriter({
+        s3Config,
+        flushIntervalMs: 60000,
+        flushBatchSize: 1000,
+        bufferMaxSize: 10000,
+        prometheusMetrics: metrics as unknown as PrometheusMetrics,
+        ...overrides,
+    });
+
+const row = (overrides: Partial<EventStreamRow> = {}): EventStreamRow => ({
+    org_id: 'org-1',
+    event_ts: '2026-07-01T12:00:00.000Z',
+    ...overrides,
+});
+
+const decodeBody = (body: Uint8Array): string =>
+    gunzipSync(Buffer.from(body)).toString('utf8');
+
+describe('BufferedEventStreamWriter', () => {
+    let metrics: MetricsMock;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        metrics = createMetricsMock();
+        s3Mocks.putObject.mockResolvedValue({});
+    });
+
+    it('writes rows as gzipped JSONL under the partitioned raw zone key', async () => {
+        const writer = createWriter(metrics);
+        const testRow = row();
+        writer.push('query_executed', testRow);
+
+        await writer.flush();
+
+        expect(s3Mocks.putObject).toHaveBeenCalledTimes(1);
+        const putArgs = s3Mocks.putObject.mock.calls[0][0];
+        expect(putArgs.Bucket).toEqual('events-bucket');
+        expect(putArgs.Key).toMatch(
+            /^events\/raw\/org_id=org-1\/stream=query_executed\/dt=2026-07-01\/[0-9a-f]{8}-[0-9a-f-]{36}\.jsonl\.gz$/,
+        );
+        expect(decodeBody(putArgs.Body)).toEqual(
+            `${JSON.stringify(testRow)}\n`,
+        );
+
+        await writer.close();
+    });
+
+    it('groups rows by org_id, stream and event date into one object each', async () => {
+        const writer = createWriter(metrics);
+        writer.push('query_executed', row());
+        writer.push('query_executed', row());
+        writer.push('query_executed', row({ org_id: 'org-2' }));
+        writer.push('dashboard_viewed', row());
+        writer.push(
+            'query_executed',
+            row({ event_ts: '2026-06-30T23:59:59.000Z' }),
+        );
+
+        await writer.flush();
+
+        expect(s3Mocks.putObject).toHaveBeenCalledTimes(4);
+        const keys = s3Mocks.putObject.mock.calls.map(
+            (call) => call[0].Key as string,
+        );
+        expect(keys).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(
+                    'events/raw/org_id=org-1/stream=query_executed/dt=2026-07-01/',
+                ),
+                expect.stringContaining(
+                    'events/raw/org_id=org-2/stream=query_executed/dt=2026-07-01/',
+                ),
+                expect.stringContaining(
+                    'events/raw/org_id=org-1/stream=dashboard_viewed/dt=2026-07-01/',
+                ),
+                expect.stringContaining(
+                    'events/raw/org_id=org-1/stream=query_executed/dt=2026-06-30/',
+                ),
+            ]),
+        );
+        // Object keys are unique across groups
+        expect(new Set(keys).size).toEqual(4);
+        // The two rows sharing a partition end up in a single object
+        const groupedCall = s3Mocks.putObject.mock.calls.find((call) =>
+            (call[0].Key as string).includes(
+                'org_id=org-1/stream=query_executed/dt=2026-07-01',
+            ),
+        );
+        expect(
+            decodeBody(groupedCall![0].Body).trimEnd().split('\n'),
+        ).toHaveLength(2);
+
+        await writer.close();
+    });
+
+    it('falls back to the current UTC date when event_ts is invalid', async () => {
+        const writer = createWriter(metrics);
+        writer.push('query_executed', row({ event_ts: 'not-a-date' }));
+
+        await writer.flush();
+
+        const today = new Date().toISOString().slice(0, 10);
+        expect(s3Mocks.putObject.mock.calls[0][0].Key).toContain(`dt=${today}`);
+
+        await writer.close();
+    });
+});

--- a/packages/backend/src/analytics/eventStream/BufferedEventStreamWriter.ts
+++ b/packages/backend/src/analytics/eventStream/BufferedEventStreamWriter.ts
@@ -1,0 +1,199 @@
+import { getErrorMessage } from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import { promisify } from 'util';
+import { gzip } from 'zlib';
+import { S3BaseClient } from '../../clients/Aws/S3BaseClient';
+import { S3Config } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+import PrometheusMetrics from '../../prometheus/PrometheusMetrics';
+import { EventStreamRow, EventStreamWriter } from './types';
+
+const gzipAsync = promisify(gzip);
+
+const S3_KEY_PREFIX = 'events/raw';
+const PUT_RETRIES = 2;
+
+type BufferedEvent = {
+    stream: string;
+    row: EventStreamRow;
+};
+
+type EventGroup = {
+    orgId: string;
+    stream: string;
+    dt: string;
+    rows: EventStreamRow[];
+};
+
+export type BufferedEventStreamWriterArgs = {
+    s3Config: Omit<S3Config, 'expirationTime'>;
+    flushIntervalMs: number;
+    flushBatchSize: number;
+    bufferMaxSize: number;
+    prometheusMetrics: PrometheusMetrics;
+};
+
+const getUtcDate = (eventTs: string): string => {
+    const parsed = new Date(eventTs);
+    const date = Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+    return date.toISOString().slice(0, 10);
+};
+
+/**
+ * Per-process buffered writer for the usage-analytics raw event zone.
+ * Buffers rows in memory and periodically flushes them to S3 as gzip JSONL
+ * objects partitioned by (org_id, stream, dt). Never throws into the caller.
+ */
+export class BufferedEventStreamWriter
+    extends S3BaseClient
+    implements EventStreamWriter
+{
+    private readonly bucket: string;
+
+    private readonly flushBatchSize: number;
+
+    private readonly bufferMaxSize: number;
+
+    private readonly prometheusMetrics: PrometheusMetrics;
+
+    private readonly writerId: string;
+
+    private readonly flushTimer: NodeJS.Timeout;
+
+    private buffer: BufferedEvent[] = [];
+
+    private flushInFlight: Promise<void> | null = null;
+
+    private closed = false;
+
+    constructor(args: BufferedEventStreamWriterArgs) {
+        super(args.s3Config);
+        this.bucket = args.s3Config.bucket;
+        this.flushBatchSize = args.flushBatchSize;
+        this.bufferMaxSize = args.bufferMaxSize;
+        this.prometheusMetrics = args.prometheusMetrics;
+        this.writerId = randomUUID().slice(0, 8);
+        this.flushTimer = setInterval(() => {
+            void this.flush();
+        }, args.flushIntervalMs);
+        // Don't keep the process alive for the flush timer
+        this.flushTimer.unref();
+    }
+
+    push(streamName: string, row: EventStreamRow): void {
+        try {
+            if (this.closed || this.buffer.length >= this.bufferMaxSize) {
+                this.prometheusMetrics.incrementUsageEventsDropped();
+                return;
+            }
+            this.buffer.push({ stream: streamName, row });
+            this.prometheusMetrics.incrementUsageEventsPushed();
+            if (this.buffer.length >= this.flushBatchSize) {
+                void this.flush();
+            }
+        } catch (error) {
+            Logger.warn(
+                `Failed to push usage event: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
+    flush(): Promise<void> {
+        if (!this.flushInFlight) {
+            this.flushInFlight = this.runFlush()
+                .catch((error) => {
+                    Logger.warn(
+                        `Failed to flush usage events: ${getErrorMessage(
+                            error,
+                        )}`,
+                    );
+                })
+                .finally(() => {
+                    this.flushInFlight = null;
+                });
+        }
+        return this.flushInFlight;
+    }
+
+    async close(): Promise<void> {
+        this.closed = true;
+        clearInterval(this.flushTimer);
+        if (this.flushInFlight) {
+            await this.flushInFlight;
+        }
+        await this.flush();
+    }
+
+    private async runFlush(): Promise<void> {
+        if (this.buffer.length === 0) {
+            return;
+        }
+        const events = this.buffer;
+        this.buffer = [];
+
+        const groups = new Map<string, EventGroup>();
+        events.forEach(({ stream, row }) => {
+            const dt = getUtcDate(row.event_ts);
+            const groupKey = `${row.org_id}|${stream}|${dt}`;
+            const group = groups.get(groupKey);
+            if (group) {
+                group.rows.push(row);
+            } else {
+                groups.set(groupKey, {
+                    orgId: row.org_id,
+                    stream,
+                    dt,
+                    rows: [row],
+                });
+            }
+        });
+
+        await Promise.all(
+            Array.from(groups.values(), (group) => this.putGroup(group)),
+        );
+    }
+
+    private async putGroup(group: EventGroup): Promise<void> {
+        const key = `${S3_KEY_PREFIX}/org_id=${group.orgId}/stream=${
+            group.stream
+        }/dt=${group.dt}/${this.writerId}-${randomUUID()}.jsonl.gz`;
+        try {
+            const jsonl = `${group.rows
+                .map((row) => JSON.stringify(row))
+                .join('\n')}\n`;
+            const body = await gzipAsync(jsonl);
+
+            for (let attempt = 0; attempt <= PUT_RETRIES; attempt += 1) {
+                try {
+                    if (!this.s3) {
+                        throw new Error('S3 client is not configured');
+                    }
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.s3.putObject({
+                        Bucket: this.bucket,
+                        Key: key,
+                        Body: body,
+                        ContentType: 'application/gzip',
+                    });
+                    this.prometheusMetrics.incrementUsageEventsFlushed(
+                        group.rows.length,
+                    );
+                    return;
+                } catch (error) {
+                    if (attempt === PUT_RETRIES) {
+                        throw error;
+                    }
+                }
+            }
+        } catch (error) {
+            this.prometheusMetrics.incrementUsageEventsPutFailure();
+            Logger.warn(
+                `Dropping ${
+                    group.rows.length
+                } usage events after failed PUT to s3://${
+                    this.bucket
+                }/${key}: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+}

--- a/packages/backend/src/analytics/eventStream/createEventStreamWriter.ts
+++ b/packages/backend/src/analytics/eventStream/createEventStreamWriter.ts
@@ -1,0 +1,24 @@
+import { LightdashConfig } from '../../config/parseConfig';
+import PrometheusMetrics from '../../prometheus/PrometheusMetrics';
+import { BufferedEventStreamWriter } from './BufferedEventStreamWriter';
+
+/**
+ * Creates the usage event stream writer when the feature is enabled,
+ * otherwise returns null so consumers can skip it cheaply.
+ */
+export const createEventStreamWriter = (
+    lightdashConfig: LightdashConfig,
+    prometheusMetrics: PrometheusMetrics,
+): BufferedEventStreamWriter | null => {
+    const { usageEvents } = lightdashConfig;
+    if (!usageEvents.enabled || usageEvents.s3 === null) {
+        return null;
+    }
+    return new BufferedEventStreamWriter({
+        s3Config: usageEvents.s3,
+        flushIntervalMs: usageEvents.flushIntervalMs,
+        flushBatchSize: usageEvents.flushBatchSize,
+        bufferMaxSize: usageEvents.bufferMaxSize,
+        prometheusMetrics,
+    });
+};

--- a/packages/backend/src/analytics/eventStream/types.ts
+++ b/packages/backend/src/analytics/eventStream/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Minimal row contract for the usage-analytics raw event stream. Sinks build
+ * typed rows on top of this shape.
+ */
+export type EventStreamRow = {
+    org_id: string;
+    event_ts: string;
+    [key: string]: unknown;
+};
+
+export interface EventStreamWriter {
+    push(streamName: string, row: EventStreamRow): void;
+    flush(): Promise<void>;
+    close(): Promise<void>;
+}

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -360,6 +360,13 @@ export const lightdashConfigMock: LightdashConfig = {
             region: 'mock_region',
         },
     },
+    usageEvents: {
+        enabled: false,
+        flushIntervalMs: 60000,
+        flushBatchSize: 1000,
+        bufferMaxSize: 10000,
+        s3: null,
+    },
     appRuntime: {
         enabled: false,
         lightdashOrigin: 'https://test.lightdash.cloud',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -940,6 +940,37 @@ export const parsePreAggregateResultsS3Config = ():
     };
 };
 
+export const parseUsageEventsS3Config = (): Omit<
+    S3Config,
+    'expirationTime'
+> | null => {
+    const baseS3Config = parseBaseS3Config();
+
+    if (!baseS3Config) {
+        return null;
+    }
+
+    const {
+        endpoint,
+        forcePathStyle,
+        useCredentialsFrom,
+        bucket: baseBucket,
+        region: baseRegion,
+        accessKey: baseAccessKey,
+        secretKey: baseSecretKey,
+    } = baseS3Config;
+
+    return {
+        endpoint,
+        forcePathStyle,
+        bucket: process.env.USAGE_EVENTS_S3_BUCKET || baseBucket,
+        region: process.env.USAGE_EVENTS_S3_REGION || baseRegion,
+        accessKey: process.env.USAGE_EVENTS_S3_ACCESS_KEY || baseAccessKey,
+        secretKey: process.env.USAGE_EVENTS_S3_SECRET_KEY || baseSecretKey,
+        useCredentialsFrom,
+    };
+};
+
 const validateTaskList = (tasks: string[], envVarName: string) => {
     const validTasks: SchedulerTaskName[] = [];
     const invalidTasks: string[] = [];
@@ -1504,6 +1535,13 @@ export type LightdashConfig = {
         /** Max memory DuckDB can use for caching parquet data and query intermediates on the shared query instance (e.g. '256MB', '1GB', '2GB'). Only affects pre-aggregate reads, not materializations which use isolated instances. */
         duckdbQueryMemoryLimit: string | null;
         s3?: Omit<S3Config, 'expirationTime'>;
+    };
+    usageEvents: {
+        enabled: boolean;
+        flushIntervalMs: number;
+        flushBatchSize: number;
+        bufferMaxSize: number;
+        s3: Omit<S3Config, 'expirationTime'> | null;
     };
     appRuntime: AppRuntimeConfig;
     enabledFeatureFlags: Set<string>;
@@ -2103,6 +2141,9 @@ export const parseConfig = (): LightdashConfig => {
     const preAggregatesEnabled =
         licenseKey !== null && process.env.PRE_AGGREGATES_ENABLED === 'true';
     const preAggregatesS3 = parsePreAggregateResultsS3Config();
+    const usageEventsEnabled =
+        licenseKey !== null && process.env.USAGE_EVENTS_ENABLED === 'true';
+    const usageEventsS3 = parseUsageEventsS3Config();
     const natsWorkerEnabled = process.env.NATS_ENABLED === 'true';
     const natsWorkerUrl = process.env.NATS_URL;
     const natsWorkerConcurrency =
@@ -2112,6 +2153,9 @@ export const parseConfig = (): LightdashConfig => {
 
     if (preAggregatesEnabled && !preAggregatesS3) {
         throw new ParseError('Pre-aggregates require S3 configuration', {});
+    }
+    if (usageEventsEnabled && !usageEventsS3) {
+        throw new ParseError('Usage events require S3 configuration', {});
     }
     if (natsWorkerEnabled && !natsWorkerUrl) {
         throw new ParseError('NATS_URL is required when NATS_ENABLED=true', {});
@@ -2754,6 +2798,22 @@ export const parseConfig = (): LightdashConfig => {
             duckdbQueryMemoryLimit:
                 process.env.PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT ?? null,
             s3: preAggregatesS3,
+        },
+        usageEvents: {
+            enabled: usageEventsEnabled,
+            flushIntervalMs:
+                getIntegerFromEnvironmentVariable(
+                    'USAGE_EVENTS_FLUSH_INTERVAL_MS',
+                ) ?? 60000,
+            flushBatchSize:
+                getIntegerFromEnvironmentVariable(
+                    'USAGE_EVENTS_FLUSH_BATCH_SIZE',
+                ) ?? 1000,
+            bufferMaxSize:
+                getIntegerFromEnvironmentVariable(
+                    'USAGE_EVENTS_BUFFER_MAX_SIZE',
+                ) ?? 10000,
+            s3: usageEventsS3,
         },
         appRuntime: parseAppRuntimeConfig(siteUrl),
         enabledFeatureFlags: new Set([

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -169,6 +169,15 @@ export default class PrometheusMetrics {
 
     public queryCacheHitCounter: prometheus.Counter<string> | null = null;
 
+    // Usage event stream writer metrics
+    public usageEventsPushedCounter: prometheus.Counter | null = null;
+
+    public usageEventsFlushedCounter: prometheus.Counter | null = null;
+
+    public usageEventsDroppedCounter: prometheus.Counter | null = null;
+
+    public usageEventsPutFailuresCounter: prometheus.Counter | null = null;
+
     public preAggregateMaterializationFileSizeHistogram: prometheus.Histogram<string> | null =
         null;
 
@@ -759,6 +768,31 @@ export default class PrometheusMetrics {
                     ...rest,
                 });
 
+                // Usage event stream writer metrics
+                this.usageEventsPushedCounter = new prometheus.Counter({
+                    name: 'lightdash_usage_events_pushed_total',
+                    help: 'Total usage events pushed into the event stream buffer',
+                    ...rest,
+                });
+
+                this.usageEventsFlushedCounter = new prometheus.Counter({
+                    name: 'lightdash_usage_events_flushed_total',
+                    help: 'Total usage events flushed to the S3 raw zone',
+                    ...rest,
+                });
+
+                this.usageEventsDroppedCounter = new prometheus.Counter({
+                    name: 'lightdash_usage_events_dropped_total',
+                    help: 'Total usage events dropped because the buffer was full',
+                    ...rest,
+                });
+
+                this.usageEventsPutFailuresCounter = new prometheus.Counter({
+                    name: 'lightdash_usage_events_put_failures_total',
+                    help: 'Total usage event batches dropped after exhausting S3 PUT retries',
+                    ...rest,
+                });
+
                 const app = express();
                 this.server = http.createServer(app);
                 app.get(metricsPath, async (req, res) => {
@@ -1339,6 +1373,22 @@ export default class PrometheusMetrics {
 
     public observeAiWritebackStageDuration(stage: string, durationMs: number) {
         this.aiWritebackStageDurationHistogram?.observe({ stage }, durationMs);
+    }
+
+    public incrementUsageEventsPushed() {
+        this.usageEventsPushedCounter?.inc();
+    }
+
+    public incrementUsageEventsFlushed(count: number) {
+        this.usageEventsFlushedCounter?.inc(count);
+    }
+
+    public incrementUsageEventsDropped() {
+        this.usageEventsDroppedCounter?.inc();
+    }
+
+    public incrementUsageEventsPutFailure() {
+        this.usageEventsPutFailuresCounter?.inc();
     }
 
     public monitorEventMetrics(eventEmitter: EventEmitter) {


### PR DESCRIPTION
## Summary

Stage 2 of the usage-analytics event pipeline: a per-process buffered event-stream writer that batches usage events in memory and flushes them to the S3 raw zone as gzip JSONL objects.

- **`BufferedEventStreamWriter`** (`packages/backend/src/analytics/eventStream/`): bounded in-process buffer with a synchronous, never-throwing `push(streamName, row)`. A background interval (default 60s) or a batch-size threshold (default 1000) triggers a flush. Rows are grouped by `(org_id, stream, dt)` — `dt` is the UTC date of `event_ts` — and each group is PUT as one gzip JSONL object under `events/raw/org_id=<org>/stream=<stream>/dt=<YYYY-MM-DD>/<writer_id>-<uuid>.jsonl.gz`. The per-process `writer_id` plus a per-object uuid means concurrent replicas need zero coordination.
- **Failure policy**: a failed PUT is retried 2 times, then the batch is dropped with a warning log and a failure counter increment. When the buffer is full, new events are dropped and counted. Nothing ever throws into the caller.
- **Config**: `USAGE_EVENTS_ENABLED` (also requires an EE license key), `USAGE_EVENTS_FLUSH_INTERVAL_MS`, `USAGE_EVENTS_FLUSH_BATCH_SIZE`, `USAGE_EVENTS_BUFFER_MAX_SIZE`, and optional `USAGE_EVENTS_S3_BUCKET/REGION/ACCESS_KEY/SECRET_KEY` overrides on top of the base S3 config (same pattern as the pre-aggregate S3 config). When disabled, `createEventStreamWriter` returns `null` and nothing is constructed.
- **Metrics**: Prometheus counters `lightdash_usage_events_{pushed,flushed,dropped,put_failures}_total` on `PrometheusMetrics`, following the existing counter patterns.
- **Lifecycle**: instantiated in `App`, `SchedulerApp`, and `NatsWorkerApp`; `close()` (which flushes remaining rows) is wired into each app's graceful shutdown (SIGTERM et al.).

Nothing emits into the writer yet — the allowlist sink on `LightdashAnalytics` lands in PROD-8604, which will build on the exported `EventStreamRow` type and the writer instance exposed on each app.

## How it was tested

- 3 vitest unit tests pinning the raw-zone object contract: `(org_id, stream, dt)` grouping and key layout, gzip JSONL content, and the invalid `event_ts` fallback.
- `pnpm -F backend test:dev:nowatch` (154 files, 2239 tests passed), `pnpm -F backend typecheck:fast`, `pnpm -F backend lint` on changed files — all green.

Closes: PROD-8606
Linear: https://linear.app/lightdash/issue/PROD-8606