### PR TITLE
feat(ai): view, edit & download knowledge documents in place

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1963,6 +1963,18 @@ export type AiAgentDocumentCreatedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentDocumentUpdatedEvent = BaseTrack & {
+    event: 'ai_agent_document.updated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string | null;
+        documentId: string;
+        contentChanged: boolean;
+        contentSizeBytes: number;
+    };
+};
+
 export type AiAgentDocumentDeletedEvent = BaseTrack & {
     event: 'ai_agent_document.deleted';
     userId: string;
@@ -2479,6 +2491,7 @@ type TypedEvent =
     | AiAgentDeletedEvent
     | AiAgentUpdatedEvent
     | AiAgentDocumentCreatedEvent
+    | AiAgentDocumentUpdatedEvent
     | AiAgentDocumentDeletedEvent
     | AiAgentPromptCreatedEvent
     | AiAgentPromptFeedbackEvent

--- a/packages/backend/src/ee/controllers/aiAgentDocumentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentDocumentController.ts
@@ -1,9 +1,11 @@
 import {
+    ApiAiAgentDocumentContentResponse,
     ApiAiAgentDocumentResponse,
     ApiAiAgentDocumentSummaryListResponse,
     ApiCreateAiAgentDocument,
     ApiErrorPayload,
     ApiSuccessEmpty,
+    ApiUpdateAiAgentDocument,
     assertRegisteredAccount,
 } from '@lightdash/common';
 import {
@@ -12,6 +14,7 @@ import {
     Get,
     Middlewares,
     OperationId,
+    Patch,
     Path,
     Post,
     Query,
@@ -74,6 +77,50 @@ export class AiAgentDocumentController extends BaseController {
             status: 'ok',
             results: await this.getService().createDocument(
                 toSessionUser(req.account),
+                body,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{documentUuid}/content')
+    @OperationId('getAiAgentDocumentContent')
+    async getDocumentContent(
+        @Request() req: express.Request,
+        @Path() documentUuid: string,
+    ): Promise<ApiAiAgentDocumentContentResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().getDocumentContent(
+                toSessionUser(req.account),
+                documentUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{documentUuid}')
+    @OperationId('updateAiAgentDocument')
+    async updateDocument(
+        @Request() req: express.Request,
+        @Path() documentUuid: string,
+        @Body() body: ApiUpdateAiAgentDocument,
+    ): Promise<ApiAiAgentDocumentResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().updateDocument(
+                toSessionUser(req.account),
+                documentUuid,
                 body,
             ),
         };

--- a/packages/backend/src/ee/models/AiAgentDocumentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentDocumentModel.ts
@@ -176,6 +176,76 @@ export class AiAgentDocumentModel {
         });
     }
 
+    async getContent(uuid: string): Promise<AiAgentDocumentContent> {
+        const row = await this.database(AiAgentDocumentTableName)
+            .select<
+                Pick<
+                    DbAiAgentDocument,
+                    'ai_agent_document_uuid' | 'name' | 'mime_type' | 'content'
+                >
+            >('ai_agent_document_uuid', 'name', 'mime_type', 'content')
+            .where(
+                `${AiAgentDocumentTableName}.ai_agent_document_uuid`,
+                uuid,
+            )
+            .first();
+
+        if (!row) {
+            throw new NotFoundError(`AI agent document ${uuid} not found`);
+        }
+
+        return {
+            uuid: row.ai_agent_document_uuid,
+            name: row.name,
+            mimeType: row.mime_type,
+            content: row.content ?? '',
+        };
+    }
+
+    async update(args: {
+        uuid: string;
+        name?: string;
+        content?: string;
+        summary?: AiAgentDocumentStructuredSummary;
+        updatedByUserUuid: string | null;
+    }): Promise<AiAgentDocument> {
+        const updateData: {
+            updated_by_user_uuid: string | null;
+            updated_at: Knex.Raw;
+            name?: string;
+            content?: string;
+            content_size_bytes?: number;
+            summary?: AiAgentDocumentStructuredSummary;
+        } = {
+            updated_by_user_uuid: args.updatedByUserUuid,
+            updated_at: this.database.fn.now(),
+        };
+        if (args.name !== undefined) {
+            updateData.name = args.name;
+        }
+        if (args.content !== undefined) {
+            updateData.content = args.content;
+            updateData.content_size_bytes = Buffer.byteLength(
+                args.content,
+                'utf8',
+            );
+        }
+        if (args.summary !== undefined) {
+            updateData.summary = args.summary;
+        }
+
+        const updated = await this.database(AiAgentDocumentTableName)
+            .where('ai_agent_document_uuid', args.uuid)
+            .update(updateData);
+        if (updated === 0) {
+            throw new NotFoundError(
+                `AI agent document ${args.uuid} not found`,
+            );
+        }
+
+        return this.get(args.uuid);
+    }
+
     private static agentAccessSubquery(qb: Knex, agentUuid: string) {
         return qb.raw(
             `(

--- a/packages/backend/src/ee/services/AiAgentDocumentService.ts
+++ b/packages/backend/src/ee/services/AiAgentDocumentService.ts
@@ -3,8 +3,10 @@ import {
     AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
     AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES,
     AiAgentDocument,
+    AiAgentDocumentContent,
     AiAgentDocumentSummary,
     ApiCreateAiAgentDocument,
+    ApiUpdateAiAgentDocument,
     CommercialFeatureFlags,
     Explore,
     ForbiddenError,
@@ -16,6 +18,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
     AiAgentDocumentCreatedEvent,
     AiAgentDocumentDeletedEvent,
+    AiAgentDocumentUpdatedEvent,
     LightdashAnalytics,
 } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -99,9 +102,9 @@ export class AiAgentDocumentService extends BaseService {
      */
     private async getProjectExploresForSummarization(
         user: SessionUser,
-        body: ApiCreateAiAgentDocument,
+        args: { agentUuid?: string; projectUuid: string | null },
     ): Promise<Explore[]> {
-        const primaryAgentUuid = body.agentAccess?.[0];
+        const primaryAgentUuid = args.agentUuid;
         try {
             if (primaryAgentUuid) {
                 const agent = await this.aiAgentService.getAgent(
@@ -114,10 +117,10 @@ export class AiAgentDocumentService extends BaseService {
                     agent.tags,
                 );
             }
-            if (body.projectUuid) {
+            if (args.projectUuid) {
                 return await this.aiAgentService.getAvailableExplores(
                     user,
-                    body.projectUuid,
+                    args.projectUuid,
                     null,
                 );
             }
@@ -128,6 +131,49 @@ export class AiAgentDocumentService extends BaseService {
                 { error: e },
             );
             return [];
+        }
+    }
+
+    /**
+     * Generate a structured summary grounded in the same explore context the
+     * agent sees at conversation time. Falls back to a default summary if the
+     * LLM call fails so uploads/edits never hard-fail on summarization.
+     */
+    private async generateSummary(
+        user: SessionUser,
+        organizationUuid: string,
+        args: {
+            name: string;
+            content: string;
+            agentUuid?: string;
+            projectUuid: string | null;
+        },
+    ): Promise<AiAgentDocument['summary']> {
+        const projectExplores = await this.getProjectExploresForSummarization(
+            user,
+            { agentUuid: args.agentUuid, projectUuid: args.projectUuid },
+        );
+        const modelOptions = {
+            ...getModel(this.lightdashConfig.ai.copilot, {
+                enableReasoning: false,
+                useFastModel: true,
+            }),
+            telemetry: {
+                organizationUuid,
+                userUuid: user.userUuid,
+            },
+        };
+        try {
+            return await generateDocumentSummary(modelOptions, {
+                name: args.name,
+                content: args.content,
+                projectExplores,
+            });
+        } catch (error) {
+            this.logger.error(
+                `Failed to generate summary for document "${args.name}", storing a fallback summary: ${error}`,
+            );
+            return createFallbackDocumentSummary(args.name);
         }
     }
 
@@ -214,6 +260,15 @@ export class AiAgentDocumentService extends BaseService {
         return document;
     }
 
+    async getDocumentContent(
+        user: SessionUser,
+        documentUuid: string,
+    ): Promise<AiAgentDocumentContent> {
+        // getDocument enforces copilot + org + view permission checks
+        await this.getDocument(user, documentUuid);
+        return this.aiAgentDocumentModel.getContent(documentUuid);
+    }
+
     async createDocument(
         user: SessionUser,
         body: ApiCreateAiAgentDocument,
@@ -257,33 +312,12 @@ export class AiAgentDocumentService extends BaseService {
             body.originalFilename,
         );
 
-        const projectExplores = await this.getProjectExploresForSummarization(
-            user,
-            body,
-        );
-        const modelOptions = {
-            ...getModel(this.lightdashConfig.ai.copilot, {
-                enableReasoning: false,
-                useFastModel: true,
-            }),
-            telemetry: {
-                organizationUuid,
-                userUuid: user.userUuid,
-            },
-        };
-        let summary: AiAgentDocument['summary'];
-        try {
-            summary = await generateDocumentSummary(modelOptions, {
-                name: body.name,
-                content: body.content,
-                projectExplores,
-            });
-        } catch (error) {
-            this.logger.error(
-                `Failed to generate summary for document "${body.name}", storing a fallback summary: ${error}`,
-            );
-            summary = createFallbackDocumentSummary(body.name);
-        }
+        const summary = await this.generateSummary(user, organizationUuid, {
+            name: body.name,
+            content: body.content,
+            agentUuid: body.agentAccess?.[0],
+            projectUuid: body.projectUuid ?? null,
+        });
 
         const storageKey = `org/${organizationUuid}/doc/${uuidv4()}.${
             mimeType === 'text/markdown' ? 'md' : 'txt'
@@ -316,6 +350,93 @@ export class AiAgentDocumentService extends BaseService {
         });
 
         return document;
+    }
+
+    async updateDocument(
+        user: SessionUser,
+        documentUuid: string,
+        body: ApiUpdateAiAgentDocument,
+    ): Promise<AiAgentDocument> {
+        const existing = await this.getDocument(user, documentUuid);
+        this.assertCanManageDocuments(
+            user,
+            existing.organizationUuid,
+            existing.projectUuid,
+        );
+
+        const existingContent =
+            await this.aiAgentDocumentModel.getContent(documentUuid);
+        const contentChanged =
+            body.content !== undefined &&
+            body.content !== existingContent.content;
+
+        let summary: AiAgentDocument['summary'] | undefined;
+        let newContentSizeBytes = existing.contentSizeBytes;
+
+        if (contentChanged) {
+            const content = body.content!;
+            const contentBytes = Buffer.byteLength(content, 'utf8');
+            if (contentBytes > AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES) {
+                throw new PayloadTooLargeError(
+                    `Content exceeds the ${AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES} byte limit.`,
+                    {
+                        contentSizeBytes: contentBytes,
+                        maxBytes: AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
+                    },
+                );
+            }
+
+            const existingTotal =
+                await this.aiAgentDocumentModel.getOrganizationContentSize(
+                    existing.organizationUuid,
+                );
+            const projectedTotal =
+                existingTotal - existing.contentSizeBytes + contentBytes;
+            if (projectedTotal > AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES) {
+                throw new PayloadTooLargeError(
+                    `Organization document quota of ${AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES} bytes would be exceeded`,
+                    {
+                        currentBytes: existingTotal,
+                        incomingBytes: contentBytes,
+                        quotaBytes: AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES,
+                    },
+                );
+            }
+
+            newContentSizeBytes = contentBytes;
+            summary = await this.generateSummary(
+                user,
+                existing.organizationUuid,
+                {
+                    name: body.name ?? existing.name,
+                    content,
+                    agentUuid: existing.agentAccess[0],
+                    projectUuid: existing.projectUuid,
+                },
+            );
+        }
+
+        const updated = await this.aiAgentDocumentModel.update({
+            uuid: documentUuid,
+            name: body.name,
+            content: contentChanged ? body.content : undefined,
+            summary,
+            updatedByUserUuid: user.userUuid,
+        });
+
+        this.analytics.track<AiAgentDocumentUpdatedEvent>({
+            event: 'ai_agent_document.updated',
+            userId: user.userUuid,
+            properties: {
+                organizationId: existing.organizationUuid,
+                projectId: existing.projectUuid,
+                documentId: documentUuid,
+                contentChanged,
+                contentSizeBytes: newContentSizeBytes,
+            },
+        });
+
+        return updated;
     }
 
     async deleteDocument(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12038,6 +12038,60 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Omit_AiAgentDocument.storageKey_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiAgentDocument.uuid-or-name-or-mimeType_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+                mimeType: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentDocumentContent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_AiAgentDocument.uuid-or-name-or-mimeType_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        content: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentDocumentContentResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentDocumentContent', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateAiAgentDocument: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                content: { dataType: 'string' },
+                name: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAiAgentDocumentSummaryListResponse: {
         dataType: 'refAlias',
         type: {
@@ -49429,6 +49483,134 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentDocumentController_getDocumentContent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        documentUuid: {
+            in: 'path',
+            name: 'documentUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/documents/:documentUuid/content',
+        ...fetchMiddlewares<RequestHandler>(AiAgentDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentDocumentController.prototype.getDocumentContent,
+        ),
+
+        async function AiAgentDocumentController_getDocumentContent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentDocumentController_getDocumentContent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentDocumentController>(
+                        AiAgentDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getDocumentContent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentDocumentController_updateDocument: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        documentUuid: {
+            in: 'path',
+            name: 'documentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiUpdateAiAgentDocument',
+        },
+    };
+    app.patch(
+        '/api/v1/aiAgents/documents/:documentUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentDocumentController.prototype.updateDocument,
+        ),
+
+        async function AiAgentDocumentController_updateDocument(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentDocumentController_updateDocument,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentDocumentController>(
+                        AiAgentDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateDocument',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13620,6 +13620,63 @@
             "AiAgentDocumentSummary": {
                 "$ref": "#/components/schemas/Omit_AiAgentDocument.storageKey_"
             },
+            "Pick_AiAgentDocument.uuid-or-name-or-mimeType_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "mimeType": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "uuid", "mimeType"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AiAgentDocumentContent": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_AiAgentDocument.uuid-or-name-or-mimeType_"
+                    },
+                    {
+                        "properties": {
+                            "content": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["content"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiAiAgentDocumentContentResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentDocumentContent"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiUpdateAiAgentDocument": {
+                "properties": {
+                    "content": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "ApiAiAgentDocumentSummaryListResponse": {
                 "properties": {
                     "results": {
@@ -44171,7 +44228,91 @@
                 }
             }
         },
+        "/api/v1/aiAgents/documents/{documentUuid}/content": {
+            "get": {
+                "operationId": "getAiAgentDocumentContent",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentDocumentContentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "documentUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
         "/api/v1/aiAgents/documents/{documentUuid}": {
+            "patch": {
+                "operationId": "updateAiAgentDocument",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentDocumentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "documentUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiUpdateAiAgentDocument"
+                            }
+                        }
+                    }
+                }
+            },
             "delete": {
                 "operationId": "deleteAiAgentDocument",
                 "responses": {

--- a/packages/common/src/ee/AiAgent/documentTypes.ts
+++ b/packages/common/src/ee/AiAgent/documentTypes.ts
@@ -49,8 +49,7 @@ export type ApiCreateAiAgentDocument = {
 
 export type ApiUpdateAiAgentDocument = {
     name?: string;
-    projectUuid?: string | null;
-    agentAccess?: string[];
+    content?: string;
 };
 
 export type ApiAiAgentDocumentResponse = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
@@ -1,0 +1,143 @@
+import { type AiAgentDocumentSummary } from '@lightdash/common';
+import {
+    Button,
+    Center,
+    Group,
+    Loader,
+    Stack,
+    TextInput,
+    useMantineColorScheme,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconDownload } from '@tabler/icons-react';
+import MDEditor from '@uiw/react-md-editor';
+import { useCallback } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import {
+    useAiAgentDocumentContent,
+    useUpdateAiAgentDocument,
+} from '../hooks/useAiAgentDocuments';
+
+type EditorProps = {
+    document: AiAgentDocumentSummary;
+    content: string;
+    onClose: () => void;
+};
+
+const DocumentEditor = ({ document, content, onClose }: EditorProps) => {
+    const { colorScheme } = useMantineColorScheme();
+    const updateDocument = useUpdateAiAgentDocument();
+    const form = useForm({
+        initialValues: { name: document.name, content },
+    });
+
+    const hasChanges =
+        form.values.name.trim() !== document.name ||
+        form.values.content !== content;
+
+    const handleDownload = useCallback(() => {
+        const blob = new Blob([form.values.content], {
+            type: `${document.mimeType};charset=utf-8`,
+        });
+        const url = URL.createObjectURL(blob);
+        const anchor = window.document.createElement('a');
+        anchor.href = url;
+        anchor.download = document.originalFilename;
+        anchor.click();
+        URL.revokeObjectURL(url);
+    }, [document.mimeType, document.originalFilename, form.values.content]);
+
+    const handleSave = useCallback(() => {
+        updateDocument.mutate(
+            {
+                documentUuid: document.uuid,
+                data: {
+                    name: form.values.name.trim(),
+                    content: form.values.content,
+                },
+            },
+            { onSuccess: () => onClose() },
+        );
+    }, [document.uuid, form.values, onClose, updateDocument]);
+
+    return (
+        <Stack gap="md">
+            <TextInput
+                label="Name"
+                value={form.values.name}
+                onChange={(e) =>
+                    form.setFieldValue('name', e.currentTarget.value)
+                }
+            />
+            <div data-color-mode={colorScheme}>
+                <MDEditor
+                    value={form.values.content}
+                    onChange={(value) =>
+                        form.setFieldValue('content', value ?? '')
+                    }
+                    preview="live"
+                    height={420}
+                    overflow={false}
+                />
+            </div>
+            <Group justify="space-between">
+                <Button
+                    variant="default"
+                    leftSection={<MantineIcon icon={IconDownload} />}
+                    onClick={handleDownload}
+                >
+                    Download
+                </Button>
+                <Group gap="xs">
+                    <Button variant="subtle" color="gray" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={handleSave}
+                        disabled={!hasChanges || form.values.name.trim() === ''}
+                        loading={updateDocument.isLoading}
+                    >
+                        Save
+                    </Button>
+                </Group>
+            </Group>
+        </Stack>
+    );
+};
+
+type Props = {
+    document: AiAgentDocumentSummary | null;
+    onClose: () => void;
+};
+
+export const AiAgentKnowledgeDocumentModal = ({ document, onClose }: Props) => {
+    const { data, isLoading } = useAiAgentDocumentContent(
+        document?.uuid ?? null,
+    );
+
+    if (!document) return null;
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title={document.name}
+            size="xl"
+            cancelLabel={false}
+        >
+            {isLoading || !data ? (
+                <Center h={480}>
+                    <Loader />
+                </Center>
+            ) : (
+                <DocumentEditor
+                    key={document.uuid}
+                    document={document}
+                    content={data.content}
+                    onClose={onClose}
+                />
+            )}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -20,6 +20,7 @@ import {
     UnstyledButton,
 } from '@mantine-8/core';
 import {
+    IconEye,
     IconFileText,
     IconFolderOpen,
     IconTrash,
@@ -38,6 +39,7 @@ import {
 } from '../hooks/useAiAgentDocuments';
 import { AiAgentDocumentRelevanceCard } from './AiAgentDocumentRelevanceCard';
 import { AiAgentIcon } from './AiAgentIcon';
+import { AiAgentKnowledgeDocumentModal } from './AiAgentKnowledgeDocumentModal';
 import styles from './AiAgentKnowledgeFilesSection.module.css';
 
 const ACCEPT_ATTR =
@@ -97,6 +99,8 @@ export const AiAgentKnowledgeFilesSection = ({
 
     const [pendingUploads, setPendingUploads] = useState<PendingUpload[]>([]);
     const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [viewingDocument, setViewingDocument] =
+        useState<AiAgentDocumentSummary | null>(null);
 
     const effectiveSelectedId = useMemo(() => {
         if (selectedId && pendingUploads.some((p) => p.tempId === selectedId)) {
@@ -442,30 +446,51 @@ export const AiAgentKnowledgeFilesSection = ({
                                             </Text>
                                         </Stack>
                                         {selectedDocument && (
-                                            <Tooltip
-                                                label="Delete document"
-                                                position="left"
-                                                withArrow
-                                            >
-                                                <ActionIcon
-                                                    variant="subtle"
-                                                    color="red"
-                                                    loading={
-                                                        deleteDocument.isLoading &&
-                                                        deleteDocument.variables ===
-                                                            selectedDocument.uuid
-                                                    }
-                                                    onClick={() =>
-                                                        deleteDocument.mutate(
-                                                            selectedDocument.uuid,
-                                                        )
-                                                    }
+                                            <Group gap={4} wrap="nowrap">
+                                                <Tooltip
+                                                    label="View & edit document"
+                                                    position="left"
+                                                    withArrow
                                                 >
-                                                    <MantineIcon
-                                                        icon={IconTrash}
-                                                    />
-                                                </ActionIcon>
-                                            </Tooltip>
+                                                    <ActionIcon
+                                                        variant="subtle"
+                                                        color="gray"
+                                                        onClick={() =>
+                                                            setViewingDocument(
+                                                                selectedDocument,
+                                                            )
+                                                        }
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconEye}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                                <Tooltip
+                                                    label="Delete document"
+                                                    position="left"
+                                                    withArrow
+                                                >
+                                                    <ActionIcon
+                                                        variant="subtle"
+                                                        color="red"
+                                                        loading={
+                                                            deleteDocument.isLoading &&
+                                                            deleteDocument.variables ===
+                                                                selectedDocument.uuid
+                                                        }
+                                                        onClick={() =>
+                                                            deleteDocument.mutate(
+                                                                selectedDocument.uuid,
+                                                            )
+                                                        }
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconTrash}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                            </Group>
                                         )}
                                     </Group>
 
@@ -528,6 +553,11 @@ export const AiAgentKnowledgeFilesSection = ({
                     </Group>
                 )}
             </Paper>
+
+            <AiAgentKnowledgeDocumentModal
+                document={viewingDocument}
+                onClose={() => setViewingDocument(null)}
+            />
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
@@ -1,9 +1,11 @@
 import type {
+    ApiAiAgentDocumentContentResponse,
     ApiAiAgentDocumentResponse,
     ApiAiAgentDocumentSummaryListResponse,
     ApiCreateAiAgentDocument,
     ApiError,
     ApiSuccessEmpty,
+    ApiUpdateAiAgentDocument,
 } from '@lightdash/common';
 import {
     useMutation,
@@ -29,6 +31,25 @@ const createDocument = async (body: ApiCreateAiAgentDocument) =>
         version: 'v1',
         url: `/aiAgents/documents`,
         method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+const getDocumentContent = async (documentUuid: string) =>
+    lightdashApi<ApiAiAgentDocumentContentResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/documents/${documentUuid}/content`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const updateDocument = async (
+    documentUuid: string,
+    body: ApiUpdateAiAgentDocument,
+) =>
+    lightdashApi<ApiAiAgentDocumentResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/documents/${documentUuid}`,
+        method: 'PATCH',
         body: JSON.stringify(body),
     });
 
@@ -69,6 +90,47 @@ export const useCreateAiAgentDocument = () => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to upload document',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useAiAgentDocumentContent = (
+    documentUuid: string | null,
+    options?: UseQueryOptions<
+        ApiAiAgentDocumentContentResponse['results'],
+        ApiError
+    >,
+) =>
+    useQuery<ApiAiAgentDocumentContentResponse['results'], ApiError>({
+        queryKey: [AI_AGENT_DOCUMENTS_KEY, 'content', documentUuid],
+        queryFn: () => getDocumentContent(documentUuid!),
+        enabled: !!documentUuid,
+        ...options,
+    });
+
+export const useUpdateAiAgentDocument = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+    return useMutation<
+        ApiAiAgentDocumentResponse['results'],
+        ApiError,
+        { documentUuid: string; data: ApiUpdateAiAgentDocument }
+    >({
+        mutationFn: ({ documentUuid, data }) =>
+            updateDocument(documentUuid, data),
+        onSuccess: async (result) => {
+            await queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_DOCUMENTS_KEY],
+            });
+            await queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_DOCUMENTS_KEY, 'content', result.uuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update document',
                 apiError: error,
             });
         },


### PR DESCRIPTION
### Description

Uploaded AI agent knowledge documents could previously only be listed and deleted — the workaround for any change was to edit locally, delete, and re-upload. This adds an in-place viewer/editor.

- **View & edit**: a new modal (MDEditor with live markdown preview) opened from the knowledge files section lets you read and edit a document's name and content.
- **Download**: download the current content using the original filename.
- **Backend**: `GET /aiAgents/documents/{uuid}/content` and `PATCH /aiAgents/documents/{uuid}`. Editing content re-validates the per-doc size limit and org quota, and regenerates the AI summary (extracted into a shared helper reused by create + update).

Permissions are unchanged — content read requires `view:AiAgentDocument`, edits require `manage:AiAgentDocument`, and edits are blocked in demo mode.

<!-- Even better add a screenshot / gif / loom -->

> Note: the `routes.ts` / `swagger.json` changes are additive only. A full `generate-api` in this environment reorders unrelated entries (tsoa output ordering differs from what produced the committed files), so only the new schemas/routes were applied to keep the diff reviewable. CI regenerates the OpenAPI spec itself.