### PR TITLE
feat(query): accept filters on POST /query/chart (GLITCH-534)

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -295,6 +295,7 @@ export class QueryController extends BaseController {
                 limit: body.limit,
                 parameters: body.parameters,
                 pivotResults: body.pivotResults,
+                filterOverrides: body.filters,
             });
 
         return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -40335,6 +40335,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        filters: { ref: 'Filters' },
                         pivotResults: { dataType: 'boolean' },
                         limit: {
                             dataType: 'union',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -40604,6 +40604,9 @@
                     },
                     {
                         "properties": {
+                            "filters": {
+                                "$ref": "#/components/schemas/Filters"
+                            },
                             "pivotResults": {
                                 "type": "boolean"
                             },
@@ -42982,7 +42985,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3295.0",
+        "version": "0.3296.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3779,4 +3779,129 @@ describe('AsyncQueryService', () => {
             );
         });
     });
+
+    describe('executeAsyncSavedChartQuery filterOverrides wiring', () => {
+        const authorizedAccount = {
+            ...sessionAccount,
+            user: {
+                ...sessionAccount.user,
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Project', action: ['view'] },
+                    { subject: 'SavedChart', action: ['view'] },
+                ]),
+            },
+        } as unknown as Account;
+
+        // metricQueryMock.filters is `{}`, so give the chart its own
+        // dimensions filter group here to make the AND-merge assertion
+        // meaningful (otherwise there'd be nothing on the chart side to merge).
+        const chartFilterGroup = {
+            id: 'chart-root',
+            and: [
+                {
+                    id: 'chart-filter-0',
+                    target: { fieldId: 'a_dim1' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['chart-value'],
+                },
+            ],
+        };
+
+        const chart = {
+            uuid: 'savedChartUuid',
+            name: 'Chart with filters',
+            organizationUuid: projectSummary.organizationUuid,
+            projectUuid,
+            spaceUuid: 'spaceUuid',
+            tableName: validExplore.name,
+            metricQuery: {
+                ...metricQueryMock,
+                filters: { dimensions: chartFilterGroup },
+            },
+            parameters: undefined,
+            pivotConfig: undefined,
+            chartConfig: { type: ChartType.CARTESIAN },
+        };
+
+        test('ANDs filterOverrides onto the chart metricQuery filters', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                savedChartModel: {
+                    get: vi.fn(async () => chart),
+                } as unknown as SavedChartModel,
+                analyticsModel: {
+                    addChartViewEvent: vi.fn(async () => {}),
+                } as unknown as AnalyticsModel,
+            });
+            service.getExploreWithUserAccessControls = vi
+                .fn()
+                .mockResolvedValue({
+                    explore: validExplore,
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                });
+            (service as AnyType).getWarehouseCredentials = vi
+                .fn()
+                .mockResolvedValue(warehouseClientMock.credentials);
+            service.combineParameters = vi.fn().mockResolvedValue(undefined);
+            (service as AnyType).getMetricQueryFields = vi
+                .fn()
+                .mockResolvedValue({ fields: {} });
+            const prepareSpy = vi.fn().mockResolvedValue({
+                sql: 'SELECT 1',
+                fields: {},
+                warnings: [],
+                parameterReferences: [],
+                missingParameterReferences: [],
+                usedParameters: {},
+                responseMetricQuery: metricQueryMock,
+                userAccessControls: {
+                    userAttributes: {},
+                    intrinsicUserAttributes: {},
+                },
+                availableParameterDefinitions: {},
+            });
+            (service as AnyType).prepareMetricQueryAsyncQueryArgs = prepareSpy;
+            service['executeAsyncQuery'] = vi.fn().mockResolvedValue({
+                queryUuid: 'queryUuid',
+                cacheMetadata: { cacheHit: false },
+            });
+
+            const overrideGroup = {
+                id: 'app-root',
+                and: [
+                    {
+                        id: 'app-filter-0',
+                        target: { fieldId: 'a_dim1' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['enterprise'],
+                    },
+                ],
+            };
+            await service.executeAsyncSavedChartQuery({
+                account: authorizedAccount,
+                projectUuid,
+                chartUuid: chart.uuid,
+                versionUuid: undefined,
+                context: QueryExecutionContext.CHART,
+                invalidateCache: false,
+                limit: undefined,
+                parameters: undefined,
+                pivotResults: false,
+                filterOverrides: {
+                    dimensions: overrideGroup,
+                },
+            });
+
+            const merged = prepareSpy.mock.calls[0][0].metricQuery;
+            // Chart's own dimensions filter group survives AND the override
+            // group is added alongside it (AND semantics, not a replace).
+            expect(merged.filters.dimensions.and).toHaveLength(2);
+            expect(merged.filters.dimensions.and).toContainEqual(
+                chartFilterGroup,
+            );
+            expect(merged.filters.dimensions.and).toContainEqual(overrideGroup);
+        });
+    });
 });

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -36,6 +36,8 @@ export type ExecuteAsyncSavedChartRequestParams =
         versionUuid?: string;
         limit?: number | null | undefined;
         pivotResults?: boolean;
+        // ANDed onto the chart's own filters server-side (narrowing only).
+        filters?: Filters;
     };
 
 export type ExecuteAsyncDashboardChartRequestParams =


### PR DESCRIPTION
## Problem

Data-app linked charts (`savedChart(uuid)` → `POST /query/chart`) have no way to narrow a chart's query — the SDK's `.filters()` is a silent no-op because the public endpoint accepts no filter field, so generated apps fall back to client-side filtering of limit-truncated rows (wrong data) or inline queries (forfeits the live link).

## Solution

Expose the service's existing `filterOverrides` capability (already used by scheduled deliveries) on the public body: `ExecuteAsyncSavedChartRequestParams.filters?: Filters`, passed through the controller as `filterOverrides`. Semantics come from `addFiltersToMetricQuery`: request filters are **ANDed onto the chart's own filters** — callers can narrow a governed chart, never widen or replace it. Optional field → backward compatible.

Includes a service regression test pinning the merge behavior, and the full `generate-api` regen (TSOA strips body fields absent from the generated schema; the regen also carries pre-existing spec drift, reviewed for endpoint/security changes — none).

Part of a stack: the follow-up PR makes `@lightdash/query-sdk`'s `savedChart().filters()` send this field.

## Testing

- `executeAsyncSavedChartQuery filterOverrides wiring` service test: merged metricQuery contains both the chart's own filter group and the override group.
- `filters` verified present in regenerated `swagger.json` + `routes.ts` validation.
- common typecheck clean; backend typecheck has one pre-existing unrelated `@azure/identity` failure (verified present on base).

Relates: GLITCH-534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
