### PR TITLE
feat(cli)!: --apps requires ids on download; add --include-apps capped at 10 [GLITCH-579]

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -1,7 +1,9 @@
 import { type DataAppCodeDownload } from '@lightdash/common';
 import {
     appsDownloadSummary,
+    capListedApps,
     ensureDownloadedAppContext,
+    MAX_INCLUDE_APPS,
     selectAppsToDownload,
 } from './appsDownload';
 
@@ -34,16 +36,45 @@ const makeDownload = (): DataAppCodeDownload =>
 
 describe('selectAppsToDownload', () => {
     it('returns explicit uuids without listing when uuids are passed', () => {
-        const selection = selectAppsToDownload(['uuid-a', 'uuid-b']);
-        expect(selection).toEqual({
+        expect(selectAppsToDownload({ apps: ['uuid-a', 'uuid-b'] })).toEqual({
             mode: 'explicit',
             appUuids: ['uuid-a', 'uuid-b'],
         });
     });
 
-    it('lists all apps when the flag is passed with no uuids', () => {
-        expect(selectAppsToDownload(true)).toEqual({ mode: 'list-all' });
-        expect(selectAppsToDownload([])).toEqual({ mode: 'list-all' });
+    it('lists all apps when --include-apps is passed', () => {
+        expect(selectAppsToDownload({ includeApps: true })).toEqual({
+            mode: 'list-all',
+            extraAppUuids: [],
+        });
+    });
+
+    it('combines --include-apps with explicitly passed uuids', () => {
+        expect(
+            selectAppsToDownload({ apps: ['uuid-a'], includeApps: true }),
+        ).toEqual({ mode: 'list-all', extraAppUuids: ['uuid-a'] });
+    });
+
+    it('skips apps when neither flag is passed', () => {
+        expect(selectAppsToDownload({})).toEqual({ mode: 'none' });
+        expect(selectAppsToDownload({ apps: [] })).toEqual({ mode: 'none' });
+    });
+});
+
+describe('capListedApps', () => {
+    it('keeps all listed apps when under the cap', () => {
+        expect(capListedApps(['a', 'b', 'c'])).toEqual({
+            appUuids: ['a', 'b', 'c'],
+            truncatedCount: 0,
+        });
+    });
+
+    it(`caps listed apps at ${MAX_INCLUDE_APPS} and reports the truncated count`, () => {
+        const listed = Array.from({ length: 12 }, (_, i) => `uuid-${i}`);
+        const result = capListedApps(listed);
+        expect(result.appUuids).toHaveLength(MAX_INCLUDE_APPS);
+        expect(result.appUuids).toEqual(listed.slice(0, MAX_INCLUDE_APPS));
+        expect(result.truncatedCount).toBe(2);
     });
 });
 

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -1,22 +1,37 @@
 import { type DataAppCodeDownload } from '@lightdash/common';
 
+export const MAX_INCLUDE_APPS = 10;
+
 export type AppsDownloadSelection =
+    | { mode: 'none' }
     | { mode: 'explicit'; appUuids: string[] }
-    | { mode: 'list-all' };
+    | { mode: 'list-all'; extraAppUuids: string[] };
 
 /**
- * Explicit UUIDs are fetched directly (works for apps not in any space);
- * only the no-uuid form falls back to listing apps via the space-scoped
- * content API, which omits apps that were never added to a space.
+ * Explicit UUIDs (--apps) are fetched directly (works for apps not in any
+ * space); only --include-apps lists apps via the space-scoped content API,
+ * which omits apps that were never added to a space.
  */
-export const selectAppsToDownload = (
-    appsOption: true | string[],
-): AppsDownloadSelection => {
-    if (Array.isArray(appsOption) && appsOption.length > 0) {
-        return { mode: 'explicit', appUuids: appsOption };
+export const selectAppsToDownload = (request: {
+    apps?: string[];
+    includeApps?: boolean;
+}): AppsDownloadSelection => {
+    const explicitUuids = request.apps ?? [];
+    if (request.includeApps) {
+        return { mode: 'list-all', extraAppUuids: explicitUuids };
     }
-    return { mode: 'list-all' };
+    if (explicitUuids.length > 0) {
+        return { mode: 'explicit', appUuids: explicitUuids };
+    }
+    return { mode: 'none' };
 };
+
+export const capListedApps = (
+    listedUuids: string[],
+): { appUuids: string[]; truncatedCount: number } => ({
+    appUuids: listedUuids.slice(0, MAX_INCLUDE_APPS),
+    truncatedCount: Math.max(0, listedUuids.length - MAX_INCLUDE_APPS),
+});
 
 /**
  * Pre-context servers return a download payload without `context`.

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -46,7 +46,9 @@ import {
 } from './apps/appCodeFiles';
 import {
     appsDownloadSummary,
+    capListedApps,
     ensureDownloadedAppContext,
+    MAX_INCLUDE_APPS,
     selectAppsToDownload,
     type AppDownloadFailure,
 } from './apps/appsDownload';
@@ -68,7 +70,8 @@ export type DownloadHandlerOptions = {
     verbose: boolean;
     charts: string[]; // These can be slugs, uuids or urls
     dashboards: string[]; // These can be slugs, uuids or urls
-    apps: string[] | boolean | null; // true = all apps; string[] = specific UUIDs; null/false/absent = skip
+    apps: string[] | boolean | null; // download: string[] = specific UUIDs; upload: true = all app folders on disk; null/false/absent = skip
+    includeApps?: boolean; // download only: include the project's apps (space-scoped listing, capped)
     force: boolean;
     path?: string; // New optional path parameter
     project?: string;
@@ -1003,18 +1006,13 @@ export const downloadHandler = async (
             }
         }
 
-        // Download data apps (enterprise, opt-in via --apps)
-        const appsOption = options.apps;
-        const shouldDownloadApps =
-            appsOption !== null &&
-            appsOption !== false &&
-            appsOption !== undefined;
+        // Download data apps (enterprise, opt-in via --apps / --include-apps)
+        const appsSelection = selectAppsToDownload({
+            apps: Array.isArray(options.apps) ? options.apps : undefined,
+            includeApps: options.includeApps === true,
+        });
 
-        if (shouldDownloadApps) {
-            const appsSelection = selectAppsToDownload(
-                Array.isArray(appsOption) ? appsOption : true,
-            );
-
+        if (appsSelection.mode !== 'none') {
             let appUuidsToDownload: string[];
 
             if (appsSelection.mode === 'explicit') {
@@ -1022,7 +1020,7 @@ export const downloadHandler = async (
             } else {
                 // List all apps via content API (paginated)
                 spinner.start(`Listing data apps in project`);
-                appUuidsToDownload = [];
+                const listedAppUuids: string[] = [];
                 let page = 1;
                 let totalPageCount = 1;
 
@@ -1036,7 +1034,7 @@ export const downloadHandler = async (
                         body: undefined,
                     });
 
-                    appUuidsToDownload.push(
+                    listedAppUuids.push(
                         ...contentResult.data
                             .filter((item) => item.contentType === 'data_app')
                             .map((item) => item.uuid),
@@ -1046,6 +1044,22 @@ export const downloadHandler = async (
                         contentResult.pagination?.totalPageCount ?? 1;
                     page += 1;
                 } while (page <= totalPageCount);
+
+                const { appUuids: cappedAppUuids, truncatedCount } =
+                    capListedApps(listedAppUuids);
+                if (truncatedCount > 0) {
+                    GlobalState.log(
+                        styles.warning(
+                            `--include-apps is capped at ${MAX_INCLUDE_APPS} apps (${listedAppUuids.length} found, ${truncatedCount} skipped). Pass --apps <uuids> to download specific apps.`,
+                        ),
+                    );
+                }
+                appUuidsToDownload = [
+                    ...new Set([
+                        ...cappedAppUuids,
+                        ...appsSelection.extraAppUuids,
+                    ]),
+                ];
             }
 
             if (appUuidsToDownload.length === 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -760,8 +760,13 @@ program
         false,
     )
     .option(
-        '--apps [appUuids...]',
-        'Include data apps (enterprise). Optionally limit to specific app UUIDs; default: all apps in the project. Apps not added to a space are only included when their UUID is passed explicitly.',
+        '--apps <appUuids...>',
+        'Include specific data apps by UUID (enterprise). Works for apps not added to a space.',
+    )
+    .option(
+        '--include-apps',
+        'Include the project\'s data apps (enterprise), capped at the first 10. Only lists apps that are in a space; use "--apps <uuids>" for the rest.',
+        false,
     )
     .action(downloadHandler);
 


### PR DESCRIPTION
Aligns the download `--apps` flag with the `--charts`/`--dashboards` conventions (breaking, but the feature is not yet advertised).

- `download --apps <appUuids...>` now requires ids and filters to exactly those apps.
- New `--include-apps` opt-in downloads the project's apps, capped at the first 10 with an explicit truncation warning pointing at `--apps <uuids>` for the rest.
- `--apps` + `--include-apps` together union. `upload --apps` grammar is deliberately unchanged (local-dir-scoped).

Closes: GLITCH-579

🤖 Generated with [Claude Code](https://claude.com/claude-code)