### PR TITLE
feat(data-apps): Google service account auth for external connections

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -813,6 +813,8 @@ A connection lives on the `external_connections` table (`packages/backend/src/ee
 
 The **instructions** are usage guidance for the app builder — auth quirks, pagination, which endpoints matter, response caveats — injected into the generation prompt (see [Saved samples → `/tmp/external-data`](#saved-samples--tmpexternal-data) below). They inherit the same admin-trust boundary as the rest of the connection: only `manage:ExternalConnection` (project admin) can set them, and an admin authoring prose is strictly weaker than an admin who already pins the host, secret, and allowed methods.
 
+The auth method (`type`) is one of **`none`**, **`api_key`** (header or query, named by `apiKeyName`/`apiKeyLocation`), **`bearer_token`**, or **`google_service_account`**. For a Google service account the encrypted secret is the service-account **keyfile JSON** and `oauth_scopes` holds the admin-entered OAuth scopes (e.g. `https://www.googleapis.com/auth/bigquery`); the proxy mints a short-lived Google access token from them per request (cached in memory by `GoogleServiceAccountTokenProvider`) and injects it as `Authorization: Bearer …`. This is what lets a data app write back to BigQuery via its REST API.
+
 Runtime fetches resolve the alias against `app_external_connections` (`resolveAppAlias`), so the link rows — not the version `resources` snapshot — are what grant an app access. When an app is **duplicated** (`AppGenerateService.duplicateApp`), its live links are copied onto the new app so the duplicate can make the same external fetches; both apps share a project, so the connection UUIDs stay valid. **Preview duplication** is the cross-project case: the target preview project has none of the source's connections, so it first clones the connections themselves (see [Preview environments](#preview-environments-copy-on-preview)) and re-links the copied apps onto those clones. **Promotion** (`promoteApp`, preview → upstream) still does **not** carry links across today — the upstream project's connections are separate entities and would need identity mapping to re-link.
 
 ### Proxy security model
@@ -821,7 +823,7 @@ The sandboxed preview iframe has no network access of its own (`default-src 'non
 
 1. The app SDK requests an external fetch over postMessage.
 2. The parent forwards it to the backend external-fetch route, which loads the linked connection, decrypts its secret server-side, and runs the request through `executeExternalFetch`.
-3. `executeExternalFetch` validates the request, enforces the SSRF guard (the request must resolve under the connection's configured base URL/host; private/loopback/link-local targets are rejected), injects the secret as the configured auth, reads a **bounded** response body, and returns `{ status, contentType, body, truncated }`.
+3. `executeExternalFetch` validates the request, enforces the SSRF guard (the request must resolve under the connection's configured base URL/host; private/loopback/link-local targets are rejected), injects the secret as the configured auth (for `google_service_account`, it first mints a short-lived OAuth access token from the stored keyfile + scopes — that token mint calls Google's fixed token endpoint directly, outside the SSRF-guarded fetch), reads a **bounded** response body, and returns `{ status, contentType, body, truncated }`.
 4. The bounded response is posted back to the iframe. The decrypted secret never crosses to the frontend.
 
 ### Method rules

--- a/packages/backend/src/ee/database/entities/externalConnections.ts
+++ b/packages/backend/src/ee/database/entities/externalConnections.ts
@@ -29,6 +29,7 @@ export type DbExternalConnection = {
     rate_limit_per_minute: number | null;
     api_key_name: string | null;
     api_key_location: ApiKeyLocation | null;
+    oauth_scopes: string[] | null;
     created_by_user_uuid: string | null;
     updated_by_user_uuid: string | null;
     created_at: Date;
@@ -46,6 +47,7 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
         allowed_path_prefixes: string;
         allowed_methods: string;
         allowed_content_types: string;
+        oauth_scopes?: string | null;
     } & Partial<
             Pick<
                 DbExternalConnection,
@@ -82,6 +84,7 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
             allowed_path_prefixes: string;
             allowed_methods: string;
             allowed_content_types: string;
+            oauth_scopes: string | null;
         }
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260702120000_add_external_connection_oauth_scopes.ts
+++ b/packages/backend/src/ee/database/migrations/20260702120000_add_external_connection_oauth_scopes.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+const ExternalConnectionsTableName = 'external_connections';
+const OAuthScopesColumn = 'oauth_scopes';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ExternalConnectionsTableName, (table) => {
+        // OAuth scopes for type 'google_service_account'; null for other types.
+        table.jsonb(OAuthScopesColumn).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ExternalConnectionsTableName, (table) => {
+        table.dropColumn(OAuthScopesColumn);
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -67,6 +67,7 @@ import { CommercialCacheService } from './services/CommercialCacheService';
 import { CommercialSlackIntegrationService } from './services/CommercialSlackIntegrationService';
 import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
+import { GoogleServiceAccountTokenProvider } from './services/ExternalConnectionService/GoogleServiceAccountTokenProvider';
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
 import { McpService } from './services/McpService/McpService';
 import { OrganizationWarehouseCredentialsService } from './services/OrganizationWarehouseCredentialsService';
@@ -455,6 +456,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     appModel: models.getAppModel(),
                     spacePermissionService:
                         repository.getSpacePermissionService(),
+                    googleTokenProvider:
+                        new GoogleServiceAccountTokenProvider(),
                 }),
             slackIntegrationService: ({ models, context, clients }) =>
                 new CommercialSlackIntegrationService({

--- a/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
@@ -41,6 +41,7 @@ const makeDbConnection = (overrides: Record<string, unknown> = {}) => ({
     rate_limit_per_minute: null,
     api_key_name: null,
     api_key_location: null,
+    oauth_scopes: null,
     created_by_user_uuid: USER_UUID,
     updated_by_user_uuid: USER_UUID,
     created_at: new Date('2026-01-01T00:00:00Z'),

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -129,7 +129,7 @@ export class ExternalConnectionModel {
                     rate_limit_per_minute: data.rateLimitPerMinute ?? null,
                     api_key_name: data.apiKeyName ?? null,
                     api_key_location: data.apiKeyLocation ?? null,
-                    oauth_scopes: data.oauthScopes
+                    oauth_scopes: data.oauthScopes?.length
                         ? JSON.stringify(data.oauthScopes)
                         : null,
                     created_by_user_uuid: userUuid,
@@ -198,6 +198,9 @@ export class ExternalConnectionModel {
                         rate_limit_per_minute: src.rate_limit_per_minute,
                         api_key_name: src.api_key_name,
                         api_key_location: src.api_key_location,
+                        oauth_scopes: src.oauth_scopes
+                            ? JSON.stringify(src.oauth_scopes)
+                            : null,
                         created_by_user_uuid: src.created_by_user_uuid,
                         updated_by_user_uuid: src.updated_by_user_uuid,
                     })
@@ -406,7 +409,7 @@ export class ExternalConnectionModel {
             if (data.apiKeyLocation !== undefined)
                 updatePayload.api_key_location = data.apiKeyLocation;
             if (data.oauthScopes !== undefined)
-                updatePayload.oauth_scopes = data.oauthScopes
+                updatePayload.oauth_scopes = data.oauthScopes?.length
                     ? JSON.stringify(data.oauthScopes)
                     : null;
 
@@ -416,9 +419,17 @@ export class ExternalConnectionModel {
 
             // Secret tri-state: `null` clears it, a non-empty string sets it,
             // and undefined/blank leaves it unchanged. Switching to type
-            // 'none' also clears any stored secret so it can never be used.
+            // 'none', or changing the auth type without supplying a new secret,
+            // also clears any stored secret so an old credential can never be
+            // reused by (or leaked through) the new auth method.
             const resultingType = data.type ?? existing.type;
-            if (resultingType === 'none' || data.secret === null) {
+            const typeChanged =
+                data.type !== undefined && data.type !== existing.type;
+            if (
+                resultingType === 'none' ||
+                data.secret === null ||
+                (typeChanged && !data.secret)
+            ) {
                 await ExternalConnectionModel.deleteSecret(trx, uuid);
             } else if (data.secret) {
                 await ExternalConnectionModel.upsertSecret(

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -71,6 +71,7 @@ export class ExternalConnectionModel {
             rateLimitPerMinute: row.rate_limit_per_minute,
             apiKeyName: row.api_key_name,
             apiKeyLocation: row.api_key_location,
+            oauthScopes: row.oauth_scopes,
             hasSecret,
             createdByUserUuid: row.created_by_user_uuid,
             updatedByUserUuid: row.updated_by_user_uuid,
@@ -128,6 +129,9 @@ export class ExternalConnectionModel {
                     rate_limit_per_minute: data.rateLimitPerMinute ?? null,
                     api_key_name: data.apiKeyName ?? null,
                     api_key_location: data.apiKeyLocation ?? null,
+                    oauth_scopes: data.oauthScopes
+                        ? JSON.stringify(data.oauthScopes)
+                        : null,
                     created_by_user_uuid: userUuid,
                     updated_by_user_uuid: userUuid,
                 })
@@ -401,6 +405,10 @@ export class ExternalConnectionModel {
                 updatePayload.api_key_name = data.apiKeyName;
             if (data.apiKeyLocation !== undefined)
                 updatePayload.api_key_location = data.apiKeyLocation;
+            if (data.oauthScopes !== undefined)
+                updatePayload.oauth_scopes = data.oauthScopes
+                    ? JSON.stringify(data.oauthScopes)
+                    : null;
 
             await trx(ExternalConnectionsTableName)
                 .where('external_connection_uuid', uuid)

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -31,6 +31,7 @@ const baseConnection = (
     rateLimitPerMinute: null,
     apiKeyName: null,
     apiKeyLocation: null,
+    oauthScopes: null,
     hasSecret: false,
     createdByUserUuid: 'user-1',
     updatedByUserUuid: 'user-1',
@@ -58,11 +59,17 @@ function buildService(opts: {
     secret?: string | null;
     canView?: boolean;
     rateCount?: number;
+    googleToken?: string;
 }) {
     const externalConnectionModel = {
         resolveAppAlias: vi.fn().mockResolvedValue(opts.connection),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? null),
         incrementRateCounter: vi.fn().mockResolvedValue(opts.rateCount ?? 1),
+    };
+    const googleTokenProvider = {
+        getAccessToken: vi
+            .fn()
+            .mockResolvedValue(opts.googleToken ?? 'test-access-token'),
     };
     const appModel = {
         getApp: vi.fn().mockResolvedValue(baseApp()),
@@ -81,6 +88,7 @@ function buildService(opts: {
         projectModel,
         spacePermissionService,
         analytics,
+        googleTokenProvider,
     } as never);
 
     // Force the CASL view decision deterministically.
@@ -97,6 +105,7 @@ function buildService(opts: {
         externalConnectionModel,
         appModel,
         analytics,
+        googleTokenProvider,
     };
 }
 
@@ -361,6 +370,67 @@ describe('ExternalConnectionService.proxyFetch', () => {
             }),
             secret: null,
         });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    const KEYFILE_SECRET =
+        '{"type":"service_account","client_email":"a@b.iam.gserviceaccount.com","private_key":"k"}';
+
+    it('mints and injects a Google service account access token as a bearer token', async () => {
+        const { service, googleTokenProvider } = buildService({
+            connection: baseConnection({
+                type: 'google_service_account',
+                oauthScopes: ['https://www.googleapis.com/auth/bigquery'],
+            }),
+            secret: KEYFILE_SECRET,
+            googleToken: 'minted-access-token',
+        });
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        expect(googleTokenProvider.getAccessToken).toHaveBeenCalledWith(
+            KEYFILE_SECRET,
+            ['https://www.googleapis.com/auth/bigquery'],
+        );
+        const [, opts] = mockSecureFetch.mock.calls[0];
+        expect(opts.headers!.Authorization).toBe('Bearer minted-access-token');
+    });
+
+    it('fails closed when a google_service_account connection has no stored secret', async () => {
+        const { service } = buildService({
+            connection: baseConnection({
+                type: 'google_service_account',
+                oauthScopes: ['https://www.googleapis.com/auth/bigquery'],
+            }),
+            secret: null,
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when Google token minting fails', async () => {
+        const { service, googleTokenProvider } = buildService({
+            connection: baseConnection({
+                type: 'google_service_account',
+                oauthScopes: ['https://www.googleapis.com/auth/bigquery'],
+            }),
+            secret: KEYFILE_SECRET,
+        });
+        googleTokenProvider.getAccessToken.mockRejectedValueOnce(
+            new Error('token endpoint unreachable'),
+        );
         await expect(
             service.proxyFetch(user, 'proj-1', 'app-1', {
                 connectionAlias: 'weather',

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -34,6 +34,7 @@ const connection: ExternalConnection = {
     rateLimitPerMinute: null,
     apiKeyName: null,
     apiKeyLocation: null,
+    oauthScopes: null,
     hasSecret: true,
     createdByUserUuid: 'user-1',
     updatedByUserUuid: 'user-1',
@@ -121,6 +122,9 @@ function buildService(opts: {
             getSpaceAccessContext: vi.fn().mockResolvedValue({}),
         } as never,
         analytics: { track: vi.fn() } as never,
+        googleTokenProvider: {
+            getAccessToken: vi.fn().mockResolvedValue('test-access-token'),
+        } as never,
     });
     return { service, model };
 }

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -78,6 +78,7 @@ const makeAccount = (_canManage: boolean): RegisteredAccount => {
 function buildService(opts: {
     connection?: ExternalConnection | null;
     secret?: string | null;
+    updateFn?: import('vitest').Mock;
     saveSampleFn?: import('vitest').Mock;
     countSamplesFn?: import('vitest').Mock;
     listSamplesFn?: import('vitest').Mock;
@@ -95,6 +96,13 @@ function buildService(opts: {
         getProjectOrganizationUuid: vi.fn().mockResolvedValue(orgUuid),
         list: vi.fn().mockResolvedValue([connection]),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? 's3cr3t'),
+        update:
+            opts.updateFn ??
+            vi
+                .fn()
+                .mockImplementation((_uuid, _user, data) =>
+                    Promise.resolve({ ...connection, ...data }),
+                ),
         saveSample: opts.saveSampleFn ?? vi.fn().mockResolvedValue(fakeSample),
         countSamples: opts.countSamplesFn ?? vi.fn().mockResolvedValue(0),
         listSamples:
@@ -219,6 +227,100 @@ describe('ExternalConnectionService reads (view, not manage)', () => {
                 secret: null,
             }),
         ).rejects.toThrow(ForbiddenError);
+    });
+});
+
+// -------------------------------------------------------------------
+// update — auth type switches must not carry the old secret/fields across
+// -------------------------------------------------------------------
+describe('ExternalConnectionService.update type switches', () => {
+    const googleConnection: ExternalConnection = {
+        ...connection,
+        type: 'google_service_account',
+        oauthScopes: ['https://www.googleapis.com/auth/bigquery'],
+        apiKeyName: null,
+        apiKeyLocation: null,
+        hasSecret: true,
+    };
+    const apiKeyConnection: ExternalConnection = {
+        ...connection,
+        type: 'api_key',
+        apiKeyName: 'X-Api-Key',
+        apiKeyLocation: 'header',
+        oauthScopes: null,
+        hasSecret: true,
+    };
+    const keyfile = JSON.stringify({
+        type: 'service_account',
+        client_email: 'sa@proj.iam.gserviceaccount.com',
+        private_key:
+            '-----BEGIN PRIVATE KEY-----\nk\n-----END PRIVATE KEY-----\n',
+    });
+
+    it('rejects switching google → bearer_token with a blank secret (no key reuse/leak)', async () => {
+        const { service, model } = buildService({
+            connection: googleConnection,
+        });
+        mockAbility(service, true);
+        await expect(
+            service.update(adminAccount, projectUuid, connectionUuid, {
+                type: 'bearer_token',
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(model.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects switching bearer_token → google without a keyfile', async () => {
+        const { service, model } = buildService({});
+        mockAbility(service, true);
+        await expect(
+            service.update(adminAccount, projectUuid, connectionUuid, {
+                type: 'google_service_account',
+                oauthScopes: ['https://www.googleapis.com/auth/bigquery'],
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(model.update).not.toHaveBeenCalled();
+    });
+
+    it('clears oauthScopes when switching google → bearer_token with a new secret', async () => {
+        const { service, model } = buildService({
+            connection: googleConnection,
+        });
+        mockAbility(service, true);
+        await service.update(adminAccount, projectUuid, connectionUuid, {
+            type: 'bearer_token',
+            secret: 'new-token',
+        });
+        expect(model.update).toHaveBeenCalledWith(
+            connectionUuid,
+            expect.anything(),
+            expect.objectContaining({
+                oauthScopes: null,
+                apiKeyName: null,
+                apiKeyLocation: null,
+            }),
+        );
+    });
+
+    it('clears api-key fields when switching api_key → google with a keyfile + scopes', async () => {
+        const { service, model } = buildService({
+            connection: apiKeyConnection,
+        });
+        mockAbility(service, true);
+        await service.update(adminAccount, projectUuid, connectionUuid, {
+            type: 'google_service_account',
+            secret: keyfile,
+            oauthScopes: ['https://www.googleapis.com/auth/bigquery'],
+        });
+        expect(model.update).toHaveBeenCalledWith(
+            connectionUuid,
+            expect.anything(),
+            expect.objectContaining({
+                apiKeyName: null,
+                apiKeyLocation: null,
+                oauthScopes: ['https://www.googleapis.com/auth/bigquery'],
+            }),
+        );
     });
 });
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -279,15 +279,58 @@ export class ExternalConnectionService extends BaseService {
             projectUuid,
             connectionUuid,
         );
+        const resultingType = data.type ?? existing.type;
+        const typeChanged =
+            data.type !== undefined && data.type !== existing.type;
+
+        // A blank secret keeps the stored one ONLY when the type is unchanged.
+        // On a type change the stored secret belongs to the old auth method, so
+        // it is dropped and the caller must supply a new one (validation then
+        // requires it). This prevents e.g. a stored service-account keyfile from
+        // being reused — and leaked — as a bearer token when switching types.
+        let hasSecretAfter: boolean;
+        if (data.secret === null) {
+            hasSecretAfter = false;
+        } else if (data.secret) {
+            hasSecretAfter = true;
+        } else {
+            hasSecretAfter = !typeChanged && existing.hasSecret;
+        }
+
+        // Resolve a field that belongs only to the resulting auth type: use the
+        // patch value if provided, else keep the existing value — but a type
+        // change never carries the previous type's values forward, and fields
+        // foreign to the resulting type are always cleared.
+        const resolveTypeField = <T>(
+            belongsToResultingType: boolean,
+            patchValue: T | undefined,
+            existingValue: T,
+        ): T | null => {
+            if (!belongsToResultingType) return null;
+            if (patchValue !== undefined) return patchValue;
+            return typeChanged ? null : existingValue;
+        };
+        const resolvedApiKeyName = resolveTypeField(
+            resultingType === 'api_key',
+            data.apiKeyName,
+            existing.apiKeyName,
+        );
+        const resolvedApiKeyLocation = resolveTypeField(
+            resultingType === 'api_key',
+            data.apiKeyLocation,
+            existing.apiKeyLocation,
+        );
+        const resolvedOauthScopes = resolveTypeField(
+            resultingType === 'google_service_account',
+            data.oauthScopes,
+            existing.oauthScopes,
+        );
+
         // Validate the resulting (merged) config so a partial update can't
         // leave the connection in an invalid or unsafe state.
-        const hasSecretAfter =
-            data.secret === null
-                ? false
-                : Boolean(data.secret) || existing.hasSecret;
         validateExternalConnectionConfig(
             {
-                type: data.type ?? existing.type,
+                type: resultingType,
                 origin: data.origin ?? existing.origin,
                 instructions:
                     data.instructions !== undefined
@@ -307,33 +350,28 @@ export class ExternalConnectionService extends BaseService {
                     data.rateLimitPerMinute !== undefined
                         ? data.rateLimitPerMinute
                         : existing.rateLimitPerMinute,
-                apiKeyName:
-                    data.apiKeyName !== undefined
-                        ? data.apiKeyName
-                        : existing.apiKeyName,
-                apiKeyLocation:
-                    data.apiKeyLocation !== undefined
-                        ? data.apiKeyLocation
-                        : existing.apiKeyLocation,
-                oauthScopes:
-                    data.oauthScopes !== undefined
-                        ? data.oauthScopes
-                        : existing.oauthScopes,
+                apiKeyName: resolvedApiKeyName,
+                apiKeyLocation: resolvedApiKeyLocation,
+                oauthScopes: resolvedOauthScopes,
             },
             hasSecretAfter,
         );
         // Validate the keyfile only when a new secret is supplied — a secret-less
-        // update keeps the already-validated stored keyfile.
-        if (
-            (data.type ?? existing.type) === 'google_service_account' &&
-            data.secret
-        ) {
+        // (same-type) update keeps the already-validated stored keyfile.
+        if (resultingType === 'google_service_account' && data.secret) {
             validateServiceAccountKeyfile(data.secret);
         }
+        // Persist the resolved type-specific fields so foreign fields (and the
+        // stale scopes/api-key config) are cleared when the type changes.
         const updated = await this.externalConnectionModel.update(
             connectionUuid,
             account.user.id,
-            data,
+            {
+                ...data,
+                apiKeyName: resolvedApiKeyName,
+                apiKeyLocation: resolvedApiKeyLocation,
+                oauthScopes: resolvedOauthScopes,
+            },
         );
         this.analytics.track({
             event: 'external_connection.updated',

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -28,7 +28,11 @@ import {
 } from '../../../utils/secureFetch/secureFetch';
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
 import { assertCanViewApp } from '../AppGenerateService/appAuthz';
-import { validateExternalConnectionConfig } from './externalConnectionConfigValidation';
+import {
+    validateExternalConnectionConfig,
+    validateServiceAccountKeyfile,
+} from './externalConnectionConfigValidation';
+import { type GoogleServiceAccountTokenProvider } from './GoogleServiceAccountTokenProvider';
 import {
     assertSafeApiKeyHeaderName,
     buildOutboundUrl,
@@ -42,6 +46,7 @@ type ExternalConnectionServiceArguments = {
     externalConnectionModel: ExternalConnectionModel;
     appModel: AppModel;
     spacePermissionService: SpacePermissionService;
+    googleTokenProvider: GoogleServiceAccountTokenProvider;
 };
 
 export class ExternalConnectionService extends BaseService {
@@ -53,6 +58,8 @@ export class ExternalConnectionService extends BaseService {
 
     private readonly spacePermissionService: SpacePermissionService;
 
+    private readonly googleTokenProvider: GoogleServiceAccountTokenProvider;
+
     private static readonly DEFAULT_RATE_LIMIT_PER_MINUTE = 60;
 
     constructor(args: ExternalConnectionServiceArguments) {
@@ -61,6 +68,7 @@ export class ExternalConnectionService extends BaseService {
         this.externalConnectionModel = args.externalConnectionModel;
         this.appModel = args.appModel;
         this.spacePermissionService = args.spacePermissionService;
+        this.googleTokenProvider = args.googleTokenProvider;
     }
 
     private assertCanManage(
@@ -167,6 +175,9 @@ export class ExternalConnectionService extends BaseService {
         }
         this.assertCanManage(account, projectUuid, organizationUuid);
         validateExternalConnectionConfig(data, Boolean(data.secret));
+        if (data.type === 'google_service_account' && data.secret) {
+            validateServiceAccountKeyfile(data.secret);
+        }
         const connection = await this.externalConnectionModel.create(
             projectUuid,
             organizationUuid,
@@ -304,9 +315,21 @@ export class ExternalConnectionService extends BaseService {
                     data.apiKeyLocation !== undefined
                         ? data.apiKeyLocation
                         : existing.apiKeyLocation,
+                oauthScopes:
+                    data.oauthScopes !== undefined
+                        ? data.oauthScopes
+                        : existing.oauthScopes,
             },
             hasSecretAfter,
         );
+        // Validate the keyfile only when a new secret is supplied — a secret-less
+        // update keeps the already-validated stored keyfile.
+        if (
+            (data.type ?? existing.type) === 'google_service_account' &&
+            data.secret
+        ) {
+            validateServiceAccountKeyfile(data.secret);
+        }
         const updated = await this.externalConnectionModel.update(
             connectionUuid,
             account.user.id,
@@ -599,7 +622,6 @@ export class ExternalConnectionService extends BaseService {
      * alias resolution — those live in the caller so M5's testConnection can
      * reuse this exact path with an admin-supplied connection.
      */
-    // eslint-disable-next-line class-methods-use-this
     private async executeExternalFetch(
         connection: ExternalConnection,
         secret: string | null,
@@ -652,6 +674,33 @@ export class ExternalConnectionService extends BaseService {
                     'Connection has an invalid api key location',
                 );
             }
+        } else if (connection.type === 'google_service_account') {
+            // Fail closed: mint a short-lived Google access token from the stored
+            // service account keyfile + scopes and inject it as a bearer token.
+            if (!secret) {
+                throw new ParameterError(
+                    'Connection is missing its service account key',
+                );
+            }
+            const scopes = connection.oauthScopes ?? [];
+            if (scopes.length === 0) {
+                throw new ParameterError(
+                    'Connection is missing its OAuth scopes',
+                );
+            }
+            let accessToken: string;
+            try {
+                accessToken = await this.googleTokenProvider.getAccessToken(
+                    secret,
+                    scopes,
+                );
+            } catch {
+                // No library/upstream detail reaches the client.
+                throw new ParameterError(
+                    'Failed to obtain Google access token',
+                );
+            }
+            headers.Authorization = `Bearer ${accessToken}`;
         }
         // type === 'none' → no auth injected.
 
@@ -805,6 +854,7 @@ export class ExternalConnectionService extends BaseService {
         'secret',
         'password',
         'x-api-key',
+        'private_key',
     ]);
 
     /**
@@ -1029,6 +1079,9 @@ export class ExternalConnectionService extends BaseService {
         // Same validation create runs, so a test can never exercise a config we
         // would refuse to store (SSRF guard, auth invariants, bounded limits).
         validateExternalConnectionConfig(data, Boolean(data.secret));
+        if (data.type === 'google_service_account' && data.secret) {
+            validateServiceAccountKeyfile(data.secret);
+        }
 
         const method: ExternalConnectionMethod = req.method ?? 'GET';
         if (!data.allowedMethods.includes(method)) {
@@ -1060,6 +1113,7 @@ export class ExternalConnectionService extends BaseService {
             rateLimitPerMinute: data.rateLimitPerMinute ?? null,
             apiKeyName: data.apiKeyName ?? null,
             apiKeyLocation: data.apiKeyLocation ?? null,
+            oauthScopes: data.oauthScopes ?? null,
             hasSecret: Boolean(data.secret),
             createdByUserUuid: null,
             updatedByUserUuid: null,

--- a/packages/backend/src/ee/services/ExternalConnectionService/GoogleServiceAccountTokenProvider.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/GoogleServiceAccountTokenProvider.test.ts
@@ -1,0 +1,114 @@
+import { google } from 'googleapis';
+import { GoogleServiceAccountTokenProvider } from './GoogleServiceAccountTokenProvider';
+
+vi.mock('googleapis', () => ({
+    google: { auth: { JWT: vi.fn() } },
+}));
+
+const JWTMock = vi.mocked(google.auth.JWT);
+
+const KEYFILE = JSON.stringify({
+    type: 'service_account',
+    client_email: 'sa@proj.iam.gserviceaccount.com',
+    private_key:
+        '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n',
+});
+
+let currentToken: string | null;
+let currentExpiry: number;
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    JWTMock.mockReset();
+    currentToken = 'tok-1';
+    currentExpiry = Date.now() + 3_600_000; // 1h
+    // Regular function so it's constructable via `new google.auth.JWT(...)`.
+    JWTMock.mockImplementation(function MockJwt(this: {
+        credentials: { expiry_date?: number };
+        getAccessToken: unknown;
+    }) {
+        this.credentials = {};
+        this.getAccessToken = vi.fn().mockImplementation(async () => {
+            this.credentials.expiry_date = currentExpiry;
+            return { token: currentToken };
+        });
+    } as unknown as typeof google.auth.JWT);
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('GoogleServiceAccountTokenProvider', () => {
+    it('mints a token from the keyfile + scopes', async () => {
+        const provider = new GoogleServiceAccountTokenProvider();
+        const token = await provider.getAccessToken(KEYFILE, [
+            'https://www.googleapis.com/auth/bigquery',
+        ]);
+        expect(token).toBe('tok-1');
+        expect(JWTMock).toHaveBeenCalledTimes(1);
+        expect(JWTMock).toHaveBeenCalledWith({
+            email: 'sa@proj.iam.gserviceaccount.com',
+            key: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n',
+            scopes: ['https://www.googleapis.com/auth/bigquery'],
+        });
+    });
+
+    it('caches the token across calls with the same keyfile + scopes', async () => {
+        const provider = new GoogleServiceAccountTokenProvider();
+        await provider.getAccessToken(KEYFILE, ['a']);
+        const second = await provider.getAccessToken(KEYFILE, ['a']);
+        expect(second).toBe('tok-1');
+        expect(JWTMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('cache key is insensitive to scope order', async () => {
+        const provider = new GoogleServiceAccountTokenProvider();
+        await provider.getAccessToken(KEYFILE, ['a', 'b']);
+        await provider.getAccessToken(KEYFILE, ['b', 'a']);
+        expect(JWTMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-mints when the scopes change', async () => {
+        const provider = new GoogleServiceAccountTokenProvider();
+        await provider.getAccessToken(KEYFILE, ['a']);
+        await provider.getAccessToken(KEYFILE, ['b']);
+        expect(JWTMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-mints when the keyfile changes', async () => {
+        const provider = new GoogleServiceAccountTokenProvider();
+        await provider.getAccessToken(KEYFILE, ['a']);
+        const otherKeyfile = JSON.stringify({
+            type: 'service_account',
+            client_email: 'other@proj.iam.gserviceaccount.com',
+            private_key:
+                '-----BEGIN PRIVATE KEY-----\nxyz\n-----END PRIVATE KEY-----\n',
+        });
+        await provider.getAccessToken(otherKeyfile, ['a']);
+        expect(JWTMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('refreshes when the cached token is within the skew buffer of expiry', async () => {
+        const provider = new GoogleServiceAccountTokenProvider();
+        currentExpiry = Date.now() + 3_600_000;
+        await provider.getAccessToken(KEYFILE, ['a']);
+
+        // Advance to within the 60s skew buffer of expiry → must re-mint.
+        vi.advanceTimersByTime(3_600_000 - 30_000);
+        currentToken = 'tok-2';
+        currentExpiry = Date.now() + 3_600_000;
+        const refreshed = await provider.getAccessToken(KEYFILE, ['a']);
+        expect(refreshed).toBe('tok-2');
+        expect(JWTMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws when Google returns no token', async () => {
+        currentToken = null;
+        const provider = new GoogleServiceAccountTokenProvider();
+        await expect(provider.getAccessToken(KEYFILE, ['a'])).rejects.toThrow(
+            'Google did not return an access token',
+        );
+    });
+});

--- a/packages/backend/src/ee/services/ExternalConnectionService/GoogleServiceAccountTokenProvider.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/GoogleServiceAccountTokenProvider.test.ts
@@ -104,6 +104,17 @@ describe('GoogleServiceAccountTokenProvider', () => {
         expect(JWTMock).toHaveBeenCalledTimes(2);
     });
 
+    it('shares a single mint across concurrent cache-miss calls (single-flight)', async () => {
+        const provider = new GoogleServiceAccountTokenProvider();
+        const [a, b] = await Promise.all([
+            provider.getAccessToken(KEYFILE, ['a']),
+            provider.getAccessToken(KEYFILE, ['a']),
+        ]);
+        expect(a).toBe('tok-1');
+        expect(b).toBe('tok-1');
+        expect(JWTMock).toHaveBeenCalledTimes(1);
+    });
+
     it('throws when Google returns no token', async () => {
         currentToken = null;
         const provider = new GoogleServiceAccountTokenProvider();

--- a/packages/backend/src/ee/services/ExternalConnectionService/GoogleServiceAccountTokenProvider.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/GoogleServiceAccountTokenProvider.ts
@@ -1,0 +1,64 @@
+import { createHash } from 'crypto';
+import { google } from 'googleapis';
+
+type ServiceAccountKeyfile = {
+    client_email: string;
+    private_key: string;
+};
+
+// Refresh a little before the real expiry to absorb clock skew and request latency.
+const EXPIRY_SKEW_MS = 60_000;
+// Access tokens live ~1h; if Google doesn't report an expiry, assume ~55m.
+const FALLBACK_TTL_MS = 3_300_000;
+
+/**
+ * Mints short-lived Google OAuth2 access tokens from a service account keyfile,
+ * caching them in memory so the external-connection proxy doesn't sign + exchange
+ * a JWT on every request. The cache key is a hash of (keyfile + scopes), so
+ * rotating the secret or editing the scopes transparently invalidates the token.
+ *
+ * The mint calls Google's token endpoint (oauth2.googleapis.com) directly via
+ * google-auth-library, bypassing secureFetch's SSRF guard — acceptable because
+ * the endpoint is a fixed, trusted Google host.
+ */
+export class GoogleServiceAccountTokenProvider {
+    private readonly cache = new Map<
+        string,
+        { token: string; expiresAt: number }
+    >();
+
+    /**
+     * @param keyfileJson decrypted service account JSON (caller must have already
+     *  validated it parses and has client_email + private_key)
+     * @param scopes non-empty list of OAuth scopes
+     */
+    async getAccessToken(
+        keyfileJson: string,
+        scopes: string[],
+    ): Promise<string> {
+        const cacheKey = createHash('sha256')
+            .update(`${keyfileJson}\n${[...scopes].sort().join(' ')}`)
+            .digest('hex');
+
+        const cached = this.cache.get(cacheKey);
+        if (cached && cached.expiresAt - Date.now() > EXPIRY_SKEW_MS) {
+            return cached.token;
+        }
+
+        const key = JSON.parse(keyfileJson) as ServiceAccountKeyfile;
+        const jwtClient = new google.auth.JWT({
+            email: key.client_email,
+            key: key.private_key,
+            scopes,
+        });
+        const { token } = await jwtClient.getAccessToken();
+        if (!token) {
+            throw new Error('Google did not return an access token');
+        }
+
+        const expiresAt =
+            jwtClient.credentials.expiry_date ?? Date.now() + FALLBACK_TTL_MS;
+        this.cache.set(cacheKey, { token, expiresAt });
+        return token;
+    }
+}

--- a/packages/backend/src/ee/services/ExternalConnectionService/GoogleServiceAccountTokenProvider.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/GoogleServiceAccountTokenProvider.ts
@@ -27,6 +27,10 @@ export class GoogleServiceAccountTokenProvider {
         { token: string; expiresAt: number }
     >();
 
+    // In-flight mints, keyed like the cache, so concurrent misses share one
+    // token-endpoint call instead of each hitting Google independently.
+    private readonly inFlight = new Map<string, Promise<string>>();
+
     /**
      * @param keyfileJson decrypted service account JSON (caller must have already
      *  validated it parses and has client_email + private_key)
@@ -45,6 +49,26 @@ export class GoogleServiceAccountTokenProvider {
             return cached.token;
         }
 
+        // Single-flight: reuse a pending mint for the same keyfile+scopes.
+        const pending = this.inFlight.get(cacheKey);
+        if (pending) {
+            return pending;
+        }
+
+        const mint = this.mint(keyfileJson, scopes, cacheKey);
+        this.inFlight.set(cacheKey, mint);
+        try {
+            return await mint;
+        } finally {
+            this.inFlight.delete(cacheKey);
+        }
+    }
+
+    private async mint(
+        keyfileJson: string,
+        scopes: string[],
+        cacheKey: string,
+    ): Promise<string> {
         const key = JSON.parse(keyfileJson) as ServiceAccountKeyfile;
         const jwtClient = new google.auth.JWT({
             email: key.client_email,
@@ -58,6 +82,15 @@ export class GoogleServiceAccountTokenProvider {
 
         const expiresAt =
             jwtClient.credentials.expiry_date ?? Date.now() + FALLBACK_TTL_MS;
+
+        // Evict expired entries so rotated keys / deleted connections don't
+        // accumulate — keeps the cache bounded to roughly the active set.
+        const now = Date.now();
+        for (const [k, v] of this.cache) {
+            if (v.expiresAt <= now) {
+                this.cache.delete(k);
+            }
+        }
         this.cache.set(cacheKey, { token, expiresAt });
         return token;
     }

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
@@ -186,6 +186,19 @@ describe('validateExternalConnectionConfig', () => {
             ).not.toThrow();
         });
 
+        it('accepts the bare OIDC scopes openid/email/profile', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        type: 'google_service_account',
+                        oauthScopes: ['openid', 'email', 'profile'],
+                    },
+                    true,
+                ),
+            ).not.toThrow();
+        });
+
         it('rejects oauthScopes on a non-google type', () => {
             expect(() =>
                 validateExternalConnectionConfig(

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
@@ -1,6 +1,7 @@
 import { ParameterError } from '@lightdash/common';
 import {
     validateExternalConnectionConfig,
+    validateServiceAccountKeyfile,
     type ValidatableExternalConnectionConfig,
 } from './externalConnectionConfigValidation';
 
@@ -129,6 +130,128 @@ describe('validateExternalConnectionConfig', () => {
                     true,
                 ),
             ).not.toThrow();
+        });
+
+        const googleScopes = ['https://www.googleapis.com/auth/bigquery'];
+
+        it('rejects google_service_account without a secret', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        type: 'google_service_account',
+                        oauthScopes: googleScopes,
+                    },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects google_service_account with no scopes', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        type: 'google_service_account',
+                        oauthScopes: [],
+                    },
+                    true,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects google_service_account with an invalid scope', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        type: 'google_service_account',
+                        oauthScopes: ['not-a-url'],
+                    },
+                    true,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('accepts google_service_account with a secret + scopes', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        type: 'google_service_account',
+                        oauthScopes: googleScopes,
+                    },
+                    true,
+                ),
+            ).not.toThrow();
+        });
+
+        it('rejects oauthScopes on a non-google type', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        type: 'bearer_token',
+                        oauthScopes: googleScopes,
+                    },
+                    true,
+                ),
+            ).toThrow(ParameterError);
+        });
+    });
+
+    describe('validateServiceAccountKeyfile', () => {
+        const validKeyfile = JSON.stringify({
+            type: 'service_account',
+            client_email: 'sa@proj.iam.gserviceaccount.com',
+            private_key:
+                '-----BEGIN PRIVATE KEY-----\nk\n-----END PRIVATE KEY-----\n',
+        });
+
+        it('accepts a valid keyfile', () => {
+            expect(() =>
+                validateServiceAccountKeyfile(validKeyfile),
+            ).not.toThrow();
+        });
+
+        it('rejects non-JSON', () => {
+            expect(() => validateServiceAccountKeyfile('not json')).toThrow(
+                ParameterError,
+            );
+        });
+
+        it('rejects a keyfile with the wrong type', () => {
+            expect(() =>
+                validateServiceAccountKeyfile(
+                    JSON.stringify({
+                        type: 'authorized_user',
+                        client_email: 'x@y.z',
+                        private_key: 'k',
+                    }),
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects a keyfile missing client_email', () => {
+            expect(() =>
+                validateServiceAccountKeyfile(
+                    JSON.stringify({
+                        type: 'service_account',
+                        private_key: 'k',
+                    }),
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects a keyfile missing private_key', () => {
+            expect(() =>
+                validateServiceAccountKeyfile(
+                    JSON.stringify({
+                        type: 'service_account',
+                        client_email: 'x@y.z',
+                    }),
+                ),
+            ).toThrow(ParameterError);
         });
     });
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
@@ -18,6 +18,9 @@ const SUPPORTED_METHODS = new Set<string>(EXTERNAL_CONNECTION_METHODS);
 // RFC 7230 token chars — valid for HTTP header names and a safe set for query keys.
 const HTTP_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 const CONTENT_TYPE = /^[a-z0-9*]+\/[a-z0-9.+*-]+$/i;
+// Google OAuth scopes are full https URLs, except the OIDC scopes
+// openid/email/profile which Google's token endpoint accepts as bare names.
+export const OAUTH_SCOPE = /^(https:\/\/\S+|openid|email|profile)$/;
 // Must be an absolute path with no whitespace, query, or fragment.
 const PATH_PREFIX = /^\/[^\s?#]*$/;
 
@@ -264,10 +267,7 @@ export function validateExternalConnectionConfig(
                 );
             }
             config.oauthScopes.forEach((scope) => {
-                if (
-                    typeof scope !== 'string' ||
-                    !/^https:\/\/\S+$/.test(scope)
-                ) {
+                if (typeof scope !== 'string' || !OAUTH_SCOPE.test(scope)) {
                     throw new ParameterError(
                         `Invalid OAuth scope: ${JSON.stringify(scope)}`,
                     );

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
@@ -39,7 +39,48 @@ export type ValidatableExternalConnectionConfig = {
     rateLimitPerMinute?: number | null;
     apiKeyName?: string | null;
     apiKeyLocation?: ApiKeyLocation | null;
+    oauthScopes?: string[] | null;
 };
+
+/**
+ * Validate a Google service account keyfile (the decrypted secret for a
+ * 'google_service_account' connection). Called where the plaintext secret is
+ * available (create / update-with-secret / testConfig) — the shape-only
+ * validateExternalConnectionConfig can't see the secret value itself.
+ */
+export function validateServiceAccountKeyfile(secret: string): void {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(secret);
+    } catch {
+        throw new ParameterError('Service account key must be valid JSON');
+    }
+    if (!parsed || typeof parsed !== 'object') {
+        throw new ParameterError('Service account key must be a JSON object');
+    }
+    const keyfile = parsed as Record<string, unknown>;
+    if (keyfile.type !== 'service_account') {
+        throw new ParameterError(
+            'Service account key must have type "service_account"',
+        );
+    }
+    if (
+        typeof keyfile.client_email !== 'string' ||
+        keyfile.client_email.length === 0
+    ) {
+        throw new ParameterError(
+            'Service account key must include a client_email',
+        );
+    }
+    if (
+        typeof keyfile.private_key !== 'string' ||
+        keyfile.private_key.length === 0
+    ) {
+        throw new ParameterError(
+            'Service account key must include a private_key',
+        );
+    }
+}
 
 const assertBoundedInt = (
     value: number | undefined,
@@ -161,6 +202,15 @@ export function validateExternalConnectionConfig(
     }
 
     // --- auth invariants ---
+    if (
+        config.type !== 'google_service_account' &&
+        config.oauthScopes &&
+        config.oauthScopes.length > 0
+    ) {
+        throw new ParameterError(
+            'OAuth scopes are only valid for type "google_service_account"',
+        );
+    }
     switch (config.type) {
         case 'none':
             if (hasSecretAfter) {
@@ -196,6 +246,33 @@ export function validateExternalConnectionConfig(
                     'type "api_key" requires apiKeyLocation of "header" or "query"',
                 );
             }
+            break;
+        case 'google_service_account':
+            if (!hasSecretAfter) {
+                throw new ParameterError(
+                    'type "google_service_account" requires a service account key',
+                );
+            }
+            if (config.apiKeyName || config.apiKeyLocation) {
+                throw new ParameterError(
+                    'type "google_service_account" must not set an api key name or location',
+                );
+            }
+            if (!config.oauthScopes || config.oauthScopes.length === 0) {
+                throw new ParameterError(
+                    'type "google_service_account" requires at least one OAuth scope',
+                );
+            }
+            config.oauthScopes.forEach((scope) => {
+                if (
+                    typeof scope !== 'string' ||
+                    !/^https:\/\/\S+$/.test(scope)
+                ) {
+                    throw new ParameterError(
+                        `Invalid OAuth scope: ${JSON.stringify(scope)}`,
+                    );
+                }
+            });
             break;
         default:
             assertUnreachable(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15119,12 +15119,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -15166,6 +15166,12 @@ const models: TsoaRoute.Models = {
                                                                                                                             'nestedObjectLiteral',
                                                                                                                         nestedProperties:
                                                                                                                             {
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 settings:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15190,12 +15196,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15279,12 +15279,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -15387,46 +15387,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
-                                                                                status: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'error',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'success',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 results:
                                                                                     {
                                                                                         dataType:
@@ -15517,12 +15477,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    name: {
+                                                                                                    label: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    label: {
+                                                                                                    name: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
@@ -15531,10 +15491,50 @@ const models: TsoaRoute.Models = {
                                                                                         },
                                                                                         required: true,
                                                                                     },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
+                                                                                },
+                                                                                status: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'error',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'success',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
                                                                                 },
                                                                             },
                                                                     },
@@ -15642,13 +15642,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
                                                                 'not_found',
                                                             ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15681,6 +15681,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15689,6 +15708,26 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
@@ -15705,13 +15744,6 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
                                                                                                         'false',
                                                                                                     ],
                                                                                                 },
@@ -15720,6 +15752,13 @@ const models: TsoaRoute.Models = {
                                                                                                         'enum',
                                                                                                     enums: [
                                                                                                         'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
                                                                                                     ],
                                                                                                 },
                                                                                             ],
@@ -15737,11 +15776,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -15765,63 +15799,29 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 fieldId:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -15843,6 +15843,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'nestedObjectLiteral',
                                                                                                     nestedProperties:
                                                                                                         {
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             settings:
                                                                                                                 {
                                                                                                                     dataType:
@@ -15867,12 +15873,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
@@ -15906,12 +15906,6 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -15922,12 +15916,18 @@ const models: TsoaRoute.Models = {
                                                                                     },
                                                                                     required: true,
                                                                                 },
-                                                                            name: {
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
                                                                                 dataType:
                                                                                     'string',
                                                                                 required: true,
                                                                             },
-                                                                            label: {
+                                                                            name: {
                                                                                 dataType:
                                                                                     'string',
                                                                                 required: true,
@@ -16098,7 +16098,7 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
+                                                uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16106,7 +16106,7 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16220,7 +16220,7 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'read',
+                                                                                            'compile',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -16234,14 +16234,14 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'search',
+                                                                                            'read',
                                                                                         ],
                                                                                     },
                                                                                     {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'compile',
+                                                                                            'search',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -16370,12 +16370,8 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['unknown'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
+                                                                'git_write_permission',
                                                             ],
                                                         },
                                                         {
@@ -16398,8 +16394,12 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['unknown'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: [
-                                                                'git_write_permission',
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16455,11 +16455,11 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
+                                                name: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16530,19 +16530,19 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['timeout'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['timeout'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16644,37 +16644,18 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                name: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                label: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -16695,6 +16676,25 @@ const models: TsoaRoute.Models = {
                                                                                 enums: [
                                                                                     'metric',
                                                                                 ],
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                             },
                                                                             {
                                                                                 dataType:
@@ -23166,6 +23166,11 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 status: { ref: 'AiAgentReviewItemStatus', required: true },
+                targetRefs: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiAgentTargetRef' },
+                    required: true,
+                },
                 priority: { ref: 'AiAgentReviewItemPriority', required: true },
                 primaryRootCause: { ref: 'AiAgentRootCause', required: true },
                 description: { dataType: 'string', required: true },
@@ -32380,7 +32385,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32390,7 +32395,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32400,7 +32405,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -32413,7 +32418,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -33075,7 +33080,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33085,7 +33090,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33095,7 +33100,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -33108,7 +33113,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1669,6 +1669,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['none'] },
                 { dataType: 'enum', enums: ['api_key'] },
                 { dataType: 'enum', enums: ['bearer_token'] },
+                { dataType: 'enum', enums: ['google_service_account'] },
             ],
             validators: {},
         },
@@ -1725,6 +1726,14 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 hasSecret: { dataType: 'boolean', required: true },
+                oauthScopes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 apiKeyLocation: {
                     dataType: 'union',
                     subSchemas: [
@@ -1810,6 +1819,13 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                oauthScopes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'enum', enums: [null] },
                     ],
                 },
@@ -1994,6 +2010,14 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { ref: 'ApiKeyLocation' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                oauthScopes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'enum', enums: [null] },
                         { dataType: 'undefined' },
                     ],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16592,18 +16592,18 @@
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
                                                                         "tableName",
-                                                                        "name",
-                                                                        "label"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -16615,13 +16615,13 @@
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "required": {
+                                                                                        "type": "boolean"
+                                                                                    },
                                                                                     "settings": {},
                                                                                     "values": {
                                                                                         "items": {},
                                                                                         "type": "array"
-                                                                                    },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
                                                                                     },
                                                                                     "operator": {
                                                                                         "type": "string"
@@ -16659,16 +16659,16 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "name",
-                                                                        "label"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -16728,16 +16728,6 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "status": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "error",
-                                                                                "success"
-                                                                            ]
-                                                                        },
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
@@ -16762,25 +16752,35 @@
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "name": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
                                                                                     "tableName",
-                                                                                    "name",
-                                                                                    "label"
+                                                                                    "label",
+                                                                                    "name"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
                                                                             "type": "array"
                                                                         },
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "label": {
                                                                             "type": "string"
+                                                                        },
+                                                                        "status": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "error",
+                                                                                "success"
+                                                                            ]
                                                                         }
                                                                     },
                                                                     "required": [
@@ -16836,8 +16836,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
-                                                            "not_found"
+                                                            "not_found",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16863,27 +16863,32 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
                                                                                 "isFromJoinedTable": {
                                                                                     "type": "boolean"
                                                                                 },
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "true",
                                                                                         "false",
-                                                                                        "not_applicable"
+                                                                                        "not_applicable",
+                                                                                        "true"
                                                                                     ]
                                                                                 },
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldType": {
@@ -16893,52 +16898,47 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "fieldId": {
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
+                                                                                "fieldId": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
+                                                                                "description",
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldFilterType",
                                                                                 "fieldValueType",
-                                                                                "table",
                                                                                 "fieldType",
-                                                                                "fieldId",
+                                                                                "table",
+                                                                                "label",
                                                                                 "name",
-                                                                                "description",
-                                                                                "label"
+                                                                                "fieldId"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "requiredFilters": {
                                                                                 "items": {
                                                                                     "properties": {
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
                                                                                         "settings": {},
                                                                                         "values": {
                                                                                             "items": {},
                                                                                             "type": "array"
-                                                                                        },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
                                                                                         },
                                                                                         "operator": {
                                                                                             "type": "string"
@@ -16964,27 +16964,27 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
                                                                             },
-                                                                            "name": {
+                                                                            "baseTable": {
                                                                                 "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
-                                                                            "name",
-                                                                            "label"
+                                                                            "baseTable",
+                                                                            "label",
+                                                                            "name"
                                                                         ],
                                                                         "type": "object"
                                                                     },
@@ -16997,8 +16997,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "fields",
                                                                     "rationale",
+                                                                    "fields",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -17107,13 +17107,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
+                                                    "uuid": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
                                                     },
-                                                    "uuid": {
+                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -17126,9 +17126,9 @@
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "slug",
-                                                    "name",
                                                     "uuid",
+                                                    "name",
+                                                    "slug",
                                                     "status"
                                                 ],
                                                 "type": "object"
@@ -17144,10 +17144,10 @@
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
-                                                                        "read",
-                                                                        "edit",
-                                                                        "search",
                                                                         "compile",
+                                                                        "edit",
+                                                                        "read",
+                                                                        "search",
                                                                         "stage"
                                                                     ]
                                                                 }
@@ -17206,12 +17206,12 @@
                                                     "errorCode": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "unknown",
-                                                            "unsupported_source_control",
+                                                            "git_write_permission",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
                                                             "pull_request_not_open",
-                                                            "git_write_permission",
+                                                            "unknown",
+                                                            "unsupported_source_control",
                                                             null
                                                         ],
                                                         "nullable": true
@@ -17230,10 +17230,10 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
+                                                    "name": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
+                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -17244,8 +17244,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "name",
+                                                    "slug",
                                                     "status"
                                                 ],
                                                 "type": "object"
@@ -17272,10 +17272,10 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "timeout",
                                                             "error",
-                                                            "success"
+                                                            "rejected",
+                                                            "success",
+                                                            "timeout"
                                                         ]
                                                     }
                                                 },
@@ -17305,26 +17305,22 @@
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
                                                                         "tableName",
-                                                                        "name",
-                                                                        "label"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
-                                                            },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
                                                             },
                                                             "type": {
                                                                 "type": "string",
@@ -17334,12 +17330,16 @@
                                                                     null
                                                                 ],
                                                                 "nullable": true
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
                                                             }
                                                         },
                                                         "required": [
                                                             "fields",
-                                                            "searchQuery",
-                                                            "type"
+                                                            "type",
+                                                            "searchQuery"
                                                         ],
                                                         "type": "object"
                                                     },
@@ -23452,6 +23452,12 @@
                     "status": {
                         "$ref": "#/components/schemas/AiAgentReviewItemStatus"
                     },
+                    "targetRefs": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentTargetRef"
+                        },
+                        "type": "array"
+                    },
                     "priority": {
                         "$ref": "#/components/schemas/AiAgentReviewItemPriority"
                     },
@@ -23504,6 +23510,7 @@
                     "ownerType",
                     "dismissedReason",
                     "status",
+                    "targetRefs",
                     "priority",
                     "primaryRootCause",
                     "description",
@@ -32956,22 +32963,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -33535,22 +33542,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -42856,7 +42863,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3291.0",
+        "version": "0.3294.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1662,7 +1662,12 @@
             },
             "ExternalConnectionAuthType": {
                 "type": "string",
-                "enum": ["none", "api_key", "bearer_token"]
+                "enum": [
+                    "none",
+                    "api_key",
+                    "bearer_token",
+                    "google_service_account"
+                ]
             },
             "ExternalConnectionMethod": {
                 "type": "string",
@@ -1692,6 +1697,13 @@
                     },
                     "hasSecret": {
                         "type": "boolean"
+                    },
+                    "oauthScopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
                     },
                     "apiKeyLocation": {
                         "allOf": [
@@ -1769,6 +1781,7 @@
                     "updatedByUserUuid",
                     "createdByUserUuid",
                     "hasSecret",
+                    "oauthScopes",
                     "apiKeyLocation",
                     "apiKeyName",
                     "rateLimitPerMinute",
@@ -1807,6 +1820,13 @@
                 "properties": {
                     "secret": {
                         "type": "string",
+                        "nullable": true
+                    },
+                    "oauthScopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
                         "nullable": true
                     },
                     "apiKeyLocation": {
@@ -1959,6 +1979,13 @@
                                 "$ref": "#/components/schemas/ApiKeyLocation"
                             }
                         ],
+                        "nullable": true
+                    },
+                    "oauthScopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
                         "nullable": true
                     },
                     "secret": {

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -1,4 +1,8 @@
-export type ExternalConnectionAuthType = 'none' | 'api_key' | 'bearer_token';
+export type ExternalConnectionAuthType =
+    | 'none'
+    | 'api_key'
+    | 'bearer_token'
+    | 'google_service_account';
 
 /** HTTP methods an admin can opt a connection into. Single source of truth for
  *  the backend validation allowlist and the frontend method pickers. */
@@ -31,6 +35,8 @@ export type ExternalConnection = {
     rateLimitPerMinute: number | null;
     apiKeyName: string | null;
     apiKeyLocation: ApiKeyLocation | null;
+    // OAuth scopes for type 'google_service_account'; null for other types.
+    oauthScopes: string[] | null;
     hasSecret: boolean;
     createdByUserUuid: string | null;
     updatedByUserUuid: string | null;
@@ -53,7 +59,8 @@ export type CreateExternalConnection = {
     rateLimitPerMinute?: number | null;
     apiKeyName?: string | null;
     apiKeyLocation?: ApiKeyLocation | null;
-    secret?: string | null; // bearer token or api key value; null for type 'none'
+    oauthScopes?: string[] | null; // OAuth scopes for type 'google_service_account'
+    secret?: string | null; // bearer token, api key, or service account keyfile JSON; null for type 'none'
 };
 
 /** Omitted/blank `secret` means the stored secret is left unchanged. */

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -22,6 +22,10 @@ import { IconPlugConnected } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
 import { MethodsField } from '../../../features/externalConnections/components/MethodsField';
 import { PathRulesField } from '../../../features/externalConnections/components/PathRulesField';
+import {
+    isValidOAuthScope,
+    SUGGESTED_GOOGLE_SCOPES,
+} from '../../../features/externalConnections/constants';
 import { useCreateExternalConnection } from '../../../features/externalConnections/hooks/useCreateExternalConnection';
 import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
 import {
@@ -40,12 +44,6 @@ const DEFAULT_ALLOWED_CONTENT_TYPES = ['application/json'];
 
 // RFC 7230 token chars — must match the backend's apiKeyName validator.
 const HTTP_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
-
-// Suggested Google OAuth scopes; admins can type any https scope.
-const SUGGESTED_GOOGLE_SCOPES = [
-    'https://www.googleapis.com/auth/bigquery',
-    'https://www.googleapis.com/auth/cloud-platform',
-];
 
 const TEST_STEP = 3;
 
@@ -286,10 +284,14 @@ export const AddConnectionWizard: FC<Props> = ({
                 }
                 return null;
             },
-            oauthScopes: (value, values) =>
-                values.type === 'google_service_account' && value.length === 0
-                    ? 'Add at least one OAuth scope'
-                    : null,
+            oauthScopes: (value, values) => {
+                if (values.type !== 'google_service_account') return null;
+                if (value.length === 0) return 'Add at least one OAuth scope';
+                const invalid = value.find((s) => !isValidOAuthScope(s));
+                return invalid
+                    ? `Invalid OAuth scope: ${invalid} (use an https:// scope)`
+                    : null;
+            },
             apiKeyName: (value, values) => {
                 if (values.type !== 'api_key') return null;
                 if (value.trim().length === 0)

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -7,11 +7,13 @@ import {
     type ExternalFetchResponse,
 } from '@lightdash/common';
 import {
+    JsonInput,
     PasswordInput,
     SegmentedControl,
     Select,
     Stack,
     Stepper,
+    TagsInput,
     Text,
     TextInput,
 } from '@mantine-8/core';
@@ -39,6 +41,12 @@ const DEFAULT_ALLOWED_CONTENT_TYPES = ['application/json'];
 // RFC 7230 token chars — must match the backend's apiKeyName validator.
 const HTTP_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 
+// Suggested Google OAuth scopes; admins can type any https scope.
+const SUGGESTED_GOOGLE_SCOPES = [
+    'https://www.googleapis.com/auth/bigquery',
+    'https://www.googleapis.com/auth/cloud-platform',
+];
+
 const TEST_STEP = 3;
 
 type WizardValues = {
@@ -48,6 +56,7 @@ type WizardValues = {
     secret: string;
     apiKeyName: string;
     apiKeyLocation: ApiKeyLocation;
+    oauthScopes: string[];
     allowedMethods: ExternalConnectionMethod[];
     pathMode: PathMode;
     allowedPathPrefixes: PathPrefix[];
@@ -81,6 +90,8 @@ const toCreatePayload = (values: WizardValues): CreateExternalConnection => ({
     secret: values.type !== 'none' ? values.secret : null,
     apiKeyName: values.type === 'api_key' ? values.apiKeyName.trim() : null,
     apiKeyLocation: values.type === 'api_key' ? values.apiKeyLocation : null,
+    oauthScopes:
+        values.type === 'google_service_account' ? values.oauthScopes : null,
     allowedMethods: values.allowedMethods,
     allowedPathPrefixes: resolvePathPrefixes(
         values.pathMode,
@@ -128,6 +139,7 @@ const AuthStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({ form }) => {
                         { value: 'none', label: 'None' },
                         { value: 'api_key', label: 'API key' },
                         { value: 'bearer_token', label: 'Bearer token' },
+                        { value: 'google_service_account', label: 'Google' },
                     ]}
                     value={type}
                     onChange={(value) =>
@@ -139,7 +151,7 @@ const AuthStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({ form }) => {
                 />
             </Stack>
 
-            {type !== 'none' && (
+            {type !== 'none' && type !== 'google_service_account' && (
                 <PasswordInput
                     required
                     label={type === 'api_key' ? 'API key' : 'Bearer token'}
@@ -150,6 +162,28 @@ const AuthStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({ form }) => {
                     }
                     {...form.getInputProps('secret')}
                 />
+            )}
+
+            {type === 'google_service_account' && (
+                <>
+                    <JsonInput
+                        required
+                        label="Service account JSON"
+                        description="Paste the full service account key file"
+                        placeholder='{ "type": "service_account", ... }'
+                        formatOnBlur
+                        autosize
+                        minRows={4}
+                        {...form.getInputProps('secret')}
+                    />
+                    <TagsInput
+                        required
+                        label="OAuth scopes"
+                        description="e.g. https://www.googleapis.com/auth/bigquery"
+                        data={SUGGESTED_GOOGLE_SCOPES}
+                        {...form.getInputProps('oauthScopes')}
+                    />
+                </>
             )}
 
             {type === 'api_key' && (
@@ -230,6 +264,7 @@ export const AddConnectionWizard: FC<Props> = ({
             secret: '',
             apiKeyName: '',
             apiKeyLocation: 'header',
+            oauthScopes: [],
             allowedMethods: ['GET'],
             pathMode: 'all',
             allowedPathPrefixes: [],
@@ -238,9 +273,22 @@ export const AddConnectionWizard: FC<Props> = ({
             name: (value) =>
                 value.trim().length === 0 ? 'Name is required' : null,
             origin: validateOrigin,
-            secret: (value, values) =>
-                values.type !== 'none' && value.length === 0
-                    ? 'A secret is required for this auth method'
+            secret: (value, values) => {
+                if (values.type === 'none') return null;
+                if (value.length === 0)
+                    return 'A secret is required for this auth method';
+                if (values.type === 'google_service_account') {
+                    try {
+                        JSON.parse(value);
+                    } catch {
+                        return 'Paste valid service account JSON';
+                    }
+                }
+                return null;
+            },
+            oauthScopes: (value, values) =>
+                values.type === 'google_service_account' && value.length === 0
+                    ? 'Add at least one OAuth scope'
                     : null,
             apiKeyName: (value, values) => {
                 if (values.type !== 'api_key') return null;
@@ -288,7 +336,8 @@ export const AddConnectionWizard: FC<Props> = ({
     const goToAccess = () => {
         const secret = form.validateField('secret');
         const apiKeyName = form.validateField('apiKeyName');
-        if (!secret.hasError && !apiKeyName.hasError) {
+        const oauthScopes = form.validateField('oauthScopes');
+        if (!secret.hasError && !apiKeyName.hasError && !oauthScopes.hasError) {
             setActive(2);
         }
     };

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -23,6 +23,8 @@ const authLabel = (type: ExternalConnection['type']): string => {
             return 'API key';
         case 'bearer_token':
             return 'Bearer token';
+        case 'google_service_account':
+            return 'Google service account';
         default:
             return assertUnreachable(type, `Unknown auth type ${type}`);
     }

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -44,6 +44,7 @@ const EditConnectionModalContent: FC<Props> = ({
             secret: '',
             apiKeyName: connection.apiKeyName ?? '',
             apiKeyLocation: connection.apiKeyLocation ?? 'header',
+            oauthScopes: connection.oauthScopes ?? [],
             allowedMethods: connection.allowedMethods,
             pathMode: pathRules.mode,
             allowedPathPrefixes: pathRules.prefixes,
@@ -60,6 +61,21 @@ const EditConnectionModalContent: FC<Props> = ({
                 value.startsWith('https://')
                     ? null
                     : 'Origin must start with https://',
+            secret: (value, values) => {
+                // Blank keeps the stored secret; only validate a new one.
+                if (values.type === 'google_service_account' && value) {
+                    try {
+                        JSON.parse(value);
+                    } catch {
+                        return 'Paste valid service account JSON';
+                    }
+                }
+                return null;
+            },
+            oauthScopes: (value, values) =>
+                values.type === 'google_service_account' && value.length === 0
+                    ? 'Add at least one OAuth scope'
+                    : null,
             allowedMethods: (value) =>
                 value.length === 0 ? 'Select at least one method' : null,
             allowedPathPrefixes: (value, values) => {
@@ -93,6 +109,10 @@ const EditConnectionModalContent: FC<Props> = ({
             apiKeyName: values.type === 'api_key' ? values.apiKeyName : null,
             apiKeyLocation:
                 values.type === 'api_key' ? values.apiKeyLocation : null,
+            oauthScopes:
+                values.type === 'google_service_account'
+                    ? values.oauthScopes
+                    : null,
             // Blank => omit so the stored secret is unchanged. A non-blank
             // value on a non-"none" type rotates it via PATCH.
             ...(values.type !== 'none' && values.secret

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -6,6 +6,7 @@ import { Button, Stack, Tabs, Text, Textarea } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { IconPencil } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { isValidOAuthScope } from '../../../features/externalConnections/constants';
 import { useUpdateExternalConnection } from '../../../features/externalConnections/hooks/useUpdateExternalConnection';
 import {
     derivePathRules,
@@ -72,10 +73,14 @@ const EditConnectionModalContent: FC<Props> = ({
                 }
                 return null;
             },
-            oauthScopes: (value, values) =>
-                values.type === 'google_service_account' && value.length === 0
-                    ? 'Add at least one OAuth scope'
-                    : null,
+            oauthScopes: (value, values) => {
+                if (values.type !== 'google_service_account') return null;
+                if (value.length === 0) return 'Add at least one OAuth scope';
+                const invalid = value.find((s) => !isValidOAuthScope(s));
+                return invalid
+                    ? `Invalid OAuth scope: ${invalid} (use an https:// scope)`
+                    : null;
+            },
             allowedMethods: (value) =>
                 value.length === 0 ? 'Select at least one method' : null,
             allowedPathPrefixes: (value, values) => {

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
@@ -1,12 +1,17 @@
-import { type ExternalConnectionMethod } from '@lightdash/common';
+import {
+    type ExternalConnectionAuthType,
+    type ExternalConnectionMethod,
+} from '@lightdash/common';
 import {
     Divider,
     Group,
+    JsonInput,
     MultiSelect,
     NumberInput,
     PasswordInput,
     Select,
     Stack,
+    TagsInput,
     TextInput,
 } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
@@ -24,10 +29,11 @@ export type ExternalConnectionFormValues = {
     name: string;
     origin: string;
     instructions: string;
-    type: 'none' | 'api_key' | 'bearer_token';
+    type: ExternalConnectionAuthType;
     secret: string;
     apiKeyName: string;
     apiKeyLocation: 'header' | 'query';
+    oauthScopes: string[];
     allowedMethods: ExternalConnectionMethod[];
     pathMode: PathMode;
     allowedPathPrefixes: PathPrefix[];
@@ -45,6 +51,12 @@ const CONTENT_TYPE_OPTIONS = [
     'text/csv',
     'text/plain',
     'text/tab-separated-values',
+];
+
+// Suggested Google OAuth scopes; admins can type any https scope.
+const SUGGESTED_GOOGLE_SCOPES = [
+    'https://www.googleapis.com/auth/bigquery',
+    'https://www.googleapis.com/auth/cloud-platform',
 ];
 
 type Props = {
@@ -95,17 +107,46 @@ export const ExternalConnectionForm: FC<Props> = ({
                     { value: 'none', label: 'None' },
                     { value: 'api_key', label: 'API key' },
                     { value: 'bearer_token', label: 'Bearer token' },
+                    {
+                        value: 'google_service_account',
+                        label: 'Google service account',
+                    },
                 ]}
                 {...form.getInputProps('type')}
             />
 
-            {type !== 'none' && (
+            {type !== 'none' && type !== 'google_service_account' && (
                 <PasswordInput
                     label={type === 'api_key' ? 'API key' : 'Bearer token'}
                     placeholder={secretPlaceholder}
                     disabled={disabled}
                     {...form.getInputProps('secret')}
                 />
+            )}
+
+            {type === 'google_service_account' && (
+                <>
+                    <JsonInput
+                        label="Service account JSON"
+                        description="Paste the full service account key file"
+                        placeholder={
+                            secretPlaceholder ??
+                            '{ "type": "service_account", ... }'
+                        }
+                        formatOnBlur
+                        autosize
+                        minRows={4}
+                        disabled={disabled}
+                        {...form.getInputProps('secret')}
+                    />
+                    <TagsInput
+                        label="OAuth scopes"
+                        description="e.g. https://www.googleapis.com/auth/bigquery"
+                        data={SUGGESTED_GOOGLE_SCOPES}
+                        disabled={disabled}
+                        {...form.getInputProps('oauthScopes')}
+                    />
+                </>
             )}
 
             {type === 'api_key' && (

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
@@ -18,6 +18,7 @@ import { type UseFormReturnType } from '@mantine/form';
 import { type FC, useState } from 'react';
 import { MethodsField } from '../../../features/externalConnections/components/MethodsField';
 import { PathRulesField } from '../../../features/externalConnections/components/PathRulesField';
+import { SUGGESTED_GOOGLE_SCOPES } from '../../../features/externalConnections/constants';
 import {
     type PathMode,
     type PathPrefix,
@@ -51,12 +52,6 @@ const CONTENT_TYPE_OPTIONS = [
     'text/csv',
     'text/plain',
     'text/tab-separated-values',
-];
-
-// Suggested Google OAuth scopes; admins can type any https scope.
-const SUGGESTED_GOOGLE_SCOPES = [
-    'https://www.googleapis.com/auth/bigquery',
-    'https://www.googleapis.com/auth/cloud-platform',
 ];
 
 type Props = {

--- a/packages/frontend/src/features/externalConnections/constants.ts
+++ b/packages/frontend/src/features/externalConnections/constants.ts
@@ -1,0 +1,14 @@
+// Suggested Google OAuth scopes shown in the connection forms; admins can type
+// any valid scope.
+export const SUGGESTED_GOOGLE_SCOPES = [
+    'https://www.googleapis.com/auth/bigquery',
+    'https://www.googleapis.com/auth/cloud-platform',
+];
+
+// Mirrors the backend OAUTH_SCOPE validator so bad scopes are caught inline
+// (externalConnectionConfigValidation.ts). Google scopes are full https URLs,
+// except the OIDC scopes openid/email/profile.
+const OAUTH_SCOPE_REGEX = /^(https:\/\/\S+|openid|email|profile)$/;
+
+export const isValidOAuthScope = (scope: string): boolean =>
+    OAUTH_SCOPE_REGEX.test(scope);


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-564/google-auth-support-for-data-app-external-connections

### Description:
Add `google_service_account` as a fourth external-connection auth type. An admin pastes a service-account keyfile and enters OAuth scopes; at request time the proxy mints a short-lived Google access token via GoogleServiceAccountTokenProvider (cached in memory, keyed by a hash of keyfile + scopes) and injects it as `Authorization: Bearer …`. This lets a data app authenticate to Google APIs — e.g. write back to BigQuery.
