### PR TITLE
feat(apps): render data app viz schema as a result card in the generator

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -82,7 +82,10 @@ function buildService(appModel: unknown) {
     // Bypass real CASL — the mapping/flow is what these tests cover.
     (
         service as unknown as { createAuditedAbility: () => unknown }
-    ).createAuditedAbility = () => ({ cannot: () => false });
+    ).createAuditedAbility = () => ({
+        can: () => true,
+        cannot: () => false,
+    });
     return service;
 }
 
@@ -170,5 +173,53 @@ describe('AppGenerateService data app vizs', () => {
                 'not-a-data-app-viz',
             ),
         ).rejects.toThrow(NotFoundError);
+    });
+
+    it('surfaces viz_schema per version as resources.vizSchema', async () => {
+        const makeVersion = (overrides: Record<string, unknown> = {}) => ({
+            app_version_id: 'app-version-1',
+            app_id: 'app-1',
+            prompt: 'build a chart',
+            status: 'ready',
+            error: null,
+            status_message: 'Visualization ready',
+            status_updated_at: new Date('2026-06-30'),
+            resources: null,
+            viz_schema: null,
+            created_at: new Date('2026-06-30'),
+            created_by_user_uuid: 'user-1',
+            created_by_user_first_name: 'A',
+            created_by_user_last_name: 'B',
+            ...overrides,
+        });
+        const appModel = {
+            getAppWithVersions: vi.fn().mockResolvedValue({
+                name: 'a',
+                description: '',
+                createdByUserUuid: 'user-1',
+                organizationUuid: 'org-1',
+                spaceUuid: null,
+                spaceName: null,
+                template: DATA_APP_VIZ_TEMPLATE,
+                pinnedListUuid: null,
+                pinnedListOrder: null,
+                hasMore: false,
+                versions: [
+                    makeVersion({ version: 2, viz_schema: vizSchema }),
+                    makeVersion({ version: 1, viz_schema: null }),
+                ],
+            }),
+        };
+        const service = buildService(appModel);
+
+        const res = await service.getAppVersions(
+            USER,
+            'project-1',
+            'app-1',
+            {},
+        );
+
+        expect(res.versions[0].resources?.vizSchema).toEqual(vizSchema);
+        expect(res.versions[1].resources?.vizSchema ?? null).toBeNull();
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -3290,7 +3290,7 @@ export class AppGenerateService extends BaseService {
                 version,
                 'ready',
                 null,
-                responseText,
+                isDataAppViz ? 'Visualization ready' : responseText,
             );
             durations.dbMs = AppGenerateService.elapsed(dbStart);
             if (!updated) {
@@ -5585,14 +5585,24 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 status: v.status,
                 statusMessage: v.status_message,
                 error: v.error,
-                // Backfill `clarifications` for rows persisted before the
-                // field existed on `resources`.
-                resources: v.resources
-                    ? {
-                          ...v.resources,
-                          clarifications: v.resources.clarifications ?? [],
-                      }
-                    : null,
+                // Attach `vizSchema` even when `resources` JSONB is null (a
+                // viz with no other attachments) — never drop existing
+                // resources fields, and backfill `clarifications` for rows
+                // persisted before the field existed on `resources`.
+                resources:
+                    v.resources || v.viz_schema
+                        ? {
+                              images: v.resources?.images ?? [],
+                              charts: v.resources?.charts ?? [],
+                              externalConnections:
+                                  v.resources?.externalConnections,
+                              dashboardName: v.resources?.dashboardName ?? null,
+                              clarifications: v.resources?.clarifications ?? [],
+                              claudeModel: v.resources?.claudeModel,
+                              design: v.resources?.design,
+                              vizSchema: v.viz_schema ?? null,
+                          }
+                        : null,
                 createdAt: v.created_at,
                 statusUpdatedAt: v.status_updated_at,
                 // LEFT JOIN may miss for hard-deleted users — collapse the

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9889,6 +9889,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                vizSchema: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DataAppVizSchema' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 design: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11256,6 +11256,14 @@
             },
             "AppVersionResources": {
                 "properties": {
+                    "vizSchema": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DataAppVizSchema"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "design": {
                         "allOf": [
                             {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -238,6 +238,11 @@ export type AppVersionResources = {
     // history reflects which theme was active even if it was later renamed
     // or deleted.
     design?: AppVersionDesignSnapshot | null;
+    // The viz declaration (fields + configOptions) for a data_app_viz version,
+    // sourced from app_versions.viz_schema. Null/absent for non-viz versions or
+    // versions whose generation emitted no valid schema. Optional for rows
+    // predating this field.
+    vizSchema?: DataAppVizSchema | null;
 };
 
 export type ApiAppImageUrlResponse = ApiSuccess<{

--- a/packages/frontend/src/features/apps/components/DataAppVizResultCard.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizResultCard.test.tsx
@@ -1,0 +1,33 @@
+import { type DataAppVizSchema } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DataAppVizResultCard from './DataAppVizResultCard';
+
+const schema: DataAppVizSchema = {
+    fields: [
+        { name: 'source', label: 'Source', type: 'dimension', required: true },
+        { name: 'value', label: 'Value', type: 'metric', required: false },
+    ],
+    configOptions: [],
+};
+
+describe('DataAppVizResultCard', () => {
+    it('renders each declared field with label, type and required state', () => {
+        renderWithProviders(<DataAppVizResultCard schema={schema} />);
+
+        expect(screen.getByText('Source')).toBeInTheDocument();
+        expect(screen.getByText('Value')).toBeInTheDocument();
+        expect(screen.getByText(/dimension/i)).toBeInTheDocument();
+        expect(screen.getByText(/metric/i)).toBeInTheDocument();
+        expect(screen.getByText(/required/i)).toBeInTheDocument();
+    });
+
+    it('renders gracefully with an empty fields array', () => {
+        renderWithProviders(
+            <DataAppVizResultCard schema={{ fields: [], configOptions: [] }} />,
+        );
+
+        expect(screen.getByText(/0 fields to map/i)).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/components/DataAppVizResultCard.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizResultCard.test.tsx
@@ -13,14 +13,19 @@ const schema: DataAppVizSchema = {
 };
 
 describe('DataAppVizResultCard', () => {
-    it('renders each declared field with label, type and required state', () => {
+    it('renders each declared field with its label and type badge', () => {
         renderWithProviders(<DataAppVizResultCard schema={schema} />);
 
         expect(screen.getByText('Source')).toBeInTheDocument();
         expect(screen.getByText('Value')).toBeInTheDocument();
         expect(screen.getByText(/dimension/i)).toBeInTheDocument();
         expect(screen.getByText(/metric/i)).toBeInTheDocument();
-        expect(screen.getByText(/required/i)).toBeInTheDocument();
+    });
+
+    it('does not badge required state on the card', () => {
+        renderWithProviders(<DataAppVizResultCard schema={schema} />);
+
+        expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
     });
 
     it('renders gracefully with an empty fields array', () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizResultCard.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizResultCard.tsx
@@ -1,11 +1,19 @@
 import { type DataAppVizField, type DataAppVizSchema } from '@lightdash/common';
 import { Badge, Card, Group, Stack, Text } from '@mantine-8/core';
 import { type FC } from 'react';
+import { LD_FIELD_COLORS } from '../../../mantineTheme';
 
-const TYPE_COLOR: Record<DataAppVizField['type'], string> = {
-    dimension: 'blue',
-    metric: 'orange',
-    series: 'grape',
+// Match the field-type colors used everywhere else (field icons, sidebar tree,
+// AI-copilot field badges) via the canonical LD_FIELD_COLORS tokens. `series`
+// has no Lightdash field-type equivalent, so it falls back to the neutral
+// default. Keyed off the union type so a new field type breaks the build here.
+const FIELD_TYPE_COLORS: Record<
+    DataAppVizField['type'],
+    { bg: string; color: string }
+> = {
+    dimension: LD_FIELD_COLORS.dimension,
+    metric: LD_FIELD_COLORS.metric,
+    series: LD_FIELD_COLORS.DEFAULT,
 };
 
 type Props = {
@@ -13,7 +21,9 @@ type Props = {
 };
 
 // Renders a data app viz's declared field schema as a summary card in the
-// generator chat, instead of the raw `{"fields":[...]}` JSON reply.
+// generator chat, instead of the raw `{"fields":[...]}` JSON reply. Required
+// fields aren't badged here — required-ness is surfaced where it's actionable
+// (the field-mapping step), matching how Parameter inputs treat it.
 const DataAppVizResultCard: FC<Props> = ({ schema }) => (
     <Card withBorder radius="md" p="sm">
         <Stack gap="xs">
@@ -25,25 +35,22 @@ const DataAppVizResultCard: FC<Props> = ({ schema }) => (
                 {schema.fields.length === 1 ? '' : 's'} to map
             </Text>
             <Stack gap={4}>
-                {schema.fields.map((f) => (
-                    <Group key={f.name} justify="space-between" gap="xs">
-                        <Text size="sm">{f.label}</Text>
-                        <Group gap={4}>
+                {schema.fields.map((f) => {
+                    const colors = FIELD_TYPE_COLORS[f.type];
+                    return (
+                        <Group key={f.name} justify="space-between" gap="xs">
+                            <Text size="sm">{f.label}</Text>
                             <Badge
                                 size="xs"
-                                variant="light"
-                                color={TYPE_COLOR[f.type]}
+                                radius="sm"
+                                bg={colors.bg}
+                                c={colors.color}
                             >
                                 {f.type}
                             </Badge>
-                            {f.required && (
-                                <Badge size="xs" variant="outline" color="gray">
-                                    required
-                                </Badge>
-                            )}
                         </Group>
-                    </Group>
-                ))}
+                    );
+                })}
             </Stack>
         </Stack>
     </Card>

--- a/packages/frontend/src/features/apps/components/DataAppVizResultCard.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizResultCard.tsx
@@ -1,0 +1,52 @@
+import { type DataAppVizField, type DataAppVizSchema } from '@lightdash/common';
+import { Badge, Card, Group, Stack, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+
+const TYPE_COLOR: Record<DataAppVizField['type'], string> = {
+    dimension: 'blue',
+    metric: 'orange',
+    series: 'grape',
+};
+
+type Props = {
+    schema: DataAppVizSchema;
+};
+
+// Renders a data app viz's declared field schema as a summary card in the
+// generator chat, instead of the raw `{"fields":[...]}` JSON reply.
+const DataAppVizResultCard: FC<Props> = ({ schema }) => (
+    <Card withBorder radius="md" p="sm">
+        <Stack gap="xs">
+            <Text size="sm" fw={600}>
+                Visualization ready
+            </Text>
+            <Text size="xs" c="dimmed">
+                {schema.fields.length} field
+                {schema.fields.length === 1 ? '' : 's'} to map
+            </Text>
+            <Stack gap={4}>
+                {schema.fields.map((f) => (
+                    <Group key={f.name} justify="space-between" gap="xs">
+                        <Text size="sm">{f.label}</Text>
+                        <Group gap={4}>
+                            <Badge
+                                size="xs"
+                                variant="light"
+                                color={TYPE_COLOR[f.type]}
+                            >
+                                {f.type}
+                            </Badge>
+                            {f.required && (
+                                <Badge size="xs" variant="outline" color="gray">
+                                    required
+                                </Badge>
+                            )}
+                        </Group>
+                    </Group>
+                ))}
+            </Stack>
+        </Stack>
+    </Card>
+);
+
+export default DataAppVizResultCard;

--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.test.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.test.ts
@@ -14,6 +14,7 @@ const baseMessage: ChatMessage = {
     version: null,
     timestamp: new Date('2026-05-15T10:00:00Z'),
     userName: 'Test User',
+    vizSchema: null,
 };
 
 describe('mergeChatMessages', () => {

--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
@@ -1,5 +1,6 @@
 import { type AppClarification } from '@lightdash/common';
 import { type ChartKind } from '@lightdash/common';
+import { type DataAppVizSchema } from '@lightdash/common';
 
 export type ChatChart = {
     name: string;
@@ -28,6 +29,7 @@ export type ChatMessage = {
     version: number | null;
     timestamp: Date;
     userName: string | null;
+    vizSchema: DataAppVizSchema | null;
     // For optimistic (local) user bubbles only. Records the latest server
     // version number known at submit time. The bubble is dropped from the
     // merged view once the server has produced a higher version — that's the

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -93,6 +93,7 @@ import ChatMessageContent from '../features/apps/ChatMessageContent';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppSpaceChip from '../features/apps/components/AppSpaceChip';
+import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCard';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -860,6 +861,7 @@ const AppGenerate: FC = () => {
                     version: null,
                     timestamp: new Date(v.createdAt),
                     userName: authorName,
+                    vizSchema: null,
                 },
             ];
             if (v.status === 'ready') {
@@ -880,6 +882,7 @@ const AppGenerate: FC = () => {
                     version: v.version,
                     timestamp: new Date(replyTimestamp),
                     userName: null,
+                    vizSchema: v.resources?.vizSchema ?? null,
                 });
             } else if (v.status === 'error') {
                 msgs.push({
@@ -898,6 +901,7 @@ const AppGenerate: FC = () => {
                     version: null,
                     timestamp: new Date(replyTimestamp),
                     userName: null,
+                    vizSchema: null,
                 });
             }
             // 'building' status is not rendered as a history message —
@@ -1065,6 +1069,7 @@ const AppGenerate: FC = () => {
                         [user.data?.firstName, user.data?.lastName]
                             .filter((s): s is string => !!s && s.length > 0)
                             .join(' ') || null,
+                    vizSchema: null,
                     submittedAtVersion: maxHistoryVersion,
                 },
             ]);
@@ -1103,6 +1108,7 @@ const AppGenerate: FC = () => {
                                 version: null,
                                 timestamp: new Date(),
                                 userName: null,
+                                vizSchema: null,
                             },
                         ]);
                     },
@@ -1509,6 +1515,7 @@ const AppGenerate: FC = () => {
                     version: null,
                     timestamp: new Date(),
                     userName: null,
+                    vizSchema: null,
                 },
             ]);
         },
@@ -1659,6 +1666,7 @@ const AppGenerate: FC = () => {
                         [user.data?.firstName, user.data?.lastName]
                             .filter((s): s is string => !!s && s.length > 0)
                             .join(' ') || null,
+                    vizSchema: null,
                     // Snapshot the highest server version known at submit time.
                     // Once history catches up past this number the optimistic
                     // bubble is dropped by `mergeChatMessages` — even if the
@@ -2235,7 +2243,13 @@ const AppGenerate: FC = () => {
                                                                     : undefined
                                                             }
                                                         />
-                                                        {msg.appUuid ? (
+                                                        {msg.vizSchema ? (
+                                                            <DataAppVizResultCard
+                                                                schema={
+                                                                    msg.vizSchema
+                                                                }
+                                                            />
+                                                        ) : msg.appUuid ? (
                                                             <AiMarkdown>
                                                                 {msg.content}
                                                             </AiMarkdown>


### PR DESCRIPTION
Replaces the raw `--json-schema` output that showed up as a `{"fields":[...]}` bubble in the app-generator chat with a clean result card.

- Surface the persisted viz schema per app version on the API (`AppVersionResources.vizSchema`). Viz versions now get a friendly "Visualization ready" status instead of the raw structured JSON.
- New `DataAppVizResultCard` renders the declared fields with the product's canonical field-type colors (dimension / metric / series), matching the field icons and tree.

Fields-only for now. Required-ness and config-option controls arrive with the interactive "test with data" panel (Tier 2, follow-up PR).