### PR TITLE
feat(analytics): usage event sink with query_events stream

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -30,6 +30,8 @@ import reDoc from 'redoc-express';
 import { URL } from 'url';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
+import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
+import { eventStreamRegistry } from './analytics/eventStream/registry';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import {
     ClientProviderMap,
@@ -190,6 +192,13 @@ export default class App {
         this.port = args.port;
         this.environment = args.environment || 'production';
         this.analyticsEventEmitter = new EventEmitter();
+        this.prometheusMetrics = new PrometheusMetrics(
+            this.lightdashConfig.prometheus,
+        );
+        this.eventStreamWriter = createEventStreamWriter(
+            this.lightdashConfig,
+            this.prometheusMetrics,
+        );
         this.analytics = new LightdashAnalytics({
             lightdashConfig: this.lightdashConfig,
             writeKey: this.lightdashConfig.rudder.writeKey || 'notrack',
@@ -202,6 +211,12 @@ export default class App {
                     this.lightdashConfig.rudder.dataPlaneUrl,
             },
             eventEmitter: this.analyticsEventEmitter,
+            eventStreamSink: this.eventStreamWriter
+                ? new EventStreamSink(
+                      eventStreamRegistry,
+                      this.eventStreamWriter,
+                  )
+                : undefined,
         });
         this.database = knex(
             this.environment === 'production'
@@ -227,14 +242,6 @@ export default class App {
             }),
             models: this.models,
         });
-        this.prometheusMetrics = new PrometheusMetrics(
-            this.lightdashConfig.prometheus,
-        );
-        this.eventStreamWriter = createEventStreamWriter(
-            this.lightdashConfig,
-            this.prometheusMetrics,
-        );
-
         this.serviceRepository = new ServiceRepository({
             serviceProviders: args.serviceProviders,
             context: new OperationContext({

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -5,6 +5,8 @@ import http from 'http';
 import knex, { Knex } from 'knex';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
+import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
+import { eventStreamRegistry } from './analytics/eventStream/registry';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import { registerOAuthRefreshStrategies } from './auth/registerOAuthRefreshStrategies';
 import {
@@ -106,6 +108,13 @@ export default class NatsWorkerApp {
         this.port = args.port;
         this.environment = args.environment || 'production';
 
+        this.prometheusMetrics = new PrometheusMetrics(
+            this.lightdashConfig.prometheus,
+        );
+        this.eventStreamWriter = createEventStreamWriter(
+            this.lightdashConfig,
+            this.prometheusMetrics,
+        );
         this.analytics = new LightdashAnalytics({
             lightdashConfig: this.lightdashConfig,
             writeKey: this.lightdashConfig.rudder.writeKey || 'notrack',
@@ -115,6 +124,12 @@ export default class NatsWorkerApp {
                     !!this.lightdashConfig.rudder.writeKey &&
                     !!this.lightdashConfig.rudder.dataPlaneUrl,
             },
+            eventStreamSink: this.eventStreamWriter
+                ? new EventStreamSink(
+                      eventStreamRegistry,
+                      this.eventStreamWriter,
+                  )
+                : undefined,
         });
 
         this.database = knex(
@@ -143,14 +158,6 @@ export default class NatsWorkerApp {
             }),
             models,
         });
-        this.prometheusMetrics = new PrometheusMetrics(
-            this.lightdashConfig.prometheus,
-        );
-        this.eventStreamWriter = createEventStreamWriter(
-            this.lightdashConfig,
-            this.prometheusMetrics,
-        );
-
         this.clients = clients;
         this.modelRepository = models;
         this.serviceRepository = new ServiceRepository({

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -6,6 +6,8 @@ import http from 'http';
 import knex, { Knex } from 'knex';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
+import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
+import { eventStreamRegistry } from './analytics/eventStream/registry';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import { registerOAuthRefreshStrategies } from './auth/registerOAuthRefreshStrategies';
 import {
@@ -137,6 +139,13 @@ export default class SchedulerApp {
         this.port = args.port;
         this.environment = args.environment || 'production';
         this.analyticsEventEmitter = new EventEmitter();
+        this.prometheusMetrics = new PrometheusMetrics(
+            this.lightdashConfig.prometheus,
+        );
+        this.eventStreamWriter = createEventStreamWriter(
+            this.lightdashConfig,
+            this.prometheusMetrics,
+        );
         this.analytics = new LightdashAnalytics({
             lightdashConfig: this.lightdashConfig,
             writeKey: this.lightdashConfig.rudder.writeKey || 'notrack',
@@ -149,6 +158,12 @@ export default class SchedulerApp {
                     this.lightdashConfig.rudder.dataPlaneUrl,
             },
             eventEmitter: this.analyticsEventEmitter,
+            eventStreamSink: this.eventStreamWriter
+                ? new EventStreamSink(
+                      eventStreamRegistry,
+                      this.eventStreamWriter,
+                  )
+                : undefined,
         });
 
         this.database = knex(
@@ -177,13 +192,6 @@ export default class SchedulerApp {
             }),
             models: this.models,
         });
-        this.prometheusMetrics = new PrometheusMetrics(
-            this.lightdashConfig.prometheus,
-        );
-        this.eventStreamWriter = createEventStreamWriter(
-            this.lightdashConfig,
-            this.prometheusMetrics,
-        );
         this.serviceRepository = new ServiceRepository({
             serviceProviders: args.serviceProviders,
             context: new OperationContext({

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -44,6 +44,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
 import { type ExternalConnectionEvent } from '../ee/analytics';
 import { VERSION } from '../version';
+import type { EventStreamSink } from './eventStream/EventStreamSink';
 
 type Identify = {
     userId: string;
@@ -55,7 +56,7 @@ type Identify = {
         is_marketing_opted_in?: boolean;
     };
 };
-type BaseTrack = Omit<AnalyticsTrack, 'context'>;
+export type BaseTrack = Omit<AnalyticsTrack, 'context'>;
 type Group = {
     userId: string;
     groupId: string;
@@ -294,6 +295,32 @@ type QueryErrorEvent = BaseTrack & {
         projectId: string;
         warehouseType: WarehouseTypes | undefined;
         executionSource: QueryExecutionSource;
+    };
+};
+
+/**
+ * Single terminal event per async query, emitted once the outcome is known
+ * (warehouse completion, cache hit, or pre-execution error). This is the
+ * only query event consumed by the usage event stream sink.
+ */
+export type QueryCompletedEvent = BaseTrack & {
+    event: 'query.completed';
+    properties: {
+        queryId: string;
+        organizationId: string;
+        projectId: string;
+        isPreviewProject: boolean;
+        status: 'success' | 'error';
+        context: QueryExecutionContext;
+        exploreName: string | null;
+        chartId: string | null;
+        dashboardId: string | null;
+        cacheHit: boolean;
+        executionSource: QueryExecutionSource | null;
+        warehouseType: WarehouseTypes | null;
+        warehouseExecutionTimeMs: number | null;
+        totalRowCount: number | null;
+        columnsCount: number | null;
     };
 };
 
@@ -2378,6 +2405,7 @@ type TypedEvent =
     | QueryExecutionEvent
     | QueryReadyEvent
     | QueryErrorEvent
+    | QueryCompletedEvent
     | PreAggregateQueryEvent
     | MaterializationEvent
     | QueryPageEvent
@@ -2518,6 +2546,7 @@ type LightdashAnalyticsArguments = {
     dataPlaneUrl: string;
     options?: ConstructorParameters<typeof Analytics>[1];
     eventEmitter?: EventEmitter;
+    eventStreamSink?: EventStreamSink;
 };
 
 export class LightdashAnalytics extends Analytics {
@@ -2527,17 +2556,21 @@ export class LightdashAnalytics extends Analytics {
 
     private readonly eventEmitter?: EventEmitter;
 
+    private readonly eventStreamSink?: EventStreamSink;
+
     constructor({
         lightdashConfig,
         writeKey,
         dataPlaneUrl,
         options,
         eventEmitter,
+        eventStreamSink,
     }: LightdashAnalyticsArguments) {
         super(writeKey, { ...options, dataPlaneUrl });
 
         this.lightdashConfig = lightdashConfig;
         this.eventEmitter = eventEmitter;
+        this.eventStreamSink = eventStreamSink;
         this.lightdashContext = {
             app: {
                 namespace: 'lightdash',
@@ -2569,6 +2602,9 @@ export class LightdashAnalytics extends Analytics {
     }
 
     track<T extends BaseTrack>(payload: TypedEvent | UntypedEvent<T>) {
+        // Usage event stream fires regardless of Rudderstack/anonymization settings
+        this.eventStreamSink?.handle(payload);
+
         if (
             this.lightdashConfig.prometheus.enabled &&
             this.lightdashConfig.prometheus.eventMetricsEnabled

--- a/packages/backend/src/analytics/eventStream/EventStreamSink.test.ts
+++ b/packages/backend/src/analytics/eventStream/EventStreamSink.test.ts
@@ -1,0 +1,150 @@
+import { QueryExecutionContext, WarehouseTypes } from '@lightdash/common';
+import { QueryCompletedEvent } from '../LightdashAnalytics';
+import { EventStreamSink } from './EventStreamSink';
+import { EVENT_STREAM_SCHEMA_VERSION } from './projection';
+import { eventStreamRegistry } from './registry';
+import { EventStreamRow } from './types';
+
+vi.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const createWriterMock = () => ({
+    push: vi.fn<(stream: string, row: EventStreamRow) => void>(),
+    flush: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+});
+
+const queryCompletedEvent: QueryCompletedEvent = {
+    event: 'query.completed',
+    userId: 'user-1',
+    properties: {
+        queryId: 'query-1',
+        organizationId: 'org-1',
+        projectId: 'project-1',
+        isPreviewProject: false,
+        status: 'success',
+        context: QueryExecutionContext.EXPLORE,
+        exploreName: 'orders',
+        chartId: 'chart-1',
+        dashboardId: 'dashboard-1',
+        cacheHit: false,
+        executionSource: 'warehouse',
+        warehouseType: WarehouseTypes.POSTGRES,
+        warehouseExecutionTimeMs: 123,
+        totalRowCount: 42,
+        columnsCount: 5,
+    },
+};
+
+describe('EventStreamSink', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('projects a successful query.completed event', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle(queryCompletedEvent);
+        expect(writer.push).toHaveBeenCalledTimes(1);
+        const [stream, row] = writer.push.mock.calls[0];
+        expect(stream).toBe('query_events');
+        expect(row).toMatchObject({
+            event_name: 'query.completed',
+            org_id: 'org-1',
+            user_id: 'user-1',
+            schema_version: EVENT_STREAM_SCHEMA_VERSION,
+            project_id: 'project-1',
+            query_id: 'query-1',
+            status: 'success',
+            context: QueryExecutionContext.EXPLORE,
+            explore_name: 'orders',
+            chart_id: 'chart-1',
+            dashboard_id: 'dashboard-1',
+            cache_hit: false,
+            execution_source: 'warehouse',
+            warehouse_type: WarehouseTypes.POSTGRES,
+            warehouse_execution_time_ms: 123,
+            total_row_count: 42,
+            columns_count: 5,
+        });
+        expect(new Date(row.event_ts).toISOString()).toBe(row.event_ts);
+    });
+
+    it('projects an errored query.completed event with null outcome columns', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        const event: QueryCompletedEvent = {
+            ...queryCompletedEvent,
+            properties: {
+                ...queryCompletedEvent.properties,
+                status: 'error',
+                warehouseType: null,
+                executionSource: null,
+                warehouseExecutionTimeMs: null,
+                totalRowCount: null,
+                columnsCount: null,
+            },
+        };
+        sink.handle(event);
+        expect(writer.push).toHaveBeenCalledTimes(1);
+        const [, row] = writer.push.mock.calls[0];
+        expect(row).toMatchObject({
+            event_name: 'query.completed',
+            status: 'error',
+            warehouse_type: null,
+            execution_source: null,
+            warehouse_execution_time_ms: null,
+            total_row_count: null,
+            columns_count: null,
+        });
+    });
+
+    it('drops events from preview projects', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle({
+            ...queryCompletedEvent,
+            properties: {
+                ...queryCompletedEvent.properties,
+                isPreviewProject: true,
+            },
+        });
+        expect(writer.push).not.toHaveBeenCalled();
+    });
+
+    it('drops events without an organization id', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle({
+            ...queryCompletedEvent,
+            properties: {
+                ...queryCompletedEvent.properties,
+                organizationId: '',
+            },
+        });
+        expect(writer.push).not.toHaveBeenCalled();
+    });
+
+    it('ignores events not in the registry', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle({
+            event: 'query.executed',
+            userId: 'user-1',
+            properties: { organizationId: 'org-1', projectId: 'project-1' },
+        });
+        sink.handle({
+            event: 'space.created',
+            userId: 'user-1',
+            properties: { name: 'My space' },
+        });
+        expect(writer.push).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/analytics/eventStream/EventStreamSink.ts
+++ b/packages/backend/src/analytics/eventStream/EventStreamSink.ts
@@ -1,0 +1,41 @@
+import Logger from '../../logging/logger';
+import type { BaseTrack } from '../LightdashAnalytics';
+import type { ProjectionResult } from './projection';
+import type { EventStreamRegistry, ProjectedEvent } from './registry';
+import type { EventStreamWriter } from './types';
+
+/**
+ * Projects allowlisted analytics events into typed rows and pushes them to
+ * the usage event stream writer. Never throws into the caller (`track()`).
+ */
+export class EventStreamSink {
+    private readonly registry: EventStreamRegistry;
+
+    private readonly writer: EventStreamWriter;
+
+    constructor(registry: EventStreamRegistry, writer: EventStreamWriter) {
+        this.registry = registry;
+        this.writer = writer;
+    }
+
+    private isProjectedEvent(payload: BaseTrack): payload is ProjectedEvent {
+        return payload.event in this.registry;
+    }
+
+    handle(payload: BaseTrack): void {
+        try {
+            if (!this.isProjectedEvent(payload)) return;
+            // Safe: the registry maps each event name to a projection accepting that event type
+            const projection = this.registry[payload.event] as (
+                p: ProjectedEvent,
+            ) => ProjectionResult;
+            const result = projection(payload);
+            if (result === null) return;
+            this.writer.push(result.stream, result.row);
+        } catch (error) {
+            Logger.warn(
+                `Failed to project analytics event "${payload.event}" into the usage event stream: ${error}`,
+            );
+        }
+    }
+}

--- a/packages/backend/src/analytics/eventStream/projection.ts
+++ b/packages/backend/src/analytics/eventStream/projection.ts
@@ -1,0 +1,33 @@
+import type { BaseTrack } from '../LightdashAnalytics';
+import { EventStreamRow } from './types';
+
+export const EVENT_STREAM_SCHEMA_VERSION = 1;
+
+export type StreamName = 'query_events';
+
+/**
+ * Common envelope stamped on every row pushed into the usage event stream.
+ */
+export type EventStreamEnvelope = {
+    event_name: string;
+    org_id: string;
+    user_id: string | null;
+    event_ts: string;
+    schema_version: number;
+};
+
+export type ProjectionResult = {
+    stream: StreamName;
+    row: EventStreamRow;
+} | null;
+
+export const buildEnvelope = (
+    payload: BaseTrack,
+    orgId: string,
+): EventStreamEnvelope => ({
+    event_name: payload.event,
+    org_id: orgId,
+    user_id: payload.userId ?? null,
+    event_ts: new Date().toISOString(),
+    schema_version: EVENT_STREAM_SCHEMA_VERSION,
+});

--- a/packages/backend/src/analytics/eventStream/queryEventsStream.ts
+++ b/packages/backend/src/analytics/eventStream/queryEventsStream.ts
@@ -1,0 +1,38 @@
+import type { QueryCompletedEvent } from '../LightdashAnalytics';
+import { buildEnvelope, ProjectionResult } from './projection';
+
+/**
+ * Projection for the `query_events` stream (v1): one row per async query,
+ * emitted at terminal state (`query.completed`). Returns null when the event
+ * can't be attributed to an organization or comes from a preview project.
+ */
+const projectQueryCompletedEvent = (
+    payload: QueryCompletedEvent,
+): ProjectionResult => {
+    const { properties } = payload;
+    if (!properties.organizationId) return null;
+    if (properties.isPreviewProject) return null;
+    return {
+        stream: 'query_events',
+        row: {
+            ...buildEnvelope(payload, properties.organizationId),
+            project_id: properties.projectId,
+            query_id: properties.queryId,
+            status: properties.status,
+            context: properties.context,
+            explore_name: properties.exploreName,
+            chart_id: properties.chartId,
+            dashboard_id: properties.dashboardId,
+            cache_hit: properties.cacheHit,
+            execution_source: properties.executionSource,
+            warehouse_type: properties.warehouseType,
+            warehouse_execution_time_ms: properties.warehouseExecutionTimeMs,
+            total_row_count: properties.totalRowCount,
+            columns_count: properties.columnsCount,
+        },
+    };
+};
+
+export const queryEventsProjections = {
+    'query.completed': projectQueryCompletedEvent,
+};

--- a/packages/backend/src/analytics/eventStream/registry.ts
+++ b/packages/backend/src/analytics/eventStream/registry.ts
@@ -1,0 +1,22 @@
+import type { QueryCompletedEvent } from '../LightdashAnalytics';
+import type { ProjectionResult } from './projection';
+import { queryEventsProjections } from './queryEventsStream';
+
+/**
+ * Union of every analytics event projected into a usage event stream.
+ * Adding a new stream/event = add the event type here and a projection entry
+ * below; nothing else needs to change.
+ */
+export type ProjectedEvent = QueryCompletedEvent;
+
+export type EventStreamRegistry = {
+    [E in ProjectedEvent as E['event']]: (payload: E) => ProjectionResult;
+};
+
+/**
+ * Allowlist of analytics events pushed into the usage event stream. Events
+ * not present here are ignored by the sink.
+ */
+export const eventStreamRegistry: EventStreamRegistry = {
+    ...queryEventsProjections,
+};

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2854,6 +2854,7 @@ describe('AsyncQueryService', () => {
                     userUuid: sessionAccount.user.id,
                     organizationUuid:
                         sessionAccount.organization.organizationUuid!,
+                    isPreviewProject: false,
                     isRegisteredUser: true,
                     projectUuid,
                     query: 'SELECT * FROM test',
@@ -2951,6 +2952,7 @@ describe('AsyncQueryService', () => {
             const runAsyncArgs: RunAsyncWarehouseQueryArgs = {
                 userUuid: sessionAccount.user.id,
                 organizationUuid: sessionAccount.organization.organizationUuid!,
+                isPreviewProject: false,
                 isRegisteredUser: true,
                 projectUuid,
                 query: 'SELECT * FROM test_table',

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -77,6 +77,7 @@ import {
     ParseError,
     PivotConfig,
     PivotConfiguration,
+    ProjectType,
     QueryExecutionContext,
     QueryHistoryStatus,
     resolveQueryTimezone,
@@ -2326,6 +2327,7 @@ export class AsyncQueryService extends ProjectService {
         warehouseQuery,
         queryCreatedAt,
         displayTimezone,
+        isPreviewProject,
     }: RunAsyncPreAggregateQueryArgs) {
         try {
             const duckDbWarehouseClient =
@@ -2334,6 +2336,7 @@ export class AsyncQueryService extends ProjectService {
             await this.runAsyncWarehouseQuery({
                 userUuid,
                 organizationUuid,
+                isPreviewProject,
                 isRegisteredUser,
                 isServiceAccount,
                 projectUuid,
@@ -2371,6 +2374,7 @@ export class AsyncQueryService extends ProjectService {
             await this.runAsyncWarehouseQuery({
                 userUuid,
                 organizationUuid,
+                isPreviewProject,
                 isRegisteredUser,
                 isServiceAccount,
                 projectUuid,
@@ -2491,6 +2495,7 @@ export class AsyncQueryService extends ProjectService {
     public async runAsyncWarehouseQuery({
         userUuid,
         organizationUuid,
+        isPreviewProject,
         isRegisteredUser,
         isServiceAccount,
         projectUuid,
@@ -2730,6 +2735,33 @@ export class AsyncQueryService extends ProjectService {
                 },
             });
 
+            this.analytics.track({
+                ...analyticsIdentity,
+                event: 'query.completed',
+                properties: {
+                    queryId: queryUuid,
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    isPreviewProject,
+                    status: 'success',
+                    context: queryTags.query_context,
+                    exploreName: queryTags.explore_name ?? null,
+                    chartId: queryTags.chart_uuid ?? null,
+                    dashboardId: queryTags.dashboard_uuid ?? null,
+                    cacheHit: false,
+                    executionSource,
+                    warehouseType: warehouseClient.credentials.type,
+                    warehouseExecutionTimeMs: Math.round(durationMs),
+                    totalRowCount: pivotDetails?.totalRows ?? totalRows,
+                    columnsCount:
+                        pivotDetails?.totalColumnCount ??
+                        Object.keys(fieldsMap).length,
+                    ...(isRegisteredUser
+                        ? undefined
+                        : { externalId: userUuid }),
+                },
+            });
+
             const queryExecMs = Date.now() - queryStartTime;
 
             if (stream) {
@@ -2889,6 +2921,30 @@ export class AsyncQueryService extends ProjectService {
                         : { externalId: userUuid }),
                 },
             });
+            this.analytics.track({
+                ...analyticsIdentity,
+                event: 'query.completed',
+                properties: {
+                    queryId: queryUuid,
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    isPreviewProject,
+                    status: 'error',
+                    context: queryTags.query_context,
+                    exploreName: queryTags.explore_name ?? null,
+                    chartId: queryTags.chart_uuid ?? null,
+                    dashboardId: queryTags.dashboard_uuid ?? null,
+                    cacheHit: false,
+                    executionSource,
+                    warehouseType: warehouseCredentialsType ?? null,
+                    warehouseExecutionTimeMs: null,
+                    totalRowCount: null,
+                    columnsCount: null,
+                    ...(isRegisteredUser
+                        ? undefined
+                        : { externalId: userUuid }),
+                },
+            });
             await this.queryHistoryModel.updateStatusToError(
                 queryUuid,
                 projectUuid,
@@ -2984,11 +3040,13 @@ export class AsyncQueryService extends ProjectService {
         const warehouseCredentialsOverrides =
             await this.deriveWarehouseCredentialsOverrides(query);
         const displayTimezone = query.metricQuery.timezone ?? null;
+        const isPreviewProject = await this.isProjectPreview(query.projectUuid);
 
         return {
             projectUuid: query.projectUuid ?? '',
             userUuid: actor.userUuid,
             organizationUuid: query.organizationUuid,
+            isPreviewProject,
             queryUuid: query.queryUuid,
             isRegisteredUser: actor.isRegisteredUser,
             isServiceAccount: actor.isServiceAccount,
@@ -3002,6 +3060,14 @@ export class AsyncQueryService extends ProjectService {
             query: query.compiledSql,
             displayTimezone,
         };
+    }
+
+    private async isProjectPreview(
+        projectUuid: string | null,
+    ): Promise<boolean> {
+        if (!projectUuid) return false;
+        const summary = await this.projectModel.getSummary(projectUuid);
+        return summary.type === ProjectType.PREVIEW;
     }
 
     private async buildPreAggregateQueryArgs(
@@ -3020,11 +3086,13 @@ export class AsyncQueryService extends ProjectService {
         const warehouseCredentialsOverrides =
             await this.deriveWarehouseCredentialsOverrides(query);
         const displayTimezone = query.metricQuery.timezone ?? null;
+        const isPreviewProject = await this.isProjectPreview(query.projectUuid);
 
         return {
             projectUuid: query.projectUuid ?? '',
             userUuid: actor.userUuid,
             organizationUuid: query.organizationUuid,
+            isPreviewProject,
             queryUuid: query.queryUuid,
             isRegisteredUser: actor.isRegisteredUser,
             isServiceAccount: actor.isServiceAccount,
@@ -3233,8 +3301,14 @@ export class AsyncQueryService extends ProjectService {
         }
 
         const params = query.requestParameters;
-        const chartUuid =
-            params && 'chartUuid' in params ? params.chartUuid : undefined;
+        // SQL chart runs identify the chart as savedSqlUuid; slug-only runs
+        // can't be attributed without a lookup and resolve to undefined.
+        let chartUuid: string | undefined;
+        if (params && 'chartUuid' in params) {
+            chartUuid = params.chartUuid;
+        } else if (params && 'savedSqlUuid' in params) {
+            chartUuid = params.savedSqlUuid;
+        }
         const dashboardUuid =
             params && 'dashboardUuid' in params
                 ? params.dashboardUuid
@@ -3505,6 +3579,7 @@ export class AsyncQueryService extends ProjectService {
         args: ExecuteAsyncMetricQueryArgs & {
             queryTags: RunQueryTags;
             explore: Explore;
+            isPreviewProject: boolean;
             // Saved chart (metric or SQL) the query was executed from, for analytics attribution
             chart?: { uuid: string };
             fields: ItemsMap;
@@ -3536,6 +3611,7 @@ export class AsyncQueryService extends ProjectService {
                     queryTags,
                     explore,
                     chart,
+                    isPreviewProject,
                     sql: compiledQuery,
                     metricQuery,
                     fields: fieldsMap,
@@ -3715,6 +3791,38 @@ export class AsyncQueryService extends ProjectService {
                                     : undefined),
                             },
                         });
+                    // Terminal outcome for queries that never reach the
+                    // background executor (cache hits and pre-execution
+                    // errors). Warehouse completions emit their own
+                    // query.completed in runAsyncWarehouseQuery.
+                    const trackQueryCompleted = (outcome: {
+                        status: 'success' | 'error';
+                        cacheHit: boolean;
+                        totalRowCount?: number | null;
+                        columnsCount?: number | null;
+                    }) =>
+                        this.analytics.trackAccount(account, {
+                            event: 'query.completed',
+                            properties: {
+                                queryId: queryHistoryUuid,
+                                organizationId: organizationUuid,
+                                projectId: projectUuid,
+                                isPreviewProject,
+                                status: outcome.status,
+                                context,
+                                exploreName: explore.name,
+                                chartId: chart?.uuid ?? null,
+                                dashboardId: queryTags.dashboard_uuid ?? null,
+                                cacheHit: outcome.cacheHit,
+                                executionSource: null,
+                                warehouseType: warehouseCredentialsType,
+                                warehouseExecutionTimeMs: outcome.cacheHit
+                                    ? 0
+                                    : null,
+                                totalRowCount: outcome.totalRowCount ?? null,
+                                columnsCount: outcome.columnsCount ?? null,
+                            },
+                        });
 
                     // Track cache hit/miss
                     this.prometheusMetrics?.incrementQueryCacheHit(
@@ -3725,6 +3833,14 @@ export class AsyncQueryService extends ProjectService {
 
                     if (resultsCache.cacheHit) {
                         trackQueryExecuted();
+                        trackQueryCompleted({
+                            status: 'success',
+                            cacheHit: true,
+                            totalRowCount: resultsCache.totalRowCount,
+                            columnsCount: resultsCache.columns
+                                ? Object.keys(resultsCache.columns).length
+                                : null,
+                        });
                         if (this.lightdashConfig.natsWorker.enabled) {
                             await this.queryHistoryModel.updateStatusToExecuting(
                                 queryHistoryUuid,
@@ -3776,6 +3892,10 @@ export class AsyncQueryService extends ProjectService {
 
                     if (missingParameterReferences.length > 0) {
                         trackQueryExecuted();
+                        trackQueryCompleted({
+                            status: 'error',
+                            cacheHit: false,
+                        });
                         await this.queryHistoryModel.updateStatusToError(
                             queryHistoryUuid,
                             projectUuid,
@@ -3852,6 +3972,10 @@ export class AsyncQueryService extends ProjectService {
 
                     if (executionPlan.target === 'error') {
                         trackQueryExecuted();
+                        trackQueryCompleted({
+                            status: 'error',
+                            cacheHit: false,
+                        });
                         await this.queryHistoryModel.updateStatusToError(
                             queryHistoryUuid,
                             projectUuid,
@@ -3886,6 +4010,7 @@ export class AsyncQueryService extends ProjectService {
                     const warehouseArgs: RunAsyncWarehouseQueryArgs = {
                         userUuid: account.user.id,
                         organizationUuid,
+                        isPreviewProject,
                         isRegisteredUser: account.isRegisteredUser(),
                         isServiceAccount: account.isServiceAccount(),
                         projectUuid,
@@ -4086,10 +4211,13 @@ export class AsyncQueryService extends ProjectService {
     ): Promise<ExecuteAsyncQueryReturn> {
         assertIsAccountWithOrg(args.account);
 
+        const projectSummary = await this.projectModel.getSummary(
+            args.projectUuid,
+        );
         const organizationUuid =
-            args.organizationUuid ??
-            (await this.projectModel.getSummary(args.projectUuid))
-                .organizationUuid;
+            args.organizationUuid ?? projectSummary.organizationUuid;
+        // Preview project queries are excluded from the usage event stream
+        const isPreviewProject = projectSummary.type === ProjectType.PREVIEW;
         const auditedAbility = this.createAuditedAbility(args.account);
         const isForbidden =
             auditedAbility.cannot(
@@ -4116,7 +4244,7 @@ export class AsyncQueryService extends ProjectService {
         }
 
         return this.executePreparedAsyncQuery(
-            args,
+            { ...args, isPreviewProject },
             requestParameters,
             organizationUuid,
         );
@@ -6749,6 +6877,7 @@ export class AsyncQueryService extends ProjectService {
                 {
                     account,
                     projectUuid,
+                    isPreviewProject: await this.isProjectPreview(projectUuid),
                     explore,
                     metricQuery,
                     context,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -200,6 +200,7 @@ export type RunAsyncWarehouseQueryArgs = {
     projectUuid: string;
     userUuid: string;
     organizationUuid: string;
+    isPreviewProject: boolean;
     queryUuid: string;
     isRegisteredUser: boolean;
     isServiceAccount?: boolean;


### PR DESCRIPTION
## What

Final slice of the usage events pipeline: an emit sink that projects an allowlist of existing `LightdashAnalytics` typed events into a typed `query_events` stream and pushes rows into the buffered S3 writer.

- **Envelope** on every row: `event_name`, `org_id`, `user_id` (null for anonymous), `event_ts` (stamped at emit time), `schema_version` (1).
- **`query_events` stream v1**: typed projections of `query.executed` (all three property-union flavours — paginated metric, plain metric, SQL runner), `query.ready`, and `query.error`. All absent values are explicit `null`.
- **Registry/allowlist** (`registry.ts`): typed map from event name to projection function. Events not in the registry are ignored; projections return `null` to drop (e.g. missing org id). Adding a future stream/event = adding an event type to `ProjectedEvent` and a registry entry — nothing else.
- **`EventStreamSink`**: takes the registry + an `EventStreamWriter`; `handle(payload)` never throws into the caller (logs a warning on projection/writer errors).
- **Hook**: `LightdashAnalytics.track()` calls `this.eventStreamSink?.handle(payload)` at the top — before the Rudderstack `writeKey` early-return and independent of `isTrackingAnonymized`, so the sink fires even when vendor telemetry is disabled. Wired in `App`, `SchedulerApp`, and `NatsWorkerApp` (sink constructed only when the buffered writer is enabled).

**Decision for reviewer:** the sink intentionally ignores `isTrackingAnonymized` (vendor-telemetry anonymization) because this data belongs to the customer's own org — flag if you disagree.

## Why

Per-org usage accounting needs query lifecycle events in the customer's own event store (S3 raw zone) rather than vendor telemetry.

Linear: https://linear.app/lightdash/issue/PROD-8604

## Stack

Depends on #25036 (buffered S3 writer + config) and #25037 (event enrichment: `exploreName`, `dashboardId`, `organizationId`). This PR sits on top of both; #25037's base was moved to `feature/prod-8606` as part of stacking.

## Testing

- Unit tests (`EventStreamSink.test.ts`): projection of all three events and all `query.executed` flavours, null handling, drop on missing org id, unknown events ignored.
- `pnpm -F backend lint`, `pnpm -F backend typecheck:fast`, `pnpm -F backend test:dev:nowatch` (645 tests, 37 files) all pass.

### E2E (local dev, MinIO)

Set `USAGE_EVENTS_ENABLED=true`, `USAGE_EVENTS_FLUSH_INTERVAL_MS=5000`, ran a saved chart query via `POST /api/v2/projects/{projectUuid}/query/chart`. Object landed in MinIO:

```
events/raw/org_id=172a2270-000f-42be-9c68-c4752c23ae51/stream=query_events/dt=2026-07-02/9516553f-b3bde3d8-626b-4b2e-8c20-cb5c6ab4d771.jsonl.gz
```

Sample rows (gunzipped JSONL):

```json
{"event_name": "query.executed", "org_id": "172a2270-000f-42be-9c68-c4752c23ae51", "user_id": "b264d83a-9000-426a-85ec-3f9c20f368ce", "event_ts": "2026-07-02T11:18:21.394Z", "schema_version": 1, "project_id": "3675b69e-8324-4110-bdca-059031aa8da3", "context": "api", "execution_source": "warehouse", "cache_hit": false, "pre_aggregate_hit": null, "query_id": "52eae88c-b137-43ae-bdd9-9e4033e61af0", "warehouse_type": "postgres", "explore_name": "fanouts_accounts_bridged_fanout", "chart_id": "f4f40541-e8fb-48ba-b746-e234f75bedfe", "dashboard_id": null, "sql_chart_id": null}
{"event_name": "query.ready", "org_id": "172a2270-000f-42be-9c68-c4752c23ae51", "user_id": "b264d83a-9000-426a-85ec-3f9c20f368ce", "event_ts": "2026-07-02T11:18:21.438Z", "schema_version": 1, "project_id": "3675b69e-8324-4110-bdca-059031aa8da3", "query_id": "52eae88c-b137-43ae-bdd9-9e4033e61af0", "warehouse_type": "postgres", "execution_source": "warehouse", "warehouse_execution_time_ms": 30.274875000000975, "total_row_count": 9, "columns_count": 2}
```

https://claude.ai/code/session_011AsrrbU7h5qFRayP3iWyGF