### PR TITLE
fix(cli): surface app download failures and old-server responses [GLITCH-576 GLITCH-577 GLITCH-578]

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -1,0 +1,91 @@
+import { type DataAppCodeDownload } from '@lightdash/common';
+import {
+    appsDownloadSummary,
+    ensureDownloadedAppContext,
+    selectAppsToDownload,
+} from './appsDownload';
+
+const makeDownload = (): DataAppCodeDownload =>
+    ({
+        manifest: {
+            codeVersion: 1 as const,
+            appUuid: 'app-uuid-1',
+            projectUuid: 'proj-uuid-1',
+            version: 3,
+            name: 'My App',
+            description: '',
+            template: null,
+            downloadedAt: '2026-06-25T00:00:00.000Z',
+        },
+        files: [],
+        context: {
+            semanticLayer: {
+                path: '.lightdash/context/semantic-layer.yml',
+                contentBase64: '',
+            },
+            parameters: null,
+            promptHistory: {
+                path: '.lightdash/context/prompt-history.md',
+                contentBase64: '',
+            },
+            theme: { instructions: null, assets: [], skippedAssetCount: 0 },
+        },
+    }) as DataAppCodeDownload;
+
+describe('selectAppsToDownload', () => {
+    it('returns explicit uuids without listing when uuids are passed', () => {
+        const selection = selectAppsToDownload(['uuid-a', 'uuid-b']);
+        expect(selection).toEqual({
+            mode: 'explicit',
+            appUuids: ['uuid-a', 'uuid-b'],
+        });
+    });
+
+    it('lists all apps when the flag is passed with no uuids', () => {
+        expect(selectAppsToDownload(true)).toEqual({ mode: 'list-all' });
+        expect(selectAppsToDownload([])).toEqual({ mode: 'list-all' });
+    });
+});
+
+describe('ensureDownloadedAppContext', () => {
+    it('returns the code unchanged when context is present', () => {
+        const code = makeDownload();
+        expect(ensureDownloadedAppContext('app-uuid-1', code)).toBe(code);
+    });
+
+    it('throws an actionable error when the server response has no context (old server)', () => {
+        const code = makeDownload();
+        const { context, ...withoutContext } = code;
+        expect(() =>
+            ensureDownloadedAppContext(
+                'app-uuid-1',
+                withoutContext as DataAppCodeDownload,
+            ),
+        ).toThrow(/does not support app context downloads/i);
+    });
+});
+
+describe('appsDownloadSummary', () => {
+    it('reports success when all apps downloaded', () => {
+        const summary = appsDownloadSummary(2, 2, [], '/tmp/x/apps');
+        expect(summary.ok).toBe(true);
+        expect(summary.message).toContain('Downloaded 2 of 2 data app(s)');
+        expect(summary.message).toContain('/tmp/x/apps');
+        expect(summary.failureLines).toEqual([]);
+    });
+
+    it('reports a warning with per-app reasons when any app failed', () => {
+        const summary = appsDownloadSummary(
+            0,
+            1,
+            [{ appUuid: 'uuid-a', message: 'server exploded' }],
+            '/tmp/x/apps',
+        );
+        expect(summary.ok).toBe(false);
+        expect(summary.message).toContain('Downloaded 0 of 1 data app(s)');
+        expect(summary.message).toContain('1 failed');
+        expect(summary.failureLines).toHaveLength(1);
+        expect(summary.failureLines[0]).toContain('uuid-a');
+        expect(summary.failureLines[0]).toContain('server exploded');
+    });
+});

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -1,0 +1,55 @@
+import { type DataAppCodeDownload } from '@lightdash/common';
+
+export type AppsDownloadSelection =
+    | { mode: 'explicit'; appUuids: string[] }
+    | { mode: 'list-all' };
+
+/**
+ * Explicit UUIDs are fetched directly (works for apps not in any space);
+ * only the no-uuid form falls back to listing apps via the space-scoped
+ * content API, which omits apps that were never added to a space.
+ */
+export const selectAppsToDownload = (
+    appsOption: true | string[],
+): AppsDownloadSelection => {
+    if (Array.isArray(appsOption) && appsOption.length > 0) {
+        return { mode: 'explicit', appUuids: appsOption };
+    }
+    return { mode: 'list-all' };
+};
+
+/**
+ * Pre-context servers return a download payload without `context`.
+ */
+export const ensureDownloadedAppContext = (
+    appUuid: string,
+    code: DataAppCodeDownload,
+): DataAppCodeDownload => {
+    if (code.context === undefined) {
+        throw new Error(
+            `This Lightdash server does not support app context downloads (app ${appUuid}). Upgrade the server, or use a CLI version matching your server.`,
+        );
+    }
+    return code;
+};
+
+export type AppDownloadFailure = { appUuid: string; message: string };
+
+export const appsDownloadSummary = (
+    successCount: number,
+    total: number,
+    failures: AppDownloadFailure[],
+    appsDir: string,
+): { ok: boolean; message: string; failureLines: string[] } => {
+    const base = `Downloaded ${successCount} of ${total} data app(s) to ${appsDir}`;
+    if (failures.length === 0) {
+        return { ok: true, message: base, failureLines: [] };
+    }
+    return {
+        ok: false,
+        message: `${base} — ${failures.length} failed`,
+        failureLines: failures.map(
+            (failure) => `  ✖ ${failure.appUuid}: ${failure.message}`,
+        ),
+    };
+};

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -44,6 +44,12 @@ import {
     writeContextToDir,
     writeFilesToDir,
 } from './apps/appCodeFiles';
+import {
+    appsDownloadSummary,
+    ensureDownloadedAppContext,
+    selectAppsToDownload,
+    type AppDownloadFailure,
+} from './apps/appsDownload';
 import { buildStaticAuthoringFiles } from './apps/scaffolding';
 import {
     checkLightdashVersion,
@@ -1005,16 +1011,14 @@ export const downloadHandler = async (
             appsOption !== undefined;
 
         if (shouldDownloadApps) {
-            // Normalize: true or [] means all apps; string[] means specific UUIDs
-            const specificAppUuids: string[] | null =
-                Array.isArray(appsOption) && appsOption.length > 0
-                    ? appsOption
-                    : null;
+            const appsSelection = selectAppsToDownload(
+                Array.isArray(appsOption) ? appsOption : true,
+            );
 
             let appUuidsToDownload: string[];
 
-            if (specificAppUuids) {
-                appUuidsToDownload = specificAppUuids;
+            if (appsSelection.mode === 'explicit') {
+                appUuidsToDownload = appsSelection.appUuids;
             } else {
                 // List all apps via content API (paginated)
                 spinner.start(`Listing data apps in project`);
@@ -1054,15 +1058,19 @@ export const downloadHandler = async (
                 const appsDir = path.join(baseDir, 'apps');
                 const takenFolders = new Set<string>();
                 let appSuccessCount = 0;
+                const appFailures: AppDownloadFailure[] = [];
 
                 for (const appUuid of appUuidsToDownload) {
                     try {
                         // eslint-disable-next-line no-await-in-loop
-                        const code = await lightdashApi<DataAppCodeDownload>({
-                            method: 'GET',
-                            url: `/api/v1/ee/projects/${projectId}/apps/${appUuid}/download`,
-                            body: undefined,
-                        });
+                        const code = ensureDownloadedAppContext(
+                            appUuid,
+                            await lightdashApi<DataAppCodeDownload>({
+                                method: 'GET',
+                                url: `/api/v1/ee/projects/${projectId}/apps/${appUuid}/download`,
+                                body: undefined,
+                            }),
+                        );
 
                         const folder = appFolderName(
                             code.manifest.name,
@@ -1090,28 +1098,34 @@ export const downloadHandler = async (
                         await writeContextToDir(appDir, code.context);
                         appSuccessCount += 1;
                     } catch (appErr) {
-                        if (
+                        const message =
                             appErr instanceof LightdashError &&
                             appErr.statusCode === 404
-                        ) {
-                            GlobalState.log(
-                                styles.warning(
-                                    `Data apps are not enabled on this instance, or app ${appUuid} was not found.`,
-                                ),
-                            );
-                        } else {
-                            GlobalState.log(
-                                styles.error(
-                                    `Failed to download app ${appUuid}: ${getErrorMessage(appErr)}`,
-                                ),
-                            );
-                        }
+                                ? `Data apps are not enabled on this instance, or app ${appUuid} was not found.`
+                                : getErrorMessage(appErr);
+                        appFailures.push({ appUuid, message });
+                        GlobalState.log(
+                            styles.error(
+                                `Failed to download app ${appUuid}: ${message}`,
+                            ),
+                        );
                     }
                 }
 
-                spinner.succeed(
-                    `Downloaded ${appSuccessCount} of ${appUuidsToDownload.length} data app(s) to ${appsDir}`,
+                const summary = appsDownloadSummary(
+                    appSuccessCount,
+                    appUuidsToDownload.length,
+                    appFailures,
+                    appsDir,
                 );
+                if (summary.ok) {
+                    spinner.succeed(summary.message);
+                } else {
+                    spinner.warn(styles.warning(summary.message));
+                    summary.failureLines.forEach((line) =>
+                        GlobalState.log(styles.warning(line)),
+                    );
+                }
             }
         }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -761,7 +761,7 @@ program
     )
     .option(
         '--apps [appUuids...]',
-        'Include data apps (enterprise). Optionally limit to specific app UUIDs; default: all apps in the project.',
+        'Include data apps (enterprise). Optionally limit to specific app UUIDs; default: all apps in the project. Apps not added to a space are only included when their UUID is passed explicitly.',
     )
     .action(downloadHandler);
 


### PR DESCRIPTION
Follow-ups from the Phase 2 QA run — robustness for `download --apps`.

- Per-app download failures now end in a `⚠` warning summary with per-app reasons, instead of a green "Downloaded 0 of 1 … Done 🕶" and exit 0.
- A pre-Phase-2 server response (no `context` key) now fails with an actionable "this server does not support app context downloads" message instead of a raw TypeError.
- Explicit `--apps <uuid>` selection is locked in by test to bypass the space-scoped content-API listing (so it works for apps not added to a space); help text documents that the all-apps listing skips space-less apps.

Closes: GLITCH-576
Closes: GLITCH-577
Closes: GLITCH-578

🤖 Generated with [Claude Code](https://claude.com/claude-code)