### PR TITLE
feat(avatars): gradient and image rendering in LightdashUserAvatar

### DIFF
--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -1,0 +1,27 @@
+.root[data-avatar-gradient] .placeholder {
+    color: var(--mantine-color-white);
+}
+.root[data-avatar-gradient='dusk'] .placeholder {
+    background: linear-gradient(135deg, #7048e8, #d6336c);
+}
+.root[data-avatar-gradient='ocean'] .placeholder {
+    background: linear-gradient(135deg, #1971c2, #0ca678);
+}
+.root[data-avatar-gradient='ember'] .placeholder {
+    background: linear-gradient(135deg, #e8590c, #f08c00);
+}
+.root[data-avatar-gradient='meadow'] .placeholder {
+    background: linear-gradient(135deg, #2f9e44, #66a80f);
+}
+.root[data-avatar-gradient='tide'] .placeholder {
+    background: linear-gradient(135deg, #0c8599, #4263eb);
+}
+.root[data-avatar-gradient='plum'] .placeholder {
+    background: linear-gradient(135deg, #9c36b5, #f06595);
+}
+.root[data-avatar-gradient='sand'] .placeholder {
+    background: linear-gradient(135deg, #e67700, #ca8a04);
+}
+.root[data-avatar-gradient='slate'] .placeholder {
+    background: linear-gradient(135deg, #3b5bdb, #748ffc);
+}

--- a/packages/frontend/src/components/Avatar.test.tsx
+++ b/packages/frontend/src/components/Avatar.test.tsx
@@ -1,0 +1,54 @@
+import { getUserAvatarGradient } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../testing/testUtils';
+import { LightdashUserAvatar } from './Avatar';
+
+const UUID_A = 'b264d83a-9000-426a-85ec-3f9c20f368ce';
+
+describe('LightdashUserAvatar', () => {
+    it('renders the deterministic gradient for a userUuid', () => {
+        renderWithProviders(
+            <LightdashUserAvatar userUuid={UUID_A} name="Ada Lovelace" />,
+        );
+        const expected = getUserAvatarGradient(UUID_A, null);
+        expect(
+            document.querySelector(`[data-avatar-gradient="${expected}"]`),
+        ).toBeInTheDocument();
+        expect(screen.getByText('AL')).toBeInTheDocument();
+    });
+
+    it('prefers the explicit gradient override', () => {
+        renderWithProviders(
+            <LightdashUserAvatar
+                userUuid={UUID_A}
+                avatarGradient="ember"
+                name="Ada Lovelace"
+            />,
+        );
+        expect(
+            document.querySelector('[data-avatar-gradient="ember"]'),
+        ).toBeInTheDocument();
+    });
+
+    it('renders the image when avatarUrl is set', () => {
+        renderWithProviders(
+            <LightdashUserAvatar
+                userUuid={UUID_A}
+                avatarUrl="/api/v1/users/x/avatar/abc"
+                name="Ada Lovelace"
+            />,
+        );
+        expect(document.querySelector('img')).toHaveAttribute(
+            'src',
+            '/api/v1/users/x/avatar/abc',
+        );
+    });
+
+    it('keeps legacy color-initials behavior without a userUuid', () => {
+        renderWithProviders(<LightdashUserAvatar name="Ada Lovelace" />);
+        expect(
+            document.querySelector('[data-avatar-gradient]'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -1,16 +1,57 @@
+import {
+    getUserAvatarGradient,
+    type UserAvatarGradientId,
+} from '@lightdash/common';
 import { Avatar, type AvatarProps } from '@mantine-8/core';
 import { forwardRef } from 'react';
+import classes from './Avatar.module.css';
 
-type Props = AvatarProps;
+type AvatarClassNames = Partial<
+    Record<'root' | 'placeholder' | 'image', string>
+>;
+
+type Props = Omit<AvatarProps, 'classNames'> & {
+    userUuid?: string;
+    avatarUrl?: string | null;
+    avatarGradient?: UserAvatarGradientId | null;
+    classNames?: AvatarClassNames;
+};
+
+const mergeClassNames = (extra?: AvatarClassNames): AvatarClassNames => ({
+    ...extra,
+    root: [classes.root, extra?.root].filter(Boolean).join(' '),
+    placeholder: [classes.placeholder, extra?.placeholder]
+        .filter(Boolean)
+        .join(' '),
+});
 
 export const LightdashUserAvatar = forwardRef<HTMLDivElement, Props>(
-    ({ ...props }, ref) => {
+    ({ userUuid, avatarUrl, avatarGradient, classNames, ...props }, ref) => {
+        if (!userUuid) {
+            return (
+                <Avatar
+                    ref={ref}
+                    variant="light"
+                    radius="100%"
+                    color="initials"
+                    classNames={classNames}
+                    {...props}
+                />
+            );
+        }
+        const gradient = getUserAvatarGradient(
+            userUuid,
+            avatarGradient ?? null,
+        );
         return (
             <Avatar
                 ref={ref}
-                variant="light"
                 radius="100%"
                 color="initials"
+                src={avatarUrl ?? undefined}
+                imageProps={{ loading: 'lazy' }}
+                data-avatar-gradient={gradient}
+                classNames={mergeClassNames(classNames)}
                 {...props}
             />
         );

--- a/packages/frontend/src/components/UserAvatar.tsx
+++ b/packages/frontend/src/components/UserAvatar.tsx
@@ -1,31 +1,35 @@
-import { Avatar, useMantineTheme, type AvatarProps } from '@mantine-8/core';
+import { useMantineTheme, type AvatarProps } from '@mantine-8/core';
 import { forwardRef } from 'react';
 import useApp from '../providers/App/useApp';
+import { LightdashUserAvatar } from './Avatar';
 import classes from './UserAvatar.module.css';
 
-export const UserAvatar = forwardRef<HTMLDivElement, AvatarProps>(
-    (props, ref) => {
-        const { user } = useApp();
-        const theme = useMantineTheme();
-        const initials = user.data
-            ? `${user.data.firstName[0]}${user.data.lastName[0]}`.trim()
-            : '';
+export const UserAvatar = forwardRef<
+    HTMLDivElement,
+    Omit<AvatarProps, 'classNames'>
+>((props, ref) => {
+    const { user } = useApp();
+    const theme = useMantineTheme();
+    const initials = user.data
+        ? `${user.data.firstName[0]}${user.data.lastName[0]}`.trim()
+        : '';
 
-        return (
-            <Avatar
-                data-testid="user-avatar"
-                ref={ref}
-                variant="light"
-                size={theme.spacing.xxl}
-                radius="lg"
-                classNames={{
-                    root: classes.avatar,
-                    placeholder: classes.placeholder,
-                }}
-                {...props}
-            >
-                {initials}
-            </Avatar>
-        );
-    },
-);
+    return (
+        <LightdashUserAvatar
+            data-testid="user-avatar"
+            ref={ref}
+            size={theme.spacing.xxl}
+            radius="lg"
+            userUuid={user.data?.userUuid}
+            avatarUrl={user.data?.avatarUrl}
+            avatarGradient={user.data?.avatarGradient}
+            classNames={{
+                root: classes.avatar,
+                placeholder: classes.placeholder,
+            }}
+            {...props}
+        >
+            {initials}
+        </LightdashUserAvatar>
+    );
+});


### PR DESCRIPTION
## Summary
Frontend avatar rendering core (stack 3/4, on #25054).

- `LightdashUserAvatar` gains optional `userUuid` / `avatarUrl` / `avatarGradient` props. With `userUuid`, the placeholder paints the deterministic (or overridden) brand gradient with initials on top; `avatarUrl` renders lazily with the gradient as the loading/error fallback — no spinners, no layout shift.
- Gradient color stops live in a CSS module keyed by `data-avatar-gradient` (ids come from common; style guide forbids inline styles).
- `UserAvatar` (navbar, current user) delegates and passes the session user's avatar fields.
- RTL tests for the rendering precedence (image > override > deterministic > legacy).

## Regression analysis
Call sites that don't pass `userUuid` keep today's `color="initials"` rendering exactly. The navbar avatar visibly changes for everyone (Mantine initials → brand gradient) — intentional; the full sweep lands in #25056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qtyCMqL6tkoDoZ46bn4Q2