### PR TITLE
feat(apps): inline test-with-data panel for generated data app viz

### DIFF
--- a/packages/frontend/src/features/apps/components/DataAppVizFieldTypeBadge.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizFieldTypeBadge.tsx
@@ -1,0 +1,30 @@
+import { type DataAppVizField } from '@lightdash/common';
+import { Badge } from '@mantine-8/core';
+import { type FC } from 'react';
+import { LD_FIELD_COLORS } from '../../../mantineTheme';
+
+// Match the field-type colors used everywhere else (field icons, sidebar tree,
+// AI-copilot field badges) via the canonical LD_FIELD_COLORS tokens. `series`
+// has no Lightdash field-type equivalent, so it falls back to the neutral
+// default. Keyed off the union type so a new field type breaks the build here.
+const FIELD_TYPE_COLORS: Record<
+    DataAppVizField['type'],
+    { bg: string; color: string }
+> = {
+    dimension: LD_FIELD_COLORS.dimension,
+    metric: LD_FIELD_COLORS.metric,
+    series: LD_FIELD_COLORS.DEFAULT,
+};
+
+const DataAppVizFieldTypeBadge: FC<{ type: DataAppVizField['type'] }> = ({
+    type,
+}) => {
+    const colors = FIELD_TYPE_COLORS[type];
+    return (
+        <Badge size="xs" radius="sm" bg={colors.bg} c={colors.color}>
+            {type}
+        </Badge>
+    );
+};
+
+export default DataAppVizFieldTypeBadge;

--- a/packages/frontend/src/features/apps/components/DataAppVizResultCard.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizResultCard.test.tsx
@@ -33,6 +33,6 @@ describe('DataAppVizResultCard', () => {
             <DataAppVizResultCard schema={{ fields: [], configOptions: [] }} />,
         );
 
-        expect(screen.getByText(/0 fields to map/i)).toBeInTheDocument();
+        expect(screen.getByText('Visualization ready')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/features/apps/components/DataAppVizResultCard.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizResultCard.tsx
@@ -1,56 +1,29 @@
-import { type DataAppVizField, type DataAppVizSchema } from '@lightdash/common';
-import { Badge, Card, Group, Stack, Text } from '@mantine-8/core';
+import { type DataAppVizSchema } from '@lightdash/common';
+import { Card, Group, Stack, Text } from '@mantine-8/core';
 import { type FC } from 'react';
-import { LD_FIELD_COLORS } from '../../../mantineTheme';
-
-// Match the field-type colors used everywhere else (field icons, sidebar tree,
-// AI-copilot field badges) via the canonical LD_FIELD_COLORS tokens. `series`
-// has no Lightdash field-type equivalent, so it falls back to the neutral
-// default. Keyed off the union type so a new field type breaks the build here.
-const FIELD_TYPE_COLORS: Record<
-    DataAppVizField['type'],
-    { bg: string; color: string }
-> = {
-    dimension: LD_FIELD_COLORS.dimension,
-    metric: LD_FIELD_COLORS.metric,
-    series: LD_FIELD_COLORS.DEFAULT,
-};
+import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
 
 type Props = {
     schema: DataAppVizSchema;
 };
 
-// Renders a data app viz's declared field schema as a summary card in the
-// generator chat, instead of the raw `{"fields":[...]}` JSON reply. Required
-// fields aren't badged here — required-ness is surfaced where it's actionable
-// (the field-mapping step), matching how Parameter inputs treat it.
+// Read-only summary of a data app viz's declared fields, shown on older history
+// versions in the generator chat (the latest ready version renders the
+// interactive DataAppVizTestPanel instead). Required fields aren't badged —
+// required-ness is surfaced where it's actionable (the field-mapping step).
 const DataAppVizResultCard: FC<Props> = ({ schema }) => (
     <Card withBorder radius="md" p="sm">
         <Stack gap="xs">
             <Text size="sm" fw={600}>
                 Visualization ready
             </Text>
-            <Text size="xs" c="dimmed">
-                {schema.fields.length} field
-                {schema.fields.length === 1 ? '' : 's'} to map
-            </Text>
             <Stack gap={4}>
-                {schema.fields.map((f) => {
-                    const colors = FIELD_TYPE_COLORS[f.type];
-                    return (
-                        <Group key={f.name} justify="space-between" gap="xs">
-                            <Text size="sm">{f.label}</Text>
-                            <Badge
-                                size="xs"
-                                radius="sm"
-                                bg={colors.bg}
-                                c={colors.color}
-                            >
-                                {f.type}
-                            </Badge>
-                        </Group>
-                    );
-                })}
+                {schema.fields.map((f) => (
+                    <Group key={f.name} justify="space-between" gap="xs">
+                        <Text size="sm">{f.label}</Text>
+                        <DataAppVizFieldTypeBadge type={f.type} />
+                    </Group>
+                ))}
             </Stack>
         </Stack>
     </Card>

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
@@ -1,0 +1,136 @@
+import { type DataAppVizSchema } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DataAppVizTestPanel from './DataAppVizTestPanel';
+import { buildTestMetricQuery, isMappingComplete } from './dataAppVizTestQuery';
+
+vi.mock('../../../hooks/useExplores', () => ({
+    useExplores: vi.fn(),
+}));
+vi.mock('../../../hooks/useExplore', () => ({
+    useExploreByProjectUuid: vi.fn(),
+}));
+vi.mock('../../../providers/Explorer/useQueryExecutor', () => ({
+    useQueryExecutor: vi.fn(),
+}));
+
+import { useExploreByProjectUuid } from '../../../hooks/useExplore';
+import { useExplores } from '../../../hooks/useExplores';
+import { useQueryExecutor } from '../../../providers/Explorer/useQueryExecutor';
+
+const schema: DataAppVizSchema = {
+    fields: [
+        { name: 'source', label: 'Source', type: 'dimension', required: true },
+        { name: 'target', label: 'Target', type: 'series', required: false },
+        { name: 'value', label: 'Value', type: 'metric', required: true },
+    ],
+    configOptions: [],
+};
+
+describe('isMappingComplete', () => {
+    it('is false until every required field is mapped', () => {
+        expect(isMappingComplete(schema, {})).toBe(false);
+        expect(isMappingComplete(schema, { source: 'orders_status' })).toBe(
+            false,
+        );
+        expect(
+            isMappingComplete(schema, {
+                source: 'orders_status',
+                value: 'orders_total',
+            }),
+        ).toBe(true);
+    });
+
+    it('ignores unmapped optional fields', () => {
+        expect(
+            isMappingComplete(schema, {
+                source: 'orders_status',
+                value: 'orders_total',
+                // `target` (optional) left unmapped
+            }),
+        ).toBe(true);
+    });
+});
+
+describe('buildTestMetricQuery', () => {
+    it('routes series/dimension fields to dimensions and metric fields to metrics', () => {
+        const q = buildTestMetricQuery('orders', schema, {
+            source: 'orders_status',
+            target: 'orders_region',
+            value: 'orders_total',
+        });
+        expect(q.exploreName).toBe('orders');
+        expect(q.dimensions).toEqual(['orders_status', 'orders_region']);
+        expect(q.metrics).toEqual(['orders_total']);
+        expect(q.limit).toBe(500);
+        expect(q.tableCalculations).toEqual([]);
+    });
+
+    it('drops unmapped fields', () => {
+        const q = buildTestMetricQuery('orders', schema, {
+            source: 'orders_status',
+            value: 'orders_total',
+        });
+        expect(q.dimensions).toEqual(['orders_status']);
+        expect(q.metrics).toEqual(['orders_total']);
+    });
+});
+
+describe('DataAppVizTestPanel', () => {
+    beforeEach(() => {
+        vi.mocked(useExplores).mockReturnValue({
+            data: [
+                { name: 'orders', label: 'Orders' },
+                { name: 'customers', label: 'Customers' },
+            ],
+        } as unknown as ReturnType<typeof useExplores>);
+        vi.mocked(useExploreByProjectUuid).mockReturnValue({
+            data: undefined,
+        } as unknown as ReturnType<typeof useExploreByProjectUuid>);
+        vi.mocked(useQueryExecutor).mockReturnValue([
+            {
+                query: { isFetching: false, error: null },
+                queryResults: {
+                    rows: [],
+                    isFetchingFirstPage: false,
+                    error: null,
+                },
+            },
+            vi.fn(),
+        ] as unknown as ReturnType<typeof useQueryExecutor>);
+    });
+
+    it('lists the declared fields and the explore picker up-front', () => {
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={schema}
+                onContextChange={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Visualization ready')).toBeInTheDocument();
+        expect(screen.getByText('Test with data')).toBeInTheDocument();
+        expect(
+            screen.getByPlaceholderText('Select an explore'),
+        ).toBeInTheDocument();
+        // Declared fields are visible before an explore is chosen.
+        expect(screen.getByText('Source')).toBeInTheDocument();
+        expect(screen.getByText('Value')).toBeInTheDocument();
+    });
+
+    it('hides the run action until an explore is selected', () => {
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={schema}
+                onContextChange={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.queryByRole('button', { name: /run test query/i }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
@@ -1,0 +1,224 @@
+import {
+    getErrorMessage,
+    getItemId,
+    getItemMap,
+    isCustomDimension,
+    isDimension,
+    isMetric,
+    isSummaryExploreError,
+    isTableCalculation,
+    QueryExecutionContext,
+    type DataAppVizContext,
+    type DataAppVizSchema,
+    type Item,
+} from '@lightdash/common';
+import { Button, Card, Group, Select, Stack, Text } from '@mantine-8/core';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import Callout from '../../../components/common/Callout';
+import FieldSelect from '../../../components/common/FieldSelect';
+import { useExploreByProjectUuid } from '../../../hooks/useExplore';
+import { useExplores } from '../../../hooks/useExplores';
+import { type QueryResultsProps } from '../../../hooks/useQueryResults';
+import { useQueryExecutor } from '../../../providers/Explorer/useQueryExecutor';
+import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
+import { buildTestMetricQuery, isMappingComplete } from './dataAppVizTestQuery';
+
+type Run = { args: QueryResultsProps; mapping: Record<string, string> };
+
+type Props = {
+    projectUuid: string;
+    schema: DataAppVizSchema;
+    onContextChange: (ctx: DataAppVizContext | null) => void;
+};
+
+// Interactive panel below the viz result card: pick an explore, map each
+// declared field to a dimension/metric, run one query, and push the resulting
+// rows into the generator preview via `onContextChange`. Fields only.
+const DataAppVizTestPanel: FC<Props> = ({
+    projectUuid,
+    schema,
+    onContextChange,
+}) => {
+    const [exploreName, setExploreName] = useState<string | null>(null);
+    const [fieldMapping, setFieldMapping] = useState<Record<string, string>>(
+        {},
+    );
+    // Snapshot of the query + mapping captured when the user clicks Run. Gates
+    // the query so nothing fires while the user is still picking fields.
+    const [run, setRun] = useState<Run | null>(null);
+
+    const explores = useExplores(projectUuid);
+    const explore = useExploreByProjectUuid(
+        exploreName ?? undefined,
+        projectUuid,
+    );
+
+    const itemsMap = useMemo(
+        () => (explore.data ? getItemMap(explore.data) : {}),
+        [explore.data],
+    );
+    const allItems = useMemo(() => Object.values(itemsMap), [itemsMap]);
+    const dimensions = useMemo(
+        () =>
+            allItems.filter(
+                (i) => isDimension(i as Item) || isCustomDimension(i as Item),
+            ),
+        [allItems],
+    );
+    const metrics = useMemo(
+        () =>
+            allItems.filter(
+                (i) => isMetric(i as Item) || isTableCalculation(i as Item),
+            ),
+        [allItems],
+    );
+
+    const [{ query, queryResults }] = useQueryExecutor(
+        run?.args ?? null,
+        [],
+        Boolean(run),
+    );
+
+    const rows = queryResults.rows;
+    // Notify the parent once the run's rows arrive (external async → parent).
+    // Only push rows belonging to this run's query — on a re-run the executor
+    // transiently re-exposes the previous query's cached page before the new
+    // queryUuid lands.
+    const runQueryUuid = query.data?.queryUuid;
+    useEffect(() => {
+        if (
+            run &&
+            rows.length > 0 &&
+            runQueryUuid &&
+            queryResults.queryUuid === runQueryUuid
+        ) {
+            onContextChange({ fieldMapping: run.mapping, rows });
+        }
+    }, [rows, run, runQueryUuid, queryResults.queryUuid, onContextChange]);
+    // Clear the preview when this panel unmounts (e.g. a newer version lands).
+    useEffect(() => () => onContextChange(null), [onContextChange]);
+
+    const clearRun = () => {
+        setRun(null);
+        onContextChange(null);
+    };
+
+    const handleExploreChange = (value: string | null) => {
+        setExploreName(value);
+        setFieldMapping({});
+        clearRun();
+    };
+
+    const setField = (name: string, id: string | null) => {
+        setFieldMapping((prev) => {
+            const next = { ...prev };
+            if (id) next[name] = id;
+            else delete next[name];
+            return next;
+        });
+        clearRun();
+    };
+
+    const handleRun = () => {
+        if (!exploreName || !isMappingComplete(schema, fieldMapping)) return;
+        setRun({
+            args: {
+                projectUuid,
+                tableId: exploreName,
+                query: buildTestMetricQuery(exploreName, schema, fieldMapping),
+                context: QueryExecutionContext.DATA_APP_SAMPLE,
+            },
+            mapping: fieldMapping,
+        });
+    };
+
+    const exploreOptions = (explores.data ?? [])
+        .filter((e) => !isSummaryExploreError(e))
+        .map((e) => ({ value: e.name, label: e.label }));
+
+    const complete =
+        Boolean(exploreName) && isMappingComplete(schema, fieldMapping);
+    const isRunning =
+        Boolean(run) && (query.isFetching || queryResults.isFetchingFirstPage);
+    const error = query.error ?? queryResults.error;
+
+    return (
+        <Card withBorder radius="md" p="sm">
+            <Stack gap="xs">
+                <Text size="sm" fw={600}>
+                    Visualization ready
+                </Text>
+                <Select
+                    size="xs"
+                    label="Test with data"
+                    placeholder="Select an explore"
+                    searchable
+                    data={exploreOptions}
+                    value={exploreName}
+                    onChange={handleExploreChange}
+                />
+
+                <Stack gap="xs">
+                    {schema.fields.map((field) => {
+                        const items =
+                            field.type === 'metric' ? metrics : dimensions;
+                        const selectedId = fieldMapping[field.name];
+                        const selectedItem = selectedId
+                            ? items.find((i) => getItemId(i) === selectedId)
+                            : undefined;
+                        return (
+                            <Stack key={field.name} gap={2}>
+                                <Group gap="xs">
+                                    <Text size="xs" fw={500}>
+                                        {field.label}
+                                    </Text>
+                                    <DataAppVizFieldTypeBadge
+                                        type={field.type}
+                                    />
+                                </Group>
+                                {exploreName && (
+                                    <FieldSelect
+                                        size="xs"
+                                        placeholder={`Select ${field.label.toLowerCase()}`}
+                                        disabled={items.length === 0}
+                                        item={selectedItem}
+                                        items={items}
+                                        onChange={(newField) =>
+                                            setField(
+                                                field.name,
+                                                newField
+                                                    ? getItemId(newField)
+                                                    : null,
+                                            )
+                                        }
+                                        clearable={!field.required}
+                                        hasGrouping
+                                    />
+                                )}
+                            </Stack>
+                        );
+                    })}
+                </Stack>
+
+                {error && (
+                    <Callout variant="danger">{getErrorMessage(error)}</Callout>
+                )}
+
+                {exploreName && (
+                    <Group justify="flex-end">
+                        <Button
+                            size="xs"
+                            onClick={handleRun}
+                            disabled={!complete || isRunning}
+                            loading={isRunning}
+                        >
+                            Run test query
+                        </Button>
+                    </Group>
+                )}
+            </Stack>
+        </Card>
+    );
+};
+
+export default DataAppVizTestPanel;

--- a/packages/frontend/src/features/apps/components/dataAppVizTestQuery.ts
+++ b/packages/frontend/src/features/apps/components/dataAppVizTestQuery.ts
@@ -1,0 +1,30 @@
+import { type DataAppVizSchema, type MetricQuery } from '@lightdash/common';
+
+/** True when every required declared field has a mapped query field id. */
+export const isMappingComplete = (
+    schema: DataAppVizSchema,
+    fieldMapping: Record<string, string>,
+): boolean =>
+    schema.fields.every((f) => !f.required || Boolean(fieldMapping[f.name]));
+
+/** Split the field mapping into a metric query. Series and dimension fields
+ *  bind to query dimensions; metric fields to query metrics. */
+export const buildTestMetricQuery = (
+    exploreName: string,
+    schema: DataAppVizSchema,
+    fieldMapping: Record<string, string>,
+): MetricQuery => ({
+    exploreName,
+    dimensions: schema.fields
+        .filter((f) => f.type !== 'metric')
+        .map((f) => fieldMapping[f.name])
+        .filter(Boolean),
+    metrics: schema.fields
+        .filter((f) => f.type === 'metric')
+        .map((f) => fieldMapping[f.name])
+        .filter(Boolean),
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+});

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -11,6 +11,7 @@ import {
     type AppExternalConnectionReference,
     type DataAppClaudeModel,
     type DataAppTemplate,
+    type DataAppVizContext,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -94,6 +95,7 @@ import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppSpaceChip from '../features/apps/components/AppSpaceChip';
 import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCard';
+import DataAppVizTestPanel from '../features/apps/components/DataAppVizTestPanel';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -203,6 +205,7 @@ type AppPreviewProps = {
     onLineageSelected?: (event: { queryUuid: string }) => void;
     lineageHighlightQueryUuid?: string | null;
     onLineageCancelled?: () => void;
+    dataAppVizContext?: DataAppVizContext;
 };
 
 const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
@@ -225,6 +228,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
             onLineageSelected,
             lineageHighlightQueryUuid,
             onLineageCancelled,
+            dataAppVizContext,
         },
         ref,
     ) => {
@@ -283,6 +287,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 lineageHighlightQueryUuid={lineageHighlightQueryUuid}
                 onLineageCancelled={onLineageCancelled}
                 capabilities={{ gsheetExport: true }}
+                dataAppVizContext={dataAppVizContext}
             />
         );
     },
@@ -670,6 +675,7 @@ const AppGenerate: FC = () => {
         setThemeChipOverride(null);
         setPendingClarification(null);
         setClarificationAnswers([]);
+        setTestVizContext(null);
         versionCacheRef.current.clear();
         versionCacheAppRef.current = undefined;
         sentImagesByPrompt.current.forEach((urls) =>
@@ -1267,6 +1273,11 @@ const AppGenerate: FC = () => {
     // semantic-layer change and wants to see it reflected without waiting
     // on the in-progress code-gen iteration.
     const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
+    // Set imperatively by the "test with data" panel (later task) when the
+    // user runs a query; pushed into the preview iframe so the generated
+    // data-app-viz renders with real result rows instead of mock data.
+    const [testVizContext, setTestVizContext] =
+        useState<DataAppVizContext | null>(null);
     // Latched on by the first manual refresh: a refresh means "show me fresh
     // data", so from then on the preview's queries bypass the warehouse cache.
     // Starts false so the initial load can still serve cached results fast.
@@ -2244,11 +2255,28 @@ const AppGenerate: FC = () => {
                                                             }
                                                         />
                                                         {msg.vizSchema ? (
-                                                            <DataAppVizResultCard
-                                                                schema={
-                                                                    msg.vizSchema
-                                                                }
-                                                            />
+                                                            msg.version !==
+                                                                null &&
+                                                            msg.version ===
+                                                                latestReadyVersion?.version ? (
+                                                                <DataAppVizTestPanel
+                                                                    projectUuid={
+                                                                        projectUuid
+                                                                    }
+                                                                    schema={
+                                                                        msg.vizSchema
+                                                                    }
+                                                                    onContextChange={
+                                                                        setTestVizContext
+                                                                    }
+                                                                />
+                                                            ) : (
+                                                                <DataAppVizResultCard
+                                                                    schema={
+                                                                        msg.vizSchema
+                                                                    }
+                                                                />
+                                                            )
                                                         ) : msg.appUuid ? (
                                                             <AiMarkdown>
                                                                 {msg.content}
@@ -3052,6 +3080,9 @@ const AppGenerate: FC = () => {
                                         }
                                         onLineageCancelled={
                                             handleLineageCancelled
+                                        }
+                                        dataAppVizContext={
+                                            testVizContext ?? undefined
                                         }
                                     />
                                 ) : (


### PR DESCRIPTION
Builds on #25039. After a data app viz generates, its result card in the generator becomes an interactive **test** panel: pick an explore, map each declared field to a dimension/metric, run one query, and see the viz render **live in the preview** — before saving it as a chart.

- Reuses the existing SDK viz-context bridge; the query's `ResultRow` shape is byte-identical to the iframe's row contract, so there's no row transform.
- Merges the result card + test panel into one card for the latest version; older history versions keep the read-only summary.
- Field-type badges use the canonical `LD_FIELD_COLORS`; pickers are `xs` to match the visualization config panels.
- Ephemeral — testing never creates a saved chart. Fields only; config-option controls are future work.

Closes: GLITCH-580