### PR TITLE
fix: disable AI agent embed autoscroll

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -275,7 +275,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 <AgentChatDisplay
                     thread={thread}
                     agentName={agentQuery.data?.name ?? 'AI'}
-                    enableAutoScroll={true}
+                    enableAutoScroll={!isEmbed}
                     promptUuid={promptUuid}
                     debug={debug}
                     projectUuid={projectUuid}


### PR DESCRIPTION
Closes: SPK-549

### Description
- Disable AI-agent chat auto-scroll on embed routes so short iframes do not jump to the bottom on load or streaming updates.
- Keep auto-scroll enabled for the normal in-app AI-agent thread route.

### Testing
- pnpm -F frontend typecheck
- pnpm -F frontend lint -- --file packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
