### PR TITLE
fix(ai): improve filter validation errors

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -1684,7 +1684,12 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                                        "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "boolean",
@@ -1719,7 +1724,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                                        "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "boolean",
@@ -1768,7 +1779,12 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                                        "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "string",
@@ -1803,7 +1819,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                                        "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "string",
@@ -1854,7 +1876,12 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                                        "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1899,7 +1926,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                                        "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1952,7 +1985,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                                        "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -2009,7 +2048,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                                        "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -2068,7 +2113,12 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                                        "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2104,7 +2154,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                                        "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2158,7 +2214,17 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                                        "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2232,7 +2298,17 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                                        "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2307,7 +2383,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                                        "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2365,7 +2447,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                                        "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2546,7 +2634,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -2581,7 +2674,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                              "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -2630,7 +2729,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -2665,7 +2769,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -2716,7 +2826,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2761,7 +2876,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                              "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2814,7 +2935,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                              "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2871,7 +2998,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                              "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2930,7 +3063,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2966,7 +3104,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3020,7 +3164,17 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3094,7 +3248,17 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3169,7 +3333,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3227,7 +3397,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3292,7 +3468,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -3327,7 +3508,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                              "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -3376,7 +3563,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -3411,7 +3603,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -3462,7 +3660,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -3507,7 +3710,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                              "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -3560,7 +3769,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                              "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -3617,7 +3832,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                              "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -3676,7 +3897,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3712,7 +3938,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3766,7 +3998,17 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3840,7 +4082,17 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3915,7 +4167,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3973,7 +4231,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -4036,7 +4300,12 @@ Example B — "Revenue by month with year-over-year comparison"
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -4081,7 +4350,13 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                          "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -4134,7 +4409,13 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                          "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -4191,7 +4472,13 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                          "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5043,7 +5330,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -5078,7 +5370,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                          "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -5127,7 +5425,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -5162,7 +5465,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -5213,7 +5522,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5258,7 +5572,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                          "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5311,7 +5631,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                          "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5368,7 +5694,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                          "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5427,7 +5759,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5463,7 +5800,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5517,7 +5860,17 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5591,7 +5944,17 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5666,7 +6029,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5724,7 +6093,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5789,7 +6164,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -5824,7 +6204,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                          "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -5873,7 +6259,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -5908,7 +6299,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -5959,7 +6356,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -6004,7 +6406,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                          "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -6057,7 +6465,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                          "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -6114,7 +6528,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                          "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -6173,7 +6593,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6209,7 +6634,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6263,7 +6694,17 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6337,7 +6778,17 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6412,7 +6863,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6470,7 +6927,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6533,7 +6996,12 @@ Usage Tips:
                   "anyOf": [
                     {
                       "additionalProperties": false,
-                      "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                      "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -6578,7 +7046,13 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
-                      "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                      "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -6631,7 +7105,13 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
-                      "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                      "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -6688,7 +7168,13 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
-                      "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                      "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1787,7 +1787,12 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "boolean",
@@ -1822,7 +1827,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                                                    "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -1866,7 +1877,12 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "string",
@@ -1901,7 +1917,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                                                    "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -1947,7 +1969,12 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "number",
@@ -1992,7 +2019,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                                                    "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -2030,7 +2063,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                                                    "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -2072,7 +2111,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                                                    "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -2116,7 +2161,12 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "date",
@@ -2152,7 +2202,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -2200,7 +2256,17 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                                                    "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -2268,7 +2334,17 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                                                    "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -2337,7 +2413,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -2379,7 +2461,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5284,7 +5372,12 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "boolean",
@@ -5319,7 +5412,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                                              "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -5363,7 +5462,12 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "string",
@@ -5398,7 +5502,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -5444,7 +5554,12 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "number",
@@ -5489,7 +5604,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                                              "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -5527,7 +5648,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                                              "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -5569,7 +5696,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                                              "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -5613,7 +5746,12 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "date",
@@ -5649,7 +5787,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5697,7 +5841,17 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5765,7 +5919,17 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5834,7 +5998,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5876,7 +6046,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6919,7 +7095,12 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
-                                "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                                "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "boolean",
@@ -6954,7 +7135,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                                "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -6998,7 +7185,12 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
-                                "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                                "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "string",
@@ -7033,7 +7225,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                                "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -7079,7 +7277,12 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
-                                "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                                "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "number",
@@ -7124,7 +7327,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                                "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -7162,7 +7371,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                                "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -7204,7 +7419,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                                "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -7248,7 +7469,12 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
-                                "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                                "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "date",
@@ -7284,7 +7510,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                                "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -7332,7 +7564,17 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                                "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -7400,7 +7642,17 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                                "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -7469,7 +7721,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                                "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -7511,7 +7769,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                                "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",

--- a/packages/backend/src/ee/services/ai/utils/validateFilterRuleErrors.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateFilterRuleErrors.test.ts
@@ -1,0 +1,238 @@
+import { FilterOperator, type FilterRule } from '@lightdash/common';
+import { vi } from 'vitest';
+import Logger from '../../../../logging/logger';
+import { mockOrdersExplore } from './validationExplore.mock';
+import { validateFilterRules } from './validators';
+
+const rule = (args: {
+    id: string;
+    fieldId: string;
+    operator: FilterOperator;
+    values?: unknown[];
+    settings?: unknown;
+}): FilterRule => ({
+    id: args.id,
+    target: { fieldId: args.fieldId },
+    operator: args.operator,
+    ...(args.values !== undefined ? { values: args.values } : {}),
+    ...(args.settings !== undefined ? { settings: args.settings } : {}),
+});
+
+const getValidationMessage = (filterRule: FilterRule): string => {
+    try {
+        validateFilterRules(mockOrdersExplore, [filterRule]);
+    } catch (error) {
+        if (error instanceof Error) {
+            return error.message;
+        }
+        return String(error);
+    }
+
+    throw new Error('Expected filter validation to fail');
+};
+
+describe('validateFilterRules error messages', () => {
+    beforeEach(() => {
+        vi.spyOn(Logger, 'error').mockImplementation(() => Logger);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('explains invalid boolean filters with available combinations', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-boolean',
+                fieldId: 'orders_is_active',
+                operator: FilterOperator.GREATER_THAN,
+                values: [true],
+            }),
+        );
+
+        expect(message).toContain(
+            'Invalid filter for field "orders_is_active" (Is Active).',
+        );
+        expect(message).toContain(
+            '"greaterThan" is not available for boolean fields.',
+        );
+        expect(message).toContain(
+            'For boolean fields, these are all available filter combinations:',
+        );
+        expect(message).toContain(
+            '{"fieldId":"orders_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains invalid string filters with available combinations', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-string',
+                fieldId: 'orders_customer_name',
+                operator: FilterOperator.GREATER_THAN,
+                values: ['Alice'],
+            }),
+        );
+
+        expect(message).toContain(
+            'Invalid filter for field "orders_customer_name" (Customer Name).',
+        );
+        expect(message).toContain(
+            '"greaterThan" is not available for string fields.',
+        );
+        expect(message).toContain(
+            'For string fields, these are all available filter combinations:',
+        );
+        expect(message).toContain(
+            '{"fieldId":"orders_customer_name","fieldType":"string","fieldFilterType":"string","operator":"include","values":["contains"]}',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('accepts normalized presence filters with empty values', () => {
+        expect(() =>
+            validateFilterRules(mockOrdersExplore, [
+                rule({
+                    id: 'filter-presence',
+                    fieldId: 'orders_customer_name',
+                    operator: FilterOperator.NULL,
+                    values: [],
+                }),
+            ]),
+        ).not.toThrow();
+    });
+
+    it('explains presence filters that include values', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-presence',
+                fieldId: 'orders_is_active',
+                operator: FilterOperator.NULL,
+                values: [true],
+            }),
+        );
+
+        expect(message).toContain(
+            '"isNull" is a presence operator and must not include values or settings. Received values=[true] settings=undefined.',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains settings on non-date filters', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-settings',
+                fieldId: 'orders_amount',
+                operator: FilterOperator.GREATER_THAN,
+                values: [100],
+                settings: { completed: false, unitOfTime: 'weeks' },
+            }),
+        );
+
+        expect(message).toContain(
+            '"settings" is only valid for relative or current date filters. Remove settings from this number filter.',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains settings on explicit date filters', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-date-settings',
+                fieldId: 'orders_order_date',
+                operator: FilterOperator.EQUALS,
+                values: ['2024-01-01'],
+                settings: { completed: false, unitOfTime: 'weeks' },
+            }),
+        );
+
+        expect(message).toContain(
+            '"settings" is only valid for relative or current date filters. Remove settings when using "equals".',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('reports omitted values in the problem description', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-omitted-value',
+                fieldId: 'orders_amount',
+                operator: FilterOperator.GREATER_THAN,
+            }),
+        );
+
+        expect(message).toContain('Received omitted.');
+    });
+
+    it('preserves explicit null values in the problem description', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-null-value',
+                fieldId: 'orders_amount',
+                operator: FilterOperator.GREATER_THAN,
+                values: null as unknown as unknown[],
+            }),
+        );
+
+        expect(message).toContain('Received null.');
+        expect(message).not.toContain('Received [].');
+    });
+
+    it('explains invalid number filters with available combinations', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-number',
+                fieldId: 'orders_amount',
+                operator: FilterOperator.GREATER_THAN,
+                values: ['100'],
+            }),
+        );
+
+        expect(message).toContain(
+            'Invalid filter for field "orders_amount" (Amount).',
+        );
+        expect(message).toContain(
+            '"greaterThan" is a valid number operator, but values must be an array with exactly one number. Received ["100"].',
+        );
+        expect(message).toContain(
+            'For number fields, these are all available filter combinations:',
+        );
+        expect(message).toContain(
+            '{"fieldId":"orders_amount","fieldType":"number","fieldFilterType":"number","operator":"greaterThan","values":[100]}',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains invalid date filters with available combinations', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-date',
+                fieldId: 'orders_order_date',
+                operator: FilterOperator.EQUALS,
+                values: ['last 2 weeks'],
+            }),
+        );
+
+        expect(message).toContain(
+            'Invalid filter for field "orders_order_date" (Order Date).',
+        );
+        expect(message).toContain(
+            '"equals" is a valid date operator, but values must be ISO date/datetime strings. Received ["last 2 weeks"].',
+        );
+        expect(message).toContain(
+            'For date fields, these are all available filter combinations:',
+        );
+        expect(message).toContain(
+            '{"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -12,15 +12,19 @@ import {
     DependencyNode,
     detectCircularDependencies,
     Explore,
+    FilterOperator,
     FilterRule,
     Filters,
     FilterType,
+    formatFilterExamplesAsJsonLines,
     getCustomMetricType,
     getErrorMessage,
     getFields,
+    getFilterExamples,
     getFilterRulesFromGroup,
     getFilterTypeFromItemType,
     getItemId,
+    getItemLabelWithoutTableName,
     isAdditionalMetric,
     isDimension,
     isMetric,
@@ -40,9 +44,11 @@ import {
     ToolRunQueryArgsTransformed,
     ToolSortField,
     TransformedCustomMetric,
+    UnitOfTime,
     WeekDay,
     WindowFunctionType,
 } from '@lightdash/common';
+import { z } from 'zod';
 import Logger from '../../../../logging/logger';
 import { populateCustomMetricsSQL } from './populateCustomMetricsSQL';
 import { serializeData } from './serializeData';
@@ -183,6 +189,299 @@ export function validateCustomMetricsDefinition(
     }
 }
 
+const getAvailableFilterOperators = (
+    filterType: FilterType,
+): FilterOperator[] =>
+    Array.from(
+        new Set(
+            getFilterExamples({
+                fieldId: 'field_id',
+                fieldType: filterType,
+                fieldFilterType: filterType,
+            }).map((example) => example.operator),
+        ),
+    );
+
+const stringifyReceivedValue = (value: unknown): string => {
+    try {
+        return JSON.stringify(value) ?? String(value);
+    } catch {
+        return String(value);
+    }
+};
+
+const getFilterFieldLabel = (
+    field: CompiledField | AdditionalMetric | TableCalculation,
+): string => {
+    const label = isAdditionalMetric(field)
+        ? field.label
+        : getItemLabelWithoutTableName(field);
+
+    return label || getItemId(field);
+};
+
+const valuesDescription = (values: unknown): string =>
+    values === undefined ? 'omitted' : stringifyReceivedValue(values);
+
+const settingsDescription = (settings: unknown): string =>
+    settings === undefined ? 'undefined' : stringifyReceivedValue(settings);
+
+const isPresenceFilterOperator = (operator: FilterOperator): boolean =>
+    [FilterOperator.NULL, FilterOperator.NOT_NULL].includes(operator);
+
+const shouldIncludeFilterValues = (filterRule: FilterRule): boolean =>
+    filterRule.values !== undefined &&
+    (!isPresenceFilterOperator(filterRule.operator) ||
+        !Array.isArray(filterRule.values) ||
+        filterRule.values.length > 0);
+
+const hasOnlyValuesOfType = (
+    values: unknown,
+    valueType: 'boolean' | 'number' | 'string',
+): boolean =>
+    Array.isArray(values) &&
+    values.every((value) => typeof value === valueType);
+
+const hasLength = (values: unknown, length: number): boolean =>
+    Array.isArray(values) && values.length === length;
+
+const relativeDateUnitSchema = z.union([
+    z.literal(UnitOfTime.days),
+    z.literal(UnitOfTime.weeks),
+    z.literal(UnitOfTime.months),
+    z.literal(UnitOfTime.quarters),
+    z.literal(UnitOfTime.years),
+]);
+
+const dateSettingsSchema = z
+    .object({
+        completed: z.boolean(),
+        unitOfTime: relativeDateUnitSchema,
+    })
+    .strict();
+
+const currentDateSettingsSchema = z
+    .object({
+        completed: z.literal(false),
+        unitOfTime: relativeDateUnitSchema,
+    })
+    .strict();
+
+const dateOrDateTimeSchema = z.union([
+    z.string().date(),
+    z.string().datetime(),
+]);
+
+const hasDateSettings = (settings: unknown): boolean =>
+    dateSettingsSchema.safeParse(settings).success;
+
+const hasCurrentDateSettings = (settings: unknown): boolean =>
+    currentDateSettingsSchema.safeParse(settings).success;
+
+const isIsoDateOrDateTime = (value: unknown): value is string =>
+    dateOrDateTimeSchema.safeParse(value).success;
+
+const hasOnlyIsoDateValues = (values: unknown): boolean =>
+    Array.isArray(values) && values.every(isIsoDateOrDateTime);
+
+const hasCurrentDateValue = (values: unknown): boolean =>
+    Array.isArray(values) && values.length === 1 && values[0] === 1;
+
+const getFilterRuleProblem = (
+    filterRule: FilterRule,
+    filterType: FilterType,
+): string => {
+    const availableOperators = getAvailableFilterOperators(filterType);
+
+    if (!availableOperators.includes(filterRule.operator)) {
+        return `"${filterRule.operator}" is not available for ${filterType} fields. Available operators: ${availableOperators.join(', ')}.`;
+    }
+
+    if (
+        isPresenceFilterOperator(filterRule.operator) &&
+        (shouldIncludeFilterValues(filterRule) ||
+            filterRule.settings !== undefined)
+    ) {
+        return `"${filterRule.operator}" is a presence operator and must not include values or settings. Received values=${valuesDescription(filterRule.values)} settings=${settingsDescription(filterRule.settings)}.`;
+    }
+
+    if (filterType !== FilterType.DATE && filterRule.settings !== undefined) {
+        return `"settings" is only valid for relative or current date filters. Remove settings from this ${filterType} filter. Received settings=${settingsDescription(filterRule.settings)}.`;
+    }
+
+    if (
+        filterType === FilterType.DATE &&
+        ![
+            FilterOperator.IN_THE_PAST,
+            FilterOperator.NOT_IN_THE_PAST,
+            FilterOperator.IN_THE_NEXT,
+            FilterOperator.IN_THE_CURRENT,
+            FilterOperator.NOT_IN_THE_CURRENT,
+        ].includes(filterRule.operator) &&
+        filterRule.settings !== undefined
+    ) {
+        return `"settings" is only valid for relative or current date filters. Remove settings when using "${filterRule.operator}". Received settings=${settingsDescription(filterRule.settings)}.`;
+    }
+
+    switch (filterType) {
+        case FilterType.BOOLEAN:
+            if (
+                [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS].includes(
+                    filterRule.operator,
+                ) &&
+                (!hasLength(filterRule.values, 1) ||
+                    !hasOnlyValuesOfType(filterRule.values, 'boolean'))
+            ) {
+                return `"${filterRule.operator}" is a valid boolean operator, but values must be an array with exactly one boolean. Received ${valuesDescription(filterRule.values)}.`;
+            }
+            break;
+        case FilterType.STRING:
+            if (
+                ![FilterOperator.NULL, FilterOperator.NOT_NULL].includes(
+                    filterRule.operator,
+                ) &&
+                !hasOnlyValuesOfType(filterRule.values, 'string')
+            ) {
+                return `"${filterRule.operator}" is a valid string operator, but values must be an array of strings. Received ${valuesDescription(filterRule.values)}.`;
+            }
+            break;
+        case FilterType.NUMBER:
+            if (
+                [
+                    FilterOperator.LESS_THAN,
+                    FilterOperator.LESS_THAN_OR_EQUAL,
+                    FilterOperator.GREATER_THAN,
+                    FilterOperator.GREATER_THAN_OR_EQUAL,
+                ].includes(filterRule.operator) &&
+                (!hasLength(filterRule.values, 1) ||
+                    !hasOnlyValuesOfType(filterRule.values, 'number'))
+            ) {
+                return `"${filterRule.operator}" is a valid number operator, but values must be an array with exactly one number. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                [
+                    FilterOperator.IN_BETWEEN,
+                    FilterOperator.NOT_IN_BETWEEN,
+                ].includes(filterRule.operator) &&
+                (!hasLength(filterRule.values, 2) ||
+                    !hasOnlyValuesOfType(filterRule.values, 'number'))
+            ) {
+                return `"${filterRule.operator}" is a valid number operator, but values must be an array with exactly two numbers. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS].includes(
+                    filterRule.operator,
+                ) &&
+                !hasOnlyValuesOfType(filterRule.values, 'number')
+            ) {
+                return `"${filterRule.operator}" is a valid number operator, but values must be an array of numbers. Received ${valuesDescription(filterRule.values)}.`;
+            }
+            break;
+        case FilterType.DATE:
+            if (
+                [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS].includes(
+                    filterRule.operator,
+                ) &&
+                !hasOnlyIsoDateValues(filterRule.values)
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be ISO date/datetime strings. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                [
+                    FilterOperator.LESS_THAN,
+                    FilterOperator.LESS_THAN_OR_EQUAL,
+                    FilterOperator.GREATER_THAN,
+                    FilterOperator.GREATER_THAN_OR_EQUAL,
+                ].includes(filterRule.operator) &&
+                (!hasLength(filterRule.values, 1) ||
+                    !hasOnlyIsoDateValues(filterRule.values))
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be an array with exactly one ISO date/datetime string. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                filterRule.operator === FilterOperator.IN_BETWEEN &&
+                (!hasLength(filterRule.values, 2) ||
+                    !hasOnlyIsoDateValues(filterRule.values))
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be an array with exactly two ISO date/datetime strings. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                [
+                    FilterOperator.IN_THE_CURRENT,
+                    FilterOperator.NOT_IN_THE_CURRENT,
+                ].includes(filterRule.operator) &&
+                (!hasCurrentDateValue(filterRule.values) ||
+                    !hasCurrentDateSettings(filterRule.settings))
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be [1] and settings must include completed=false and unitOfTime. Received values=${valuesDescription(filterRule.values)} settings=${settingsDescription(filterRule.settings)}.`;
+            }
+
+            if (
+                [
+                    FilterOperator.IN_THE_PAST,
+                    FilterOperator.NOT_IN_THE_PAST,
+                    FilterOperator.IN_THE_NEXT,
+                ].includes(filterRule.operator) &&
+                (!hasLength(filterRule.values, 1) ||
+                    !hasOnlyValuesOfType(filterRule.values, 'number') ||
+                    !hasDateSettings(filterRule.settings))
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be one number and settings must include completed and unitOfTime. Received values=${valuesDescription(filterRule.values)} settings=${settingsDescription(filterRule.settings)}.`;
+            }
+            break;
+        default:
+            return assertUnreachable(
+                filterType,
+                `Invalid field type: ${filterType}`,
+            );
+    }
+
+    return `The filter JSON does not match any supported ${filterType} filter combination.`;
+};
+
+const formatFilterRuleValidationError = (
+    filterRule: FilterRule,
+    field: CompiledField | AdditionalMetric | TableCalculation,
+    filterType: FilterType,
+): string => {
+    const examples = formatFilterExamplesAsJsonLines(
+        getFilterExamples({
+            fieldId: filterRule.target.fieldId,
+            fieldType: field.type ?? filterType,
+            fieldFilterType: filterType,
+        }),
+    );
+
+    return `Invalid filter for field "${filterRule.target.fieldId}" (${getFilterFieldLabel(field)}).
+
+Problem: ${getFilterRuleProblem(filterRule, filterType)}
+
+For ${filterType} fields, these are all available filter combinations:
+${examples}`;
+};
+
+const getFilterSchemaInput = (
+    filterRule: FilterRule,
+    field: CompiledField | AdditionalMetric | TableCalculation,
+    fieldFilterType: FilterType,
+) => ({
+    fieldId: filterRule.target.fieldId,
+    fieldType: field.type,
+    fieldFilterType,
+    operator: filterRule.operator,
+    ...(shouldIncludeFilterValues(filterRule)
+        ? { values: filterRule.values }
+        : {}),
+    ...(filterRule.settings !== undefined
+        ? { settings: filterRule.settings }
+        : {}),
+});
+
 function validateFilterRule(
     filterRule: FilterRule,
     field: CompiledField | AdditionalMetric | TableCalculation,
@@ -195,66 +494,65 @@ function validateFilterRule(
 
     switch (filterType) {
         case FilterType.BOOLEAN:
-            const parsedBooleanFilterRule = booleanFilterSchema.safeParse({
-                fieldId: filterRule.target.fieldId,
-                fieldType: field.type,
-                fieldFilterType: 'boolean',
-                operator: filterRule.operator,
-                values: filterRule.values,
-            });
+            const parsedBooleanFilterRule = booleanFilterSchema.safeParse(
+                getFilterSchemaInput(filterRule, field, FilterType.BOOLEAN),
+            );
 
             if (!parsedBooleanFilterRule.success) {
                 throw new AiAgentValidatorError(
-                    `Expected boolean filter rule for field ${filterRule.target.fieldId}. Error: ${parsedBooleanFilterRule.error.message}`,
+                    formatFilterRuleValidationError(
+                        filterRule,
+                        field,
+                        FilterType.BOOLEAN,
+                    ),
                 );
             }
 
             break;
         case FilterType.DATE:
-            const parsedDateFilterRule = dateFilterSchema.safeParse({
-                fieldId: filterRule.target.fieldId,
-                fieldType: field.type,
-                fieldFilterType: 'date',
-                operator: filterRule.operator,
-                values: filterRule.values,
-                settings: filterRule.settings,
-            });
+            const parsedDateFilterRule = dateFilterSchema.safeParse(
+                getFilterSchemaInput(filterRule, field, FilterType.DATE),
+            );
 
             if (!parsedDateFilterRule.success) {
                 throw new AiAgentValidatorError(
-                    `Expected date filter rule for field ${filterRule.target.fieldId}. Error: ${parsedDateFilterRule.error.message}`,
+                    formatFilterRuleValidationError(
+                        filterRule,
+                        field,
+                        FilterType.DATE,
+                    ),
                 );
             }
 
             break;
         case FilterType.NUMBER:
-            const parsedNumberFilterRule = numberFilterSchema.safeParse({
-                fieldId: filterRule.target.fieldId,
-                fieldType: field.type,
-                fieldFilterType: 'number',
-                operator: filterRule.operator,
-                values: filterRule.values,
-            });
+            const parsedNumberFilterRule = numberFilterSchema.safeParse(
+                getFilterSchemaInput(filterRule, field, FilterType.NUMBER),
+            );
 
             if (!parsedNumberFilterRule.success) {
                 throw new AiAgentValidatorError(
-                    `Expected number filter rule for field ${filterRule.target.fieldId}. Error: ${parsedNumberFilterRule.error.message}`,
+                    formatFilterRuleValidationError(
+                        filterRule,
+                        field,
+                        FilterType.NUMBER,
+                    ),
                 );
             }
 
             break;
         case FilterType.STRING:
-            const parsedStringFilterRule = stringFilterSchema.safeParse({
-                fieldId: filterRule.target.fieldId,
-                fieldType: field.type,
-                fieldFilterType: 'string',
-                operator: filterRule.operator,
-                values: filterRule.values,
-            });
+            const parsedStringFilterRule = stringFilterSchema.safeParse(
+                getFilterSchemaInput(filterRule, field, FilterType.STRING),
+            );
 
             if (!parsedStringFilterRule.success) {
                 throw new AiAgentValidatorError(
-                    `Expected string filter rule for field ${filterRule.target.fieldId}. Error: ${parsedStringFilterRule.error.message}`,
+                    formatFilterRuleValidationError(
+                        filterRule,
+                        field,
+                        FilterType.STRING,
+                    ),
                 );
             }
 

--- a/packages/common/src/ee/AiAgent/schemas/filters/booleanFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/booleanFilters.ts
@@ -3,10 +3,10 @@ import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
 import {
-    filterJsonExamples,
     filterOperatorList,
     valuePresenceOperatorDescription,
 } from './filterDescriptionUtils';
+import { filterJsonExamplesForOperators } from './filterExamples';
 
 const commonBooleanFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -17,6 +17,7 @@ const commonBooleanFilterRuleSchema = z.object({
     fieldFilterType: z.literal(FilterType.BOOLEAN),
 });
 
+// Strict variants prevent Zod from silently stripping invalid AI keys like values/settings.
 const booleanFilterSchema = z.union([
     commonBooleanFilterRuleSchema
         .extend({
@@ -27,19 +28,14 @@ const booleanFilterSchema = z.union([
                 ])
                 .describe(valuePresenceOperatorDescription),
         })
+        .strict()
         .describe(
-            `Use for boolean fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+            `Use for boolean fields when checking if a value is missing or present. Do not include values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'users_is_active',
                     fieldType: DimensionType.BOOLEAN,
                     fieldFilterType: FilterType.BOOLEAN,
-                    operator: FilterOperator.NULL,
-                },
-                {
-                    fieldId: 'users_is_active',
-                    fieldType: DimensionType.BOOLEAN,
-                    fieldFilterType: FilterType.BOOLEAN,
-                    operator: FilterOperator.NOT_NULL,
+                    operators: [FilterOperator.NULL, FilterOperator.NOT_NULL],
                 },
             )}`,
         ),
@@ -58,21 +54,17 @@ const booleanFilterSchema = z.union([
                 .length(1)
                 .describe('Exactly one boolean value, e.g. [true] or [false].'),
         })
+        .strict()
         .describe(
-            `Use for boolean fields when matching or excluding true/false values. ${filterJsonExamples(
+            `Use for boolean fields when matching or excluding true/false values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'users_is_active',
                     fieldType: DimensionType.BOOLEAN,
                     fieldFilterType: FilterType.BOOLEAN,
-                    operator: FilterOperator.EQUALS,
-                    values: [true],
-                },
-                {
-                    fieldId: 'users_is_active',
-                    fieldType: DimensionType.BOOLEAN,
-                    fieldFilterType: FilterType.BOOLEAN,
-                    operator: FilterOperator.NOT_EQUALS,
-                    values: [false],
+                    operators: [
+                        FilterOperator.EQUALS,
+                        FilterOperator.NOT_EQUALS,
+                    ],
                 },
             )}`,
         ),

--- a/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
@@ -8,9 +8,9 @@ import {
 import { getFieldIdSchema } from '../fieldId';
 import {
     datePresenceOperatorDescription,
-    filterJsonExamples,
     filterOperatorList,
 } from './filterDescriptionUtils';
+import { filterJsonExamplesForOperators } from './filterExamples';
 
 const dateOrDateTimeSchema = z
     .union([z.string().date(), z.string().datetime()])
@@ -29,6 +29,7 @@ const commonDateFilterRuleSchema = z.object({
     fieldFilterType: z.literal(FilterType.DATE),
 });
 
+// Strict variants prevent Zod from silently stripping invalid AI keys like values/settings.
 const dateFilterSchema = z.union([
     commonDateFilterRuleSchema
         .extend({
@@ -39,19 +40,14 @@ const dateFilterSchema = z.union([
                 ])
                 .describe(datePresenceOperatorDescription),
         })
+        .strict()
         .describe(
-            `Use for date/timestamp fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+            `Use for date/timestamp fields when checking if a value is missing or present. Do not include values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NULL,
-                },
-                {
-                    fieldId: 'orders_created_at',
-                    fieldType: DimensionType.TIMESTAMP,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NOT_NULL,
+                    operators: [FilterOperator.NULL, FilterOperator.NOT_NULL],
                 },
             )}`,
         ),
@@ -69,21 +65,17 @@ const dateFilterSchema = z.union([
                 .array(dateOrDateTimeSchema)
                 .describe('One or more explicit ISO dates/datetimes.'),
         })
+        .strict()
         .describe(
-            `Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use ${FilterOperator.IN_THE_PAST}. ${filterJsonExamples(
+            `Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use ${FilterOperator.IN_THE_PAST}. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.EQUALS,
-                    values: ['2024-01-01'],
-                },
-                {
-                    fieldId: 'orders_created_at',
-                    fieldType: DimensionType.TIMESTAMP,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NOT_EQUALS,
-                    values: ['2024-01-01T00:00:00Z'],
+                    operators: [
+                        FilterOperator.EQUALS,
+                        FilterOperator.NOT_EQUALS,
+                    ],
                 },
             )}`,
         ),
@@ -120,53 +112,21 @@ const dateFilterSchema = z.union([
                         ])
                         .describe('Period unit for the relative date filter.'),
                 })
+                .strict()
                 .describe('Relative period settings.'),
         })
+        .strict()
         .describe(
-            `Use for relative date requests such as "last 2 weeks" or "next 3 months". ${filterJsonExamples(
+            `Use for relative date requests such as "last 2 weeks" or "next 3 months". ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_THE_PAST,
-                    values: [2],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.weeks,
-                    },
-                },
-                {
-                    fieldId: 'orders_order_date',
-                    fieldType: DimensionType.DATE,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_THE_PAST,
-                    values: [3],
-                    settings: {
-                        completed: true,
-                        unitOfTime: UnitOfTime.months,
-                    },
-                },
-                {
-                    fieldId: 'orders_ship_date',
-                    fieldType: DimensionType.DATE,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_THE_NEXT,
-                    values: [14],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.days,
-                    },
-                },
-                {
-                    fieldId: 'orders_order_date',
-                    fieldType: DimensionType.DATE,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NOT_IN_THE_PAST,
-                    values: [7],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.days,
-                    },
+                    operators: [
+                        FilterOperator.IN_THE_PAST,
+                        FilterOperator.NOT_IN_THE_PAST,
+                        FilterOperator.IN_THE_NEXT,
+                    ],
                 },
             )}`,
         ),
@@ -201,31 +161,20 @@ const dateFilterSchema = z.union([
                             'Current period unit, e.g. weeks for this week.',
                         ),
                 })
+                .strict()
                 .describe('Current-period settings.'),
         })
+        .strict()
         .describe(
-            `Use for current date requests such as "today", "this week", "this month", or "this year". ${filterJsonExamples(
+            `Use for current date requests such as "today", "this week", "this month", or "this year". ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_THE_CURRENT,
-                    values: [1],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.days,
-                    },
-                },
-                {
-                    fieldId: 'orders_order_date',
-                    fieldType: DimensionType.DATE,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NOT_IN_THE_CURRENT,
-                    values: [1],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.months,
-                    },
+                    operators: [
+                        FilterOperator.IN_THE_CURRENT,
+                        FilterOperator.NOT_IN_THE_CURRENT,
+                    ],
                 },
             )}`,
         ),
@@ -246,21 +195,19 @@ const dateFilterSchema = z.union([
                 .length(1)
                 .describe('Exactly one explicit ISO date/datetime threshold.'),
         })
+        .strict()
         .describe(
-            `Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. ${filterJsonExamples(
+            `Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.GREATER_THAN_OR_EQUAL,
-                    values: ['2024-01-01'],
-                },
-                {
-                    fieldId: 'orders_created_at',
-                    fieldType: DimensionType.TIMESTAMP,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.LESS_THAN,
-                    values: ['2024-02-01T00:00:00Z'],
+                    operators: [
+                        FilterOperator.LESS_THAN,
+                        FilterOperator.LESS_THAN_OR_EQUAL,
+                        FilterOperator.GREATER_THAN,
+                        FilterOperator.GREATER_THAN_OR_EQUAL,
+                    ],
                 },
             )}`,
         ),
@@ -278,21 +225,14 @@ const dateFilterSchema = z.union([
                     'Exactly two explicit ISO dates/datetimes: [start, end].',
                 ),
         })
+        .strict()
         .describe(
-            `Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. ${filterJsonExamples(
+            `Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_BETWEEN,
-                    values: ['2024-01-01', '2024-01-31'],
-                },
-                {
-                    fieldId: 'orders_created_at',
-                    fieldType: DimensionType.TIMESTAMP,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_BETWEEN,
-                    values: ['2024-01-01T00:00:00Z', '2024-01-31T23:59:59Z'],
+                    operators: [FilterOperator.IN_BETWEEN],
                 },
             )}`,
         ),

--- a/packages/common/src/ee/AiAgent/schemas/filters/filterDescriptionUtils.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/filterDescriptionUtils.ts
@@ -6,8 +6,3 @@ export const filterOperatorList = (...operators: FilterOperator[]): string =>
 export const valuePresenceOperatorDescription = `Use ${FilterOperator.NULL} for missing values, ${FilterOperator.NOT_NULL} for present values.`;
 
 export const datePresenceOperatorDescription = `Use ${FilterOperator.NULL} for missing dates, ${FilterOperator.NOT_NULL} for present dates.`;
-
-export const filterJsonExamples = (
-    ...examples: Record<string, unknown>[]
-): string =>
-    `Examples: ${examples.map((example) => JSON.stringify(example)).join('; ')}`;

--- a/packages/common/src/ee/AiAgent/schemas/filters/filterExamples.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/filterExamples.ts
@@ -1,0 +1,380 @@
+import { DimensionType, MetricType } from '../../../../types/field';
+import {
+    FilterOperator,
+    FilterType,
+    UnitOfTime,
+} from '../../../../types/filter';
+import assertUnreachable from '../../../../utils/assertUnreachable';
+
+export type AiFilterExample = {
+    fieldId: string;
+    fieldType: string;
+    fieldFilterType: FilterType;
+    operator: FilterOperator;
+    values?: unknown[];
+    settings?: {
+        completed: boolean;
+        unitOfTime: UnitOfTime;
+    };
+};
+
+type FilterExampleTemplate = Omit<
+    AiFilterExample,
+    'fieldId' | 'fieldType' | 'fieldFilterType'
+>;
+
+type GetFilterExamplesArgs = {
+    fieldId: string;
+    fieldType: string;
+    fieldFilterType: FilterType;
+    operators?: FilterOperator[];
+};
+
+const booleanFilterExampleTemplates: FilterExampleTemplate[] = [
+    { operator: FilterOperator.NULL },
+    { operator: FilterOperator.NOT_NULL },
+    { operator: FilterOperator.EQUALS, values: [true] },
+    { operator: FilterOperator.NOT_EQUALS, values: [false] },
+];
+
+const stringFilterExampleTemplates: FilterExampleTemplate[] = [
+    { operator: FilterOperator.NULL },
+    { operator: FilterOperator.NOT_NULL },
+    { operator: FilterOperator.EQUALS, values: ['example'] },
+    { operator: FilterOperator.NOT_EQUALS, values: ['excluded'] },
+    { operator: FilterOperator.STARTS_WITH, values: ['prefix'] },
+    { operator: FilterOperator.ENDS_WITH, values: ['suffix'] },
+    { operator: FilterOperator.INCLUDE, values: ['contains'] },
+    { operator: FilterOperator.NOT_INCLUDE, values: ['exclude'] },
+];
+
+const numberFilterExampleTemplates: FilterExampleTemplate[] = [
+    { operator: FilterOperator.NULL },
+    { operator: FilterOperator.NOT_NULL },
+    { operator: FilterOperator.EQUALS, values: [100] },
+    { operator: FilterOperator.NOT_EQUALS, values: [100] },
+    { operator: FilterOperator.LESS_THAN, values: [100] },
+    { operator: FilterOperator.LESS_THAN_OR_EQUAL, values: [100] },
+    { operator: FilterOperator.GREATER_THAN, values: [100] },
+    { operator: FilterOperator.GREATER_THAN_OR_EQUAL, values: [100] },
+    { operator: FilterOperator.IN_BETWEEN, values: [100, 500] },
+    { operator: FilterOperator.NOT_IN_BETWEEN, values: [100, 500] },
+];
+
+const dateRelativeUnits = [
+    UnitOfTime.days,
+    UnitOfTime.weeks,
+    UnitOfTime.months,
+    UnitOfTime.quarters,
+    UnitOfTime.years,
+] as const;
+
+const dateRelativeFilterExampleTemplates: FilterExampleTemplate[] = [
+    FilterOperator.IN_THE_PAST,
+    FilterOperator.NOT_IN_THE_PAST,
+    FilterOperator.IN_THE_NEXT,
+].flatMap((operator) =>
+    dateRelativeUnits.flatMap((unitOfTime) =>
+        [false, true].map((completed) => ({
+            operator,
+            values: [2],
+            settings: { completed, unitOfTime },
+        })),
+    ),
+);
+
+const dateCurrentFilterExampleTemplates: FilterExampleTemplate[] = [
+    FilterOperator.IN_THE_CURRENT,
+    FilterOperator.NOT_IN_THE_CURRENT,
+].flatMap((operator) =>
+    dateRelativeUnits.map((unitOfTime) => ({
+        operator,
+        values: [1],
+        settings: { completed: false, unitOfTime },
+    })),
+);
+
+const dateFilterExampleTemplates: FilterExampleTemplate[] = [
+    { operator: FilterOperator.NULL },
+    { operator: FilterOperator.NOT_NULL },
+    { operator: FilterOperator.EQUALS, values: ['2024-01-01'] },
+    {
+        operator: FilterOperator.NOT_EQUALS,
+        values: ['2024-01-01T00:00:00Z'],
+    },
+    ...dateRelativeFilterExampleTemplates,
+    ...dateCurrentFilterExampleTemplates,
+    { operator: FilterOperator.LESS_THAN, values: ['2024-02-01T00:00:00Z'] },
+    {
+        operator: FilterOperator.LESS_THAN_OR_EQUAL,
+        values: ['2024-02-01'],
+    },
+    { operator: FilterOperator.GREATER_THAN, values: ['2024-01-01'] },
+    {
+        operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+        values: ['2024-01-01'],
+    },
+    {
+        operator: FilterOperator.IN_BETWEEN,
+        values: ['2024-01-01', '2024-01-31'],
+    },
+];
+
+const getFilterExampleTemplates = (
+    fieldFilterType: FilterType,
+): FilterExampleTemplate[] => {
+    switch (fieldFilterType) {
+        case FilterType.BOOLEAN:
+            return booleanFilterExampleTemplates;
+        case FilterType.STRING:
+            return stringFilterExampleTemplates;
+        case FilterType.NUMBER:
+            return numberFilterExampleTemplates;
+        case FilterType.DATE:
+            return dateFilterExampleTemplates;
+        default:
+            return assertUnreachable(
+                fieldFilterType,
+                `Unknown filter type ${fieldFilterType}`,
+            );
+    }
+};
+
+export const getFilterExamples = ({
+    fieldId,
+    fieldType,
+    fieldFilterType,
+    operators,
+}: GetFilterExamplesArgs): AiFilterExample[] => {
+    const allowedOperators = operators ? new Set(operators) : null;
+
+    return getFilterExampleTemplates(fieldFilterType)
+        .filter(
+            (template) =>
+                allowedOperators === null ||
+                allowedOperators.has(template.operator),
+        )
+        .map((template) => ({
+            fieldId,
+            fieldType,
+            fieldFilterType,
+            ...template,
+        }));
+};
+
+export const formatFilterExamplesAsJsonLines = (
+    examples: AiFilterExample[],
+): string => examples.map((example) => JSON.stringify(example)).join('\n');
+
+const literalUnion = (values: unknown[]): string =>
+    Array.from(new Set(values.map((value) => JSON.stringify(value)))).join(
+        ' | ',
+    );
+
+const enumValuesList = (...enumValues: object[]): string =>
+    Array.from(
+        new Set(
+            enumValues.flatMap((values) =>
+                Object.values(values).filter(
+                    (value): value is string => typeof value === 'string',
+                ),
+            ),
+        ),
+    ).join(', ');
+
+const validFieldTypes = enumValuesList(DimensionType, MetricType);
+const validFieldFilterTypes = enumValuesList(FilterType);
+
+type SupportedExamplePrimitive = boolean | number | string;
+
+type SupportedExamplePrimitiveName = 'boolean' | 'number' | 'string';
+
+const isSupportedExamplePrimitive = (
+    value: unknown,
+): value is SupportedExamplePrimitive =>
+    ['boolean', 'number', 'string'].includes(typeof value);
+
+const primitiveName = (
+    value: SupportedExamplePrimitive,
+): SupportedExamplePrimitiveName => {
+    switch (typeof value) {
+        case 'boolean':
+            return 'boolean';
+        case 'number':
+            return 'number';
+        case 'string':
+            return 'string';
+        default:
+            return assertUnreachable(
+                value,
+                `Unsupported example value type: ${typeof value}`,
+            );
+    }
+};
+
+const valuesTypeForOperator = (
+    operator: FilterOperator,
+    primitive: SupportedExamplePrimitiveName | 'unknown',
+): string | null => {
+    switch (operator) {
+        case FilterOperator.NULL:
+        case FilterOperator.NOT_NULL:
+            return null;
+        case FilterOperator.EQUALS:
+        case FilterOperator.NOT_EQUALS:
+            return primitive === 'boolean' ? '[boolean]' : `${primitive}[]`;
+        case FilterOperator.STARTS_WITH:
+        case FilterOperator.ENDS_WITH:
+        case FilterOperator.INCLUDE:
+        case FilterOperator.NOT_INCLUDE:
+            return 'string[]';
+        case FilterOperator.LESS_THAN:
+        case FilterOperator.LESS_THAN_OR_EQUAL:
+        case FilterOperator.GREATER_THAN:
+        case FilterOperator.GREATER_THAN_OR_EQUAL:
+        case FilterOperator.IN_THE_PAST:
+        case FilterOperator.NOT_IN_THE_PAST:
+        case FilterOperator.IN_THE_NEXT:
+            return `[${primitive}]`;
+        case FilterOperator.IN_BETWEEN:
+        case FilterOperator.NOT_IN_BETWEEN:
+            return `[${primitive}, ${primitive}]`;
+        case FilterOperator.IN_THE_CURRENT:
+        case FilterOperator.NOT_IN_THE_CURRENT:
+            return '[1]';
+        case FilterOperator.IN_PERIOD_TO_DATE:
+            return null;
+        default:
+            return assertUnreachable(
+                operator,
+                `Unsupported filter operator: ${operator}`,
+            );
+    }
+};
+
+const valuesTypeForExamples = (examples: AiFilterExample[]): string | null => {
+    const valuesExample = examples.find((example) => example.values)?.values;
+    if (!valuesExample) return null;
+
+    const firstValue = valuesExample[0];
+    const primitive = isSupportedExamplePrimitive(firstValue)
+        ? primitiveName(firstValue)
+        : 'unknown';
+    const valueTypes = new Set(
+        examples
+            .map((example) =>
+                valuesTypeForOperator(example.operator, primitive),
+            )
+            .filter((valueType) => valueType !== null),
+    );
+
+    return Array.from(valueTypes).join(' | ');
+};
+
+const valuesCommentForOperator = (
+    operator: FilterOperator,
+    primitive: SupportedExamplePrimitiveName | 'unknown',
+): string => {
+    switch (operator) {
+        case FilterOperator.NULL:
+        case FilterOperator.NOT_NULL:
+        case FilterOperator.IN_PERIOD_TO_DATE:
+            return '';
+        case FilterOperator.EQUALS:
+        case FilterOperator.NOT_EQUALS:
+            return primitive === 'boolean' ? ' // exactly one array value' : '';
+        case FilterOperator.IN_THE_CURRENT:
+        case FilterOperator.NOT_IN_THE_CURRENT:
+            return ' // exactly one array value; always [1] for current-period filters';
+        case FilterOperator.IN_THE_PAST:
+        case FilterOperator.NOT_IN_THE_PAST:
+        case FilterOperator.IN_THE_NEXT:
+            return ' // exactly one array value; number of periods';
+        case FilterOperator.IN_BETWEEN:
+        case FilterOperator.NOT_IN_BETWEEN:
+            return ' // exactly two array values; lower and upper bounds';
+        case FilterOperator.LESS_THAN:
+        case FilterOperator.LESS_THAN_OR_EQUAL:
+        case FilterOperator.GREATER_THAN:
+        case FilterOperator.GREATER_THAN_OR_EQUAL:
+            return ' // exactly one array value';
+        case FilterOperator.STARTS_WITH:
+        case FilterOperator.ENDS_WITH:
+        case FilterOperator.INCLUDE:
+        case FilterOperator.NOT_INCLUDE:
+            return '';
+        default:
+            return assertUnreachable(
+                operator,
+                `Unsupported filter operator: ${operator}`,
+            );
+    }
+};
+
+const valuesCommentForExamples = (examples: AiFilterExample[]): string => {
+    const valuesExample = examples.find((example) => example.values)?.values;
+    if (!valuesExample) return '';
+
+    const firstValue = valuesExample[0];
+    const primitive = isSupportedExamplePrimitive(firstValue)
+        ? primitiveName(firstValue)
+        : 'unknown';
+    const comments = new Set(
+        examples
+            .map((example) =>
+                valuesCommentForOperator(example.operator, primitive),
+            )
+            .filter((comment) => comment !== ''),
+    );
+
+    return Array.from(comments).join(' | ');
+};
+
+const settingsTypeForExamples = (
+    examples: AiFilterExample[],
+): string | null => {
+    const settingsExamples = examples
+        .map((example) => example.settings)
+        .filter((settings) => settings !== undefined);
+
+    if (settingsExamples.length === 0) return null;
+
+    return `{
+  completed: ${literalUnion(settingsExamples.map((settings) => settings.completed))}; // false includes current partial period; true means completed periods only
+  unitOfTime: ${literalUnion(settingsExamples.map((settings) => settings.unitOfTime))};
+}`;
+};
+
+export const formatFilterExamplesAsTypeDeclaration = (
+    examples: AiFilterExample[],
+): string => {
+    const firstExample = examples[0];
+    if (!firstExample) return '{}';
+
+    const valuesType = valuesTypeForExamples(examples);
+    const settingsType = settingsTypeForExamples(examples);
+
+    return `{
+  fieldId: "${firstExample.fieldId}"; // use the actual field id
+  fieldType: "${firstExample.fieldType}"; // one of: ${validFieldTypes}
+  fieldFilterType: "${firstExample.fieldFilterType}"; // one of: ${validFieldFilterTypes}; used to choose valid operators
+  operator: ${literalUnion(examples.map((example) => example.operator))}; // | means or${
+      valuesType
+          ? `
+  values: ${valuesType};${valuesCommentForExamples(examples)}`
+          : ''
+  }${
+      settingsType
+          ? `
+  settings: ${settingsType};`
+          : ''
+  }
+}`;
+};
+
+export const filterJsonExamplesForOperators = (
+    args: GetFilterExamplesArgs & { operators: FilterOperator[] },
+): string =>
+    `Type shape: ${formatFilterExamplesAsTypeDeclaration(
+        getFilterExamples(args),
+    )}`;

--- a/packages/common/src/ee/AiAgent/schemas/filters/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/index.ts
@@ -18,6 +18,7 @@ export {
     numberFilterSchema,
     stringFilterSchema,
 };
+export * from './filterExamples';
 
 const filterAndOrSchema = z
     .union([z.literal('and'), z.literal('or')])

--- a/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
@@ -3,10 +3,10 @@ import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
 import {
-    filterJsonExamples,
     filterOperatorList,
     valuePresenceOperatorDescription,
 } from './filterDescriptionUtils';
+import { filterJsonExamplesForOperators } from './filterExamples';
 
 const commonNumberFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -27,6 +27,7 @@ const commonNumberFilterRuleSchema = z.object({
     fieldFilterType: z.literal(FilterType.NUMBER),
 });
 
+// Strict variants prevent Zod from silently stripping invalid AI keys like values/settings.
 const numberFilterSchema = z.union([
     commonNumberFilterRuleSchema
         .extend({
@@ -37,19 +38,14 @@ const numberFilterSchema = z.union([
                 ])
                 .describe(valuePresenceOperatorDescription),
         })
+        .strict()
         .describe(
-            `Use for numeric fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+            `Use for numeric fields when checking if a value is missing or present. Do not include values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_total_revenue',
                     fieldType: MetricType.SUM,
                     fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.NULL,
-                },
-                {
-                    fieldId: 'orders_total_revenue',
-                    fieldType: MetricType.SUM,
-                    fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.NOT_NULL,
+                    operators: [FilterOperator.NULL, FilterOperator.NOT_NULL],
                 },
             )}`,
         ),
@@ -67,21 +63,17 @@ const numberFilterSchema = z.union([
                 .array(z.number())
                 .describe('One or more exact numeric values to match.'),
         })
+        .strict()
         .describe(
-            `Use for numeric fields that equal or exclude specific values. ${filterJsonExamples(
+            `Use for numeric fields that equal or exclude specific values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_item_count',
                     fieldType: MetricType.COUNT,
                     fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.EQUALS,
-                    values: [1, 2],
-                },
-                {
-                    fieldId: 'orders_discount_percent',
-                    fieldType: DimensionType.NUMBER,
-                    fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.NOT_EQUALS,
-                    values: [0],
+                    operators: [
+                        FilterOperator.EQUALS,
+                        FilterOperator.NOT_EQUALS,
+                    ],
                 },
             )}`,
         ),
@@ -102,21 +94,19 @@ const numberFilterSchema = z.union([
                 .length(1)
                 .describe('Exactly one numeric threshold value.'),
         })
+        .strict()
         .describe(
-            `Use for numeric fields with a single comparison threshold. ${filterJsonExamples(
+            `Use for numeric fields with a single comparison threshold. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_total_revenue',
                     fieldType: MetricType.SUM,
                     fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.GREATER_THAN,
-                    values: [1000],
-                },
-                {
-                    fieldId: 'orders_discount_percent',
-                    fieldType: DimensionType.NUMBER,
-                    fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.LESS_THAN_OR_EQUAL,
-                    values: [0.15],
+                    operators: [
+                        FilterOperator.LESS_THAN,
+                        FilterOperator.LESS_THAN_OR_EQUAL,
+                        FilterOperator.GREATER_THAN,
+                        FilterOperator.GREATER_THAN_OR_EQUAL,
+                    ],
                 },
             )}`,
         ),
@@ -133,21 +123,17 @@ const numberFilterSchema = z.union([
                 .length(2)
                 .describe('Exactly two numeric bounds: [lower, upper].'),
         })
+        .strict()
         .describe(
-            `Use for numeric fields inside or outside a two-value range. ${filterJsonExamples(
+            `Use for numeric fields inside or outside a two-value range. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_total_revenue',
                     fieldType: MetricType.SUM,
                     fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.IN_BETWEEN,
-                    values: [100, 500],
-                },
-                {
-                    fieldId: 'orders_margin_percent',
-                    fieldType: DimensionType.NUMBER,
-                    fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.NOT_IN_BETWEEN,
-                    values: [0.2, 0.4],
+                    operators: [
+                        FilterOperator.IN_BETWEEN,
+                        FilterOperator.NOT_IN_BETWEEN,
+                    ],
                 },
             )}`,
         ),

--- a/packages/common/src/ee/AiAgent/schemas/filters/stringFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/stringFilters.ts
@@ -3,10 +3,10 @@ import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
 import {
-    filterJsonExamples,
     filterOperatorList,
     valuePresenceOperatorDescription,
 } from './filterDescriptionUtils';
+import { filterJsonExamplesForOperators } from './filterExamples';
 
 const commonStringFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -17,6 +17,7 @@ const commonStringFilterRuleSchema = z.object({
     fieldFilterType: z.literal(FilterType.STRING),
 });
 
+// Strict variants prevent Zod from silently stripping invalid AI keys like values/settings.
 const stringFilterSchema = z.union([
     commonStringFilterRuleSchema
         .extend({
@@ -27,19 +28,14 @@ const stringFilterSchema = z.union([
                 ])
                 .describe(valuePresenceOperatorDescription),
         })
+        .strict()
         .describe(
-            `Use for string fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+            `Use for string fields when checking if a value is missing or present. Do not include values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_status',
                     fieldType: DimensionType.STRING,
                     fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.NULL,
-                },
-                {
-                    fieldId: 'orders_status',
-                    fieldType: DimensionType.STRING,
-                    fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.NOT_NULL,
+                    operators: [FilterOperator.NULL, FilterOperator.NOT_NULL],
                 },
             )}`,
         ),
@@ -63,35 +59,21 @@ const stringFilterSchema = z.union([
                     'String values to match. Do not put natural-language date ranges here.',
                 ),
         })
+        .strict()
         .describe(
-            `Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. ${filterJsonExamples(
+            `Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_status',
                     fieldType: DimensionType.STRING,
                     fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.EQUALS,
-                    values: ['complete', 'paid'],
-                },
-                {
-                    fieldId: 'customers_email',
-                    fieldType: DimensionType.STRING,
-                    fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.INCLUDE,
-                    values: ['@lightdash.com'],
-                },
-                {
-                    fieldId: 'products_sku',
-                    fieldType: DimensionType.STRING,
-                    fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.STARTS_WITH,
-                    values: ['SKU-'],
-                },
-                {
-                    fieldId: 'orders_status',
-                    fieldType: DimensionType.STRING,
-                    fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.NOT_EQUALS,
-                    values: ['cancelled'],
+                    operators: [
+                        FilterOperator.EQUALS,
+                        FilterOperator.NOT_EQUALS,
+                        FilterOperator.STARTS_WITH,
+                        FilterOperator.ENDS_WITH,
+                        FilterOperator.INCLUDE,
+                        FilterOperator.NOT_INCLUDE,
+                    ],
                 },
             )}`,
         ),

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -5,6 +5,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": false
             },
             "description": "Clear the active AI agent from context. After clearing, tool calls will no longer be scoped to a specific agent's explores, tags, or instructions. The active project is preserved.",
@@ -22,6 +23,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": false,
+                "openWorldHint": false,
                 "readOnlyHint": false
             },
             "description": "Create a new dashboard or chart, consult the skills for the required fields. Returns the created content with the final persisted slug.",
@@ -197,6 +199,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": false,
+                "openWorldHint": true,
                 "readOnlyHint": false
             },
             "description": "Create a LIVE scheduled delivery that sends a saved chart or dashboard to Slack channels and/or email recipients on a cron schedule. IMPORTANT: before calling this tool, propose the full configuration to the user (name, schedule in plain words, timezone, destinations, format, AI augmentation prompt if any) and wait for their explicit confirmation in the conversation. Requires an existing saved chart or dashboard — if the content only exists in this conversation, create it with createContent first, then schedule the created uuid. On success, share the returned href with the user — the delivery is managed (paused, edited, deleted) from that page.",
@@ -331,8 +334,9 @@
         },
         {
             "annotations": {
-                "destructiveHint": false,
+                "destructiveHint": true,
                 "idempotentHint": false,
+                "openWorldHint": false,
                 "readOnlyHint": false
             },
             "description": "Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting",
@@ -367,6 +371,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: \"findContent\"\nPurpose:\nFinds spaces, charts, or dashboards by name or description within a project, returning detailed information about each.\n\nUsage tips:\n- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., \"revenue based on campaigns\" instead of just \"campaigns\").\n- The search engine understands natural language and context — more descriptive queries yield better results.\n- You can provide multiple search queries to look for different topics simultaneously (e.g., [\"monthly revenue\", \"user acquisition trends\"]).\n- Pass spaceSlug to search only inside that space and its descendants.\n- If results aren't relevant, retry with the full user query or more specific terms.\n- Dashboards with validation errors will be deprioritized.\n- Returns space breadcrumb/path metadata and chart/dashboard URLs when available.\n- Dashboards show a preview of the first 5 charts and the total chart count. Use \"getDashboardCharts\" to see all charts for a specific dashboard.\n- It doesn't provide summaries for dashboards yet, so don't suggest this capability.",
@@ -404,6 +409,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: findExplores\n\nPurpose:\nReturns explores matching the query with their joined tables, required filters, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.\nIMPORTANT: Each explore may include fields from multiple joined tables. Check the \"joinedTables\" elements to see which tables are included in the explore.\n\nParameters:\n- searchQuery: Keyword terms for finding relevant explores\n\nOutput:\n- Matching explores with searchRank scores\n- Top matching fields with their explore names and searchRank scores\n- Required filters set on matching explores, including default values\n",
@@ -646,6 +652,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: \"findFields\"\n\nPurpose:\nFinds the most relevant Fields (Metrics & Dimensions) within Explores, returning detailed info about each.\n\nUsage tips:\n- Use \"findExplores\" first to discover available Explores and their field labels.\n- Use full field labels in search terms (e.g. \"Total Revenue\", \"Order Date\").\n- Pass all needed fields in one request.\n- Fields are sorted by relevance, with a maximum score of 1 and a minimum of 0, so the top results are the most relevant.\n- If results aren't relevant, retry with clearer or more specific terms.\n- Results are paginated — use the next page token to get more results if needed.\n",
@@ -858,6 +865,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. The active agent is usually established by route_agent; use this to inspect the current automatic or manually overridden selection before making data queries.",
@@ -875,6 +883,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Get the currently active project and its configuration. Returns the project UUID, name, and any selected tags. Use this to verify context before calling data tools.",
@@ -892,6 +901,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Get the current Lightdash version",
@@ -909,6 +919,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: get_metadata\n\nPurpose:\nGet the full metadata for specific explores and/or fields that you already know the IDs of (typically from grep_fields). grep_fields is lean — it tells you WHICH fields exist; get_metadata gives you the DETAIL you need to build a correct query: an explore's joined tables and table filters, and a field's filter type, case-sensitivity, resolved default time dimension, hints, and whether it comes from a joined table.\n\nCall this AFTER grep_fields, once you have narrowed down to the explore(s) and field(s) you intend to use, and BEFORE render_chart. You can ask for several explores and several fields across explores in a SINGLE call — batch everything you need at once instead of one request per item.\n\nEach entry in `requests` is one of:\n- `{ \"type\": \"explore\", \"exploreIds\": [\"orders\", \"customers\"] }` — full metadata for those explores (joined tables, table filters, field counts).\n- `{ \"type\": \"field\", \"fields\": [{ \"exploreId\": \"orders\", \"fieldId\": \"orders_status\" }] }` — full metadata for those specific fields.\n",
@@ -1238,6 +1249,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Poll for the result of a long-running MCP query started by run_sql or run_metric_query.\n\nUse this tool when run_sql or run_metric_query returns a running result. Clients with structured output see this as structuredContent.result.status = \"running\"; text-only clients should extract the queryUuid from the content text.\nEach call waits up to the MCP wait window before returning another running response.\nFor completed run_metric_query results, If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after get_query_result returns done. render_chart currently supports completed run_metric_query results.\n\nParameters:\n- queryUuid: The async query UUID returned by run_sql or run_metric_query.\n\nResponse shape (MCP CallToolResult):\n- Running: content contains polling status text and structuredContent.result contains { status: \"running\", queryUuid, nextPollAfterMs, heartbeatAt }. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.\n- Completed SQL: content contains CSV text and structuredContent.result contains { status: \"done\", queryUuid, rows, columns, rowCount, sqlRunnerUrl }.\n- Completed metric query: content has the CSV text plus a separate `queryUuid: <id>` text block (copy this exact id for render_chart), and structuredContent.result contains { status: \"done\", queryUuid, rows, fields, exploreUrl }.\n- Failed/cancelled/expired: content contains status/error text and structuredContent.result contains { status, queryUuid, error }.\n\nNotes:\n- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.\n- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.\n- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.\n",
@@ -1406,6 +1418,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: grep_fields\n\nPurpose:\nFind which explores and fields can answer a question by grepping an in-memory, annotated view of the project's fields (names, labels, descriptions, hints and tags). Returns matching fields as `explore/fieldId  [kind type]` lines grouped by explore.\n\nUse this as the FIRST step whenever the user asks a data question (counts, totals, breakdowns, trends, \"what is\", \"show me\", \"how many\"). Do NOT call this for questions about existing dashboards/charts (use find_content).\n\nEach pattern is a case-insensitive keyword pattern (not a full regex): use `|` to OR synonyms (\"revenue|sales\") and a space or `.*` between words to require all of them (\"order.*status\" matches fields mentioning both \"order\" and \"status\"). Pass 1–5 patterns in a SINGLE call covering the different angles of the question — they run together so you see all results at once instead of grepping one at a time. Start broad with meaningful keywords (e.g. [\"revenue|sales\", \"country|region\", \"segment|tier\"]) and narrow from there — long natural-language phrases will not match. If results are empty, try synonyms or broader patterns before giving up. Read the returned fieldIds and pick the single explore that answers at the right grain before building a query.\n",
@@ -1748,6 +1761,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection; use this tool when you need to inspect candidates or choose one manually before calling set_agent.",
@@ -1769,6 +1783,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: \"listContent\"\nPurpose:\nLists accessible Lightdash content in a project as a browsable hierarchy.\n\nUsage tips:\n- By default, lists root-level spaces.\n- Pass a spaceSlug to list direct children and content inside that space.\n- Use page for pagination. Page starts at 1.\n- Results include names, slugs, content types, URLs, and space content counts.",
@@ -1796,6 +1811,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: listExplores\n\nPurpose:\nLists all Explores available to the user in the current project. Returns a summary of each explore including its name, label, base table, and tags.\n\nUsage Tips:\n- Use this to discover what data sources are available before using MCP schema-discovery tools for detailed field information\n- No arguments needed - automatically uses the current project context\n- Results are filtered based on user permissions and selected tags\n- Returns explore metadata without field details for quick overview\n",
@@ -1813,6 +1829,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations. Each project includes a \"type\": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so run_sql and run_metric_query can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.",
@@ -1830,6 +1847,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "List Lightdash built-in skills available to this MCP server. Use this when the client does not expose MCP resources directly.",
@@ -1937,6 +1955,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "List all verified charts and dashboards in the active project. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Requires an active project set via set_project. Each item includes contentType (chart or dashboard), contentUuid, name, description, space, view count, last update time, and verification metadata (who verified it and when); charts also include chartKind and exploreName. To learn the full structure of a verified item (dimensions, metrics, filters), drill into it with find_content or MCP schema-discovery tools on its explore.",
@@ -1954,6 +1973,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Read a dashboard or chart as JSON using its slug. Call this before editing.",
@@ -1983,6 +2003,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Read the main SKILL.md instructions for a Lightdash built-in skill. Call list_skills first to discover available skill names.",
@@ -2096,6 +2117,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Read a supporting resource file for a Lightdash built-in skill. Use the resource path returned by list_skills.",
@@ -2216,6 +2238,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Render a chart for a completed query result in MCP App-capable clients.\n\nUse this after a query tool or get_query_result returns done and the user wants a visual chart. This tool does not start, poll, or rerun the query. If the query is still running, call get_query_result first. Pass the exact queryUuid that run_metric_query (or get_query_result) returned for this query in the current conversation — it is included in that tool's response as a `queryUuid: <id>` text block. Never invent, guess, or reuse a queryUuid from a different query or session; an unknown id fails with \"not found\". Lightdash loads the completed metric query from query history.\n\nCurrent support: completed run_metric_query results. SQL Runner/run_sql results are not supported by render_chart. Other query result types are rejected until their chart rendering path is implemented.\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: string }] — short render status message.\n- structuredContent: {\n    result: {\n      status: \"done\",\n      queryUuid: string,\n      exploreUrl: string | null,\n      echartsOption: Record<string, unknown> | null // lightweight placeholder; full chart payload is app metadata\n    }\n  }",
@@ -2358,6 +2381,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: resolveUrl\n\nPurpose:\nExpands a Lightdash share short-link into the full URL it redirects to. Share links are opaque — this tool is the only way to see what they point at.\n\nWhen to use:\n- ONLY for URLs whose path is \"/share/<id>\" (e.g. \"<host>/share/aBcD1234...\"). Nothing else is a share link.\n- NEVER call this for any other URL. A URL like \"/projects/<uuid>/saved/<uuid>\" or \"/projects/<uuid>/dashboards/<uuid>\" already contains its identifiers — read them directly from the path and go straight to the appropriate tool.\n\nUsage tips:\n- Read the identifiers (project uuid, chart or dashboard uuid, explore name) from the expanded URL, then use other tools (e.g. readContent) to fetch the content.\n- URLs that don't belong to this Lightdash instance cannot be resolved.",
@@ -2382,6 +2406,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": false,
+                "openWorldHint": false,
                 "readOnlyHint": false
             },
             "description": "Automatically select and activate the best AI agent for a user request within the active project. Call this at the start of each new user request after setting project context. Returns routing metadata plus the selected agent context; use set_agent only when you want to override the automatic choice manually.",
@@ -2497,8 +2522,9 @@
         },
         {
             "annotations": {
-                "destructiveHint": false,
+                "destructiveHint": true,
                 "idempotentHint": false,
+                "openWorldHint": true,
                 "readOnlyHint": false
             },
             "description": "Tool: run_ai_writeback\n\nPurpose:\nMake a change to the dbt project that backs the active Lightdash project by describing it in natural language, then open a pull request with the result. The target GitHub repository and dbt sub-folder are resolved server-side from the active project's dbt connection — you never specify them.\n\nHow it works:\n- This tool starts the run and returns immediately with an aiWritebackRunUuid — it does NOT wait for the run to finish.\n- In the background: a sandbox is created, the project's GitHub repository is cloned, and the prompt is executed by the Claude Code CLI against the dbt project. If the agent changes any files, a branch is committed, pushed, and a pull request is opened.\n- Call get_ai_writeback_status with the returned aiWritebackRunUuid to check progress and get the pull request URL once the run finishes. The run typically takes a few minutes (cloning, running the agent, opening the PR) — poll every 10-15 seconds rather than immediately looping.\n- Clients that declare the MCP Tasks extension (io.modelcontextprotocol/tasks) in their per-request capabilities instead receive a task handle (resultType: \"task\", taskId = the run id) and should poll tasks/get / cancel via tasks/cancel rather than calling get_ai_writeback_status.\n\nRequirements:\n- An active project must be set first via set_project (or the X-Lightdash-Project header).\n- The project's dbt connection must be GitHub-backed, and the organization must have the GitHub App installed.\n- The AI writeback feature must be enabled for the organization.\n\nImportant:\n- This tool is NOT read-only and NOT idempotent — each call can start a run that opens a new pull request. Use it only when the user explicitly wants to change their dbt project.\n- Some projects have more than one dbt source. If the prompt doesn't make clear which one to change, the run finishes with status \"error\" and an error message listing the sources by name and repository — call run_ai_writeback again naming the intended source in the prompt itself (e.g. \"In jaffle-2, add ...\"). You never pass an id.\n\nParameters:\n- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. \"Add a 'total_revenue' metric to the orders model as the sum of amount\"). When the project has more than one dbt source, name the intended source here (e.g. \"In the marketing dbt project, ...\").\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: \"<human-readable message telling you the run started and to poll get_ai_writeback_status>\" }]\n- structuredContent: {\n    aiWritebackRunUuid: string   // pass this to get_ai_writeback_status\n  }\n",
@@ -2546,6 +2572,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Execute a metric query.\n\nThis tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.\n- If the query finishes before the MCP wait window, structuredContent: {\n    result: {\n      status: \"done\",\n      queryUuid: string,\n      rows: Array<Record<string, unknown>>,\n      fields: Record<string, unknown>,\n      exploreUrl: string | null\n    }\n  }\n- If the query is still running, structuredContent: {\n    result: {\n      status: \"running\",\n      queryUuid: string,\n      nextPollAfterMs: number,\n      heartbeatAt: string\n    }\n  }\n  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.\n\nNotes:\n- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.\n- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.\n- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.\n",
@@ -2661,7 +2688,7 @@
                                                                         "anyOf": [
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"isNull\"}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notNull\"}",
+                                                                                "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "boolean",
@@ -2696,7 +2723,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for boolean fields when matching or excluding true/false values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"equals\",\"values\":[true]}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notEquals\",\"values\":[false]}",
+                                                                                "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: [boolean]; // exactly one array value\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "boolean",
@@ -2745,7 +2772,7 @@
                                                                         "anyOf": [
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notNull\"}",
+                                                                                "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "string",
@@ -2780,7 +2807,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"equals\",\"values\":[\"complete\",\"paid\"]}; {\"fieldId\":\"customers_email\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"include\",\"values\":[\"@lightdash.com\"]}; {\"fieldId\":\"products_sku\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"startsWith\",\"values\":[\"SKU-\"]}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notEquals\",\"values\":[\"cancelled\"]}",
+                                                                                "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\" | \"startsWith\" | \"endsWith\" | \"include\" | \"doesNotInclude\"; // | means or\n  values: string[];\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "string",
@@ -2831,7 +2858,7 @@
                                                                         "anyOf": [
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
+                                                                                "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "number",
@@ -2876,7 +2903,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
+                                                                                "description": "Use for numeric fields that equal or exclude specific values. Type shape: {\n  fieldId: \"orders_item_count\"; // use the actual field id\n  fieldType: \"count\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: number[];\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "number",
@@ -2929,7 +2956,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
+                                                                                "description": "Use for numeric fields with a single comparison threshold. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [number]; // exactly one array value\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "number",
@@ -2986,7 +3013,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
+                                                                                "description": "Use for numeric fields inside or outside a two-value range. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\" | \"notInBetween\"; // | means or\n  values: [number, number]; // exactly two array values; lower and upper bounds\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "number",
@@ -3045,7 +3072,7 @@
                                                                         "anyOf": [
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notNull\"}",
+                                                                                "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "date",
@@ -3081,7 +3108,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"equals\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notEquals\",\"values\":[\"2024-01-01T00:00:00Z\"]}",
+                                                                                "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: string[];\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "date",
@@ -3135,7 +3162,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[2],\"settings\":{\"completed\":false,\"unitOfTime\":\"weeks\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[3],\"settings\":{\"completed\":true,\"unitOfTime\":\"months\"}}; {\"fieldId\":\"orders_ship_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheNext\",\"values\":[14],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInThePast\",\"values\":[7],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}",
+                                                                                "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inThePast\" | \"notInThePast\" | \"inTheNext\"; // | means or\n  values: [number]; // exactly one array value; number of periods\n  settings: {\n  completed: false | true; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "date",
@@ -3209,7 +3236,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"months\"}}",
+                                                                                "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inTheCurrent\" | \"notInTheCurrent\"; // | means or\n  values: [1]; // exactly one array value; always [1] for current-period filters\n  settings: {\n  completed: false; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "date",
@@ -3284,7 +3311,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"greaterThanOrEqual\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"lessThan\",\"values\":[\"2024-02-01T00:00:00Z\"]}",
+                                                                                "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [string]; // exactly one array value\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "date",
@@ -3342,7 +3369,7 @@
                                                                             },
                                                                             {
                                                                                 "additionalProperties": false,
-                                                                                "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01\",\"2024-01-31\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01T00:00:00Z\",\"2024-01-31T23:59:59Z\"]}",
+                                                                                "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\"; // | means or\n  values: [string, string]; // exactly two array values; lower and upper bounds\n}",
                                                                                 "properties": {
                                                                                     "fieldFilterType": {
                                                                                         "const": "date",
@@ -3523,7 +3550,7 @@
                                                     "anyOf": [
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"isNull\"}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notNull\"}",
+                                                            "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "boolean",
@@ -3558,7 +3585,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for boolean fields when matching or excluding true/false values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"equals\",\"values\":[true]}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notEquals\",\"values\":[false]}",
+                                                            "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: [boolean]; // exactly one array value\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "boolean",
@@ -3607,7 +3634,7 @@
                                                     "anyOf": [
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notNull\"}",
+                                                            "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "string",
@@ -3642,7 +3669,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"equals\",\"values\":[\"complete\",\"paid\"]}; {\"fieldId\":\"customers_email\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"include\",\"values\":[\"@lightdash.com\"]}; {\"fieldId\":\"products_sku\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"startsWith\",\"values\":[\"SKU-\"]}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notEquals\",\"values\":[\"cancelled\"]}",
+                                                            "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\" | \"startsWith\" | \"endsWith\" | \"include\" | \"doesNotInclude\"; // | means or\n  values: string[];\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "string",
@@ -3693,7 +3720,7 @@
                                                     "anyOf": [
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
+                                                            "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "number",
@@ -3738,7 +3765,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
+                                                            "description": "Use for numeric fields that equal or exclude specific values. Type shape: {\n  fieldId: \"orders_item_count\"; // use the actual field id\n  fieldType: \"count\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: number[];\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "number",
@@ -3791,7 +3818,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
+                                                            "description": "Use for numeric fields with a single comparison threshold. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [number]; // exactly one array value\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "number",
@@ -3848,7 +3875,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
+                                                            "description": "Use for numeric fields inside or outside a two-value range. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\" | \"notInBetween\"; // | means or\n  values: [number, number]; // exactly two array values; lower and upper bounds\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "number",
@@ -3907,7 +3934,7 @@
                                                     "anyOf": [
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notNull\"}",
+                                                            "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -3943,7 +3970,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"equals\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notEquals\",\"values\":[\"2024-01-01T00:00:00Z\"]}",
+                                                            "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: string[];\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -3997,7 +4024,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[2],\"settings\":{\"completed\":false,\"unitOfTime\":\"weeks\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[3],\"settings\":{\"completed\":true,\"unitOfTime\":\"months\"}}; {\"fieldId\":\"orders_ship_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheNext\",\"values\":[14],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInThePast\",\"values\":[7],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}",
+                                                            "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inThePast\" | \"notInThePast\" | \"inTheNext\"; // | means or\n  values: [number]; // exactly one array value; number of periods\n  settings: {\n  completed: false | true; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4071,7 +4098,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"months\"}}",
+                                                            "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inTheCurrent\" | \"notInTheCurrent\"; // | means or\n  values: [1]; // exactly one array value; always [1] for current-period filters\n  settings: {\n  completed: false; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4146,7 +4173,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"greaterThanOrEqual\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"lessThan\",\"values\":[\"2024-02-01T00:00:00Z\"]}",
+                                                            "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [string]; // exactly one array value\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4204,7 +4231,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01\",\"2024-01-31\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01T00:00:00Z\",\"2024-01-31T23:59:59Z\"]}",
+                                                            "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\"; // | means or\n  values: [string, string]; // exactly two array values; lower and upper bounds\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4269,7 +4296,7 @@
                                                     "anyOf": [
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"isNull\"}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notNull\"}",
+                                                            "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "boolean",
@@ -4304,7 +4331,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for boolean fields when matching or excluding true/false values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"equals\",\"values\":[true]}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notEquals\",\"values\":[false]}",
+                                                            "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: [boolean]; // exactly one array value\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "boolean",
@@ -4353,7 +4380,7 @@
                                                     "anyOf": [
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notNull\"}",
+                                                            "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "string",
@@ -4388,7 +4415,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"equals\",\"values\":[\"complete\",\"paid\"]}; {\"fieldId\":\"customers_email\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"include\",\"values\":[\"@lightdash.com\"]}; {\"fieldId\":\"products_sku\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"startsWith\",\"values\":[\"SKU-\"]}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notEquals\",\"values\":[\"cancelled\"]}",
+                                                            "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\" | \"startsWith\" | \"endsWith\" | \"include\" | \"doesNotInclude\"; // | means or\n  values: string[];\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "string",
@@ -4439,7 +4466,7 @@
                                                     "anyOf": [
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
+                                                            "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "number",
@@ -4484,7 +4511,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
+                                                            "description": "Use for numeric fields that equal or exclude specific values. Type shape: {\n  fieldId: \"orders_item_count\"; // use the actual field id\n  fieldType: \"count\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: number[];\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "number",
@@ -4537,7 +4564,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
+                                                            "description": "Use for numeric fields with a single comparison threshold. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [number]; // exactly one array value\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "number",
@@ -4594,7 +4621,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
+                                                            "description": "Use for numeric fields inside or outside a two-value range. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\" | \"notInBetween\"; // | means or\n  values: [number, number]; // exactly two array values; lower and upper bounds\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "number",
@@ -4653,7 +4680,7 @@
                                                     "anyOf": [
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notNull\"}",
+                                                            "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4689,7 +4716,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"equals\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notEquals\",\"values\":[\"2024-01-01T00:00:00Z\"]}",
+                                                            "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: string[];\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4743,7 +4770,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[2],\"settings\":{\"completed\":false,\"unitOfTime\":\"weeks\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[3],\"settings\":{\"completed\":true,\"unitOfTime\":\"months\"}}; {\"fieldId\":\"orders_ship_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheNext\",\"values\":[14],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInThePast\",\"values\":[7],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}",
+                                                            "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inThePast\" | \"notInThePast\" | \"inTheNext\"; // | means or\n  values: [number]; // exactly one array value; number of periods\n  settings: {\n  completed: false | true; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4817,7 +4844,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"months\"}}",
+                                                            "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inTheCurrent\" | \"notInTheCurrent\"; // | means or\n  values: [1]; // exactly one array value; always [1] for current-period filters\n  settings: {\n  completed: false; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4892,7 +4919,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"greaterThanOrEqual\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"lessThan\",\"values\":[\"2024-02-01T00:00:00Z\"]}",
+                                                            "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [string]; // exactly one array value\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -4950,7 +4977,7 @@
                                                         },
                                                         {
                                                             "additionalProperties": false,
-                                                            "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01\",\"2024-01-31\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01T00:00:00Z\",\"2024-01-31T23:59:59Z\"]}",
+                                                            "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\"; // | means or\n  values: [string, string]; // exactly two array values; lower and upper bounds\n}",
                                                             "properties": {
                                                                 "fieldFilterType": {
                                                                     "const": "date",
@@ -5013,7 +5040,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -5058,7 +5085,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
+                                                    "description": "Use for numeric fields that equal or exclude specific values. Type shape: {\n  fieldId: \"orders_item_count\"; // use the actual field id\n  fieldType: \"count\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: number[];\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -5111,7 +5138,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
+                                                    "description": "Use for numeric fields with a single comparison threshold. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [number]; // exactly one array value\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -5168,7 +5195,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
+                                                    "description": "Use for numeric fields inside or outside a two-value range. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\" | \"notInBetween\"; // | means or\n  values: [number, number]; // exactly two array values; lower and upper bounds\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -5736,6 +5763,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Execute an arbitrary SQL query against the project's data warehouse and return the results. The platform already gives the user a way to continue this exact query in SQL Runner — do not add your own SQL Runner link in the final answer text; a link you write in prose cannot be scoped to a specific query and will point at the wrong one if this tool is called more than once in a turn.\n\nUse this tool when the user wants to run a custom SQL query that doesn't fit the explore-based metric query model.\nThis is useful for ad-hoc analysis, data exploration, or queries that join across tables not modeled in explores.\nIf the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, prefer run_metric_query and then render_chart when the request fits the semantic layer. render_chart does not support run_sql results.\n\nThe query is executed directly against the warehouse, so use the SQL dialect appropriate for the connected warehouse (e.g., PostgreSQL, BigQuery, Snowflake, etc.).\n\nParameters:\n- sql: The SQL query to execute. Must be a valid SELECT statement.\n- limit: Maximum number of rows to return (default 500, max 5000).\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: string }] — human-readable fallback. Completed queries return CSV with a header row plus data rows. Empty results return prose text like \"Query returned 0 rows.\"; running queries return polling status text; errors return an error message.\n- If the query finishes before the MCP wait window, structuredContent: {\n    result: {\n      status: \"done\",\n      rows:     Array<Record<string, unknown>>,  // each row keyed by column name\n      columns:  string[],                        // column names in order\n      rowCount: number,                          // total rows returned\n      sqlRunnerUrl: string | null                // shareable URL to inspect/edit the SQL in SQL Runner\n    }\n  }\n- If the query is still running, structuredContent: {\n    result: {\n      status: \"running\",\n      queryUuid: string,\n      nextPollAfterMs: number,\n      heartbeatAt: string\n    }\n  }\n  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.\n\nNotes:\n- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.\n- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.\n- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.\n- Values in rows are JSON-serializable primitives: numbers, strings, booleans, ISO date strings, or null. They are NOT pre-stringified — there's no need for parseFloat / parseInt on numeric columns.\n- Empty results still return structuredContent.result with { status: \"done\", rows: [], columns, rowCount: 0, sqlRunnerUrl } — distinct from a parse failure.\n- Lightdash applies the requested row limit to the SQL query. Ensure the SELECT statement is complete; malformed trailing SQL can surface errors near the generated LIMIT.\n- On startup/validation/application/warehouse error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.\n",
@@ -5848,6 +5876,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": true
             },
             "description": "Tool: searchFieldValues\n\nPurpose:\nSearch for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.\n\nUsage Tips:\n- Specify the table and field you want to search values for\n- Query parameter: use it to narrow down the search to matching values\n- Optionally add filters to further restrict the results\n- Results are returned as a list of unique field values (limited to 100)\n",
@@ -5871,7 +5900,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"isNull\"}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "boolean",
@@ -5904,7 +5933,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for boolean fields when matching or excluding true/false values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"equals\",\"values\":[true]}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notEquals\",\"values\":[false]}",
+                                                    "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: [boolean]; // exactly one array value\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "boolean",
@@ -5951,7 +5980,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "string",
@@ -5984,7 +6013,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"equals\",\"values\":[\"complete\",\"paid\"]}; {\"fieldId\":\"customers_email\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"include\",\"values\":[\"@lightdash.com\"]}; {\"fieldId\":\"products_sku\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"startsWith\",\"values\":[\"SKU-\"]}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notEquals\",\"values\":[\"cancelled\"]}",
+                                                    "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\" | \"startsWith\" | \"endsWith\" | \"include\" | \"doesNotInclude\"; // | means or\n  values: string[];\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "string",
@@ -6033,7 +6062,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -6078,7 +6107,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
+                                                    "description": "Use for numeric fields that equal or exclude specific values. Type shape: {\n  fieldId: \"orders_item_count\"; // use the actual field id\n  fieldType: \"count\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: number[];\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -6131,7 +6160,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
+                                                    "description": "Use for numeric fields with a single comparison threshold. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [number]; // exactly one array value\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -6188,7 +6217,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
+                                                    "description": "Use for numeric fields inside or outside a two-value range. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\" | \"notInBetween\"; // | means or\n  values: [number, number]; // exactly two array values; lower and upper bounds\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -6247,7 +6276,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -6283,7 +6312,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"equals\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notEquals\",\"values\":[\"2024-01-01T00:00:00Z\"]}",
+                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: string[];\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -6337,7 +6366,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[2],\"settings\":{\"completed\":false,\"unitOfTime\":\"weeks\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[3],\"settings\":{\"completed\":true,\"unitOfTime\":\"months\"}}; {\"fieldId\":\"orders_ship_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheNext\",\"values\":[14],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInThePast\",\"values\":[7],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}",
+                                                    "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inThePast\" | \"notInThePast\" | \"inTheNext\"; // | means or\n  values: [number]; // exactly one array value; number of periods\n  settings: {\n  completed: false | true; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -6411,7 +6440,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"months\"}}",
+                                                    "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inTheCurrent\" | \"notInTheCurrent\"; // | means or\n  values: [1]; // exactly one array value; always [1] for current-period filters\n  settings: {\n  completed: false; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -6486,7 +6515,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"greaterThanOrEqual\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"lessThan\",\"values\":[\"2024-02-01T00:00:00Z\"]}",
+                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [string]; // exactly one array value\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -6544,7 +6573,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01\",\"2024-01-31\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01T00:00:00Z\",\"2024-01-31T23:59:59Z\"]}",
+                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\"; // | means or\n  values: [string, string]; // exactly two array values; lower and upper bounds\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -6609,7 +6638,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"isNull\"}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "boolean",
@@ -6642,7 +6671,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for boolean fields when matching or excluding true/false values. Examples: {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"equals\",\"values\":[true]}; {\"fieldId\":\"users_is_active\",\"fieldType\":\"boolean\",\"fieldFilterType\":\"boolean\",\"operator\":\"notEquals\",\"values\":[false]}",
+                                                    "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {\n  fieldId: \"users_is_active\"; // use the actual field id\n  fieldType: \"boolean\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"boolean\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: [boolean]; // exactly one array value\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "boolean",
@@ -6689,7 +6718,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "string",
@@ -6722,7 +6751,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Examples: {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"equals\",\"values\":[\"complete\",\"paid\"]}; {\"fieldId\":\"customers_email\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"include\",\"values\":[\"@lightdash.com\"]}; {\"fieldId\":\"products_sku\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"startsWith\",\"values\":[\"SKU-\"]}; {\"fieldId\":\"orders_status\",\"fieldType\":\"string\",\"fieldFilterType\":\"string\",\"operator\":\"notEquals\",\"values\":[\"cancelled\"]}",
+                                                    "description": "Use for text matching on string fields. For dates like \"last 2 weeks\", use a date filter instead. Type shape: {\n  fieldId: \"orders_status\"; // use the actual field id\n  fieldType: \"string\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"string\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\" | \"startsWith\" | \"endsWith\" | \"include\" | \"doesNotInclude\"; // | means or\n  values: string[];\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "string",
@@ -6771,7 +6800,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -6816,7 +6845,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
+                                                    "description": "Use for numeric fields that equal or exclude specific values. Type shape: {\n  fieldId: \"orders_item_count\"; // use the actual field id\n  fieldType: \"count\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: number[];\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -6869,7 +6898,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
+                                                    "description": "Use for numeric fields with a single comparison threshold. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [number]; // exactly one array value\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -6926,7 +6955,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
+                                                    "description": "Use for numeric fields inside or outside a two-value range. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\" | \"notInBetween\"; // | means or\n  values: [number, number]; // exactly two array values; lower and upper bounds\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "number",
@@ -6985,7 +7014,7 @@
                                             "anyOf": [
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notNull\"}",
+                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -7021,7 +7050,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"equals\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"notEquals\",\"values\":[\"2024-01-01T00:00:00Z\"]}",
+                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like \"last 2 weeks\", use inThePast. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: string[];\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -7075,7 +7104,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[2],\"settings\":{\"completed\":false,\"unitOfTime\":\"weeks\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inThePast\",\"values\":[3],\"settings\":{\"completed\":true,\"unitOfTime\":\"months\"}}; {\"fieldId\":\"orders_ship_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheNext\",\"values\":[14],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInThePast\",\"values\":[7],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}",
+                                                    "description": "Use for relative date requests such as \"last 2 weeks\" or \"next 3 months\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inThePast\" | \"notInThePast\" | \"inTheNext\"; // | means or\n  values: [number]; // exactly one array value; number of periods\n  settings: {\n  completed: false | true; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -7149,7 +7178,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"days\"}}; {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"notInTheCurrent\",\"values\":[1],\"settings\":{\"completed\":false,\"unitOfTime\":\"months\"}}",
+                                                    "description": "Use for current date requests such as \"today\", \"this week\", \"this month\", or \"this year\". Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inTheCurrent\" | \"notInTheCurrent\"; // | means or\n  values: [1]; // exactly one array value; always [1] for current-period filters\n  settings: {\n  completed: false; // false includes current partial period; true means completed periods only\n  unitOfTime: \"days\" | \"weeks\" | \"months\" | \"quarters\" | \"years\";\n};\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -7224,7 +7253,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"greaterThanOrEqual\",\"values\":[\"2024-01-01\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"lessThan\",\"values\":[\"2024-02-01T00:00:00Z\"]}",
+                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [string]; // exactly one array value\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -7282,7 +7311,7 @@
                                                 },
                                                 {
                                                     "additionalProperties": false,
-                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {\"fieldId\":\"orders_order_date\",\"fieldType\":\"date\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01\",\"2024-01-31\"]}; {\"fieldId\":\"orders_created_at\",\"fieldType\":\"timestamp\",\"fieldFilterType\":\"date\",\"operator\":\"inBetween\",\"values\":[\"2024-01-01T00:00:00Z\",\"2024-01-31T23:59:59Z\"]}",
+                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {\n  fieldId: \"orders_order_date\"; // use the actual field id\n  fieldType: \"date\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"date\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\"; // | means or\n  values: [string, string]; // exactly two array values; lower and upper bounds\n}",
                                                     "properties": {
                                                         "fieldFilterType": {
                                                             "const": "date",
@@ -7345,7 +7374,7 @@
                                     "anyOf": [
                                         {
                                             "additionalProperties": false,
-                                            "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"isNull\"}; {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"notNull\"}",
+                                            "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"isNull\" | \"notNull\"; // | means or\n}",
                                             "properties": {
                                                 "fieldFilterType": {
                                                     "const": "number",
@@ -7390,7 +7419,7 @@
                                         },
                                         {
                                             "additionalProperties": false,
-                                            "description": "Use for numeric fields that equal or exclude specific values. Examples: {\"fieldId\":\"orders_item_count\",\"fieldType\":\"count\",\"fieldFilterType\":\"number\",\"operator\":\"equals\",\"values\":[1,2]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notEquals\",\"values\":[0]}",
+                                            "description": "Use for numeric fields that equal or exclude specific values. Type shape: {\n  fieldId: \"orders_item_count\"; // use the actual field id\n  fieldType: \"count\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"equals\" | \"notEquals\"; // | means or\n  values: number[];\n}",
                                             "properties": {
                                                 "fieldFilterType": {
                                                     "const": "number",
@@ -7443,7 +7472,7 @@
                                         },
                                         {
                                             "additionalProperties": false,
-                                            "description": "Use for numeric fields with a single comparison threshold. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"greaterThan\",\"values\":[1000]}; {\"fieldId\":\"orders_discount_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"lessThanOrEqual\",\"values\":[0.15]}",
+                                            "description": "Use for numeric fields with a single comparison threshold. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"lessThan\" | \"lessThanOrEqual\" | \"greaterThan\" | \"greaterThanOrEqual\"; // | means or\n  values: [number]; // exactly one array value\n}",
                                             "properties": {
                                                 "fieldFilterType": {
                                                     "const": "number",
@@ -7500,7 +7529,7 @@
                                         },
                                         {
                                             "additionalProperties": false,
-                                            "description": "Use for numeric fields inside or outside a two-value range. Examples: {\"fieldId\":\"orders_total_revenue\",\"fieldType\":\"sum\",\"fieldFilterType\":\"number\",\"operator\":\"inBetween\",\"values\":[100,500]}; {\"fieldId\":\"orders_margin_percent\",\"fieldType\":\"number\",\"fieldFilterType\":\"number\",\"operator\":\"notInBetween\",\"values\":[0.2,0.4]}",
+                                            "description": "Use for numeric fields inside or outside a two-value range. Type shape: {\n  fieldId: \"orders_total_revenue\"; // use the actual field id\n  fieldType: \"sum\"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median\n  fieldFilterType: \"number\"; // one of: string, number, date, boolean; used to choose valid operators\n  operator: \"inBetween\" | \"notInBetween\"; // | means or\n  values: [number, number]; // exactly two array values; lower and upper bounds\n}",
                                             "properties": {
                                                 "fieldFilterType": {
                                                     "const": "number",
@@ -7586,6 +7615,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": false
             },
             "description": "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling MCP schema-discovery tools, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
@@ -7608,6 +7638,7 @@
             "annotations": {
                 "destructiveHint": false,
                 "idempotentHint": true,
+                "openWorldHint": false,
                 "readOnlyHint": false
             },
             "description": "Set the active project for all subsequent MCP operations. Most tools (list_explores, MCP schema-discovery tools, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request; use list_agents and set_agent only for manual override.",


### PR DESCRIPTION
Supersedes #24494, #24392, and #24393.

- replace raw Zod filter dumps with actionable repair errors
- share canonical filter examples between schemas and validation
- keep generated agent and MCP filter contracts in sync
