### PR TITLE
feat(ai): view, edit and download agent knowledge documents

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1963,6 +1963,17 @@ export type AiAgentDocumentCreatedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentDocumentUpdatedEvent = BaseTrack & {
+    event: 'ai_agent_document.updated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string | null;
+        documentId: string;
+        contentChanged: boolean;
+    };
+};
+
 export type AiAgentDocumentDeletedEvent = BaseTrack & {
     event: 'ai_agent_document.deleted';
     userId: string;
@@ -2479,6 +2490,7 @@ type TypedEvent =
     | AiAgentDeletedEvent
     | AiAgentUpdatedEvent
     | AiAgentDocumentCreatedEvent
+    | AiAgentDocumentUpdatedEvent
     | AiAgentDocumentDeletedEvent
     | AiAgentPromptCreatedEvent
     | AiAgentPromptFeedbackEvent

--- a/packages/backend/src/ee/controllers/aiAgentDocumentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentDocumentController.ts
@@ -1,9 +1,11 @@
 import {
+    ApiAiAgentDocumentContentResponse,
     ApiAiAgentDocumentResponse,
     ApiAiAgentDocumentSummaryListResponse,
     ApiCreateAiAgentDocument,
     ApiErrorPayload,
     ApiSuccessEmpty,
+    ApiUpdateAiAgentDocument,
     assertRegisteredAccount,
 } from '@lightdash/common';
 import {
@@ -12,6 +14,7 @@ import {
     Get,
     Middlewares,
     OperationId,
+    Patch,
     Path,
     Post,
     Query,
@@ -56,6 +59,25 @@ export class AiAgentDocumentController extends BaseController {
         };
     }
 
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{documentUuid}/content')
+    @OperationId('getAiAgentDocumentContent')
+    async getDocumentContent(
+        @Request() req: express.Request,
+        @Path() documentUuid: string,
+    ): Promise<ApiAiAgentDocumentContentResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().getDocumentContent(
+                toSessionUser(req.account),
+                documentUuid,
+            ),
+        };
+    }
+
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
@@ -74,6 +96,31 @@ export class AiAgentDocumentController extends BaseController {
             status: 'ok',
             results: await this.getService().createDocument(
                 toSessionUser(req.account),
+                body,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{documentUuid}')
+    @OperationId('updateAiAgentDocument')
+    async updateDocument(
+        @Request() req: express.Request,
+        @Path() documentUuid: string,
+        @Body() body: ApiUpdateAiAgentDocument,
+    ): Promise<ApiAiAgentDocumentResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().updateDocument(
+                toSessionUser(req.account),
+                documentUuid,
                 body,
             ),
         };

--- a/packages/backend/src/ee/models/AiAgentDocumentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentDocumentModel.ts
@@ -114,6 +114,29 @@ export class AiAgentDocumentModel {
         return doc;
     }
 
+    async getContent(uuid: string): Promise<AiAgentDocumentContent> {
+        const row = await this.database(AiAgentDocumentTableName)
+            .select<
+                Pick<
+                    DbAiAgentDocument,
+                    'ai_agent_document_uuid' | 'name' | 'mime_type' | 'content'
+                >
+            >('ai_agent_document_uuid', 'name', 'mime_type', 'content')
+            .where(`${AiAgentDocumentTableName}.ai_agent_document_uuid`, uuid)
+            .first();
+
+        if (!row) {
+            throw new NotFoundError(`AI agent document ${uuid} not found`);
+        }
+
+        return {
+            uuid: row.ai_agent_document_uuid,
+            name: row.name,
+            mimeType: row.mime_type,
+            content: row.content ?? '',
+        };
+    }
+
     async getOrganizationContentSize(
         organizationUuid: string,
     ): Promise<number> {
@@ -174,6 +197,42 @@ export class AiAgentDocumentModel {
             }
             return created;
         });
+    }
+
+    async update(args: {
+        uuid: string;
+        name?: string;
+        content?: string;
+        summary?: AiAgentDocumentStructuredSummary;
+        updatedByUserUuid: string | null;
+    }): Promise<AiAgentDocument> {
+        const patch: Omit<Partial<DbAiAgentDocument>, 'updated_at'> & {
+            updated_at: Knex.Raw;
+        } = {
+            updated_by_user_uuid: args.updatedByUserUuid,
+            updated_at: this.database.fn.now(),
+        };
+        if (args.name !== undefined) {
+            patch.name = args.name;
+        }
+        if (args.content !== undefined) {
+            patch.content = args.content;
+            patch.content_size_bytes = Buffer.byteLength(args.content, 'utf8');
+        }
+        if (args.summary !== undefined) {
+            patch.summary = args.summary;
+        }
+
+        const updated = await this.database(AiAgentDocumentTableName)
+            .where('ai_agent_document_uuid', args.uuid)
+            .update(patch)
+            .returning('ai_agent_document_uuid');
+
+        if (updated.length === 0) {
+            throw new NotFoundError(`AI agent document ${args.uuid} not found`);
+        }
+
+        return this.get(args.uuid);
     }
 
     private static agentAccessSubquery(qb: Knex, agentUuid: string) {

--- a/packages/backend/src/ee/services/AiAgentDocumentService.ts
+++ b/packages/backend/src/ee/services/AiAgentDocumentService.ts
@@ -3,8 +3,11 @@ import {
     AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
     AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES,
     AiAgentDocument,
+    AiAgentDocumentContent,
+    AiAgentDocumentStructuredSummary,
     AiAgentDocumentSummary,
     ApiCreateAiAgentDocument,
+    ApiUpdateAiAgentDocument,
     CommercialFeatureFlags,
     Explore,
     ForbiddenError,
@@ -16,6 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
     AiAgentDocumentCreatedEvent,
     AiAgentDocumentDeletedEvent,
+    AiAgentDocumentUpdatedEvent,
     LightdashAnalytics,
 } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -99,9 +103,12 @@ export class AiAgentDocumentService extends BaseService {
      */
     private async getProjectExploresForSummarization(
         user: SessionUser,
-        body: ApiCreateAiAgentDocument,
+        {
+            agentAccess,
+            projectUuid,
+        }: { agentAccess: string[]; projectUuid: string | null },
     ): Promise<Explore[]> {
-        const primaryAgentUuid = body.agentAccess?.[0];
+        const primaryAgentUuid = agentAccess[0];
         try {
             if (primaryAgentUuid) {
                 const agent = await this.aiAgentService.getAgent(
@@ -114,10 +121,10 @@ export class AiAgentDocumentService extends BaseService {
                     agent.tags,
                 );
             }
-            if (body.projectUuid) {
+            if (projectUuid) {
                 return await this.aiAgentService.getAvailableExplores(
                     user,
-                    body.projectUuid,
+                    projectUuid,
                     null,
                 );
             }
@@ -128,6 +135,55 @@ export class AiAgentDocumentService extends BaseService {
                 { error: e },
             );
             return [];
+        }
+    }
+
+    /**
+     * Generate a structured summary for a document, grounded in the explores
+     * the agent (or project) can see. Falls back to a placeholder summary if
+     * generation fails so uploads/edits never hard-fail on the AI call.
+     */
+    private async generateSummary(
+        user: SessionUser,
+        {
+            organizationUuid,
+            name,
+            content,
+            agentAccess,
+            projectUuid,
+        }: {
+            organizationUuid: string;
+            name: string;
+            content: string;
+            agentAccess: string[];
+            projectUuid: string | null;
+        },
+    ): Promise<AiAgentDocumentStructuredSummary> {
+        const projectExplores = await this.getProjectExploresForSummarization(
+            user,
+            { agentAccess, projectUuid },
+        );
+        const modelOptions = {
+            ...getModel(this.lightdashConfig.ai.copilot, {
+                enableReasoning: false,
+                useFastModel: true,
+            }),
+            telemetry: {
+                organizationUuid,
+                userUuid: user.userUuid,
+            },
+        };
+        try {
+            return await generateDocumentSummary(modelOptions, {
+                name,
+                content,
+                projectExplores,
+            });
+        } catch (error) {
+            this.logger.error(
+                `Failed to generate summary for document "${name}", storing a fallback summary: ${error}`,
+            );
+            return createFallbackDocumentSummary(name);
         }
     }
 
@@ -214,6 +270,92 @@ export class AiAgentDocumentService extends BaseService {
         return document;
     }
 
+    async getDocumentContent(
+        user: SessionUser,
+        documentUuid: string,
+    ): Promise<AiAgentDocumentContent> {
+        // getDocument enforces copilot + org + view permission
+        await this.getDocument(user, documentUuid);
+        return this.aiAgentDocumentModel.getContent(documentUuid);
+    }
+
+    async updateDocument(
+        user: SessionUser,
+        documentUuid: string,
+        body: ApiUpdateAiAgentDocument,
+    ): Promise<AiAgentDocument> {
+        const existing = await this.getDocument(user, documentUuid);
+        this.assertCanManageDocuments(
+            user,
+            existing.organizationUuid,
+            existing.projectUuid,
+        );
+
+        const name = body.name ?? existing.name;
+        const contentChanged = body.content !== undefined;
+
+        let summary: AiAgentDocumentStructuredSummary | undefined;
+        if (contentChanged) {
+            const content = body.content!;
+            const contentBytes = Buffer.byteLength(content, 'utf8');
+            if (contentBytes > AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES) {
+                throw new PayloadTooLargeError(
+                    `Content exceeds the ${AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES} byte limit.`,
+                    {
+                        contentSizeBytes: contentBytes,
+                        maxBytes: AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
+                    },
+                );
+            }
+
+            const existingTotal =
+                await this.aiAgentDocumentModel.getOrganizationContentSize(
+                    existing.organizationUuid,
+                );
+            const projectedTotal =
+                existingTotal - existing.contentSizeBytes + contentBytes;
+            if (projectedTotal > AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES) {
+                throw new PayloadTooLargeError(
+                    `Organization document quota of ${AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES} bytes would be exceeded`,
+                    {
+                        currentBytes: existingTotal,
+                        incomingBytes: contentBytes,
+                        quotaBytes: AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES,
+                    },
+                );
+            }
+
+            summary = await this.generateSummary(user, {
+                organizationUuid: existing.organizationUuid,
+                name,
+                content,
+                agentAccess: existing.agentAccess,
+                projectUuid: existing.projectUuid,
+            });
+        }
+
+        const document = await this.aiAgentDocumentModel.update({
+            uuid: documentUuid,
+            name: body.name,
+            content: body.content,
+            summary,
+            updatedByUserUuid: user.userUuid,
+        });
+
+        this.analytics.track<AiAgentDocumentUpdatedEvent>({
+            event: 'ai_agent_document.updated',
+            userId: user.userUuid,
+            properties: {
+                organizationId: document.organizationUuid,
+                projectId: document.projectUuid,
+                documentId: document.uuid,
+                contentChanged,
+            },
+        });
+
+        return document;
+    }
+
     async createDocument(
         user: SessionUser,
         body: ApiCreateAiAgentDocument,
@@ -257,33 +399,13 @@ export class AiAgentDocumentService extends BaseService {
             body.originalFilename,
         );
 
-        const projectExplores = await this.getProjectExploresForSummarization(
-            user,
-            body,
-        );
-        const modelOptions = {
-            ...getModel(this.lightdashConfig.ai.copilot, {
-                enableReasoning: false,
-                useFastModel: true,
-            }),
-            telemetry: {
-                organizationUuid,
-                userUuid: user.userUuid,
-            },
-        };
-        let summary: AiAgentDocument['summary'];
-        try {
-            summary = await generateDocumentSummary(modelOptions, {
-                name: body.name,
-                content: body.content,
-                projectExplores,
-            });
-        } catch (error) {
-            this.logger.error(
-                `Failed to generate summary for document "${body.name}", storing a fallback summary: ${error}`,
-            );
-            summary = createFallbackDocumentSummary(body.name);
-        }
+        const summary = await this.generateSummary(user, {
+            organizationUuid,
+            name: body.name,
+            content: body.content,
+            agentAccess: body.agentAccess ?? [],
+            projectUuid: body.projectUuid ?? null,
+        });
 
         const storageKey = `org/${organizationUuid}/doc/${uuidv4()}.${
             mimeType === 'text/markdown' ? 'md' : 'txt'

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12057,6 +12057,48 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiAgentDocument.uuid-or-name-or-mimeType_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+                mimeType: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentDocumentContent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_AiAgentDocument.uuid-or-name-or-mimeType_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        content: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentDocumentContentResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentDocumentContent', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentDocument: {
         dataType: 'refAlias',
         type: {
@@ -12141,6 +12183,18 @@ const models: TsoaRoute.Models = {
                 mimeType: { dataType: 'string', required: true },
                 originalFilename: { dataType: 'string', required: true },
                 name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateAiAgentDocument: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                content: { dataType: 'string' },
+                name: { dataType: 'string' },
             },
             validators: {},
         },
@@ -49375,6 +49429,67 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentDocumentController_getDocumentContent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        documentUuid: {
+            in: 'path',
+            name: 'documentUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/documents/:documentUuid/content',
+        ...fetchMiddlewares<RequestHandler>(AiAgentDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentDocumentController.prototype.getDocumentContent,
+        ),
+
+        async function AiAgentDocumentController_getDocumentContent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentDocumentController_getDocumentContent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentDocumentController>(
+                        AiAgentDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getDocumentContent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsAiAgentDocumentController_createDocument: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -49429,6 +49544,73 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentDocumentController_updateDocument: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        documentUuid: {
+            in: 'path',
+            name: 'documentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiUpdateAiAgentDocument',
+        },
+    };
+    app.patch(
+        '/api/v1/aiAgents/documents/:documentUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentDocumentController.prototype.updateDocument,
+        ),
+
+        async function AiAgentDocumentController_updateDocument(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentDocumentController_updateDocument,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentDocumentController>(
+                        AiAgentDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateDocument',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13637,6 +13637,52 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "Pick_AiAgentDocument.uuid-or-name-or-mimeType_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "mimeType": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "uuid", "mimeType"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AiAgentDocumentContent": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_AiAgentDocument.uuid-or-name-or-mimeType_"
+                    },
+                    {
+                        "properties": {
+                            "content": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["content"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiAiAgentDocumentContentResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentDocumentContent"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "AiAgentDocument": {
                 "properties": {
                     "updatedAt": {
@@ -13749,6 +13795,17 @@
                     }
                 },
                 "required": ["content", "mimeType", "originalFilename", "name"],
+                "type": "object"
+            },
+            "ApiUpdateAiAgentDocument": {
+                "properties": {
+                    "content": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
                 "type": "object"
             },
             "AiAgentModelConfig": {
@@ -44171,7 +44228,91 @@
                 }
             }
         },
+        "/api/v1/aiAgents/documents/{documentUuid}/content": {
+            "get": {
+                "operationId": "getAiAgentDocumentContent",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentDocumentContentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "documentUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
         "/api/v1/aiAgents/documents/{documentUuid}": {
+            "patch": {
+                "operationId": "updateAiAgentDocument",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentDocumentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "documentUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiUpdateAiAgentDocument"
+                            }
+                        }
+                    }
+                }
+            },
             "delete": {
                 "operationId": "deleteAiAgentDocument",
                 "responses": {

--- a/packages/common/src/ee/AiAgent/documentTypes.ts
+++ b/packages/common/src/ee/AiAgent/documentTypes.ts
@@ -49,8 +49,7 @@ export type ApiCreateAiAgentDocument = {
 
 export type ApiUpdateAiAgentDocument = {
     name?: string;
-    projectUuid?: string | null;
-    agentAccess?: string[];
+    content?: string;
 };
 
 export type ApiAiAgentDocumentResponse = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
@@ -1,0 +1,186 @@
+import {
+    AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
+    type AiAgentDocumentContent,
+} from '@lightdash/common';
+import {
+    Button,
+    Center,
+    Loader,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconDownload } from '@tabler/icons-react';
+import MDEditor from '@uiw/react-md-editor';
+import { useCallback, useMemo } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import { formatFileSize } from '../../../../utils/formatters';
+import {
+    useAiAgentDocumentContent,
+    useUpdateAiAgentDocument,
+} from '../hooks/useAiAgentDocuments';
+
+const byteLength = (value: string): number =>
+    new TextEncoder().encode(value).length;
+
+const downloadDocument = (document: AiAgentDocumentContent) => {
+    const extension = document.mimeType === 'text/markdown' ? '.md' : '.txt';
+    const blob = new Blob([document.content], {
+        type: `${document.mimeType};charset=utf-8`,
+    });
+    const url = URL.createObjectURL(blob);
+    const link = window.document.createElement('a');
+    link.href = url;
+    link.download = `${document.name}${extension}`;
+    window.document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+};
+
+type BodyProps = {
+    document: AiAgentDocumentContent;
+    canManage: boolean;
+    onClose: () => void;
+};
+
+const AiAgentKnowledgeDocumentModalBody = ({
+    document,
+    canManage,
+    onClose,
+}: BodyProps) => {
+    const updateDocument = useUpdateAiAgentDocument();
+
+    const form = useForm({
+        initialValues: {
+            name: document.name,
+            content: document.content,
+        },
+    });
+
+    const contentBytes = useMemo(
+        () => byteLength(form.values.content),
+        [form.values.content],
+    );
+    const exceedsLimit = contentBytes > AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES;
+    const hasChanges =
+        form.values.name.trim() !== document.name ||
+        form.values.content !== document.content;
+
+    const handleSave = useCallback(async () => {
+        const nextName = form.values.name.trim();
+        // Only send content when it changed — a rename shouldn't trigger a
+        // summary regeneration on the backend.
+        await updateDocument.mutateAsync({
+            documentUuid: document.uuid,
+            data: {
+                ...(nextName !== document.name ? { name: nextName } : {}),
+                ...(form.values.content !== document.content
+                    ? { content: form.values.content }
+                    : {}),
+            },
+        });
+        onClose();
+    }, [
+        document.uuid,
+        document.name,
+        document.content,
+        form.values,
+        onClose,
+        updateDocument,
+    ]);
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title={document.name}
+            size="xl"
+            confirmBeforeClose={hasChanges}
+            headerActions={
+                <Button
+                    variant="subtle"
+                    size="compact-sm"
+                    leftSection={<MantineIcon icon={IconDownload} />}
+                    onClick={() => downloadDocument(document)}
+                >
+                    Download
+                </Button>
+            }
+            onConfirm={canManage ? () => void handleSave() : undefined}
+            confirmLabel="Save"
+            confirmLoading={updateDocument.isLoading}
+            confirmDisabled={
+                !hasChanges ||
+                exceedsLimit ||
+                form.values.name.trim().length === 0
+            }
+            cancelLabel={canManage ? 'Cancel' : 'Close'}
+        >
+            <Stack gap="sm">
+                {canManage && (
+                    <TextInput label="Name" {...form.getInputProps('name')} />
+                )}
+                <div data-color-mode="light">
+                    <MDEditor
+                        preview={canManage ? 'edit' : 'preview'}
+                        hideToolbar={!canManage}
+                        height={480}
+                        overflow={false}
+                        value={form.values.content}
+                        onChange={(value) =>
+                            form.setFieldValue('content', value ?? '')
+                        }
+                    />
+                </div>
+                <Text size="xs" c={exceedsLimit ? 'red' : 'dimmed'} ta="right">
+                    {formatFileSize(contentBytes)} /{' '}
+                    {formatFileSize(AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES)}
+                </Text>
+            </Stack>
+        </MantineModal>
+    );
+};
+
+type Props = {
+    documentUuid: string;
+    documentName: string;
+    canManage: boolean;
+    onClose: () => void;
+};
+
+export const AiAgentKnowledgeDocumentModal = ({
+    documentUuid,
+    documentName,
+    canManage,
+    onClose,
+}: Props) => {
+    const { data, isLoading } = useAiAgentDocumentContent(documentUuid);
+
+    if (isLoading || !data) {
+        return (
+            <MantineModal
+                opened
+                onClose={onClose}
+                title={documentName}
+                size="xl"
+                cancelLabel={false}
+            >
+                <Center h={480}>
+                    <Loader />
+                </Center>
+            </MantineModal>
+        );
+    }
+
+    return (
+        <AiAgentKnowledgeDocumentModalBody
+            key={documentUuid}
+            document={data}
+            canManage={canManage}
+            onClose={onClose}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -20,6 +20,7 @@ import {
     UnstyledButton,
 } from '@mantine-8/core';
 import {
+    IconEye,
     IconFileText,
     IconFolderOpen,
     IconTrash,
@@ -38,6 +39,7 @@ import {
 } from '../hooks/useAiAgentDocuments';
 import { AiAgentDocumentRelevanceCard } from './AiAgentDocumentRelevanceCard';
 import { AiAgentIcon } from './AiAgentIcon';
+import { AiAgentKnowledgeDocumentModal } from './AiAgentKnowledgeDocumentModal';
 import styles from './AiAgentKnowledgeFilesSection.module.css';
 
 const ACCEPT_ATTR =
@@ -97,6 +99,10 @@ export const AiAgentKnowledgeFilesSection = ({
 
     const [pendingUploads, setPendingUploads] = useState<PendingUpload[]>([]);
     const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [viewDocument, setViewDocument] = useState<{
+        uuid: string;
+        name: string;
+    } | null>(null);
 
     const effectiveSelectedId = useMemo(() => {
         if (selectedId && pendingUploads.some((p) => p.tempId === selectedId)) {
@@ -442,30 +448,52 @@ export const AiAgentKnowledgeFilesSection = ({
                                             </Text>
                                         </Stack>
                                         {selectedDocument && (
-                                            <Tooltip
-                                                label="Delete document"
-                                                position="left"
-                                                withArrow
-                                            >
-                                                <ActionIcon
-                                                    variant="subtle"
-                                                    color="red"
-                                                    loading={
-                                                        deleteDocument.isLoading &&
-                                                        deleteDocument.variables ===
-                                                            selectedDocument.uuid
-                                                    }
-                                                    onClick={() =>
-                                                        deleteDocument.mutate(
-                                                            selectedDocument.uuid,
-                                                        )
-                                                    }
+                                            <Group gap={4} wrap="nowrap">
+                                                <Tooltip
+                                                    label="View / edit document"
+                                                    position="left"
+                                                    withArrow
                                                 >
-                                                    <MantineIcon
-                                                        icon={IconTrash}
-                                                    />
-                                                </ActionIcon>
-                                            </Tooltip>
+                                                    <ActionIcon
+                                                        variant="subtle"
+                                                        color="gray"
+                                                        onClick={() =>
+                                                            setViewDocument({
+                                                                uuid: selectedDocument.uuid,
+                                                                name: selectedDocument.name,
+                                                            })
+                                                        }
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconEye}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                                <Tooltip
+                                                    label="Delete document"
+                                                    position="left"
+                                                    withArrow
+                                                >
+                                                    <ActionIcon
+                                                        variant="subtle"
+                                                        color="red"
+                                                        loading={
+                                                            deleteDocument.isLoading &&
+                                                            deleteDocument.variables ===
+                                                                selectedDocument.uuid
+                                                        }
+                                                        onClick={() =>
+                                                            deleteDocument.mutate(
+                                                                selectedDocument.uuid,
+                                                            )
+                                                        }
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconTrash}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                            </Group>
                                         )}
                                     </Group>
 
@@ -528,6 +556,15 @@ export const AiAgentKnowledgeFilesSection = ({
                     </Group>
                 )}
             </Paper>
+
+            {viewDocument && (
+                <AiAgentKnowledgeDocumentModal
+                    documentUuid={viewDocument.uuid}
+                    documentName={viewDocument.name}
+                    canManage
+                    onClose={() => setViewDocument(null)}
+                />
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
@@ -1,9 +1,11 @@
 import type {
+    ApiAiAgentDocumentContentResponse,
     ApiAiAgentDocumentResponse,
     ApiAiAgentDocumentSummaryListResponse,
     ApiCreateAiAgentDocument,
     ApiError,
     ApiSuccessEmpty,
+    ApiUpdateAiAgentDocument,
 } from '@lightdash/common';
 import {
     useMutation,
@@ -29,6 +31,25 @@ const createDocument = async (body: ApiCreateAiAgentDocument) =>
         version: 'v1',
         url: `/aiAgents/documents`,
         method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+const getDocumentContent = async (documentUuid: string) =>
+    lightdashApi<ApiAiAgentDocumentContentResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/documents/${documentUuid}/content`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const updateDocument = async (
+    documentUuid: string,
+    body: ApiUpdateAiAgentDocument,
+) =>
+    lightdashApi<ApiAiAgentDocumentResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/documents/${documentUuid}`,
+        method: 'PATCH',
         body: JSON.stringify(body),
     });
 
@@ -69,6 +90,47 @@ export const useCreateAiAgentDocument = () => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to upload document',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useAiAgentDocumentContent = (
+    documentUuid: string | null,
+    options?: UseQueryOptions<
+        ApiAiAgentDocumentContentResponse['results'],
+        ApiError
+    >,
+) =>
+    useQuery<ApiAiAgentDocumentContentResponse['results'], ApiError>({
+        queryKey: [AI_AGENT_DOCUMENTS_KEY, documentUuid, 'content'],
+        queryFn: () => getDocumentContent(documentUuid!),
+        enabled: !!documentUuid,
+        ...options,
+    });
+
+export const useUpdateAiAgentDocument = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+    return useMutation<
+        ApiAiAgentDocumentResponse['results'],
+        ApiError,
+        { documentUuid: string; data: ApiUpdateAiAgentDocument }
+    >({
+        mutationFn: ({ documentUuid, data }) =>
+            updateDocument(documentUuid, data),
+        onSuccess: async (_result, { documentUuid }) => {
+            await queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_DOCUMENTS_KEY],
+            });
+            await queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_DOCUMENTS_KEY, documentUuid, 'content'],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update document',
                 apiError: error,
             });
         },


### PR DESCRIPTION
Uploaded knowledge documents could previously only be uploaded and deleted — there was no way to see or change what an agent was actually reading. This adds view/edit-in-place and download.

**What's new**
- Open a document from the knowledge documents list to view and edit its content (markdown) and name in place, via an `MDEditor` modal.
- Download the document (`.md`/`.txt`).
- Editing content re-validates the per-document size limit and org quota, and regenerates the AI summary. A rename alone does not trigger regeneration.

**API**
- `GET /api/v1/aiAgents/documents/{documentUuid}/content` — returns document content (view permission).
- `PATCH /api/v1/aiAgents/documents/{documentUuid}` — update `name` and/or `content` (manage permission).

**Notes**
- `routes.ts` / `swagger.json` changes are the generated additions for the two new endpoints only.

Closes PROD-8646.