### PR TITLE
fix(data-apps): prevent deselecting the Authentication

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
@@ -90,6 +90,7 @@ export const ExternalConnectionForm: FC<Props> = ({
             <Select
                 label="Authentication"
                 disabled={disabled}
+                allowDeselect={false}
                 data={[
                     { value: 'none', label: 'None' },
                     { value: 'api_key', label: 'API key' },


### PR DESCRIPTION
### Description:
Mantine v8 Select defaults allowDeselect to true, so clicking the already-selected option cleared it to null. 'none' is a valid auth choice, so the field should never be empty.
