### PR TITLE
feat(analytics): enrich query lifecycle events with explore, dashboard and org ids

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -214,6 +214,8 @@ export const getContextFromQueryOrHeader = (
 };
 
 export type MetricQueryExecutionProperties = {
+    exploreName: string;
+    dashboardId: string | null;
     chartId?: string;
     metricsCount: number;
     dimensionsCount: number;
@@ -274,6 +276,7 @@ type QueryReadyEvent = BaseTrack & {
     event: 'query.ready';
     properties: {
         queryId: string;
+        organizationId: string;
         projectId: string;
         warehouseType: WarehouseTypes;
         executionSource: QueryExecutionSource;
@@ -287,6 +290,7 @@ type QueryErrorEvent = BaseTrack & {
     event: 'query.error';
     properties: {
         queryId: string;
+        organizationId: string;
         projectId: string;
         warehouseType: WarehouseTypes | undefined;
         executionSource: QueryExecutionSource;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2714,6 +2714,7 @@ export class AsyncQueryService extends ProjectService {
                 event: 'query.ready',
                 properties: {
                     queryId: queryUuid,
+                    organizationId: organizationUuid,
                     projectId: projectUuid,
                     warehouseType: warehouseClient.credentials.type,
                     executionSource,
@@ -2879,6 +2880,7 @@ export class AsyncQueryService extends ProjectService {
                 event: 'query.error',
                 properties: {
                     queryId: queryUuid,
+                    organizationId: organizationUuid,
                     projectId: projectUuid,
                     warehouseType: warehouseCredentialsType,
                     executionSource,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -573,11 +573,13 @@ export class ProjectService extends BaseService {
         metricQuery: MetricQuery;
         dateZoom: DateZoom | undefined;
         chartUuid: string | undefined;
-        queryTags: Record<string, unknown>;
+        queryTags: Omit<RunQueryTags, 'query_context'>;
         explore: Explore;
         parameters: ParametersValuesMap | undefined;
     }): MetricQueryExecutionProperties {
         return {
+            exploreName: explore.name,
+            dashboardId: queryTags.dashboard_uuid ?? null,
             dimensionsCount: metricQuery.dimensions.length,
             metricsCount: metricQuery.metrics.length,
             filtersCount: countTotalFilterRules(metricQuery.filters),
@@ -655,9 +657,6 @@ export class ProjectService extends BaseService {
             ...countCustomDimensionsInMetricQuery(metricQuery),
             dateZoomGranularity: dateZoom?.granularity || null,
             timezone: metricQuery.timezone,
-            ...(queryTags?.dashboard_uuid
-                ? { dashboardId: queryTags.dashboard_uuid }
-                : {}),
             chartId: chartUuid,
             ...(explore.type === ExploreType.VIRTUAL
                 ? { virtualViewId: explore.name }


### PR DESCRIPTION
## What

Enriches the three query lifecycle analytics events so they can answer the usage-analytics questions for the upcoming `query_events` stream (top dashboards, common tables hit, latency per query, per-org scoping):

- **`query.executed`** (metric-query flavours): adds required `exploreName` and `dashboardId: string | null` to `MetricQueryExecutionProperties`. Both are populated centrally in `ProjectService.getMetricQueryExecutionProperties` (from the compiled explore and `queryTags.dashboard_uuid`), which covers both emit sites (`ProjectService.runQueryAndFormatRows` path and `AsyncQueryService` async metric queries). The previously untyped conditional `dashboardId` spread is replaced with an explicit typed value; the `queryTags` param is tightened from `Record<string, unknown>` to `Omit<RunQueryTags, 'query_context'>`. SQL executions have no explore, so they are unchanged.
- **`query.ready` / `query.error`**: adds required `organizationId: string`, populated from `organizationUuid` in `AsyncQueryService.runAsyncWarehouseQuery` (the only emit site for both events).

## Why

Precursor to the PROD-8604 sink PR, which will forward these events to per-org storage as the `query_events` stream (joinable on `queryId`). Auditing found these gaps blocked per-org scoping and dashboard/explore attribution. The extra properties also flow to Rudderstack, which is expected.

## How tested

- `pnpm -F backend typecheck:fast` — pass
- `pnpm -F backend lint` — pass
- `pnpm -F backend test:dev:nowatch` — 668 tests passed (39 files)

Relates: PROD-8604
https://linear.app/lightdash/issue/PROD-8604

https://claude.ai/code/session_011AsrrbU7h5qFRayP3iWyGF