### PR TITLE
feat(analytics): nightly compaction of usage events raw zone to typed parquet

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -103,6 +103,7 @@ const schedulerWorkerFactory = (context: {
     utils: UtilRepository;
     // Optional only so the EE factory override (which reads context.workerHealth) typechecks against this shape.
     workerHealth?: SchedulerWorkerHealth;
+    prometheusMetrics?: PrometheusMetrics;
 }) =>
     new SchedulerWorker({
         lightdashConfig: context.lightdashConfig,
@@ -138,6 +139,7 @@ const schedulerWorkerFactory = (context: {
         resolveOrganizationName: createOrganizationNameResolver(
             context.models.getOrganizationModel(),
         ),
+        prometheusMetrics: context.prometheusMetrics,
     });
 
 export type AppArguments = {
@@ -980,6 +982,7 @@ export default class App {
             models: this.models,
             clients: this.clients,
             utils: this.utils,
+            prometheusMetrics: this.prometheusMetrics,
         });
 
         this.schedulerWorker.run().catch((e) => {

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -69,6 +69,7 @@ const schedulerWorkerFactory = (context: {
     clients: ClientRepository;
     utils: UtilRepository;
     workerHealth: SchedulerWorkerHealth;
+    prometheusMetrics?: PrometheusMetrics;
 }) =>
     new SchedulerWorker({
         lightdashConfig: context.lightdashConfig,
@@ -105,6 +106,7 @@ const schedulerWorkerFactory = (context: {
         resolveOrganizationName: createOrganizationNameResolver(
             context.models.getOrganizationModel(),
         ),
+        prometheusMetrics: context.prometheusMetrics,
     });
 
 export default class SchedulerApp {
@@ -263,6 +265,7 @@ export default class SchedulerApp {
             clients: this.clients,
             utils: this.utils,
             workerHealth,
+            prometheusMetrics: this.prometheusMetrics,
         });
         await worker.run();
         return { worker, workerHealth };

--- a/packages/backend/src/analytics/eventStream/UsageEventsCompactor.test.ts
+++ b/packages/backend/src/analytics/eventStream/UsageEventsCompactor.test.ts
@@ -1,0 +1,340 @@
+import Logger from '../../logging/logger';
+import PrometheusMetrics from '../../prometheus/PrometheusMetrics';
+import { queryEventsCompactedColumns } from './queryEventsStream';
+import {
+    buildCompactionSql,
+    buildPartFileName,
+    DELETE_MAX_ATTEMPTS,
+    groupRawKeysIntoPartitions,
+    parseRawKey,
+    UsageEventsCompactor,
+} from './UsageEventsCompactor';
+
+vi.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const s3Mocks = vi.hoisted(() => {
+    const listObjectsV2 = vi.fn();
+    const deleteObjects = vi.fn();
+    class FakeS3 {
+        listObjectsV2 = listObjectsV2;
+
+        deleteObjects = deleteObjects;
+    }
+    return { listObjectsV2, deleteObjects, FakeS3 };
+});
+
+vi.mock('@aws-sdk/client-s3', () => ({
+    S3: s3Mocks.FakeS3,
+}));
+
+const duckdbMocks = vi.hoisted(() => {
+    const runSqlWithMetrics = vi.fn();
+    class FakeDuckdbWarehouseClient {
+        runSqlWithMetrics = runSqlWithMetrics;
+    }
+    return { runSqlWithMetrics, FakeDuckdbWarehouseClient };
+});
+
+vi.mock('@lightdash/warehouses', () => ({
+    DuckdbWarehouseClient: duckdbMocks.FakeDuckdbWarehouseClient,
+}));
+
+const s3Config = {
+    endpoint: 'https://s3.example.com',
+    region: 'us-east-1',
+    bucket: 'events-bucket',
+    accessKey: 'AKIA',
+    secretKey: 'SECRET',
+    forcePathStyle: true,
+};
+
+const NOW = new Date('2026-07-02T10:00:00.000Z');
+
+const rawKey = (
+    orgId: string,
+    stream: string,
+    dt: string,
+    file = 'writer01-file-1.jsonl.gz',
+) => `events/raw/org_id=${orgId}/stream=${stream}/dt=${dt}/${file}`;
+
+const createMetricsMock = () => ({
+    incrementUsageEventsCompactedPartitions: vi.fn(),
+    incrementUsageEventsCompactionFailures: vi.fn(),
+    observeUsageEventsCompactionRunDuration: vi.fn(),
+    observeUsageEventsCompactionPartition: vi.fn(),
+    setUsageEventsCompactionBacklog: vi.fn(),
+});
+
+type MetricsMock = ReturnType<typeof createMetricsMock>;
+
+const createCompactor = (metrics: MetricsMock) =>
+    new UsageEventsCompactor({
+        s3Config,
+        prometheusMetrics: metrics as unknown as PrometheusMetrics,
+    });
+
+const mockListedKeys = (keys: string[]) => {
+    s3Mocks.listObjectsV2.mockResolvedValue({
+        Contents: keys.map((Key) => ({ Key })),
+        IsTruncated: false,
+    });
+};
+
+describe('parseRawKey', () => {
+    it('parses a valid raw zone key', () => {
+        expect(
+            parseRawKey(rawKey('org-1', 'query_events', '2026-07-01')),
+        ).toEqual({
+            orgId: 'org-1',
+            stream: 'query_events',
+            dt: '2026-07-01',
+            key: rawKey('org-1', 'query_events', '2026-07-01'),
+        });
+    });
+
+    it('returns null for keys outside the raw layout', () => {
+        expect(
+            parseRawKey('events/raw/org_id=org-1/loose.jsonl.gz'),
+        ).toBeNull();
+        expect(
+            parseRawKey(
+                'events/compacted/org_id=org-1/stream=query_events/dt=2026-07-01/part-x.parquet',
+            ),
+        ).toBeNull();
+        expect(
+            parseRawKey(
+                'events/raw/org_id=org-1/stream=query_events/dt=2026-7-1/file.jsonl.gz',
+            ),
+        ).toBeNull();
+        expect(
+            parseRawKey(
+                'events/raw/org_id=org-1/stream=query_events/dt=2026-07-01/file.parquet',
+            ),
+        ).toBeNull();
+    });
+});
+
+describe('groupRawKeysIntoPartitions', () => {
+    it('groups keys by partition and excludes today and future dates', () => {
+        const partitions = groupRawKeysIntoPartitions(
+            [
+                rawKey('org-1', 'query_events', '2026-07-01', 'a.jsonl.gz'),
+                rawKey('org-1', 'query_events', '2026-07-01', 'b.jsonl.gz'),
+                rawKey('org-2', 'query_events', '2026-06-30'),
+                rawKey('org-1', 'other_stream', '2026-07-01'),
+                rawKey('org-1', 'query_events', '2026-07-02'), // open day
+                rawKey('org-1', 'query_events', '2026-07-03'), // future
+                'events/raw/not-a-partition.jsonl.gz',
+            ],
+            '2026-07-02',
+        );
+
+        expect(partitions).toEqual([
+            {
+                orgId: 'org-2',
+                stream: 'query_events',
+                dt: '2026-06-30',
+                keys: [rawKey('org-2', 'query_events', '2026-06-30')],
+            },
+            {
+                orgId: 'org-1',
+                stream: 'other_stream',
+                dt: '2026-07-01',
+                keys: [rawKey('org-1', 'other_stream', '2026-07-01')],
+            },
+            {
+                orgId: 'org-1',
+                stream: 'query_events',
+                dt: '2026-07-01',
+                keys: [
+                    rawKey('org-1', 'query_events', '2026-07-01', 'a.jsonl.gz'),
+                    rawKey('org-1', 'query_events', '2026-07-01', 'b.jsonl.gz'),
+                ],
+            },
+        ]);
+    });
+});
+
+describe('buildPartFileName', () => {
+    it('is deterministic and independent of input order', () => {
+        const keys = ['k/b.jsonl.gz', 'k/a.jsonl.gz'];
+        expect(buildPartFileName(keys)).toEqual(
+            buildPartFileName([...keys].reverse()),
+        );
+        expect(buildPartFileName(keys)).toMatch(/^part-[0-9a-f]{40}\.parquet$/);
+    });
+
+    it('changes when the input file set changes', () => {
+        expect(buildPartFileName(['k/a.jsonl.gz'])).not.toEqual(
+            buildPartFileName(['k/a.jsonl.gz', 'k/b.jsonl.gz']),
+        );
+    });
+});
+
+describe('buildCompactionSql', () => {
+    it('builds a typed COPY from the exact raw files to a deterministic parquet part', () => {
+        const partition = {
+            orgId: 'org-1',
+            stream: 'query_events',
+            dt: '2026-07-01',
+            keys: [
+                rawKey('org-1', 'query_events', '2026-07-01', 'a.jsonl.gz'),
+                rawKey('org-1', 'query_events', '2026-07-01', 'b.jsonl.gz'),
+            ],
+        };
+        const { sql, compactedKey } = buildCompactionSql({
+            bucket: 'events-bucket',
+            partition,
+            columns: queryEventsCompactedColumns,
+        });
+
+        expect(compactedKey).toEqual(
+            `events/compacted/org_id=org-1/stream=query_events/dt=2026-07-01/${buildPartFileName(
+                partition.keys,
+            )}`,
+        );
+        expect(sql).toEqual(
+            'COPY (SELECT "event_name", "org_id", "user_id", "event_ts", "schema_version", ' +
+                '"project_id", "query_id", "status", "context", "explore_name", "chart_id", ' +
+                '"dashboard_id", "cache_hit", "execution_source", "warehouse_type", ' +
+                '"warehouse_execution_time_ms", "total_row_count", "columns_count" ' +
+                "FROM read_json(['s3://events-bucket/events/raw/org_id=org-1/stream=query_events/dt=2026-07-01/a.jsonl.gz', " +
+                "'s3://events-bucket/events/raw/org_id=org-1/stream=query_events/dt=2026-07-01/b.jsonl.gz'], " +
+                "format='newline_delimited', " +
+                'columns={"event_name": \'VARCHAR\', "org_id": \'VARCHAR\', "user_id": \'VARCHAR\', ' +
+                '"event_ts": \'TIMESTAMP\', "schema_version": \'INTEGER\', "project_id": \'VARCHAR\', ' +
+                '"query_id": \'VARCHAR\', "status": \'VARCHAR\', "context": \'VARCHAR\', ' +
+                '"explore_name": \'VARCHAR\', "chart_id": \'VARCHAR\', "dashboard_id": \'VARCHAR\', ' +
+                '"cache_hit": \'BOOLEAN\', "execution_source": \'VARCHAR\', "warehouse_type": \'VARCHAR\', ' +
+                '"warehouse_execution_time_ms": \'BIGINT\', ' +
+                '"total_row_count": \'BIGINT\', "columns_count": \'INTEGER\'})) ' +
+                `TO 's3://events-bucket/${compactedKey}' (FORMAT PARQUET, COMPRESSION zstd)`,
+        );
+    });
+});
+
+describe('UsageEventsCompactor.run', () => {
+    let metrics: MetricsMock;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        metrics = createMetricsMock();
+        duckdbMocks.runSqlWithMetrics.mockResolvedValue({
+            bootstrapMs: 1,
+            queryMs: 1,
+            totalMs: 2,
+        });
+        s3Mocks.deleteObjects.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('never deletes raw files when the compaction write fails', async () => {
+        duckdbMocks.runSqlWithMetrics.mockRejectedValue(
+            new Error('duckdb exploded'),
+        );
+        mockListedKeys([rawKey('org-1', 'query_events', '2026-07-01')]);
+
+        const summary = await createCompactor(metrics).run(NOW);
+
+        expect(summary.partitionsFailed).toEqual(1);
+        expect(summary.partitionsCompacted).toEqual(0);
+        expect(s3Mocks.deleteObjects).not.toHaveBeenCalled();
+        expect(
+            metrics.incrementUsageEventsCompactionFailures,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+            metrics.observeUsageEventsCompactionPartition,
+        ).toHaveBeenCalledWith(
+            expect.any(Number),
+            'failed',
+            expect.any(Number),
+        );
+        // Failed partition stays in the backlog for the next run
+        expect(metrics.setUsageEventsCompactionBacklog).toHaveBeenCalledWith(1);
+        expect(
+            metrics.observeUsageEventsCompactionRunDuration,
+        ).toHaveBeenCalledWith(expect.any(Number), 'partial');
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('duckdb exploded'),
+        );
+    });
+
+    it('retries only the raw keys that failed to delete and still compacts the partition', async () => {
+        vi.useFakeTimers();
+        const keys = [
+            rawKey('org-1', 'query_events', '2026-07-01', 'a.jsonl.gz'),
+            rawKey('org-1', 'query_events', '2026-07-01', 'b.jsonl.gz'),
+        ];
+        mockListedKeys(keys);
+        s3Mocks.deleteObjects
+            .mockResolvedValueOnce({
+                Errors: [{ Key: keys[1], Message: 'InternalError' }],
+            })
+            .mockResolvedValueOnce({});
+
+        const runPromise = createCompactor(metrics).run(NOW);
+        await vi.runAllTimersAsync();
+        const summary = await runPromise;
+
+        expect(summary.partitionsCompacted).toEqual(1);
+        expect(summary.partitionsFailed).toEqual(0);
+        expect(summary.rawObjectsDeleted).toEqual(2);
+        expect(s3Mocks.deleteObjects).toHaveBeenCalledTimes(2);
+        expect(s3Mocks.deleteObjects).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                Delete: expect.objectContaining({
+                    Objects: [{ Key: keys[1] }],
+                }),
+            }),
+        );
+    });
+
+    it('fails the partition with a cleanup warning when delete retries are exhausted', async () => {
+        vi.useFakeTimers();
+        const key = rawKey('org-1', 'query_events', '2026-07-01');
+        mockListedKeys([key]);
+        s3Mocks.deleteObjects.mockResolvedValue({
+            Errors: [{ Key: key, Message: 'AccessDenied' }],
+        });
+
+        const runPromise = createCompactor(metrics).run(NOW);
+        await vi.runAllTimersAsync();
+        const summary = await runPromise;
+
+        expect(summary.partitionsFailed).toEqual(1);
+        expect(summary.partitionsCompacted).toEqual(0);
+        expect(s3Mocks.deleteObjects).toHaveBeenCalledTimes(
+            DELETE_MAX_ATTEMPTS,
+        );
+        expect(
+            metrics.incrementUsageEventsCompactionFailures,
+        ).toHaveBeenCalledTimes(1);
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('deleted manually'),
+        );
+    });
+
+    it('excludes unknown-stream partitions from the backlog gauge', async () => {
+        mockListedKeys([
+            rawKey('org-1', 'query_events', '2026-07-01'),
+            rawKey('org-1', 'mystery_stream', '2026-07-01'),
+        ]);
+
+        const summary = await createCompactor(metrics).run(NOW);
+
+        expect(summary.partitionsCompacted).toEqual(1);
+        expect(summary.partitionsSkippedUnknownStream).toEqual(1);
+        expect(metrics.setUsageEventsCompactionBacklog).toHaveBeenCalledWith(0);
+    });
+});

--- a/packages/backend/src/analytics/eventStream/UsageEventsCompactor.ts
+++ b/packages/backend/src/analytics/eventStream/UsageEventsCompactor.ts
@@ -1,0 +1,379 @@
+import { getErrorMessage } from '@lightdash/common';
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
+import { createHash } from 'crypto';
+import { S3BaseClient } from '../../clients/Aws/S3BaseClient';
+import { S3Config } from '../../config/parseConfig';
+import { getDuckdbRuntimeConfig } from '../../ee/services/AsyncQueryService/getDuckdbRuntimeConfig';
+import { quoteDuckdbIdentifier } from '../../ee/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable';
+import Logger from '../../logging/logger';
+import PrometheusMetrics from '../../prometheus/PrometheusMetrics';
+import { getCompactedStreamColumns } from './registry';
+import { CompactedStreamColumn } from './types';
+
+const RAW_KEY_PREFIX = 'events/raw/';
+const COMPACTED_KEY_PREFIX = 'events/compacted';
+export const MAX_PARTITIONS_PER_RUN = 500;
+const DELETE_BATCH_SIZE = 1000;
+export const DELETE_MAX_ATTEMPTS = 3;
+const DELETE_RETRY_BASE_DELAY_MS = 1_000;
+
+const sleep = (ms: number) =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+const RAW_KEY_PATTERN =
+    /^events\/raw\/org_id=([^/=]+)\/stream=([^/=]+)\/dt=(\d{4}-\d{2}-\d{2})\/[^/]+\.jsonl\.gz$/;
+
+export type RawPartition = {
+    orgId: string;
+    stream: string;
+    dt: string;
+    keys: string[];
+};
+
+export type ParsedRawKey = {
+    orgId: string;
+    stream: string;
+    dt: string;
+    key: string;
+};
+
+export const parseRawKey = (key: string): ParsedRawKey | null => {
+    const match = key.match(RAW_KEY_PATTERN);
+    if (!match) return null;
+    return { orgId: match[1], stream: match[2], dt: match[3], key };
+};
+
+/**
+ * Groups raw object keys into (org_id, stream, dt) partitions, keeping only
+ * closed partitions (dt strictly before today's UTC date). Unparseable keys
+ * are ignored. Partitions are returned oldest-first so a capped run drains
+ * the backlog in order.
+ */
+export const groupRawKeysIntoPartitions = (
+    keys: string[],
+    todayUtc: string,
+): RawPartition[] => {
+    const partitions = new Map<string, RawPartition>();
+    keys.forEach((key) => {
+        const parsed = parseRawKey(key);
+        if (!parsed || parsed.dt >= todayUtc) return;
+        const partitionKey = `${parsed.orgId}|${parsed.stream}|${parsed.dt}`;
+        const partition = partitions.get(partitionKey);
+        if (partition) {
+            partition.keys.push(key);
+        } else {
+            partitions.set(partitionKey, {
+                orgId: parsed.orgId,
+                stream: parsed.stream,
+                dt: parsed.dt,
+                keys: [key],
+            });
+        }
+    });
+    return Array.from(partitions.values()).sort(
+        (a, b) =>
+            a.dt.localeCompare(b.dt) ||
+            a.orgId.localeCompare(b.orgId) ||
+            a.stream.localeCompare(b.stream),
+    );
+};
+
+/**
+ * Deterministic parquet part name derived from the raw input file set, so a
+ * re-run over the same inputs overwrites the same part instead of duplicating
+ * rows. Late-arriving raw files produce a different set and thus a new part.
+ */
+export const buildPartFileName = (rawKeys: string[]): string => {
+    const hash = createHash('sha1')
+        .update([...rawKeys].sort().join('\n'))
+        .digest('hex');
+    return `part-${hash}.parquet`;
+};
+
+const escapeSqlString = (value: string): string => value.replace(/'/g, "''");
+
+export const buildCompactionSql = ({
+    bucket,
+    partition,
+    columns,
+}: {
+    bucket: string;
+    partition: RawPartition;
+    columns: CompactedStreamColumn[];
+}): { sql: string; compactedKey: string } => {
+    const compactedKey = `${COMPACTED_KEY_PREFIX}/org_id=${partition.orgId}/stream=${
+        partition.stream
+    }/dt=${partition.dt}/${buildPartFileName(partition.keys)}`;
+    const columnDefs = columns
+        .map(
+            (column) =>
+                `${quoteDuckdbIdentifier(column.name)}: '${column.type}'`,
+        )
+        .join(', ');
+    const selectList = columns
+        .map((column) => quoteDuckdbIdentifier(column.name))
+        .join(', ');
+    // Read the exact listed files (not a glob) so objects written between
+    // listing and COPY are never deleted uncompacted nor compacted twice.
+    const fileList = partition.keys
+        .map((key) => `'s3://${escapeSqlString(`${bucket}/${key}`)}'`)
+        .join(', ');
+    const sql = `COPY (SELECT ${selectList} FROM read_json([${fileList}], format='newline_delimited', columns={${columnDefs}})) TO 's3://${escapeSqlString(
+        `${bucket}/${compactedKey}`,
+    )}' (FORMAT PARQUET, COMPRESSION zstd)`;
+    return { sql, compactedKey };
+};
+
+export type CompactionRunSummary = {
+    partitionsDiscovered: number;
+    partitionsCompacted: number;
+    partitionsFailed: number;
+    partitionsSkippedUnknownStream: number;
+    rawObjectsDeleted: number;
+};
+
+export type UsageEventsCompactorArgs = {
+    s3Config: Omit<S3Config, 'expirationTime'>;
+    prometheusMetrics: PrometheusMetrics | null;
+};
+
+/**
+ * Nightly compaction of the usage-events raw zone: converts every closed
+ * (org_id, stream, dt) partition of gzip JSONL objects into a typed zstd
+ * parquet part, then deletes exactly the raw objects it read. Per-partition
+ * failures are logged and counted without aborting the run.
+ */
+export class UsageEventsCompactor extends S3BaseClient {
+    private readonly bucket: string;
+
+    private readonly s3Config: Omit<S3Config, 'expirationTime'>;
+
+    private readonly prometheusMetrics: PrometheusMetrics | null;
+
+    constructor(args: UsageEventsCompactorArgs) {
+        super(args.s3Config);
+        this.bucket = args.s3Config.bucket;
+        this.s3Config = args.s3Config;
+        this.prometheusMetrics = args.prometheusMetrics;
+    }
+
+    async run(now: Date = new Date()): Promise<CompactionRunSummary> {
+        const runStart = Date.now();
+        const todayUtc = now.toISOString().slice(0, 10);
+        const { keys: rawKeys, bytesByKey } = await this.listRawKeys();
+        let partitions = groupRawKeysIntoPartitions(rawKeys, todayUtc);
+        const summary: CompactionRunSummary = {
+            partitionsDiscovered: partitions.length,
+            partitionsCompacted: 0,
+            partitionsFailed: 0,
+            partitionsSkippedUnknownStream: 0,
+            rawObjectsDeleted: 0,
+        };
+        if (partitions.length === 0) {
+            this.prometheusMetrics?.setUsageEventsCompactionBacklog(0);
+            this.prometheusMetrics?.observeUsageEventsCompactionRunDuration(
+                Date.now() - runStart,
+                'success',
+            );
+            Logger.info('Usage events compaction: no closed partitions found');
+            return summary;
+        }
+        if (partitions.length > MAX_PARTITIONS_PER_RUN) {
+            Logger.warn(
+                `Usage events compaction: capping run to ${MAX_PARTITIONS_PER_RUN} of ${partitions.length} closed partitions`,
+            );
+            partitions = partitions.slice(0, MAX_PARTITIONS_PER_RUN);
+        }
+
+        const duckdb = this.createDuckdbClient();
+        for (let i = 0; i < partitions.length; i += 1) {
+            const partition = partitions[i];
+            const partitionLabel = `org_id=${partition.orgId}/stream=${partition.stream}/dt=${partition.dt}`;
+            const columns = getCompactedStreamColumns(partition.stream);
+            if (columns === null) {
+                summary.partitionsSkippedUnknownStream += 1;
+                Logger.warn(
+                    `Usage events compaction: skipping unknown stream partition ${partitionLabel} (${partition.keys.length} raw objects left in place)`,
+                );
+            } else {
+                const partitionStart = Date.now();
+                const partitionRawBytes = partition.keys.reduce(
+                    (total, key) => total + (bytesByKey.get(key) ?? 0),
+                    0,
+                );
+                try {
+                    const { sql, compactedKey } = buildCompactionSql({
+                        bucket: this.bucket,
+                        partition,
+                        columns,
+                    });
+                    // eslint-disable-next-line no-await-in-loop
+                    const duckdbMetrics = await duckdb.runSqlWithMetrics(sql);
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.deleteRawKeys(partition.keys);
+                    summary.partitionsCompacted += 1;
+                    summary.rawObjectsDeleted += partition.keys.length;
+                    this.prometheusMetrics?.incrementUsageEventsCompactedPartitions();
+                    this.prometheusMetrics?.observeUsageEventsCompactionPartition(
+                        Date.now() - partitionStart,
+                        'success',
+                        partitionRawBytes,
+                    );
+                    Logger.info(
+                        `Usage events compaction: compacted ${partition.keys.length} raw objects (${partitionRawBytes} bytes) from ${partitionLabel} into s3://${this.bucket}/${compactedKey} in ${
+                            Date.now() - partitionStart
+                        }ms (duckdb query ${Math.round(duckdbMetrics.queryMs)}ms)`,
+                    );
+                } catch (error) {
+                    summary.partitionsFailed += 1;
+                    this.prometheusMetrics?.incrementUsageEventsCompactionFailures();
+                    this.prometheusMetrics?.observeUsageEventsCompactionPartition(
+                        Date.now() - partitionStart,
+                        'failed',
+                        partitionRawBytes,
+                    );
+                    Logger.error(
+                        `Usage events compaction: failed partition ${partitionLabel}: ${getErrorMessage(
+                            error,
+                        )}`,
+                    );
+                }
+            }
+        }
+
+        // Failed and cap-deferred partitions stay in the raw zone for the
+        // next run; a growing gauge means compaction is falling behind.
+        // Unknown-stream partitions are excluded: they are not retryable work
+        // (they compact only once their stream is registered) and are
+        // surfaced via the warn log above instead.
+        this.prometheusMetrics?.setUsageEventsCompactionBacklog(
+            summary.partitionsDiscovered -
+                summary.partitionsCompacted -
+                summary.partitionsSkippedUnknownStream,
+        );
+        this.prometheusMetrics?.observeUsageEventsCompactionRunDuration(
+            Date.now() - runStart,
+            summary.partitionsFailed > 0 ? 'partial' : 'success',
+        );
+        Logger.info(
+            `Usage events compaction complete in ${
+                Date.now() - runStart
+            }ms: ${summary.partitionsCompacted} partitions compacted (${summary.rawObjectsDeleted} raw objects deleted), ${summary.partitionsFailed} failed, ${summary.partitionsSkippedUnknownStream} skipped (unknown stream), ${summary.partitionsDiscovered} discovered`,
+        );
+        return summary;
+    }
+
+    private createDuckdbClient(): DuckdbWarehouseClient {
+        const runtimeConfig = getDuckdbRuntimeConfig(this.s3Config);
+        if (!runtimeConfig) {
+            throw new Error(
+                'Usage events compaction: missing S3 configuration for DuckDB',
+            );
+        }
+        return new DuckdbWarehouseClient(
+            { type: 'duckdb_s3', s3Config: runtimeConfig },
+            {
+                resourceLimits: { memoryLimit: '256MB', threads: 1 },
+                logger: Logger,
+            },
+        );
+    }
+
+    private async listRawKeys(): Promise<{
+        keys: string[];
+        bytesByKey: Map<string, number>;
+    }> {
+        if (!this.s3) {
+            throw new Error('S3 client is not configured');
+        }
+        const keys: string[] = [];
+        const bytesByKey = new Map<string, number>();
+        let continuationToken: string | undefined;
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            const response = await this.s3.listObjectsV2({
+                Bucket: this.bucket,
+                Prefix: RAW_KEY_PREFIX,
+                ContinuationToken: continuationToken,
+            });
+            (response.Contents ?? []).forEach((object) => {
+                if (object.Key) {
+                    keys.push(object.Key);
+                    bytesByKey.set(object.Key, object.Size ?? 0);
+                }
+            });
+            continuationToken = response.IsTruncated
+                ? response.NextContinuationToken
+                : undefined;
+        } while (continuationToken);
+        return { keys, bytesByKey };
+    }
+
+    /**
+     * Deletes raw keys with retries. A raw key that survives after its
+     * parquet part was written would be compacted again into a second part on
+     * the next run (different key set, different part hash), duplicating its
+     * rows — so exhausted retries throw with an explicit cleanup warning.
+     */
+    private async deleteRawKeys(keys: string[]): Promise<void> {
+        let pending = keys;
+        let lastError = 'unknown error';
+        for (let attempt = 1; attempt <= DELETE_MAX_ATTEMPTS; attempt += 1) {
+            if (attempt > 1) {
+                // eslint-disable-next-line no-await-in-loop
+                await sleep(DELETE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 2));
+                Logger.warn(
+                    `Usage events compaction: retrying delete of ${pending.length} raw objects (attempt ${attempt}/${DELETE_MAX_ATTEMPTS})`,
+                );
+            }
+            // eslint-disable-next-line no-await-in-loop
+            const failed = await this.tryDeleteRawKeys(pending);
+            if (failed.keys.length === 0) return;
+            pending = failed.keys;
+            lastError = failed.lastError;
+        }
+        throw new Error(
+            `Failed to delete ${pending.length} raw objects after ${DELETE_MAX_ATTEMPTS} attempts (first: ${pending[0]}, last error: ${lastError}). ` +
+                `The parquet part was already written, so these raw objects must be deleted manually before the next run to avoid duplicated rows in the compacted zone`,
+        );
+    }
+
+    private async tryDeleteRawKeys(
+        keys: string[],
+    ): Promise<{ keys: string[]; lastError: string }> {
+        if (!this.s3) {
+            throw new Error('S3 client is not configured');
+        }
+        const failedKeys: string[] = [];
+        let lastError = 'unknown error';
+        for (let i = 0; i < keys.length; i += DELETE_BATCH_SIZE) {
+            const batch = keys.slice(i, i + DELETE_BATCH_SIZE);
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                const response = await this.s3.deleteObjects({
+                    Bucket: this.bucket,
+                    Delete: {
+                        Objects: batch.map((Key) => ({ Key })),
+                        Quiet: true,
+                    },
+                });
+                const responseErrors = response.Errors ?? [];
+                responseErrors.forEach((error) => {
+                    if (error.Key) failedKeys.push(error.Key);
+                });
+                const lastMessage = responseErrors
+                    .map((error) => error.Message)
+                    .filter(Boolean)
+                    .pop();
+                if (lastMessage) lastError = lastMessage;
+            } catch (error) {
+                // Request-level failure: deletes are idempotent, retry the whole batch
+                failedKeys.push(...batch);
+                lastError = getErrorMessage(error);
+            }
+        }
+        return { keys: failedKeys, lastError };
+    }
+}

--- a/packages/backend/src/analytics/eventStream/queryEventsStream.ts
+++ b/packages/backend/src/analytics/eventStream/queryEventsStream.ts
@@ -1,5 +1,32 @@
 import type { QueryCompletedEvent } from '../LightdashAnalytics';
 import { buildEnvelope, ProjectionResult } from './projection';
+import type { CompactedStreamColumn } from './types';
+
+/**
+ * Typed column list for the compacted (parquet) zone of the `query_events`
+ * stream, v1. Envelope columns first, then one typed column per field of the
+ * query.completed projection below — one row per query.
+ */
+export const queryEventsCompactedColumns: CompactedStreamColumn[] = [
+    { name: 'event_name', type: 'VARCHAR' },
+    { name: 'org_id', type: 'VARCHAR' },
+    { name: 'user_id', type: 'VARCHAR' },
+    { name: 'event_ts', type: 'TIMESTAMP' },
+    { name: 'schema_version', type: 'INTEGER' },
+    { name: 'project_id', type: 'VARCHAR' },
+    { name: 'query_id', type: 'VARCHAR' },
+    { name: 'status', type: 'VARCHAR' },
+    { name: 'context', type: 'VARCHAR' },
+    { name: 'explore_name', type: 'VARCHAR' },
+    { name: 'chart_id', type: 'VARCHAR' },
+    { name: 'dashboard_id', type: 'VARCHAR' },
+    { name: 'cache_hit', type: 'BOOLEAN' },
+    { name: 'execution_source', type: 'VARCHAR' },
+    { name: 'warehouse_type', type: 'VARCHAR' },
+    { name: 'warehouse_execution_time_ms', type: 'BIGINT' },
+    { name: 'total_row_count', type: 'BIGINT' },
+    { name: 'columns_count', type: 'INTEGER' },
+];
 
 /**
  * Projection for the `query_events` stream (v1): one row per async query,

--- a/packages/backend/src/analytics/eventStream/registry.ts
+++ b/packages/backend/src/analytics/eventStream/registry.ts
@@ -1,6 +1,10 @@
 import type { QueryCompletedEvent } from '../LightdashAnalytics';
-import type { ProjectionResult } from './projection';
-import { queryEventsProjections } from './queryEventsStream';
+import type { ProjectionResult, StreamName } from './projection';
+import {
+    queryEventsCompactedColumns,
+    queryEventsProjections,
+} from './queryEventsStream';
+import type { CompactedStreamColumn } from './types';
 
 /**
  * Union of every analytics event projected into a usage event stream.
@@ -20,3 +24,22 @@ export type EventStreamRegistry = {
 export const eventStreamRegistry: EventStreamRegistry = {
     ...queryEventsProjections,
 };
+
+/**
+ * Typed parquet schema per stream, used by the nightly compaction job.
+ * Streams found in the raw zone without an entry here are skipped (their raw
+ * files are never deleted).
+ */
+export const compactedStreamSchemas: Record<
+    StreamName,
+    CompactedStreamColumn[]
+> = {
+    query_events: queryEventsCompactedColumns,
+};
+
+export const getCompactedStreamColumns = (
+    stream: string,
+): CompactedStreamColumn[] | null =>
+    stream in compactedStreamSchemas
+        ? compactedStreamSchemas[stream as StreamName]
+        : null;

--- a/packages/backend/src/analytics/eventStream/types.ts
+++ b/packages/backend/src/analytics/eventStream/types.ts
@@ -13,3 +13,20 @@ export interface EventStreamWriter {
     flush(): Promise<void>;
     close(): Promise<void>;
 }
+
+/**
+ * DuckDB types allowed in compacted (parquet) stream schemas. Each stream
+ * declares its typed column list next to its projections so schema and cast
+ * stay together.
+ */
+export type CompactedColumnType =
+    | 'VARCHAR'
+    | 'TIMESTAMP'
+    | 'BOOLEAN'
+    | 'INTEGER'
+    | 'BIGINT';
+
+export type CompactedStreamColumn = {
+    name: string;
+    type: CompactedColumnType;
+};

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -896,6 +896,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.serviceRepository.getProjectContextService<ProjectContextService>(),
                 projectModel: context.models.getProjectModel(),
                 openIdIdentityModel: context.models.getOpenIdIdentityModel(),
+                prometheusMetrics: context.prometheusMetrics,
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -178,6 +178,23 @@ export default class PrometheusMetrics {
 
     public usageEventsPutFailuresCounter: prometheus.Counter | null = null;
 
+    public usageEventsCompactedPartitionsCounter: prometheus.Counter | null =
+        null;
+
+    public usageEventsCompactionFailuresCounter: prometheus.Counter | null =
+        null;
+
+    public usageEventsCompactionRunDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
+    public usageEventsCompactionPartitionDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
+    public usageEventsCompactionPartitionBytesHistogram: prometheus.Histogram | null =
+        null;
+
+    public usageEventsCompactionBacklogGauge: prometheus.Gauge | null = null;
+
     public preAggregateMaterializationFileSizeHistogram: prometheus.Histogram<string> | null =
         null;
 
@@ -793,6 +810,60 @@ export default class PrometheusMetrics {
                     ...rest,
                 });
 
+                this.usageEventsCompactedPartitionsCounter =
+                    new prometheus.Counter({
+                        name: 'lightdash_usage_events_compacted_partitions_total',
+                        help: 'Total raw usage event partitions compacted to parquet',
+                        ...rest,
+                    });
+
+                this.usageEventsCompactionFailuresCounter =
+                    new prometheus.Counter({
+                        name: 'lightdash_usage_events_compaction_failures_total',
+                        help: 'Total usage event partition compactions that failed',
+                        ...rest,
+                    });
+
+                this.usageEventsCompactionRunDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_usage_events_compaction_run_duration_ms',
+                        help: 'Duration of a full usage events compaction run in milliseconds',
+                        labelNames: ['outcome'],
+                        buckets: [
+                            1_000, 5_000, 15_000, 60_000, 300_000, 900_000,
+                            1_800_000, 3_600_000,
+                        ],
+                        ...rest,
+                    });
+
+                this.usageEventsCompactionPartitionDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_usage_events_compaction_partition_duration_ms',
+                        help: 'Duration of a single partition compaction in milliseconds',
+                        labelNames: ['outcome'],
+                        buckets: [
+                            100, 500, 1_000, 5_000, 15_000, 60_000, 300_000,
+                        ],
+                        ...rest,
+                    });
+
+                this.usageEventsCompactionPartitionBytesHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_usage_events_compaction_partition_raw_bytes',
+                        help: 'Total gzip raw bytes read per partition compaction (DuckDB memory pressure signal)',
+                        buckets: [
+                            10_000, 100_000, 1_000_000, 10_000_000, 50_000_000,
+                            100_000_000, 250_000_000, 1_000_000_000,
+                        ],
+                        ...rest,
+                    });
+
+                this.usageEventsCompactionBacklogGauge = new prometheus.Gauge({
+                    name: 'lightdash_usage_events_compaction_backlog_partitions',
+                    help: 'Closed raw partitions still awaiting compaction after the last run (cap deferrals + failures)',
+                    ...rest,
+                });
+
                 const app = express();
                 this.server = http.createServer(app);
                 app.get(metricsPath, async (req, res) => {
@@ -1389,6 +1460,40 @@ export default class PrometheusMetrics {
 
     public incrementUsageEventsPutFailure() {
         this.usageEventsPutFailuresCounter?.inc();
+    }
+
+    public incrementUsageEventsCompactedPartitions() {
+        this.usageEventsCompactedPartitionsCounter?.inc();
+    }
+
+    public incrementUsageEventsCompactionFailures() {
+        this.usageEventsCompactionFailuresCounter?.inc();
+    }
+
+    public observeUsageEventsCompactionRunDuration(
+        durationMs: number,
+        outcome: 'success' | 'partial',
+    ) {
+        this.usageEventsCompactionRunDurationHistogram?.observe(
+            { outcome },
+            durationMs,
+        );
+    }
+
+    public observeUsageEventsCompactionPartition(
+        durationMs: number,
+        outcome: 'success' | 'failed',
+        rawBytes: number,
+    ) {
+        this.usageEventsCompactionPartitionDurationHistogram?.observe(
+            { outcome },
+            durationMs,
+        );
+        this.usageEventsCompactionPartitionBytesHistogram?.observe(rawBytes);
+    }
+
+    public setUsageEventsCompactionBacklog(partitions: number) {
+        this.usageEventsCompactionBacklogGauge?.set(partitions);
     }
 
     public monitorEventMetrics(eventEmitter: EventEmitter) {

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -256,6 +256,7 @@ const getTagsForTask: {
     }),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: () => ({}),
+    [SCHEDULER_TASKS.COMPACT_USAGE_EVENTS]: () => ({}),
     [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -7,6 +7,7 @@ import {
     SchedulerJobStatus,
     type SchedulerTaskName,
 } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import {
     Logger as GraphileLogger,
     parseCronItems,
@@ -15,8 +16,10 @@ import {
     type CronItem,
 } from 'graphile-worker';
 import moment from 'moment';
+import { UsageEventsCompactor } from '../analytics/eventStream/UsageEventsCompactor';
 import { DEFAULT_DB_MAX_CONNECTIONS } from '../knexfile';
 import Logger from '../logging/logger';
+import type PrometheusMetrics from '../prometheus/PrometheusMetrics';
 import { type OrganizationNameResolver } from '../sentry/organizationNameResolver';
 import { SchedulerClient } from './SchedulerClient';
 import {
@@ -35,6 +38,8 @@ export type SchedulerWorkerArguments = SchedulerTaskArguments & {
     // job-activity events alone.
     workerHealth?: SchedulerWorkerHealth;
     resolveOrganizationName?: OrganizationNameResolver;
+    // When omitted, worker tasks that report metrics simply skip reporting.
+    prometheusMetrics?: PrometheusMetrics;
 };
 
 const workerLogger = new GraphileLogger(
@@ -67,12 +72,15 @@ export class SchedulerWorker extends SchedulerTask {
 
     private readonly resolveOrganizationName?: OrganizationNameResolver;
 
+    private readonly prometheusMetrics: PrometheusMetrics | null;
+
     constructor(schedulerWorkerArgs: SchedulerWorkerArguments) {
         super(schedulerWorkerArgs);
         this.enabledTasks = this.lightdashConfig.scheduler.tasks;
         this.workerHealth = schedulerWorkerArgs.workerHealth;
         this.resolveOrganizationName =
             schedulerWorkerArgs.resolveOrganizationName;
+        this.prometheusMetrics = schedulerWorkerArgs.prometheusMetrics ?? null;
     }
 
     async run() {
@@ -232,6 +240,14 @@ export class SchedulerWorker extends SchedulerTask {
                 pattern: '0 * * * *', // Every hour
                 options: {
                     backfillPeriod: 2 * 3600 * 1000, // 2 hours in ms
+                    maxAttempts: 3,
+                },
+            },
+            {
+                task: SCHEDULER_TASKS.COMPACT_USAGE_EVENTS,
+                pattern: '30 0 * * *', // 00:30 UTC daily
+                options: {
+                    backfillPeriod: 12 * 3600 * 1000, // 12 hours in ms
                     maxAttempts: 3,
                 },
             },
@@ -1327,6 +1343,32 @@ export class SchedulerWorker extends SchedulerTask {
             },
             [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: async () => {
                 await this.schedulerService.checkForStuckJobs();
+            },
+            [SCHEDULER_TASKS.COMPACT_USAGE_EVENTS]: async () => {
+                const { usageEvents } = this.lightdashConfig;
+                if (!usageEvents.enabled || usageEvents.s3 === null) {
+                    Logger.debug(
+                        'Usage events compaction skipped: usage events are not enabled',
+                    );
+                    return;
+                }
+                const compactor = new UsageEventsCompactor({
+                    s3Config: usageEvents.s3,
+                    prometheusMetrics: this.prometheusMetrics,
+                });
+                const summary = await compactor.run();
+                Sentry.getActiveSpan()?.setAttributes({
+                    'lightdash.usage_events.partitions_discovered':
+                        summary.partitionsDiscovered,
+                    'lightdash.usage_events.partitions_compacted':
+                        summary.partitionsCompacted,
+                    'lightdash.usage_events.partitions_failed':
+                        summary.partitionsFailed,
+                    'lightdash.usage_events.partitions_skipped_unknown_stream':
+                        summary.partitionsSkippedUnknownStream,
+                    'lightdash.usage_events.raw_objects_deleted':
+                        summary.rawObjectsDeleted,
+                });
             },
             [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: async () => {
                 // EE-only: implemented in CommercialSchedulerWorker

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -121,6 +121,7 @@ export const SCHEDULER_TASKS = {
     MANAGED_AGENT_HEARTBEAT: 'managedAgentHeartbeat',
     CLEAN_EXPIRED_PREVIEWS: 'cleanExpiredPreviews',
     INGEST_PROJECT_CONTEXT: 'ingestProjectContext',
+    COMPACT_USAGE_EVENTS: 'compactUsageEvents',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -165,6 +166,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: ManagedAgentHeartbeatPayload;
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: TraceTaskBase;
     [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: TraceTaskBase;
+    [SCHEDULER_TASKS.COMPACT_USAGE_EVENTS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;


### PR DESCRIPTION
Stage 3 of the usage-analytics event pipeline: a nightly job that rolls the raw gzip-JSONL zone into typed, compacted Parquet.

**Stack note: depends on #25045** (`feature/prod-8606` → `feature/prod-8604-enrich-query-events` → `feature/prod-8604` → this).

## What

- **`compactUsageEvents` scheduler task** registered in the Graphile Worker crontab at **00:30 UTC nightly** (`SchedulerWorker.getCronItems`, backfill 12h, 3 attempts). No-ops cheaply when `lightdashConfig.usageEvents` is disabled.
- **`UsageEventsCompactor`** (`analytics/eventStream/`): lists `events/raw/`, groups keys into `(org_id, stream, dt)` partitions, keeps only **closed** partitions (`dt <` today UTC — the open day is never touched), and per partition runs an isolated DuckDB session (256MB / 1 thread, same pattern as `LocalParquetUploadStream`) executing:
  `COPY (SELECT <typed columns> FROM read_json([<exact raw keys>], format='newline_delimited', columns={...})) TO 's3://<bucket>/events/compacted/.../part-<sha1>.parquet' (FORMAT PARQUET, COMPRESSION zstd)`
- **Delete-after-write**: the raw keys that were read are deleted (batched `DeleteObjects`) only after the COPY succeeds.
- **Typed schema colocated with the stream**: `queryEventsCompactedColumns` (DuckDB types for `query_events` v1, envelope + typed columns) lives in `queryEventsStream.ts` next to the projections; `registry.ts` exposes the stream → schema lookup, so adding a stream keeps projection + parquet schema together.
- **Prometheus**: `lightdash_usage_events_compacted_partitions_total` / `lightdash_usage_events_compaction_failures_total`, following the existing `lightdash_usage_events_*` counters. `PrometheusMetrics` is threaded into the worker via a new optional factory/context arg.

## Judgment calls

- **Deterministic part naming**: `part-<sha1 of sorted raw key set>.parquet` — a re-run after a crash overwrites the same part before deleting raw (no duplicates); late-arriving raw files for an already-compacted day produce an additional part (readers glob `*.parquet`).
- **Exact file list instead of a glob** in `read_json`: objects flushed between listing and COPY are neither deleted uncompacted nor compacted twice.
- **Unknown streams are skipped with a warning** — raw data that wasn't compacted is never deleted.
- **Per-partition try/catch** — one bad partition doesn't abort the rest; run capped at 500 partitions.
- **`warehouse_execution_time_ms` is `BIGINT`**: raw values are fractional ms; DuckDB rounds on read (e.g. `30.274875` → `30`). ms-integer precision judged sufficient for usage analytics.
- Run summary logs partitions/objects (not row counts) — the internal DuckDB `runSql` path doesn't return rows and a count query would add an S3 round-trip per partition.

## Testing

- Unit tests (7): key parsing, partition grouping + closed-day filtering, deterministic part naming, exact SQL string for `query_events`, and never-deleting raw files when the compaction write fails (mocked S3 + DuckDB).
- `pnpm -F backend lint` / `typecheck:fast` / `test:dev:nowatch` (3287 passed) all green.

## E2E (local MinIO + pm2 scheduler)

Fabricated a closed partition by copying the real raw object to `dt=2026-07-01`; the real `dt=2026-07-02` object stayed as the open-day control. Triggered via `graphile_worker.add_job('compactUsageEvents', '{}')`.

Before:
```
events/raw/org_id=172a…/stream=query_events/dt=2026-07-01/9516553f-copytest-0001.jsonl.gz
events/raw/org_id=172a…/stream=query_events/dt=2026-07-02/9516553f-b3bd….jsonl.gz
```

Run 1 log:
```
Usage events compaction: compacted 1 raw objects from org_id=172a…/stream=query_events/dt=2026-07-01 into s3://default/events/compacted/org_id=172a…/stream=query_events/dt=2026-07-01/part-235da68518c10794223e35f690deef39ad92c8d2.parquet
Usage events compaction complete: 1 partitions compacted (1 raw objects deleted), 0 failed, 0 skipped (unknown stream), 1 discovered
```

After: compacted parquet present, `dt=2026-07-01` raw deleted, `dt=2026-07-02` (open) raw untouched. Parquet inspected via DuckDB — schema fully typed (`event_ts TIMESTAMP`, `cache_hit BOOLEAN`, `total_row_count BIGINT`, …) and both rows survived with values intact (`query.executed` with `cache_hit=false`/`explore_name`, `query.ready` with `total_row_count=9`/`columns_count=2`; missing-per-event columns read as NULL).

Run 2 (idempotency): `Usage events compaction: no closed partitions found` — clean no-op in 34ms. The cron identifier is registered in `graphile_worker.known_crontabs`.

Closes: PROD-8607
https://linear.app/lightdash/issue/PROD-8607

https://claude.ai/code/session_011AsrrbU7h5qFRayP3iWyGF