### PR TITLE
feat(cli): upload --create-new forces a new app; offer manifest retarget after create [GLITCH-581]

### DIFF
--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -6,6 +6,7 @@ import {
     appFolderName,
     buildImportBody,
     readBundleFromDir,
+    retargetManifest,
     writeBundleToDir,
     writeContextToDir,
 } from './appCodeFiles';
@@ -71,6 +72,21 @@ describe('buildImportBody', () => {
         const code = makeCode('app-uuid-1', 'proj-uuid-1');
         const body = buildImportBody(code, 'proj-uuid-1', {});
         expect(body.code).toBe(code);
+    });
+
+    it('forces a create when createNew is set, even in the same project', () => {
+        const code = makeCode('app-uuid-1', 'proj-uuid-1');
+        const body = buildImportBody(code, 'proj-uuid-1', { createNew: true });
+        expect(body.targetAppUuid).toBeUndefined();
+    });
+
+    it('createNew overrides an explicit app target', () => {
+        const code = makeCode('app-uuid-1', 'proj-uuid-1');
+        const body = buildImportBody(code, 'proj-uuid-1', {
+            app: 'explicit-app-uuid',
+            createNew: true,
+        });
+        expect(body.targetAppUuid).toBeUndefined();
     });
 });
 
@@ -146,6 +162,24 @@ it('upload reads back only src/ files, ignoring scaffolding and context', async 
     expect(read.files.map((f) => f.path).sort()).toEqual(
         bundle.files.map((f) => f.path).sort(),
     );
+});
+
+describe('retargetManifest', () => {
+    it('rewrites appUuid, projectUuid and version, preserving other fields', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-app-'));
+        await writeBundleToDir(dir, bundle);
+        await retargetManifest(dir, {
+            appUuid: 'new-app-uuid',
+            projectUuid: 'new-proj-uuid',
+            version: 1,
+        });
+        const read = await readBundleFromDir(dir);
+        expect(read.manifest.appUuid).toBe('new-app-uuid');
+        expect(read.manifest.projectUuid).toBe('new-proj-uuid');
+        expect(read.manifest.version).toBe(1);
+        expect(read.manifest.name).toBe('N');
+        expect(read.manifest.downloadedAt).toBe('2026-06-30T00:00:00.000Z');
+    });
 });
 
 it('throws a clear error when the manifest is not valid YAML', async () => {

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -126,10 +126,13 @@ const collectFiles = async (
 export const buildImportBody = (
     code: DataAppCode,
     targetProjectUuid: string,
-    opts: { app?: string; space?: string },
+    opts: { app?: string; space?: string; createNew?: boolean },
 ): ImportAppCodeRequestBody => {
     let targetAppUuid: string | undefined;
-    if (opts.app) {
+    if (opts.createNew) {
+        // No target app -> the server always creates a new app
+        targetAppUuid = undefined;
+    } else if (opts.app) {
         targetAppUuid = opts.app;
     } else if (targetProjectUuid === code.manifest.projectUuid) {
         targetAppUuid = code.manifest.appUuid;
@@ -140,6 +143,25 @@ export const buildImportBody = (
         targetAppUuid,
         spaceUuid: opts.space,
     };
+};
+
+/**
+ * Points a downloaded app folder's manifest at a different app, so future
+ * uploads update that app instead of the one it was downloaded from.
+ */
+export const retargetManifest = async (
+    dir: string,
+    target: { appUuid: string; projectUuid: string; version: number },
+): Promise<void> => {
+    const manifestPath = path.join(dir, MANIFEST_FILENAME);
+    const manifest = YAML.parse(
+        await fs.readFile(manifestPath, 'utf-8'),
+    ) as DataAppManifest;
+    await fs.writeFile(
+        manifestPath,
+        YAML.stringify({ ...manifest, ...target }),
+        'utf-8',
+    );
 };
 
 export const readBundleFromDir = async (dir: string): Promise<DataAppCode> => {

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -27,6 +27,7 @@ import {
     type SpaceAsCode,
 } from '@lightdash/common';
 import { Dirent, promises as fs, type Stats } from 'fs';
+import inquirer from 'inquirer';
 import * as yaml from 'js-yaml';
 import groupBy from 'lodash/groupBy';
 import pLimit from 'p-limit';
@@ -40,6 +41,7 @@ import {
     appFolderName,
     buildImportBody,
     readBundleFromDir,
+    retargetManifest,
     writeBundleToDir,
     writeContextToDir,
     writeFilesToDir,
@@ -72,6 +74,7 @@ export type DownloadHandlerOptions = {
     dashboards: string[]; // These can be slugs, uuids or urls
     apps: string[] | boolean | null; // download: string[] = specific UUIDs; upload: true = all app folders on disk; null/false/absent = skip
     includeApps?: boolean; // download only: include the project's apps (space-scoped listing, capped)
+    createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
     force: boolean;
     path?: string; // New optional path parameter
     project?: string;
@@ -1913,7 +1916,9 @@ export const uploadHandler = async (
                         continue;
                     }
 
-                    const body = buildImportBody(code, projectId, {});
+                    const body = buildImportBody(code, projectId, {
+                        createNew: options.createNew === true,
+                    });
 
                     // eslint-disable-next-line no-await-in-loop
                     const { appUuid, version, action } = await lightdashApi<
@@ -1931,6 +1936,44 @@ export const uploadHandler = async (
                             `Uploaded "${code.manifest.name}" — ${actionLabel} v${version} (${appUuid}). Building in the background; the app will show "building" until the server finishes.`,
                         ),
                     );
+
+                    if (action === 'create') {
+                        GlobalState.log(
+                            `New app: ${config.context.serverUrl}/projects/${projectId}/apps/${appUuid}`,
+                        );
+                        if (process.stdin.isTTY && process.stdout.isTTY) {
+                            // eslint-disable-next-line no-await-in-loop
+                            const { retarget } = await inquirer.prompt<{
+                                retarget: boolean;
+                            }>([
+                                {
+                                    type: 'confirm',
+                                    name: 'retarget',
+                                    message: `Update ${subDir.name}/lightdash-app.yml to target the new app, so future uploads update it?`,
+                                    default: true,
+                                },
+                            ]);
+                            if (retarget) {
+                                // eslint-disable-next-line no-await-in-loop
+                                await retargetManifest(folderPath, {
+                                    appUuid,
+                                    projectUuid: projectId,
+                                    version,
+                                });
+                                GlobalState.log(
+                                    styles.success(
+                                        `Updated ${subDir.name}/lightdash-app.yml to target ${appUuid}.`,
+                                    ),
+                                );
+                            }
+                        } else {
+                            GlobalState.log(
+                                styles.warning(
+                                    `${subDir.name}/lightdash-app.yml still targets the original app. Set appUuid: ${appUuid} (and projectUuid: ${projectId}) there to update the new app on future uploads.`,
+                                ),
+                            );
+                        }
+                    }
                 } catch (appErr) {
                     const status =
                         appErr instanceof LightdashError

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -822,6 +822,11 @@ program
         '--apps [appUuids...]',
         'Include data apps (enterprise). Optionally limit to specific app UUIDs; default: all app folders on disk.',
     )
+    .option(
+        '--create-new',
+        'Always create a new app from the uploaded code instead of updating the app referenced by lightdash-app.yml.',
+        false,
+    )
     .action(uploadHandler);
 
 program


### PR DESCRIPTION
- `upload --apps --create-new` always creates a new app from the uploaded code (CLI omits `targetAppUuid`; no backend change needed).
- After any create, the CLI prints the new app's URL and, on a TTY, offers to retarget the folder's `lightdash-app.yml` to the new app so future uploads update it. Non-TTY (CI) prints a manual hint and leaves the manifest untouched.

Relates: GLITCH-581

🤖 Generated with [Claude Code](https://claude.com/claude-code)
