### PR TITLE
feat(avatars): profile settings avatar section and user call sites

### DIFF
--- a/packages/common/src/types/userAvatars.test.ts
+++ b/packages/common/src/types/userAvatars.test.ts
@@ -30,9 +30,9 @@ describe('getUserAvatarGradient', () => {
         expect(
             getUserAvatarGradient(
                 'b264d83a-9000-426a-85ec-3f9c20f368ce',
-                'ember',
+                'lilac',
             ),
-        ).toBe('ember');
+        ).toBe('lilac');
     });
 
     it('spreads different uuids across gradients', () => {
@@ -52,7 +52,7 @@ describe('getUserAvatarGradient', () => {
 
 describe('isUserAvatarGradientId', () => {
     it('accepts known ids and rejects unknown strings', () => {
-        expect(isUserAvatarGradientId('ember')).toBe(true);
+        expect(isUserAvatarGradientId('lilac')).toBe(true);
         expect(isUserAvatarGradientId('not-a-gradient')).toBe(false);
     });
 });

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -1,12 +1,19 @@
 export const USER_AVATAR_GRADIENT_IDS = [
     'dusk',
+    'lilac',
     'ocean',
     'ember',
-    'meadow',
-    'tide',
-    'plum',
-    'sand',
-    'slate',
+    'blush',
+    'minty',
+    'forest',
+    'sunrise',
+    'twilight',
+    'lavender',
+    'emerald',
+    'amethyst',
+    'sage',
+    'orchid',
+    'jungle',
 ] as const;
 
 export type UserAvatarGradientId = (typeof USER_AVATAR_GRADIENT_IDS)[number];

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -2,8 +2,8 @@ export const USER_AVATAR_GRADIENT_IDS = [
     'lilac',
     'blush',
     'minty',
-    'sunrise',
     'amethyst',
+    'sunrise',
 ] as const;
 
 export type UserAvatarGradientId = (typeof USER_AVATAR_GRADIENT_IDS)[number];

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -1,18 +1,9 @@
 export const USER_AVATAR_GRADIENT_IDS = [
-    'dusk',
     'lilac',
-    'ocean',
-    'ember',
     'blush',
     'minty',
-    'forest',
     'sunrise',
-    'twilight',
-    'lavender',
-    'emerald',
     'amethyst',
-    'sage',
-    'orchid',
     'jungle',
 ] as const;
 

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -1,9 +1,9 @@
 export const USER_AVATAR_GRADIENT_IDS = [
     'lilac',
     'blush',
-    'slate',
     'amethyst',
     'sunrise',
+    'slate',
 ] as const;
 
 export type UserAvatarGradientId = (typeof USER_AVATAR_GRADIENT_IDS)[number];

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -1,7 +1,7 @@
 export const USER_AVATAR_GRADIENT_IDS = [
     'lilac',
     'blush',
-    'minty',
+    'slate',
     'amethyst',
     'sunrise',
 ] as const;

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -4,7 +4,6 @@ export const USER_AVATAR_GRADIENT_IDS = [
     'minty',
     'sunrise',
     'amethyst',
-    'jungle',
 ] as const;
 
 export type UserAvatarGradientId = (typeof USER_AVATAR_GRADIENT_IDS)[number];

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -24,7 +24,7 @@
         radial-gradient(circle at 80% 70%, #8f6fff 0%, transparent 50%),
         radial-gradient(circle at 15% 65%, #b884ff 0%, transparent 55%),
         radial-gradient(circle at 55% 50%, #9d7fff 0%, transparent 60%), #a383ff;
-    border: 1px solid rgba(159, 111, 255, 0.6);
+    border: 1px solid rgba(159, 111, 255, 0.2);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
@@ -33,7 +33,7 @@
         radial-gradient(circle at 85% 65%, #c499ff 0%, transparent 52%),
         radial-gradient(circle at 10% 70%, #d98ac0 0%, transparent 55%),
         radial-gradient(circle at 50% 55%, #d984c8 0%, transparent 58%), #d987c8;
-    border: 1px solid rgba(255, 100, 190, 0.6);
+    border: 1px solid rgba(255, 100, 190, 0.2);
 }
 .root[data-avatar-gradient='slate'] .placeholder {
     background:
@@ -42,7 +42,7 @@
         radial-gradient(circle at 80% 70%, #4a4a4a 0%, transparent 52%),
         radial-gradient(circle at 15% 65%, #2a2a2a 0%, transparent 55%),
         radial-gradient(circle at 55% 50%, #383838 0%, transparent 58%), #353535;
-    border: 1px solid rgba(60, 60, 60, 0.6);
+    border: 1px solid rgba(60, 60, 60, 0.2);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
@@ -51,7 +51,7 @@
         radial-gradient(circle at 80% 75%, #30cf87 0%, transparent 52%),
         radial-gradient(circle at 10% 65%, #c1f1db 0%, transparent 55%),
         radial-gradient(circle at 50% 50%, #6fa0d8 0%, transparent 58%), #7fb5c2;
-    border: 1px solid rgba(94, 76, 255, 0.6);
+    border: 1px solid rgba(94, 76, 255, 0.2);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
@@ -60,5 +60,5 @@
         radial-gradient(circle at 80% 80%, #b8cd55 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #a8c755 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #b8c855 0%, transparent 50%), #b8c855;
-    border: 1px solid rgba(180, 160, 255, 0.6);
+    border: 1px solid rgba(180, 160, 255, 0.2);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -24,7 +24,7 @@
         radial-gradient(circle at 80% 70%, #8f6fff 0%, transparent 50%),
         radial-gradient(circle at 15% 65%, #b884ff 0%, transparent 55%),
         radial-gradient(circle at 55% 50%, #9d7fff 0%, transparent 60%), #a383ff;
-    border: 1px solid rgba(159, 111, 255, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(159, 111, 255, 0.3);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
@@ -33,7 +33,7 @@
         radial-gradient(circle at 85% 65%, #c499ff 0%, transparent 52%),
         radial-gradient(circle at 10% 70%, #d98ac0 0%, transparent 55%),
         radial-gradient(circle at 50% 55%, #d984c8 0%, transparent 58%), #d987c8;
-    border: 1px solid rgba(255, 100, 190, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(255, 99, 180, 0.3);
 }
 .root[data-avatar-gradient='slate'] .placeholder {
     background:
@@ -42,16 +42,16 @@
         radial-gradient(circle at 80% 70%, #4a4a4a 0%, transparent 52%),
         radial-gradient(circle at 15% 65%, #2a2a2a 0%, transparent 55%),
         radial-gradient(circle at 55% 50%, #383838 0%, transparent 58%), #353535;
-    border: 1px solid rgba(60, 60, 60, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(70, 70, 70, 0.4);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 20% 30%, #5e4cff 0%, transparent 48%),
-        radial-gradient(circle at 75% 15%, #83e2b7 0%, transparent 50%),
-        radial-gradient(circle at 80% 75%, #30cf87 0%, transparent 52%),
-        radial-gradient(circle at 10% 65%, #c1f1db 0%, transparent 55%),
-        radial-gradient(circle at 50% 50%, #6fa0d8 0%, transparent 58%), #7fb5c2;
-    border: 1px solid rgba(94, 76, 255, 0.2);
+        radial-gradient(circle at 75% 15%, #5e4cff 0%, transparent 50%),
+        radial-gradient(circle at 20% 30%, #83e2b7 0%, transparent 48%),
+        radial-gradient(circle at 10% 65%, #30cf87 0%, transparent 55%),
+        radial-gradient(circle at 80% 75%, #c1f1db 0%, transparent 52%),
+        radial-gradient(circle at 50% 50%, #7fb5c2 0%, transparent 58%), #6fa0d8;
+    box-shadow: inset 0 0 0 1px rgba(131, 226, 183, 0.3);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
@@ -60,5 +60,5 @@
         radial-gradient(circle at 80% 80%, #b8cd55 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #a8c755 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #b8c855 0%, transparent 50%), #b8c855;
-    border: 1px solid rgba(180, 160, 255, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(180, 160, 255, 0.3);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -7,17 +7,6 @@
     color: var(--mantine-color-white);
 }
 
-.root[data-avatar-gradient] .placeholder::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.95' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100' height='100' filter='url(%23n)' opacity='0.15'/%3E%3C/svg%3E");
-    background-size: 100px 100px;
-    mix-blend-mode: overlay;
-    pointer-events: none;
-}
-
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
         radial-gradient(circle at 25% 30%, #d1ccff 0%, transparent 60%),

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -19,39 +19,39 @@
 
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #a499ff 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #8f6fff 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #b884ff 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #9970ff 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #9d7fff 0%, transparent 50%), #a383ff;
+        radial-gradient(circle at 25% 30%, #d1ccff 0%, transparent 45%),
+        radial-gradient(circle at 70% 15%, #a499ff 0%, transparent 55%),
+        radial-gradient(circle at 80% 70%, #8f6fff 0%, transparent 50%),
+        radial-gradient(circle at 15% 65%, #b884ff 0%, transparent 55%),
+        radial-gradient(circle at 55% 50%, #9d7fff 0%, transparent 60%), #a383ff;
     border: 1px solid rgba(159, 111, 255, 0.6);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #ff99d9 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #c499ff 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #d98ac0 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #d87fb8 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #d984c8 0%, transparent 50%), #d987c8;
+        radial-gradient(circle at 30% 25%, #ffd1e8 0%, transparent 48%),
+        radial-gradient(circle at 65% 10%, #ff99d9 0%, transparent 50%),
+        radial-gradient(circle at 85% 65%, #c499ff 0%, transparent 52%),
+        radial-gradient(circle at 10% 70%, #d98ac0 0%, transparent 55%),
+        radial-gradient(circle at 50% 55%, #d984c8 0%, transparent 58%), #d987c8;
     border: 1px solid rgba(255, 100, 190, 0.6);
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #d4e066 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #b8e037 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #a8d729 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #c4dd55 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #bfd93f 0%, transparent 50%), #b8d73a;
+        radial-gradient(circle at 35% 20%, #e8ff99 0%, transparent 48%),
+        radial-gradient(circle at 75% 35%, #b8e037 0%, transparent 52%),
+        radial-gradient(circle at 65% 75%, #7cd68c 0%, transparent 50%),
+        radial-gradient(circle at 15% 60%, #a8d729 0%, transparent 55%),
+        radial-gradient(circle at 45% 45%, #c4dd55 0%, transparent 60%), #b8d73a;
     border: 1px solid rgba(168, 215, 41, 0.6);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #5e4cff 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #83e2b7 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #30cf87 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #c1f1db 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #6fa0d8 0%, transparent 50%), #7fb5c2;
-    border: 1px solid rgba(94, 76, 255, 0.6);
+        radial-gradient(circle at 15% 35%, #8001fe 0%, transparent 45%),
+        radial-gradient(circle at 75% 20%, #6f00ff 0%, transparent 55%),
+        radial-gradient(circle at 85% 75%, #4c0198 0%, transparent 50%),
+        radial-gradient(circle at 25% 70%, #7500e8 0%, transparent 55%),
+        radial-gradient(circle at 60% 45%, #5e4cff 0%, transparent 60%), #6a3dff;
+    border: 1px solid rgba(128, 1, 254, 0.6);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -6,6 +6,17 @@
     color: var(--mantine-color-white);
 }
 
+.root[data-avatar-gradient] .placeholder::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.95' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100' height='100' filter='url(%23n)' opacity='0.15'/%3E%3C/svg%3E");
+    background-size: 100px 100px;
+    mix-blend-mode: overlay;
+    pointer-events: none;
+}
+
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
         radial-gradient(circle at 20% 20%, #d1ccff 0%, transparent 50%),
@@ -13,7 +24,7 @@
         radial-gradient(circle at 80% 80%, #d9b3ff 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #b8a5ff 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #c0b6ff 0%, transparent 50%), #bfb4ff;
-    box-shadow: inset 0 0 0 1.5px rgba(212, 204, 255, 0.6);
+    box-shadow: inset 0 0 0 1px rgba(212, 204, 255, 0.6);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
@@ -22,7 +33,7 @@
         radial-gradient(circle at 80% 80%, #f0a5d8 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #e8b8e8 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #dfa5d0 0%, transparent 50%), #dfa5d0;
-    box-shadow: inset 0 0 0 1.5px rgba(255, 179, 230, 0.6);
+    box-shadow: inset 0 0 0 1px rgba(255, 179, 230, 0.6);
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
@@ -31,16 +42,7 @@
         radial-gradient(circle at 80% 80%, #d4f9a0 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #e5f9c0 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #ddf58e 0%, transparent 50%), #ddf58e;
-    box-shadow: inset 0 0 0 1.5px rgba(219, 254, 149, 0.6);
-}
-.root[data-avatar-gradient='sunrise'] .placeholder {
-    background:
-        radial-gradient(circle at 20% 20%, #d1ccff 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #daf6a2 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #d5eea5 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #cfd8b8 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #cccdb3 0%, transparent 50%), #cccdb3;
-    box-shadow: inset 0 0 0 1.5px rgba(218, 246, 162, 0.6);
+    box-shadow: inset 0 0 0 1px rgba(219, 254, 149, 0.6);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
@@ -49,5 +51,14 @@
         radial-gradient(circle at 80% 80%, #9980ff 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #ad7dff 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #a87dff 0%, transparent 50%), #a87dff;
-    box-shadow: inset 0 0 0 1.5px rgba(180, 153, 255, 0.6);
+    box-shadow: inset 0 0 0 1px rgba(180, 153, 255, 0.6);
+}
+.root[data-avatar-gradient='sunrise'] .placeholder {
+    background:
+        radial-gradient(circle at 20% 20%, #d1ccff 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #daf6a2 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #d5eea5 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #cfd8b8 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #cccdb3 0%, transparent 50%), #cccdb3;
+    box-shadow: inset 0 0 0 1px rgba(218, 246, 162, 0.6);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -9,46 +9,151 @@
 
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
-        radial-gradient(circle at 25% 30%, #d1ccff 0%, transparent 60%),
-        radial-gradient(circle at 70% 15%, #a499ff 0%, transparent 65%),
-        radial-gradient(circle at 80% 70%, #8f6fff 0%, transparent 60%),
-        radial-gradient(circle at 15% 65%, #b884ff 0%, transparent 65%),
-        radial-gradient(circle at 55% 50%, #9d7fff 0%, transparent 70%), #a383ff;
+        radial-gradient(
+            ellipse 75% 75% at 25% 30%,
+            #d1ccff 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 70% 15%,
+            #a499ff 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 80% 70%,
+            #8f6fff 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 15% 65%,
+            #b884ff 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 55% 50%,
+            #9d7fff 0%,
+            transparent 100%
+        ),
+        #a383ff;
     box-shadow: inset 0 0 3px rgba(159, 111, 255, 0.4);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
-        radial-gradient(circle at 30% 25%, #ffd1e8 0%, transparent 62%),
-        radial-gradient(circle at 65% 10%, #ff99d9 0%, transparent 63%),
-        radial-gradient(circle at 85% 65%, #c499ff 0%, transparent 65%),
-        radial-gradient(circle at 10% 70%, #d98ac0 0%, transparent 65%),
-        radial-gradient(circle at 50% 55%, #d984c8 0%, transparent 68%), #d987c8;
+        radial-gradient(
+            ellipse 75% 75% at 30% 25%,
+            #ffd1e8 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 65% 10%,
+            #ff99d9 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 85% 65%,
+            #c499ff 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 10% 70%,
+            #d98ac0 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 50% 55%,
+            #d984c8 0%,
+            transparent 100%
+        ),
+        #d987c8;
     box-shadow: inset 0 0 3px rgba(255, 99, 180, 0.4);
 }
 .root[data-avatar-gradient='slate'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #3a3a3a 0%, transparent 62%),
-        radial-gradient(circle at 70% 20%, #1a1a1a 0%, transparent 63%),
-        radial-gradient(circle at 80% 70%, #4a4a4a 0%, transparent 65%),
-        radial-gradient(circle at 15% 65%, #2a2a2a 0%, transparent 65%),
-        radial-gradient(circle at 55% 50%, #383838 0%, transparent 68%), #353535;
+        radial-gradient(
+            ellipse 75% 75% at 25% 35%,
+            #3a3a3a 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 70% 20%,
+            #1a1a1a 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 80% 70%,
+            #4a4a4a 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 15% 65%,
+            #2a2a2a 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 55% 50%,
+            #383838 0%,
+            transparent 100%
+        ),
+        #353535;
     box-shadow: inset 0 0 3px rgba(70, 70, 70, 0.5);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 75% 15%, #5e4cff 0%, transparent 63%),
-        radial-gradient(circle at 20% 30%, #83e2b7 0%, transparent 62%),
-        radial-gradient(circle at 10% 65%, #30cf87 0%, transparent 65%),
-        radial-gradient(circle at 80% 75%, #c1f1db 0%, transparent 65%),
-        radial-gradient(circle at 50% 50%, #7fb5c2 0%, transparent 68%), #6fa0d8;
+        radial-gradient(
+            ellipse 75% 75% at 75% 15%,
+            #5e4cff 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 20% 30%,
+            #83e2b7 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 10% 65%,
+            #30cf87 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 80% 75%,
+            #c1f1db 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 50% 50%,
+            #7fb5c2 0%,
+            transparent 100%
+        ),
+        #6fa0d8;
     box-shadow: inset 0 0 3px rgba(131, 226, 183, 0.4);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #b3a0ff 0%, transparent 63%),
-        radial-gradient(circle at 80% 20%, #c4d966 0%, transparent 63%),
-        radial-gradient(circle at 80% 80%, #b8cd55 0%, transparent 63%),
-        radial-gradient(circle at 20% 80%, #a8c755 0%, transparent 63%),
-        radial-gradient(circle at 50% 50%, #b8c855 0%, transparent 63%), #b8c855;
+        radial-gradient(
+            ellipse 75% 75% at 20% 20%,
+            #b3a0ff 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 80% 20%,
+            #c4d966 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 80% 80%,
+            #b8cd55 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 20% 80%,
+            #a8c755 0%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse 75% 75% at 50% 50%,
+            #b8c855 0%,
+            transparent 100%
+        ),
+        #b8c855;
     box-shadow: inset 0 0 3px rgba(180, 160, 255, 0.4);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -46,12 +46,12 @@
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #8001fe 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #7500e8 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #6d00d1 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #7d00f5 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #7900ec 0%, transparent 50%), #7600e6;
-    border: 1px solid rgba(128, 1, 254, 0.6);
+        radial-gradient(circle at 20% 20%, #5e4cff 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #83e2b7 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #30cf87 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #c1f1db 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #6fa0d8 0%, transparent 50%), #7fb5c2;
+    border: 1px solid rgba(94, 76, 255, 0.6);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -7,152 +7,137 @@
 }
 
 .root[data-avatar-gradient='dusk'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #a499ff,
-        #8372d9,
-        #5e4cff,
-        #8372d9,
-        #a499ff
+    background: radial-gradient(
+        circle at 50% 50%,
+        #8372d9 0%,
+        #8372d9 30%,
+        #6b5fbe 60%,
+        #5e4cff 100%
     );
 }
 .root[data-avatar-gradient='lilac'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #d1ccff,
-        #bfb4ff,
-        #a499ff,
-        #bfb4ff,
-        #d1ccff
+    background: radial-gradient(
+        circle at 50% 50%,
+        #d1ccff 0%,
+        #c5baff 35%,
+        #b3a0ff 70%,
+        #a499ff 100%
     );
 }
 .root[data-avatar-gradient='ocean'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #8001fe,
-        #4a319f,
-        #1200b2,
-        #4a319f,
-        #8001fe
+    background: radial-gradient(
+        circle at 50% 50%,
+        #4a319f 0%,
+        #4527a0 40%,
+        #381ea0 70%,
+        #1200b2 100%
     );
 }
 .root[data-avatar-gradient='ember'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #b267fe,
-        #6d3690,
-        #26004c,
-        #6d3690,
-        #b267fe
+    background: radial-gradient(
+        circle at 50% 50%,
+        #6d3690 0%,
+        #642c8a 40%,
+        #521d7f 70%,
+        #26004c 100%
     );
 }
 .root[data-avatar-gradient='blush'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #ffd1e8,
-        #f0c5e3,
-        #d9b3ff,
-        #f0c5e3,
-        #ffd1e8
+    background: radial-gradient(
+        circle at 50% 50%,
+        #f0c5e3 0%,
+        #e8b3d9 40%,
+        #dfa5d0 70%,
+        #d9b3ff 100%
     );
 }
 .root[data-avatar-gradient='minty'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #edfbd0,
-        #e5fb9e,
-        #dbfe95,
-        #e5fb9e,
-        #edfbd0
+    background: radial-gradient(
+        circle at 50% 50%,
+        #e5fb9e 0%,
+        #e1f896 40%,
+        #ddf58e 70%,
+        #dbfe95 100%
     );
 }
 .root[data-avatar-gradient='forest'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #1d7c51,
-        #1a3f71,
-        #1200b2,
-        #1a3f71,
-        #1d7c51
+    background: radial-gradient(
+        circle at 50% 50%,
+        #1a3f71 0%,
+        #193575 40%,
+        #182b7a 70%,
+        #1200b2 100%
     );
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #d1ccff,
-        #d0e1bf,
-        #daf6a2,
-        #d0e1bf,
-        #d1ccff
+    background: radial-gradient(
+        circle at 50% 50%,
+        #d0e1bf 0%,
+        #ced7b9 40%,
+        #cccdb3 70%,
+        #daf6a2 100%
     );
 }
 .root[data-avatar-gradient='twilight'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #26004c,
-        #172038,
-        #0e3e29,
-        #172038,
-        #26004c
+    background: radial-gradient(
+        circle at 50% 50%,
+        #172038 0%,
+        #151b32 40%,
+        #13162c 70%,
+        #0e3e29 100%
     );
 }
 .root[data-avatar-gradient='lavender'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #d1ccff,
-        #d5bfff,
-        #d9b3ff,
-        #d5bfff,
-        #d1ccff
+    background: radial-gradient(
+        circle at 50% 50%,
+        #d5bfff 0%,
+        #d1b8ff 40%,
+        #cdb0ff 70%,
+        #d9b3ff 100%
     );
 }
 .root[data-avatar-gradient='emerald'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #30cf87,
-        #1f6b52,
-        #0e3e29,
-        #1f6b52,
-        #30cf87
+    background: radial-gradient(
+        circle at 50% 50%,
+        #1f6b52 0%,
+        #1d6450 40%,
+        #1b5d4e 70%,
+        #0e3e29 100%
     );
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #8001fe,
-        #7043d6,
-        #5e4cff,
-        #7043d6,
-        #8001fe
+    background: radial-gradient(
+        circle at 50% 50%,
+        #7043d6 0%,
+        #6a3acd 40%,
+        #6331c4 70%,
+        #5e4cff 100%
     );
 }
 .root[data-avatar-gradient='sage'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #edfbd0,
-        #c5e8ac,
-        #83e2b7,
-        #c5e8ac,
-        #edfbd0
+    background: radial-gradient(
+        circle at 50% 50%,
+        #c5e8ac 0%,
+        #bfe19f 40%,
+        #b9da92 70%,
+        #83e2b7 100%
     );
 }
 .root[data-avatar-gradient='orchid'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #d9b3ff,
-        #b589f0,
-        #8001fe,
-        #b589f0,
-        #d9b3ff
+    background: radial-gradient(
+        circle at 50% 50%,
+        #b589f0 0%,
+        #ae7ae9 40%,
+        #a76be2 70%,
+        #8001fe 100%
     );
 }
 .root[data-avatar-gradient='jungle'] .placeholder {
-    background: conic-gradient(
-        from 0deg,
-        #3b5408,
-        #2e6527,
-        #1d7c51,
-        #2e6527,
-        #3b5408
+    background: radial-gradient(
+        circle at 50% 50%,
+        #2e6527 0%,
+        #2d5f26 40%,
+        #2c5825 70%,
+        #1d7c51 100%
     );
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -3,6 +3,7 @@
     overflow: hidden;
     isolation: isolate;
     border-radius: 50%;
+    clip-path: circle(50%);
     color: var(--mantine-color-white);
 }
 
@@ -19,46 +20,46 @@
 
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
-        radial-gradient(circle at 25% 30%, #d1ccff 0%, transparent 45%),
-        radial-gradient(circle at 70% 15%, #a499ff 0%, transparent 55%),
-        radial-gradient(circle at 80% 70%, #8f6fff 0%, transparent 50%),
-        radial-gradient(circle at 15% 65%, #b884ff 0%, transparent 55%),
-        radial-gradient(circle at 55% 50%, #9d7fff 0%, transparent 60%), #a383ff;
+        radial-gradient(circle at 25% 30%, #d1ccff 0%, transparent 60%),
+        radial-gradient(circle at 70% 15%, #a499ff 0%, transparent 65%),
+        radial-gradient(circle at 80% 70%, #8f6fff 0%, transparent 60%),
+        radial-gradient(circle at 15% 65%, #b884ff 0%, transparent 65%),
+        radial-gradient(circle at 55% 50%, #9d7fff 0%, transparent 70%), #a383ff;
     box-shadow: inset 0 0 3px rgba(159, 111, 255, 0.4);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
-        radial-gradient(circle at 30% 25%, #ffd1e8 0%, transparent 48%),
-        radial-gradient(circle at 65% 10%, #ff99d9 0%, transparent 50%),
-        radial-gradient(circle at 85% 65%, #c499ff 0%, transparent 52%),
-        radial-gradient(circle at 10% 70%, #d98ac0 0%, transparent 55%),
-        radial-gradient(circle at 50% 55%, #d984c8 0%, transparent 58%), #d987c8;
+        radial-gradient(circle at 30% 25%, #ffd1e8 0%, transparent 62%),
+        radial-gradient(circle at 65% 10%, #ff99d9 0%, transparent 63%),
+        radial-gradient(circle at 85% 65%, #c499ff 0%, transparent 65%),
+        radial-gradient(circle at 10% 70%, #d98ac0 0%, transparent 65%),
+        radial-gradient(circle at 50% 55%, #d984c8 0%, transparent 68%), #d987c8;
     box-shadow: inset 0 0 3px rgba(255, 99, 180, 0.4);
 }
 .root[data-avatar-gradient='slate'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #3a3a3a 0%, transparent 48%),
-        radial-gradient(circle at 70% 20%, #1a1a1a 0%, transparent 50%),
-        radial-gradient(circle at 80% 70%, #4a4a4a 0%, transparent 52%),
-        radial-gradient(circle at 15% 65%, #2a2a2a 0%, transparent 55%),
-        radial-gradient(circle at 55% 50%, #383838 0%, transparent 58%), #353535;
+        radial-gradient(circle at 25% 35%, #3a3a3a 0%, transparent 62%),
+        radial-gradient(circle at 70% 20%, #1a1a1a 0%, transparent 63%),
+        radial-gradient(circle at 80% 70%, #4a4a4a 0%, transparent 65%),
+        radial-gradient(circle at 15% 65%, #2a2a2a 0%, transparent 65%),
+        radial-gradient(circle at 55% 50%, #383838 0%, transparent 68%), #353535;
     box-shadow: inset 0 0 3px rgba(70, 70, 70, 0.5);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 75% 15%, #5e4cff 0%, transparent 50%),
-        radial-gradient(circle at 20% 30%, #83e2b7 0%, transparent 48%),
-        radial-gradient(circle at 10% 65%, #30cf87 0%, transparent 55%),
-        radial-gradient(circle at 80% 75%, #c1f1db 0%, transparent 52%),
-        radial-gradient(circle at 50% 50%, #7fb5c2 0%, transparent 58%), #6fa0d8;
+        radial-gradient(circle at 75% 15%, #5e4cff 0%, transparent 63%),
+        radial-gradient(circle at 20% 30%, #83e2b7 0%, transparent 62%),
+        radial-gradient(circle at 10% 65%, #30cf87 0%, transparent 65%),
+        radial-gradient(circle at 80% 75%, #c1f1db 0%, transparent 65%),
+        radial-gradient(circle at 50% 50%, #7fb5c2 0%, transparent 68%), #6fa0d8;
     box-shadow: inset 0 0 3px rgba(131, 226, 183, 0.4);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #b3a0ff 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #c4d966 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #b8cd55 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #a8c755 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #b8c855 0%, transparent 50%), #b8c855;
+        radial-gradient(circle at 20% 20%, #b3a0ff 0%, transparent 63%),
+        radial-gradient(circle at 80% 20%, #c4d966 0%, transparent 63%),
+        radial-gradient(circle at 80% 80%, #b8cd55 0%, transparent 63%),
+        radial-gradient(circle at 20% 80%, #a8c755 0%, transparent 63%),
+        radial-gradient(circle at 50% 50%, #b8c855 0%, transparent 63%), #b8c855;
     box-shadow: inset 0 0 3px rgba(180, 160, 255, 0.4);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -7,137 +7,92 @@
 }
 
 .root[data-avatar-gradient='dusk'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #8372d9 0%,
-        #8372d9 30%,
-        #6b5fbe 60%,
-        #5e4cff 100%
-    );
+    background:
+        radial-gradient(circle at 20% 30%, #a499ff 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, #5e4cff 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #7a5cff 0%, transparent 60%);
 }
 .root[data-avatar-gradient='lilac'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #d1ccff 0%,
-        #c5baff 35%,
-        #b3a0ff 70%,
-        #a499ff 100%
-    );
+    background:
+        radial-gradient(circle at 25% 35%, #d1ccff 0%, transparent 50%),
+        radial-gradient(circle at 75% 65%, #a499ff 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #c0b6ff 0%, transparent 60%);
 }
 .root[data-avatar-gradient='ocean'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #4a319f 0%,
-        #4527a0 40%,
-        #381ea0 70%,
-        #1200b2 100%
-    );
+    background:
+        radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 50%),
+        radial-gradient(circle at 80% 75%, #1200b2 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #4a319f 0%, transparent 60%);
 }
 .root[data-avatar-gradient='ember'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #6d3690 0%,
-        #642c8a 40%,
-        #521d7f 70%,
-        #26004c 100%
-    );
+    background:
+        radial-gradient(circle at 25% 30%, #b267fe 0%, transparent 50%),
+        radial-gradient(circle at 75% 70%, #26004c 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #6d3690 0%, transparent 60%);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #f0c5e3 0%,
-        #e8b3d9 40%,
-        #dfa5d0 70%,
-        #d9b3ff 100%
-    );
+    background:
+        radial-gradient(circle at 20% 30%, #ffd1e8 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, #d9b3ff 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #f0c5e3 0%, transparent 60%);
 }
 .root[data-avatar-gradient='minty'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #e5fb9e 0%,
-        #e1f896 40%,
-        #ddf58e 70%,
-        #dbfe95 100%
-    );
+    background:
+        radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 50%),
+        radial-gradient(circle at 75% 65%, #dbfe95 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #e5fb9e 0%, transparent 60%);
 }
 .root[data-avatar-gradient='forest'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #1a3f71 0%,
-        #193575 40%,
-        #182b7a 70%,
-        #1200b2 100%
-    );
+    background:
+        radial-gradient(circle at 20% 25%, #1d7c51 0%, transparent 50%),
+        radial-gradient(circle at 80% 75%, #1200b2 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #1a3f71 0%, transparent 60%);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #d0e1bf 0%,
-        #ced7b9 40%,
-        #cccdb3 70%,
-        #daf6a2 100%
-    );
+    background:
+        radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, #daf6a2 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #d0e1bf 0%, transparent 60%);
 }
 .root[data-avatar-gradient='twilight'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #172038 0%,
-        #151b32 40%,
-        #13162c 70%,
-        #0e3e29 100%
-    );
+    background:
+        radial-gradient(circle at 25% 35%, #26004c 0%, transparent 50%),
+        radial-gradient(circle at 75% 65%, #0e3e29 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #172038 0%, transparent 60%);
 }
 .root[data-avatar-gradient='lavender'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #d5bfff 0%,
-        #d1b8ff 40%,
-        #cdb0ff 70%,
-        #d9b3ff 100%
-    );
+    background:
+        radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, #d9b3ff 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #d5bfff 0%, transparent 60%);
 }
 .root[data-avatar-gradient='emerald'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #1f6b52 0%,
-        #1d6450 40%,
-        #1b5d4e 70%,
-        #0e3e29 100%
-    );
+    background:
+        radial-gradient(circle at 25% 35%, #30cf87 0%, transparent 50%),
+        radial-gradient(circle at 75% 65%, #0e3e29 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #1f6b52 0%, transparent 60%);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #7043d6 0%,
-        #6a3acd 40%,
-        #6331c4 70%,
-        #5e4cff 100%
-    );
+    background:
+        radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 50%),
+        radial-gradient(circle at 80% 75%, #5e4cff 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #7043d6 0%, transparent 60%);
 }
 .root[data-avatar-gradient='sage'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #c5e8ac 0%,
-        #bfe19f 40%,
-        #b9da92 70%,
-        #83e2b7 100%
-    );
+    background:
+        radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 50%),
+        radial-gradient(circle at 75% 65%, #83e2b7 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #c5e8ac 0%, transparent 60%);
 }
 .root[data-avatar-gradient='orchid'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #b589f0 0%,
-        #ae7ae9 40%,
-        #a76be2 70%,
-        #8001fe 100%
-    );
+    background:
+        radial-gradient(circle at 20% 30%, #d9b3ff 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, #8001fe 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #b589f0 0%, transparent 60%);
 }
 .root[data-avatar-gradient='jungle'] .placeholder {
-    background: radial-gradient(
-        circle at 50% 50%,
-        #2e6527 0%,
-        #2d5f26 40%,
-        #2c5825 70%,
-        #1d7c51 100%
-    );
+    background:
+        radial-gradient(circle at 25% 35%, #3b5408 0%, transparent 50%),
+        radial-gradient(circle at 75% 65%, #1d7c51 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #2e6527 0%, transparent 60%);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -19,46 +19,46 @@
 
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #d1ccff 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #a499ff 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #d9b3ff 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #b8a5ff 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #c0b6ff 0%, transparent 50%), #bfb4ff;
-    border: 1px solid rgba(212, 204, 255, 0.6);
+        radial-gradient(circle at 20% 20%, #a499ff 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #8f6fff 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #b884ff 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #9970ff 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #9d7fff 0%, transparent 50%), #a383ff;
+    border: 1px solid rgba(159, 111, 255, 0.6);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #ffd1e8 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #d9b3ff 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #f0a5d8 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #e8b8e8 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #dfa5d0 0%, transparent 50%), #dfa5d0;
-    border: 1px solid rgba(255, 179, 230, 0.6);
+        radial-gradient(circle at 20% 20%, #ff99d9 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #c499ff 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #d98ac0 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #d87fb8 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #d984c8 0%, transparent 50%), #d987c8;
+    border: 1px solid rgba(255, 100, 190, 0.6);
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #edfbd0 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #dbfe95 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #d4f9a0 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #e5f9c0 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #ddf58e 0%, transparent 50%), #ddf58e;
-    border: 1px solid rgba(219, 254, 149, 0.6);
+        radial-gradient(circle at 20% 20%, #d4e066 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #b8e037 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #a8d729 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #c4dd55 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #bfd93f 0%, transparent 50%), #b8d73a;
+    border: 1px solid rgba(168, 215, 41, 0.6);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #b267fe 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #a499ff 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #9980ff 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #ad7dff 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #a87dff 0%, transparent 50%), #a87dff;
-    border: 1px solid rgba(180, 153, 255, 0.6);
+        radial-gradient(circle at 20% 20%, #8001fe 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #7500e8 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #6d00d1 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #7d00f5 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #7900ec 0%, transparent 50%), #7600e6;
+    border: 1px solid rgba(128, 1, 254, 0.6);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
-        radial-gradient(circle at 20% 20%, #d1ccff 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, #daf6a2 0%, transparent 50%),
-        radial-gradient(circle at 80% 80%, #d5eea5 0%, transparent 50%),
-        radial-gradient(circle at 20% 80%, #cfd8b8 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #cccdb3 0%, transparent 50%), #cccdb3;
-    border: 1px solid rgba(218, 246, 162, 0.6);
+        radial-gradient(circle at 20% 20%, #b3a0ff 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #c4d966 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #b8cd55 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #a8c755 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #b8c855 0%, transparent 50%), #b8c855;
+    border: 1px solid rgba(180, 160, 255, 0.6);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -24,7 +24,7 @@
         radial-gradient(circle at 80% 80%, #d9b3ff 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #b8a5ff 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #c0b6ff 0%, transparent 50%), #bfb4ff;
-    box-shadow: inset 0 0 0 1px rgba(212, 204, 255, 0.6);
+    border: 1px solid rgba(212, 204, 255, 0.6);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
@@ -33,7 +33,7 @@
         radial-gradient(circle at 80% 80%, #f0a5d8 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #e8b8e8 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #dfa5d0 0%, transparent 50%), #dfa5d0;
-    box-shadow: inset 0 0 0 1px rgba(255, 179, 230, 0.6);
+    border: 1px solid rgba(255, 179, 230, 0.6);
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
@@ -42,7 +42,7 @@
         radial-gradient(circle at 80% 80%, #d4f9a0 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #e5f9c0 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #ddf58e 0%, transparent 50%), #ddf58e;
-    box-shadow: inset 0 0 0 1px rgba(219, 254, 149, 0.6);
+    border: 1px solid rgba(219, 254, 149, 0.6);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
@@ -51,7 +51,7 @@
         radial-gradient(circle at 80% 80%, #9980ff 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #ad7dff 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #a87dff 0%, transparent 50%), #a87dff;
-    box-shadow: inset 0 0 0 1px rgba(180, 153, 255, 0.6);
+    border: 1px solid rgba(180, 153, 255, 0.6);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
@@ -60,5 +60,5 @@
         radial-gradient(circle at 80% 80%, #d5eea5 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #cfd8b8 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #cccdb3 0%, transparent 50%), #cccdb3;
-    box-shadow: inset 0 0 0 1px rgba(218, 246, 162, 0.6);
+    border: 1px solid rgba(218, 246, 162, 0.6);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -35,23 +35,23 @@
         radial-gradient(circle at 50% 55%, #d984c8 0%, transparent 58%), #d987c8;
     border: 1px solid rgba(255, 100, 190, 0.6);
 }
-.root[data-avatar-gradient='minty'] .placeholder {
+.root[data-avatar-gradient='slate'] .placeholder {
     background:
-        radial-gradient(circle at 35% 20%, #e8ff99 0%, transparent 48%),
-        radial-gradient(circle at 75% 35%, #b8e037 0%, transparent 52%),
-        radial-gradient(circle at 65% 75%, #7cd68c 0%, transparent 50%),
-        radial-gradient(circle at 15% 60%, #a8d729 0%, transparent 55%),
-        radial-gradient(circle at 45% 45%, #c4dd55 0%, transparent 60%), #b8d73a;
-    border: 1px solid rgba(168, 215, 41, 0.6);
+        radial-gradient(circle at 25% 35%, #3a3a3a 0%, transparent 48%),
+        radial-gradient(circle at 70% 20%, #1a1a1a 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, #4a4a4a 0%, transparent 52%),
+        radial-gradient(circle at 15% 65%, #2a2a2a 0%, transparent 55%),
+        radial-gradient(circle at 55% 50%, #383838 0%, transparent 58%), #353535;
+    border: 1px solid rgba(60, 60, 60, 0.6);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 15% 35%, #8001fe 0%, transparent 45%),
-        radial-gradient(circle at 75% 20%, #6f00ff 0%, transparent 55%),
-        radial-gradient(circle at 85% 75%, #4c0198 0%, transparent 50%),
-        radial-gradient(circle at 25% 70%, #7500e8 0%, transparent 55%),
-        radial-gradient(circle at 60% 45%, #5e4cff 0%, transparent 60%), #6a3dff;
-    border: 1px solid rgba(128, 1, 254, 0.6);
+        radial-gradient(circle at 20% 30%, #5e4cff 0%, transparent 48%),
+        radial-gradient(circle at 75% 15%, #83e2b7 0%, transparent 50%),
+        radial-gradient(circle at 80% 75%, #30cf87 0%, transparent 52%),
+        radial-gradient(circle at 10% 65%, #c1f1db 0%, transparent 55%),
+        radial-gradient(circle at 50% 50%, #6fa0d8 0%, transparent 58%), #7fb5c2;
+    border: 1px solid rgba(94, 76, 255, 0.6);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -8,91 +8,76 @@
 
 .root[data-avatar-gradient='dusk'] .placeholder {
     background:
-        radial-gradient(circle at 20% 30%, #a499ff 0%, transparent 50%),
-        radial-gradient(circle at 80% 70%, #5e4cff 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #7a5cff 0%, transparent 60%);
+        radial-gradient(circle at 20% 30%, #a499ff 0%, transparent 60%),
+        radial-gradient(circle at 80% 70%, #5e4cff 0%, transparent 60%), #6b5fb8;
 }
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #d1ccff 0%, transparent 50%),
-        radial-gradient(circle at 75% 65%, #a499ff 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #c0b6ff 0%, transparent 60%);
+        radial-gradient(circle at 25% 35%, #d1ccff 0%, transparent 60%),
+        radial-gradient(circle at 75% 65%, #a499ff 0%, transparent 60%), #b3a0ff;
 }
 .root[data-avatar-gradient='ocean'] .placeholder {
     background:
-        radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 50%),
-        radial-gradient(circle at 80% 75%, #1200b2 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #4a319f 0%, transparent 60%);
+        radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 60%),
+        radial-gradient(circle at 80% 75%, #1200b2 0%, transparent 60%), #381ea0;
 }
 .root[data-avatar-gradient='ember'] .placeholder {
     background:
-        radial-gradient(circle at 25% 30%, #b267fe 0%, transparent 50%),
-        radial-gradient(circle at 75% 70%, #26004c 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #6d3690 0%, transparent 60%);
+        radial-gradient(circle at 25% 30%, #b267fe 0%, transparent 60%),
+        radial-gradient(circle at 75% 70%, #26004c 0%, transparent 60%), #521d7f;
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
-        radial-gradient(circle at 20% 30%, #ffd1e8 0%, transparent 50%),
-        radial-gradient(circle at 80% 70%, #d9b3ff 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #f0c5e3 0%, transparent 60%);
+        radial-gradient(circle at 20% 30%, #ffd1e8 0%, transparent 60%),
+        radial-gradient(circle at 80% 70%, #d9b3ff 0%, transparent 60%), #dfa5d0;
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 50%),
-        radial-gradient(circle at 75% 65%, #dbfe95 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #e5fb9e 0%, transparent 60%);
+        radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 60%),
+        radial-gradient(circle at 75% 65%, #dbfe95 0%, transparent 60%), #ddf58e;
 }
 .root[data-avatar-gradient='forest'] .placeholder {
     background:
-        radial-gradient(circle at 20% 25%, #1d7c51 0%, transparent 50%),
-        radial-gradient(circle at 80% 75%, #1200b2 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #1a3f71 0%, transparent 60%);
+        radial-gradient(circle at 20% 25%, #1d7c51 0%, transparent 60%),
+        radial-gradient(circle at 80% 75%, #1200b2 0%, transparent 60%), #182b7a;
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
-        radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 50%),
-        radial-gradient(circle at 80% 70%, #daf6a2 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #d0e1bf 0%, transparent 60%);
+        radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 60%),
+        radial-gradient(circle at 80% 70%, #daf6a2 0%, transparent 60%), #cccdb3;
 }
 .root[data-avatar-gradient='twilight'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #26004c 0%, transparent 50%),
-        radial-gradient(circle at 75% 65%, #0e3e29 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #172038 0%, transparent 60%);
+        radial-gradient(circle at 25% 35%, #26004c 0%, transparent 60%),
+        radial-gradient(circle at 75% 65%, #0e3e29 0%, transparent 60%), #13162c;
 }
 .root[data-avatar-gradient='lavender'] .placeholder {
     background:
-        radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 50%),
-        radial-gradient(circle at 80% 70%, #d9b3ff 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #d5bfff 0%, transparent 60%);
+        radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 60%),
+        radial-gradient(circle at 80% 70%, #d9b3ff 0%, transparent 60%), #cdb0ff;
 }
 .root[data-avatar-gradient='emerald'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #30cf87 0%, transparent 50%),
-        radial-gradient(circle at 75% 65%, #0e3e29 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #1f6b52 0%, transparent 60%);
+        radial-gradient(circle at 25% 35%, #30cf87 0%, transparent 60%),
+        radial-gradient(circle at 75% 65%, #0e3e29 0%, transparent 60%), #1b5d4e;
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 50%),
-        radial-gradient(circle at 80% 75%, #5e4cff 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #7043d6 0%, transparent 60%);
+        radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 60%),
+        radial-gradient(circle at 80% 75%, #5e4cff 0%, transparent 60%), #6331c4;
 }
 .root[data-avatar-gradient='sage'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 50%),
-        radial-gradient(circle at 75% 65%, #83e2b7 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #c5e8ac 0%, transparent 60%);
+        radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 60%),
+        radial-gradient(circle at 75% 65%, #83e2b7 0%, transparent 60%), #b9da92;
 }
 .root[data-avatar-gradient='orchid'] .placeholder {
     background:
-        radial-gradient(circle at 20% 30%, #d9b3ff 0%, transparent 50%),
-        radial-gradient(circle at 80% 70%, #8001fe 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #b589f0 0%, transparent 60%);
+        radial-gradient(circle at 20% 30%, #d9b3ff 0%, transparent 60%),
+        radial-gradient(circle at 80% 70%, #8001fe 0%, transparent 60%), #a76be2;
 }
 .root[data-avatar-gradient='jungle'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #3b5408 0%, transparent 50%),
-        radial-gradient(circle at 75% 65%, #1d7c51 0%, transparent 50%),
-        radial-gradient(circle at 50% 50%, #2e6527 0%, transparent 60%);
+        radial-gradient(circle at 25% 35%, #3b5408 0%, transparent 60%),
+        radial-gradient(circle at 75% 65%, #1d7c51 0%, transparent 60%), #2c5825;
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -8,26 +8,41 @@
 
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #d1ccff 0%, transparent 60%),
-        radial-gradient(circle at 75% 65%, #a499ff 0%, transparent 60%), #b3a0ff;
+        radial-gradient(circle at 20% 20%, #d1ccff 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #a499ff 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #d9b3ff 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #b8a5ff 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #c0b6ff 0%, transparent 50%), #bfb4ff;
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
-        radial-gradient(circle at 20% 30%, #ffd1e8 0%, transparent 60%),
-        radial-gradient(circle at 80% 70%, #d9b3ff 0%, transparent 60%), #dfa5d0;
+        radial-gradient(circle at 20% 20%, #ffd1e8 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #d9b3ff 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #f0a5d8 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #e8b8e8 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #dfa5d0 0%, transparent 50%), #dfa5d0;
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
-        radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 60%),
-        radial-gradient(circle at 75% 65%, #dbfe95 0%, transparent 60%), #ddf58e;
+        radial-gradient(circle at 20% 20%, #edfbd0 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #dbfe95 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #d4f9a0 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #e5f9c0 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #ddf58e 0%, transparent 50%), #ddf58e;
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
-        radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 60%),
-        radial-gradient(circle at 80% 70%, #daf6a2 0%, transparent 60%), #cccdb3;
+        radial-gradient(circle at 20% 20%, #d1ccff 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #daf6a2 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #d5eea5 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #cfd8b8 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #cccdb3 0%, transparent 50%), #cccdb3;
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 20% 25%, #b267fe 0%, transparent 60%),
-        radial-gradient(circle at 80% 75%, #a499ff 0%, transparent 60%), #a87dff;
+        radial-gradient(circle at 20% 20%, #b267fe 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, #a499ff 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, #9980ff 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, #ad7dff 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, #a87dff 0%, transparent 50%), #a87dff;
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -1,27 +1,111 @@
 .root[data-avatar-gradient] .placeholder {
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+    border-radius: 50%;
     color: var(--mantine-color-white);
 }
+
+/* Subtle grain overlay — sits behind the initials so legibility isn't affected. */
+.root[data-avatar-gradient] .placeholder::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100' height='100' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-size: 100px 100px;
+    opacity: 0.35;
+    mix-blend-mode: overlay;
+    pointer-events: none;
+}
+
 .root[data-avatar-gradient='dusk'] .placeholder {
-    background: linear-gradient(135deg, #7048e8, #d6336c);
+    background:
+        radial-gradient(120% 120% at 25% 25%, #a499ff 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #5e4cff 0%, transparent 65%),
+        #7a5cff;
+}
+.root[data-avatar-gradient='lilac'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #d1ccff 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #a499ff 0%, transparent 65%),
+        #c2b8ff;
 }
 .root[data-avatar-gradient='ocean'] .placeholder {
-    background: linear-gradient(135deg, #1971c2, #0ca678);
+    background:
+        radial-gradient(120% 120% at 25% 25%, #8001fe 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #1200b2 0%, transparent 65%),
+        #4b2f9e;
 }
 .root[data-avatar-gradient='ember'] .placeholder {
-    background: linear-gradient(135deg, #e8590c, #f08c00);
+    background:
+        radial-gradient(120% 120% at 25% 25%, #b267fe 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #26004c 0%, transparent 65%),
+        #5c1a94;
 }
-.root[data-avatar-gradient='meadow'] .placeholder {
-    background: linear-gradient(135deg, #2f9e44, #66a80f);
+.root[data-avatar-gradient='blush'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #ffd1e8 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #d9b3ff 0%, transparent 65%),
+        #f0bedd;
 }
-.root[data-avatar-gradient='tide'] .placeholder {
-    background: linear-gradient(135deg, #0c8599, #4263eb);
+.root[data-avatar-gradient='minty'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #edfbd0 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #dbfe95 0%, transparent 65%),
+        #dff9b0;
 }
-.root[data-avatar-gradient='plum'] .placeholder {
-    background: linear-gradient(135deg, #9c36b5, #f06595);
+.root[data-avatar-gradient='forest'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #1d7c51 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #1200b2 0%, transparent 65%),
+        #1a3e71;
 }
-.root[data-avatar-gradient='sand'] .placeholder {
-    background: linear-gradient(135deg, #e67700, #ca8a04);
+.root[data-avatar-gradient='sunrise'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #d1ccff 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #daf6a2 0%, transparent 65%),
+        #cde1bd;
 }
-.root[data-avatar-gradient='slate'] .placeholder {
-    background: linear-gradient(135deg, #3b5bdb, #748ffc);
+.root[data-avatar-gradient='twilight'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #26004c 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #0e3e29 0%, transparent 65%),
+        #151f3a;
+}
+.root[data-avatar-gradient='lavender'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #d1ccff 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #d9b3ff 0%, transparent 65%),
+        #d5c2ff;
+}
+.root[data-avatar-gradient='emerald'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #30cf87 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #0e3e29 0%, transparent 65%),
+        #1a6b54;
+}
+.root[data-avatar-gradient='amethyst'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #8001fe 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #5e4cff 0%, transparent 65%),
+        #7040cd;
+}
+.root[data-avatar-gradient='sage'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #edfbd0 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #83e2b7 0%, transparent 65%),
+        #c1e8a0;
+}
+.root[data-avatar-gradient='orchid'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #d9b3ff 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #8001fe 0%, transparent 65%),
+        #b589f0;
+}
+.root[data-avatar-gradient='jungle'] .placeholder {
+    background:
+        radial-gradient(120% 120% at 25% 25%, #3b5408 0%, transparent 65%),
+        radial-gradient(120% 120% at 75% 75%, #1d7c51 0%, transparent 65%),
+        #2e6527;
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -8,91 +8,91 @@
 
 .root[data-avatar-gradient='dusk'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #a499ff 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #5e4cff 0%, transparent 55%),
-        #8270cc;
+        radial-gradient(180% 180% at 20% 20%, #a499ff 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #5e4cff 0%, transparent 50%),
+        #8372d9;
 }
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #d1ccff 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #a499ff 0%, transparent 55%),
-        #c0b6ff;
+        radial-gradient(180% 180% at 20% 20%, #d1ccff 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #a499ff 0%, transparent 50%),
+        #bfb4ff;
 }
 .root[data-avatar-gradient='ocean'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #8001fe 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #1200b2 0%, transparent 55%),
-        #4a2f9e;
+        radial-gradient(180% 180% at 20% 20%, #8001fe 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #1200b2 0%, transparent 50%),
+        #4a319f;
 }
 .root[data-avatar-gradient='ember'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #b267fe 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #26004c 0%, transparent 55%),
-        #6d2d8a;
+        radial-gradient(180% 180% at 20% 20%, #b267fe 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #26004c 0%, transparent 50%),
+        #6d3690;
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #ffd1e8 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #d9b3ff 0%, transparent 55%),
-        #f0c0e0;
+        radial-gradient(180% 180% at 20% 20%, #ffd1e8 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #d9b3ff 0%, transparent 50%),
+        #f0c5e3;
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #edfbd0 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #dbfe95 0%, transparent 55%),
-        #e5faa0;
+        radial-gradient(180% 180% at 20% 20%, #edfbd0 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #dbfe95 0%, transparent 50%),
+        #e5fb9e;
 }
 .root[data-avatar-gradient='forest'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #1d7c51 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #1200b2 0%, transparent 55%),
+        radial-gradient(180% 180% at 20% 20%, #1d7c51 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #1200b2 0%, transparent 50%),
         #1a3f71;
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #d1ccff 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #daf6a2 0%, transparent 55%),
-        #d0e1b8;
+        radial-gradient(180% 180% at 20% 20%, #d1ccff 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #daf6a2 0%, transparent 50%),
+        #d0e1bf;
 }
 .root[data-avatar-gradient='twilight'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #26004c 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #0e3e29 0%, transparent 55%),
+        radial-gradient(180% 180% at 20% 20%, #26004c 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #0e3e29 0%, transparent 50%),
         #172038;
 }
 .root[data-avatar-gradient='lavender'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #d1ccff 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #d9b3ff 0%, transparent 55%),
+        radial-gradient(180% 180% at 20% 20%, #d1ccff 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #d9b3ff 0%, transparent 50%),
         #d5bfff;
 }
 .root[data-avatar-gradient='emerald'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #30cf87 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #0e3e29 0%, transparent 55%),
+        radial-gradient(180% 180% at 20% 20%, #30cf87 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #0e3e29 0%, transparent 50%),
         #1f6b52;
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #8001fe 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #5e4cff 0%, transparent 55%),
+        radial-gradient(180% 180% at 20% 20%, #8001fe 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #5e4cff 0%, transparent 50%),
         #7043d6;
 }
 .root[data-avatar-gradient='sage'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #edfbd0 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #83e2b7 0%, transparent 55%),
-        #c5e8a8;
+        radial-gradient(180% 180% at 20% 20%, #edfbd0 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #83e2b7 0%, transparent 50%),
+        #c5e8ac;
 }
 .root[data-avatar-gradient='orchid'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #d9b3ff 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #8001fe 0%, transparent 55%),
+        radial-gradient(180% 180% at 20% 20%, #d9b3ff 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #8001fe 0%, transparent 50%),
         #b589f0;
 }
 .root[data-avatar-gradient='jungle'] .placeholder {
     background:
-        radial-gradient(130% 130% at 30% 30%, #3b5408 0%, transparent 55%),
-        radial-gradient(130% 130% at 70% 70%, #1d7c51 0%, transparent 55%),
+        radial-gradient(180% 180% at 20% 20%, #3b5408 0%, transparent 50%),
+        radial-gradient(180% 180% at 80% 80%, #1d7c51 0%, transparent 50%),
         #2e6527;
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -13,65 +13,85 @@
 .root[data-avatar-gradient='lilac'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 20% 15%,
-            rgba(255, 255, 255, 0.85) 0%,
-            transparent 35%
+            circle at 15% 10%,
+            rgba(255, 255, 255, 0.95) 0%,
+            transparent 42%
         ),
-        radial-gradient(circle at 70% 25%, #d1ccff 0%, transparent 55%),
-        radial-gradient(circle at 30% 70%, #a499ff 0%, transparent 55%),
-        radial-gradient(circle at 80% 80%, #8f6fff 0%, transparent 55%),
-        linear-gradient(135deg, #e0d9ff 0%, #9d7fff 100%);
+        radial-gradient(
+            circle at 88% 92%,
+            rgba(255, 255, 255, 0.35) 0%,
+            transparent 38%
+        ),
+        radial-gradient(circle at 68% 28%, #7c4dff 0%, transparent 30%),
+        radial-gradient(circle at 32% 68%, #b18aff 0%, transparent 32%),
+        linear-gradient(135deg, #f2eeff 0%, #9d7fff 100%);
     box-shadow: inset 0 0 3px rgba(159, 111, 255, 0.4);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 80% 15%,
-            rgba(255, 255, 255, 0.85) 0%,
-            transparent 35%
+            circle at 85% 10%,
+            rgba(255, 255, 255, 0.95) 0%,
+            transparent 42%
         ),
-        radial-gradient(circle at 20% 30%, #ffd1e8 0%, transparent 55%),
-        radial-gradient(circle at 75% 70%, #ff99d9 0%, transparent 55%),
-        radial-gradient(circle at 20% 80%, #c499ff 0%, transparent 55%),
-        linear-gradient(135deg, #ffe0f0 0%, #c499ff 100%);
+        radial-gradient(
+            circle at 12% 90%,
+            rgba(255, 255, 255, 0.35) 0%,
+            transparent 38%
+        ),
+        radial-gradient(circle at 22% 32%, #ff5cb8 0%, transparent 30%),
+        radial-gradient(circle at 75% 68%, #b366ff 0%, transparent 32%),
+        linear-gradient(135deg, #fff0f8 0%, #c499ff 100%);
     box-shadow: inset 0 0 3px rgba(255, 99, 180, 0.4);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 15% 80%,
-            rgba(255, 255, 255, 0.8) 0%,
-            transparent 35%
+            circle at 12% 88%,
+            rgba(255, 255, 255, 0.9) 0%,
+            transparent 42%
         ),
-        radial-gradient(circle at 75% 20%, #c1f1db 0%, transparent 55%),
-        radial-gradient(circle at 25% 30%, #83e2b7 0%, transparent 55%),
-        radial-gradient(circle at 80% 75%, #5e4cff 0%, transparent 55%),
-        linear-gradient(135deg, #c1f1db 0%, #5e4cff 100%);
+        radial-gradient(
+            circle at 90% 12%,
+            rgba(255, 255, 255, 0.3) 0%,
+            transparent 38%
+        ),
+        radial-gradient(circle at 72% 22%, #30cf87 0%, transparent 30%),
+        radial-gradient(circle at 78% 78%, #5e4cff 0%, transparent 32%),
+        linear-gradient(135deg, #eafff5 0%, #5e4cff 100%);
     box-shadow: inset 0 0 3px rgba(131, 226, 183, 0.4);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 80% 80%,
-            rgba(255, 255, 255, 0.8) 0%,
-            transparent 35%
+            circle at 85% 85%,
+            rgba(255, 255, 255, 0.9) 0%,
+            transparent 42%
         ),
-        radial-gradient(circle at 20% 20%, #d9d1ff 0%, transparent 55%),
-        radial-gradient(circle at 75% 25%, #b3a0ff 0%, transparent 55%),
-        radial-gradient(circle at 25% 75%, #c4d966 0%, transparent 55%),
-        linear-gradient(135deg, #b3a0ff 0%, #c4d966 100%);
+        radial-gradient(
+            circle at 15% 15%,
+            rgba(255, 255, 255, 0.3) 0%,
+            transparent 38%
+        ),
+        radial-gradient(circle at 72% 25%, #8a6bff 0%, transparent 30%),
+        radial-gradient(circle at 25% 75%, #d4e047 0%, transparent 32%),
+        linear-gradient(135deg, #ece5ff 0%, #c4d966 100%);
     box-shadow: inset 0 0 3px rgba(180, 160, 255, 0.4);
 }
 .root[data-avatar-gradient='slate'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 20% 15%,
-            rgba(255, 255, 255, 0.5) 0%,
+            circle at 18% 12%,
+            rgba(255, 255, 255, 0.7) 0%,
+            transparent 40%
+        ),
+        radial-gradient(
+            circle at 85% 90%,
+            rgba(255, 255, 255, 0.15) 0%,
             transparent 35%
         ),
-        radial-gradient(circle at 75% 25%, #4a4a4a 0%, transparent 55%),
-        radial-gradient(circle at 25% 75%, #2a2a2a 0%, transparent 55%),
-        radial-gradient(circle at 80% 80%, #0f0f0f 0%, transparent 55%),
-        linear-gradient(135deg, #3a3a3a 0%, #0a0a0a 100%);
+        radial-gradient(circle at 75% 25%, #6a6a6a 0%, transparent 32%),
+        radial-gradient(circle at 25% 75%, #050505 0%, transparent 34%),
+        linear-gradient(135deg, #4a4a4a 0%, #0a0a0a 100%);
     box-shadow: inset 0 0 3px rgba(90, 90, 90, 0.5);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -8,91 +8,91 @@
 
 .root[data-avatar-gradient='dusk'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #a499ff 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #5e4cff 0%, transparent 65%),
-        #7a5cff;
+        radial-gradient(130% 130% at 30% 30%, #a499ff 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #5e4cff 0%, transparent 55%),
+        #8270cc;
 }
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #d1ccff 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #a499ff 0%, transparent 65%),
-        #c2b8ff;
+        radial-gradient(130% 130% at 30% 30%, #d1ccff 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #a499ff 0%, transparent 55%),
+        #c0b6ff;
 }
 .root[data-avatar-gradient='ocean'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #8001fe 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #1200b2 0%, transparent 65%),
-        #4b2f9e;
+        radial-gradient(130% 130% at 30% 30%, #8001fe 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #1200b2 0%, transparent 55%),
+        #4a2f9e;
 }
 .root[data-avatar-gradient='ember'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #b267fe 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #26004c 0%, transparent 65%),
-        #5c1a94;
+        radial-gradient(130% 130% at 30% 30%, #b267fe 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #26004c 0%, transparent 55%),
+        #6d2d8a;
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #ffd1e8 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #d9b3ff 0%, transparent 65%),
-        #f0bedd;
+        radial-gradient(130% 130% at 30% 30%, #ffd1e8 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #d9b3ff 0%, transparent 55%),
+        #f0c0e0;
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #edfbd0 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #dbfe95 0%, transparent 65%),
-        #dff9b0;
+        radial-gradient(130% 130% at 30% 30%, #edfbd0 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #dbfe95 0%, transparent 55%),
+        #e5faa0;
 }
 .root[data-avatar-gradient='forest'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #1d7c51 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #1200b2 0%, transparent 65%),
-        #1a3e71;
+        radial-gradient(130% 130% at 30% 30%, #1d7c51 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #1200b2 0%, transparent 55%),
+        #1a3f71;
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #d1ccff 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #daf6a2 0%, transparent 65%),
-        #cde1bd;
+        radial-gradient(130% 130% at 30% 30%, #d1ccff 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #daf6a2 0%, transparent 55%),
+        #d0e1b8;
 }
 .root[data-avatar-gradient='twilight'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #26004c 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #0e3e29 0%, transparent 65%),
-        #151f3a;
+        radial-gradient(130% 130% at 30% 30%, #26004c 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #0e3e29 0%, transparent 55%),
+        #172038;
 }
 .root[data-avatar-gradient='lavender'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #d1ccff 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #d9b3ff 0%, transparent 65%),
-        #d5c2ff;
+        radial-gradient(130% 130% at 30% 30%, #d1ccff 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #d9b3ff 0%, transparent 55%),
+        #d5bfff;
 }
 .root[data-avatar-gradient='emerald'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #30cf87 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #0e3e29 0%, transparent 65%),
-        #1a6b54;
+        radial-gradient(130% 130% at 30% 30%, #30cf87 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #0e3e29 0%, transparent 55%),
+        #1f6b52;
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #8001fe 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #5e4cff 0%, transparent 65%),
-        #7040cd;
+        radial-gradient(130% 130% at 30% 30%, #8001fe 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #5e4cff 0%, transparent 55%),
+        #7043d6;
 }
 .root[data-avatar-gradient='sage'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #edfbd0 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #83e2b7 0%, transparent 65%),
-        #c1e8a0;
+        radial-gradient(130% 130% at 30% 30%, #edfbd0 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #83e2b7 0%, transparent 55%),
+        #c5e8a8;
 }
 .root[data-avatar-gradient='orchid'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #d9b3ff 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #8001fe 0%, transparent 65%),
+        radial-gradient(130% 130% at 30% 30%, #d9b3ff 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #8001fe 0%, transparent 55%),
         #b589f0;
 }
 .root[data-avatar-gradient='jungle'] .placeholder {
     background:
-        radial-gradient(120% 120% at 25% 25%, #3b5408 0%, transparent 65%),
-        radial-gradient(120% 120% at 75% 75%, #1d7c51 0%, transparent 65%),
+        radial-gradient(130% 130% at 30% 30%, #3b5408 0%, transparent 55%),
+        radial-gradient(130% 130% at 70% 70%, #1d7c51 0%, transparent 55%),
         #2e6527;
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -6,25 +6,10 @@
     color: var(--mantine-color-white);
 }
 
-.root[data-avatar-gradient='dusk'] .placeholder {
-    background:
-        radial-gradient(circle at 20% 30%, #a499ff 0%, transparent 60%),
-        radial-gradient(circle at 80% 70%, #5e4cff 0%, transparent 60%), #6b5fb8;
-}
 .root[data-avatar-gradient='lilac'] .placeholder {
     background:
         radial-gradient(circle at 25% 35%, #d1ccff 0%, transparent 60%),
         radial-gradient(circle at 75% 65%, #a499ff 0%, transparent 60%), #b3a0ff;
-}
-.root[data-avatar-gradient='ocean'] .placeholder {
-    background:
-        radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 60%),
-        radial-gradient(circle at 80% 75%, #1200b2 0%, transparent 60%), #381ea0;
-}
-.root[data-avatar-gradient='ember'] .placeholder {
-    background:
-        radial-gradient(circle at 25% 30%, #b267fe 0%, transparent 60%),
-        radial-gradient(circle at 75% 70%, #26004c 0%, transparent 60%), #521d7f;
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
@@ -36,45 +21,15 @@
         radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 60%),
         radial-gradient(circle at 75% 65%, #dbfe95 0%, transparent 60%), #ddf58e;
 }
-.root[data-avatar-gradient='forest'] .placeholder {
-    background:
-        radial-gradient(circle at 20% 25%, #1d7c51 0%, transparent 60%),
-        radial-gradient(circle at 80% 75%, #1200b2 0%, transparent 60%), #182b7a;
-}
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
         radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 60%),
         radial-gradient(circle at 80% 70%, #daf6a2 0%, transparent 60%), #cccdb3;
 }
-.root[data-avatar-gradient='twilight'] .placeholder {
-    background:
-        radial-gradient(circle at 25% 35%, #26004c 0%, transparent 60%),
-        radial-gradient(circle at 75% 65%, #0e3e29 0%, transparent 60%), #13162c;
-}
-.root[data-avatar-gradient='lavender'] .placeholder {
-    background:
-        radial-gradient(circle at 20% 30%, #d1ccff 0%, transparent 60%),
-        radial-gradient(circle at 80% 70%, #d9b3ff 0%, transparent 60%), #cdb0ff;
-}
-.root[data-avatar-gradient='emerald'] .placeholder {
-    background:
-        radial-gradient(circle at 25% 35%, #30cf87 0%, transparent 60%),
-        radial-gradient(circle at 75% 65%, #0e3e29 0%, transparent 60%), #1b5d4e;
-}
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
         radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 60%),
         radial-gradient(circle at 80% 75%, #5e4cff 0%, transparent 60%), #6331c4;
-}
-.root[data-avatar-gradient='sage'] .placeholder {
-    background:
-        radial-gradient(circle at 25% 35%, #edfbd0 0%, transparent 60%),
-        radial-gradient(circle at 75% 65%, #83e2b7 0%, transparent 60%), #b9da92;
-}
-.root[data-avatar-gradient='orchid'] .placeholder {
-    background:
-        radial-gradient(circle at 20% 30%, #d9b3ff 0%, transparent 60%),
-        radial-gradient(circle at 80% 70%, #8001fe 0%, transparent 60%), #a76be2;
 }
 .root[data-avatar-gradient='jungle'] .placeholder {
     background:

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -7,92 +7,152 @@
 }
 
 .root[data-avatar-gradient='dusk'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #a499ff 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #5e4cff 0%, transparent 50%),
-        #8372d9;
+    background: conic-gradient(
+        from 0deg,
+        #a499ff,
+        #8372d9,
+        #5e4cff,
+        #8372d9,
+        #a499ff
+    );
 }
 .root[data-avatar-gradient='lilac'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #d1ccff 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #a499ff 0%, transparent 50%),
-        #bfb4ff;
+    background: conic-gradient(
+        from 0deg,
+        #d1ccff,
+        #bfb4ff,
+        #a499ff,
+        #bfb4ff,
+        #d1ccff
+    );
 }
 .root[data-avatar-gradient='ocean'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #8001fe 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #1200b2 0%, transparent 50%),
-        #4a319f;
+    background: conic-gradient(
+        from 0deg,
+        #8001fe,
+        #4a319f,
+        #1200b2,
+        #4a319f,
+        #8001fe
+    );
 }
 .root[data-avatar-gradient='ember'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #b267fe 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #26004c 0%, transparent 50%),
-        #6d3690;
+    background: conic-gradient(
+        from 0deg,
+        #b267fe,
+        #6d3690,
+        #26004c,
+        #6d3690,
+        #b267fe
+    );
 }
 .root[data-avatar-gradient='blush'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #ffd1e8 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #d9b3ff 0%, transparent 50%),
-        #f0c5e3;
+    background: conic-gradient(
+        from 0deg,
+        #ffd1e8,
+        #f0c5e3,
+        #d9b3ff,
+        #f0c5e3,
+        #ffd1e8
+    );
 }
 .root[data-avatar-gradient='minty'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #edfbd0 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #dbfe95 0%, transparent 50%),
-        #e5fb9e;
+    background: conic-gradient(
+        from 0deg,
+        #edfbd0,
+        #e5fb9e,
+        #dbfe95,
+        #e5fb9e,
+        #edfbd0
+    );
 }
 .root[data-avatar-gradient='forest'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #1d7c51 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #1200b2 0%, transparent 50%),
-        #1a3f71;
+    background: conic-gradient(
+        from 0deg,
+        #1d7c51,
+        #1a3f71,
+        #1200b2,
+        #1a3f71,
+        #1d7c51
+    );
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #d1ccff 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #daf6a2 0%, transparent 50%),
-        #d0e1bf;
+    background: conic-gradient(
+        from 0deg,
+        #d1ccff,
+        #d0e1bf,
+        #daf6a2,
+        #d0e1bf,
+        #d1ccff
+    );
 }
 .root[data-avatar-gradient='twilight'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #26004c 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #0e3e29 0%, transparent 50%),
-        #172038;
+    background: conic-gradient(
+        from 0deg,
+        #26004c,
+        #172038,
+        #0e3e29,
+        #172038,
+        #26004c
+    );
 }
 .root[data-avatar-gradient='lavender'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #d1ccff 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #d9b3ff 0%, transparent 50%),
-        #d5bfff;
+    background: conic-gradient(
+        from 0deg,
+        #d1ccff,
+        #d5bfff,
+        #d9b3ff,
+        #d5bfff,
+        #d1ccff
+    );
 }
 .root[data-avatar-gradient='emerald'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #30cf87 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #0e3e29 0%, transparent 50%),
-        #1f6b52;
+    background: conic-gradient(
+        from 0deg,
+        #30cf87,
+        #1f6b52,
+        #0e3e29,
+        #1f6b52,
+        #30cf87
+    );
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #8001fe 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #5e4cff 0%, transparent 50%),
-        #7043d6;
+    background: conic-gradient(
+        from 0deg,
+        #8001fe,
+        #7043d6,
+        #5e4cff,
+        #7043d6,
+        #8001fe
+    );
 }
 .root[data-avatar-gradient='sage'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #edfbd0 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #83e2b7 0%, transparent 50%),
-        #c5e8ac;
+    background: conic-gradient(
+        from 0deg,
+        #edfbd0,
+        #c5e8ac,
+        #83e2b7,
+        #c5e8ac,
+        #edfbd0
+    );
 }
 .root[data-avatar-gradient='orchid'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #d9b3ff 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #8001fe 0%, transparent 50%),
-        #b589f0;
+    background: conic-gradient(
+        from 0deg,
+        #d9b3ff,
+        #b589f0,
+        #8001fe,
+        #b589f0,
+        #d9b3ff
+    );
 }
 .root[data-avatar-gradient='jungle'] .placeholder {
-    background:
-        radial-gradient(180% 180% at 20% 20%, #3b5408 0%, transparent 50%),
-        radial-gradient(180% 180% at 80% 80%, #1d7c51 0%, transparent 50%),
-        #2e6527;
+    background: conic-gradient(
+        from 0deg,
+        #3b5408,
+        #2e6527,
+        #1d7c51,
+        #2e6527,
+        #3b5408
+    );
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -28,11 +28,6 @@
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
-        radial-gradient(circle at 20% 25%, #8001fe 0%, transparent 60%),
-        radial-gradient(circle at 80% 75%, #5e4cff 0%, transparent 60%), #6331c4;
-}
-.root[data-avatar-gradient='jungle'] .placeholder {
-    background:
-        radial-gradient(circle at 25% 35%, #3b5408 0%, transparent 60%),
-        radial-gradient(circle at 75% 65%, #1d7c51 0%, transparent 60%), #2c5825;
+        radial-gradient(circle at 20% 25%, #b267fe 0%, transparent 60%),
+        radial-gradient(circle at 80% 75%, #a499ff 0%, transparent 60%), #a87dff;
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -5,155 +5,58 @@
     border-radius: 50%;
     clip-path: circle(50%);
     color: var(--mantine-color-white);
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 160% 160%;
 }
 
 .root[data-avatar-gradient='lilac'] .placeholder {
-    background:
+    background-image:
         radial-gradient(
-            ellipse 75% 75% at 25% 30%,
-            #d1ccff 0%,
-            transparent 100%
+            circle at 30% 25%,
+            rgba(255, 255, 255, 0.5) 0%,
+            transparent 45%
         ),
-        radial-gradient(
-            ellipse 75% 75% at 70% 15%,
-            #a499ff 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 80% 70%,
-            #8f6fff 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 15% 65%,
-            #b884ff 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 55% 50%,
-            #9d7fff 0%,
-            transparent 100%
-        ),
-        #a383ff;
+        linear-gradient(135deg, #ffc9ec 0%, #d1ccff 45%, #8f6fff 100%);
     box-shadow: inset 0 0 3px rgba(159, 111, 255, 0.4);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
-    background:
+    background-image:
         radial-gradient(
-            ellipse 75% 75% at 30% 25%,
-            #ffd1e8 0%,
-            transparent 100%
+            circle at 30% 25%,
+            rgba(255, 255, 255, 0.5) 0%,
+            transparent 45%
         ),
-        radial-gradient(
-            ellipse 75% 75% at 65% 10%,
-            #ff99d9 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 85% 65%,
-            #c499ff 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 10% 70%,
-            #d98ac0 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 50% 55%,
-            #d984c8 0%,
-            transparent 100%
-        ),
-        #d987c8;
+        linear-gradient(135deg, #ffd1e8 0%, #ff99d9 45%, #c499ff 100%);
     box-shadow: inset 0 0 3px rgba(255, 99, 180, 0.4);
 }
-.root[data-avatar-gradient='slate'] .placeholder {
-    background:
-        radial-gradient(
-            ellipse 75% 75% at 25% 35%,
-            #3a3a3a 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 70% 20%,
-            #1a1a1a 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 80% 70%,
-            #4a4a4a 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 15% 65%,
-            #2a2a2a 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 55% 50%,
-            #383838 0%,
-            transparent 100%
-        ),
-        #353535;
-    box-shadow: inset 0 0 3px rgba(70, 70, 70, 0.5);
-}
 .root[data-avatar-gradient='amethyst'] .placeholder {
-    background:
+    background-image:
         radial-gradient(
-            ellipse 75% 75% at 75% 15%,
-            #5e4cff 0%,
-            transparent 100%
+            circle at 30% 25%,
+            rgba(255, 255, 255, 0.5) 0%,
+            transparent 45%
         ),
-        radial-gradient(
-            ellipse 75% 75% at 20% 30%,
-            #83e2b7 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 10% 65%,
-            #30cf87 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 80% 75%,
-            #c1f1db 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 50% 50%,
-            #7fb5c2 0%,
-            transparent 100%
-        ),
-        #6fa0d8;
+        linear-gradient(135deg, #c1f1db 0%, #83e2b7 45%, #5e4cff 100%);
     box-shadow: inset 0 0 3px rgba(131, 226, 183, 0.4);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
-    background:
+    background-image:
         radial-gradient(
-            ellipse 75% 75% at 20% 20%,
-            #b3a0ff 0%,
-            transparent 100%
+            circle at 30% 25%,
+            rgba(255, 255, 255, 0.5) 0%,
+            transparent 45%
         ),
-        radial-gradient(
-            ellipse 75% 75% at 80% 20%,
-            #c4d966 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 80% 80%,
-            #b8cd55 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 20% 80%,
-            #a8c755 0%,
-            transparent 100%
-        ),
-        radial-gradient(
-            ellipse 75% 75% at 50% 50%,
-            #b8c855 0%,
-            transparent 100%
-        ),
-        #b8c855;
+        linear-gradient(135deg, #d9d1ff 0%, #b3a0ff 45%, #c4d966 100%);
     box-shadow: inset 0 0 3px rgba(180, 160, 255, 0.4);
+}
+.root[data-avatar-gradient='slate'] .placeholder {
+    background-image:
+        radial-gradient(
+            circle at 30% 25%,
+            rgba(255, 255, 255, 0.25) 0%,
+            transparent 45%
+        ),
+        linear-gradient(135deg, #4a4a4a 0%, #2a2a2a 45%, #0f0f0f 100%);
+    box-shadow: inset 0 0 3px rgba(90, 90, 90, 0.5);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -6,19 +6,6 @@
     color: var(--mantine-color-white);
 }
 
-/* Subtle grain overlay — sits behind the initials so legibility isn't affected. */
-.root[data-avatar-gradient] .placeholder::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100' height='100' filter='url(%23n)'/%3E%3C/svg%3E");
-    background-size: 100px 100px;
-    opacity: 0.35;
-    mix-blend-mode: overlay;
-    pointer-events: none;
-}
-
 .root[data-avatar-gradient='dusk'] .placeholder {
     background:
         radial-gradient(120% 120% at 25% 25%, #a499ff 0%, transparent 65%),

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -7,56 +7,71 @@
     color: var(--mantine-color-white);
     background-repeat: no-repeat;
     background-position: center;
-    background-size: 160% 160%;
+    background-size: 180% 180%;
 }
 
 .root[data-avatar-gradient='lilac'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 30% 25%,
-            rgba(255, 255, 255, 0.5) 0%,
-            transparent 45%
+            circle at 20% 15%,
+            rgba(255, 255, 255, 0.85) 0%,
+            transparent 35%
         ),
-        linear-gradient(135deg, #ffc9ec 0%, #d1ccff 45%, #8f6fff 100%);
+        radial-gradient(circle at 70% 25%, #d1ccff 0%, transparent 55%),
+        radial-gradient(circle at 30% 70%, #a499ff 0%, transparent 55%),
+        radial-gradient(circle at 80% 80%, #8f6fff 0%, transparent 55%),
+        linear-gradient(135deg, #e0d9ff 0%, #9d7fff 100%);
     box-shadow: inset 0 0 3px rgba(159, 111, 255, 0.4);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 30% 25%,
-            rgba(255, 255, 255, 0.5) 0%,
-            transparent 45%
+            circle at 80% 15%,
+            rgba(255, 255, 255, 0.85) 0%,
+            transparent 35%
         ),
-        linear-gradient(135deg, #ffd1e8 0%, #ff99d9 45%, #c499ff 100%);
+        radial-gradient(circle at 20% 30%, #ffd1e8 0%, transparent 55%),
+        radial-gradient(circle at 75% 70%, #ff99d9 0%, transparent 55%),
+        radial-gradient(circle at 20% 80%, #c499ff 0%, transparent 55%),
+        linear-gradient(135deg, #ffe0f0 0%, #c499ff 100%);
     box-shadow: inset 0 0 3px rgba(255, 99, 180, 0.4);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 30% 25%,
-            rgba(255, 255, 255, 0.5) 0%,
-            transparent 45%
+            circle at 15% 80%,
+            rgba(255, 255, 255, 0.8) 0%,
+            transparent 35%
         ),
-        linear-gradient(135deg, #c1f1db 0%, #83e2b7 45%, #5e4cff 100%);
+        radial-gradient(circle at 75% 20%, #c1f1db 0%, transparent 55%),
+        radial-gradient(circle at 25% 30%, #83e2b7 0%, transparent 55%),
+        radial-gradient(circle at 80% 75%, #5e4cff 0%, transparent 55%),
+        linear-gradient(135deg, #c1f1db 0%, #5e4cff 100%);
     box-shadow: inset 0 0 3px rgba(131, 226, 183, 0.4);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 30% 25%,
-            rgba(255, 255, 255, 0.5) 0%,
-            transparent 45%
+            circle at 80% 80%,
+            rgba(255, 255, 255, 0.8) 0%,
+            transparent 35%
         ),
-        linear-gradient(135deg, #d9d1ff 0%, #b3a0ff 45%, #c4d966 100%);
+        radial-gradient(circle at 20% 20%, #d9d1ff 0%, transparent 55%),
+        radial-gradient(circle at 75% 25%, #b3a0ff 0%, transparent 55%),
+        radial-gradient(circle at 25% 75%, #c4d966 0%, transparent 55%),
+        linear-gradient(135deg, #b3a0ff 0%, #c4d966 100%);
     box-shadow: inset 0 0 3px rgba(180, 160, 255, 0.4);
 }
 .root[data-avatar-gradient='slate'] .placeholder {
     background-image:
         radial-gradient(
-            circle at 30% 25%,
-            rgba(255, 255, 255, 0.25) 0%,
-            transparent 45%
+            circle at 20% 15%,
+            rgba(255, 255, 255, 0.5) 0%,
+            transparent 35%
         ),
-        linear-gradient(135deg, #4a4a4a 0%, #2a2a2a 45%, #0f0f0f 100%);
+        radial-gradient(circle at 75% 25%, #4a4a4a 0%, transparent 55%),
+        radial-gradient(circle at 25% 75%, #2a2a2a 0%, transparent 55%),
+        radial-gradient(circle at 80% 80%, #0f0f0f 0%, transparent 55%),
+        linear-gradient(135deg, #3a3a3a 0%, #0a0a0a 100%);
     box-shadow: inset 0 0 3px rgba(90, 90, 90, 0.5);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -13,6 +13,7 @@
         radial-gradient(circle at 80% 80%, #d9b3ff 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #b8a5ff 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #c0b6ff 0%, transparent 50%), #bfb4ff;
+    box-shadow: inset 0 0 0 1.5px rgba(212, 204, 255, 0.6);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
@@ -21,6 +22,7 @@
         radial-gradient(circle at 80% 80%, #f0a5d8 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #e8b8e8 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #dfa5d0 0%, transparent 50%), #dfa5d0;
+    box-shadow: inset 0 0 0 1.5px rgba(255, 179, 230, 0.6);
 }
 .root[data-avatar-gradient='minty'] .placeholder {
     background:
@@ -29,6 +31,7 @@
         radial-gradient(circle at 80% 80%, #d4f9a0 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #e5f9c0 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #ddf58e 0%, transparent 50%), #ddf58e;
+    box-shadow: inset 0 0 0 1.5px rgba(219, 254, 149, 0.6);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
@@ -37,6 +40,7 @@
         radial-gradient(circle at 80% 80%, #d5eea5 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #cfd8b8 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #cccdb3 0%, transparent 50%), #cccdb3;
+    box-shadow: inset 0 0 0 1.5px rgba(218, 246, 162, 0.6);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
@@ -45,4 +49,5 @@
         radial-gradient(circle at 80% 80%, #9980ff 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #ad7dff 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #a87dff 0%, transparent 50%), #a87dff;
+    box-shadow: inset 0 0 0 1.5px rgba(180, 153, 255, 0.6);
 }

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -24,7 +24,7 @@
         radial-gradient(circle at 80% 70%, #8f6fff 0%, transparent 50%),
         radial-gradient(circle at 15% 65%, #b884ff 0%, transparent 55%),
         radial-gradient(circle at 55% 50%, #9d7fff 0%, transparent 60%), #a383ff;
-    box-shadow: inset 0 0 0 1px rgba(159, 111, 255, 0.3);
+    box-shadow: inset 0 0 3px rgba(159, 111, 255, 0.4);
 }
 .root[data-avatar-gradient='blush'] .placeholder {
     background:
@@ -33,7 +33,7 @@
         radial-gradient(circle at 85% 65%, #c499ff 0%, transparent 52%),
         radial-gradient(circle at 10% 70%, #d98ac0 0%, transparent 55%),
         radial-gradient(circle at 50% 55%, #d984c8 0%, transparent 58%), #d987c8;
-    box-shadow: inset 0 0 0 1px rgba(255, 99, 180, 0.3);
+    box-shadow: inset 0 0 3px rgba(255, 99, 180, 0.4);
 }
 .root[data-avatar-gradient='slate'] .placeholder {
     background:
@@ -42,7 +42,7 @@
         radial-gradient(circle at 80% 70%, #4a4a4a 0%, transparent 52%),
         radial-gradient(circle at 15% 65%, #2a2a2a 0%, transparent 55%),
         radial-gradient(circle at 55% 50%, #383838 0%, transparent 58%), #353535;
-    box-shadow: inset 0 0 0 1px rgba(70, 70, 70, 0.4);
+    box-shadow: inset 0 0 3px rgba(70, 70, 70, 0.5);
 }
 .root[data-avatar-gradient='amethyst'] .placeholder {
     background:
@@ -51,7 +51,7 @@
         radial-gradient(circle at 10% 65%, #30cf87 0%, transparent 55%),
         radial-gradient(circle at 80% 75%, #c1f1db 0%, transparent 52%),
         radial-gradient(circle at 50% 50%, #7fb5c2 0%, transparent 58%), #6fa0d8;
-    box-shadow: inset 0 0 0 1px rgba(131, 226, 183, 0.3);
+    box-shadow: inset 0 0 3px rgba(131, 226, 183, 0.4);
 }
 .root[data-avatar-gradient='sunrise'] .placeholder {
     background:
@@ -60,5 +60,5 @@
         radial-gradient(circle at 80% 80%, #b8cd55 0%, transparent 50%),
         radial-gradient(circle at 20% 80%, #a8c755 0%, transparent 50%),
         radial-gradient(circle at 50% 50%, #b8c855 0%, transparent 50%), #b8c855;
-    box-shadow: inset 0 0 0 1px rgba(180, 160, 255, 0.3);
+    box-shadow: inset 0 0 3px rgba(180, 160, 255, 0.4);
 }

--- a/packages/frontend/src/components/Avatar.test.tsx
+++ b/packages/frontend/src/components/Avatar.test.tsx
@@ -1,4 +1,3 @@
-import { getUserAvatarGradient } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { renderWithProviders } from '../testing/testUtils';
@@ -7,14 +6,13 @@ import { LightdashUserAvatar } from './Avatar';
 const UUID_A = 'b264d83a-9000-426a-85ec-3f9c20f368ce';
 
 describe('LightdashUserAvatar', () => {
-    it('renders the deterministic gradient for a userUuid', () => {
+    it('falls back to the legacy plain avatar with a userUuid but no gradient or photo', () => {
         renderWithProviders(
             <LightdashUserAvatar userUuid={UUID_A} name="Ada Lovelace" />,
         );
-        const expected = getUserAvatarGradient(UUID_A, null);
         expect(
-            document.querySelector(`[data-avatar-gradient="${expected}"]`),
-        ).toBeInTheDocument();
+            document.querySelector('[data-avatar-gradient]'),
+        ).not.toBeInTheDocument();
         expect(screen.getByText('AL')).toBeInTheDocument();
     });
 

--- a/packages/frontend/src/components/Avatar.test.tsx
+++ b/packages/frontend/src/components/Avatar.test.tsx
@@ -20,12 +20,12 @@ describe('LightdashUserAvatar', () => {
         renderWithProviders(
             <LightdashUserAvatar
                 userUuid={UUID_A}
-                avatarGradient="ember"
+                avatarGradient="lilac"
                 name="Ada Lovelace"
             />,
         );
         expect(
-            document.querySelector('[data-avatar-gradient="ember"]'),
+            document.querySelector('[data-avatar-gradient="lilac"]'),
         ).toBeInTheDocument();
     });
 

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -1,7 +1,4 @@
-import {
-    getUserAvatarGradient,
-    type UserAvatarGradientId,
-} from '@lightdash/common';
+import { type UserAvatarGradientId } from '@lightdash/common';
 import { Avatar, type AvatarProps } from '@mantine-8/core';
 import { forwardRef } from 'react';
 import classes from './Avatar.module.css';
@@ -25,33 +22,41 @@ const mergeClassNames = (extra?: AvatarClassNames): AvatarClassNames => ({
         .join(' '),
 });
 
+// No photo and no explicit gradient choice falls back to the original plain avatar.
 export const LightdashUserAvatar = forwardRef<HTMLDivElement, Props>(
     ({ userUuid, avatarUrl, avatarGradient, classNames, ...props }, ref) => {
-        if (!userUuid) {
+        if (avatarUrl) {
             return (
                 <Avatar
                     ref={ref}
-                    variant="light"
                     radius="100%"
                     color="initials"
+                    src={avatarUrl}
+                    imageProps={{ loading: 'lazy' }}
                     classNames={classNames}
                     {...props}
                 />
             );
         }
-        const gradient = getUserAvatarGradient(
-            userUuid,
-            avatarGradient ?? null,
-        );
+        if (userUuid && avatarGradient) {
+            return (
+                <Avatar
+                    ref={ref}
+                    radius="100%"
+                    color="initials"
+                    data-avatar-gradient={avatarGradient}
+                    classNames={mergeClassNames(classNames)}
+                    {...props}
+                />
+            );
+        }
         return (
             <Avatar
                 ref={ref}
+                variant="light"
                 radius="100%"
                 color="initials"
-                src={avatarUrl ?? undefined}
-                imageProps={{ loading: 'lazy' }}
-                data-avatar-gradient={gradient}
-                classNames={mergeClassNames(classNames)}
+                classNames={classNames}
                 {...props}
             />
         );

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
@@ -8,6 +8,7 @@
 }
 
 .swatchSelected {
-    outline: 1px solid #000;
-    outline-offset: 2px;
+    box-shadow:
+        0 0 8px rgba(60, 60, 60, 0.5),
+        inset 0 0 0 1px rgba(100, 100, 100, 0.3);
 }

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
@@ -1,0 +1,13 @@
+.swatchButton {
+    border: none;
+    background: none;
+    padding: 0;
+    border-radius: 50%;
+    cursor: pointer;
+    line-height: 0;
+}
+
+.swatchSelected {
+    outline: 2px solid var(--mantine-color-blue-5);
+    outline-offset: 2px;
+}

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
@@ -8,6 +8,6 @@
 }
 
 .swatchSelected {
-    outline: 2px solid #5e4cff;
+    outline: 1px solid #000;
     outline-offset: 2px;
 }

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
@@ -9,6 +9,6 @@
 
 .swatchSelected {
     box-shadow:
-        0 0 8px rgba(60, 60, 60, 0.5),
-        inset 0 0 0 1px rgba(100, 100, 100, 0.3);
+        0 0 6px rgba(80, 80, 80, 0.25),
+        inset 0 0 0 1px rgba(120, 120, 120, 0.15);
 }

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
@@ -8,6 +8,6 @@
 }
 
 .swatchSelected {
-    outline: 2px solid var(--mantine-color-blue-5);
+    outline: 2px solid #5e4cff;
     outline-offset: 2px;
 }

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,7 +1,4 @@
-import {
-    getUserAvatarGradient,
-    USER_AVATAR_GRADIENT_IDS,
-} from '@lightdash/common';
+import { USER_AVATAR_GRADIENT_IDS } from '@lightdash/common';
 import {
     Button,
     FileButton,
@@ -33,8 +30,6 @@ const AvatarSettings: FC = () => {
     const { userUuid, firstName, lastName, avatarUrl, avatarGradient } =
         user.data;
     const initials = `${firstName[0] ?? ''}${lastName[0] ?? ''}`.trim();
-    const activeGradient = getUserAvatarGradient(userUuid, avatarGradient);
-    const defaultGradient = getUserAvatarGradient(userUuid, null);
 
     const handleFile = (file: File | null) => {
         if (!file) return;
@@ -91,34 +86,44 @@ const AvatarSettings: FC = () => {
                     Or pick a color — it shows when you have no photo.
                 </Text>
                 <Group gap="xs">
-                    {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
-                        <Tooltip
-                            key={gradientId}
-                            label={
-                                gradientId === defaultGradient
-                                    ? `${gradientId} (default)`
-                                    : gradientId
+                    <Tooltip label="No color (default)">
+                        <button
+                            type="button"
+                            aria-label="Use default avatar"
+                            className={
+                                !avatarGradient
+                                    ? `${classes.swatchButton} ${classes.swatchSelected}`
+                                    : classes.swatchButton
+                            }
+                            onClick={() =>
+                                updateUserMutation.mutate({
+                                    avatarGradient: null,
+                                })
                             }
                         >
+                            <LightdashUserAvatar size="sm">
+                                {initials}
+                            </LightdashUserAvatar>
+                        </button>
+                    </Tooltip>
+                    {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
+                        <Tooltip key={gradientId} label={gradientId}>
                             <button
                                 type="button"
                                 aria-label={`Use ${gradientId} avatar color`}
                                 className={
-                                    gradientId === activeGradient
+                                    gradientId === avatarGradient
                                         ? `${classes.swatchButton} ${classes.swatchSelected}`
                                         : classes.swatchButton
                                 }
                                 onClick={() =>
                                     updateUserMutation.mutate({
-                                        avatarGradient:
-                                            gradientId === defaultGradient
-                                                ? null
-                                                : gradientId,
+                                        avatarGradient: gradientId,
                                     })
                                 }
                             >
                                 <LightdashUserAvatar
-                                    size="md"
+                                    size="sm"
                                     userUuid={userUuid}
                                     avatarGradient={gradientId}
                                 >

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,12 +1,5 @@
 import { USER_AVATAR_GRADIENT_IDS } from '@lightdash/common';
-import {
-    Button,
-    Divider,
-    FileButton,
-    Group,
-    Text,
-    Tooltip,
-} from '@mantine-8/core';
+import { Button, Divider, FileButton, Group, Tooltip } from '@mantine-8/core';
 import { type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
@@ -58,23 +51,17 @@ const AvatarSettings: FC = () => {
                 accept="image/png,image/jpeg,image/webp"
             >
                 {(fileProps) => (
-                    <Text
-                        component="button"
-                        size="sm"
-                        c="dimmed"
+                    <Button
+                        variant="default"
+                        size="xs"
+                        loading={uploadMutation.isLoading}
                         {...fileProps}
-                        style={{
-                            cursor: 'pointer',
-                            border: 'none',
-                            background: 'none',
-                            padding: 0,
-                        }}
                     >
-                        upload
-                    </Text>
+                        Upload
+                    </Button>
                 )}
             </FileButton>
-            <Divider orientation="vertical" />
+            <Divider orientation="vertical" my={0} h={24} />
             {avatarUrl && (
                 <Button
                     variant="subtle"

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,5 +1,12 @@
 import { USER_AVATAR_GRADIENT_IDS } from '@lightdash/common';
-import { Button, FileButton, Group, Tooltip } from '@mantine-8/core';
+import {
+    Button,
+    Divider,
+    FileButton,
+    Group,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
 import { type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
@@ -51,16 +58,23 @@ const AvatarSettings: FC = () => {
                 accept="image/png,image/jpeg,image/webp"
             >
                 {(fileProps) => (
-                    <Button
-                        variant="default"
-                        size="xs"
-                        loading={uploadMutation.isLoading}
+                    <Text
+                        component="button"
+                        size="sm"
+                        c="dimmed"
                         {...fileProps}
+                        style={{
+                            cursor: 'pointer',
+                            border: 'none',
+                            background: 'none',
+                            padding: 0,
+                        }}
                     >
-                        Upload photo
-                    </Button>
+                        upload
+                    </Text>
                 )}
             </FileButton>
+            <Divider orientation="vertical" />
             {avatarUrl && (
                 <Button
                     variant="subtle"

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,14 +1,20 @@
-import { USER_AVATAR_GRADIENT_IDS } from '@lightdash/common';
+import {
+    USER_AVATAR_GRADIENT_IDS,
+    type UserAvatarGradientId,
+} from '@lightdash/common';
 import {
     Button,
+    ColorPicker,
     Divider,
     FileButton,
     Group,
     Popover,
+    Stack,
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { type FC } from 'react';
+import { useDisclosure } from '@mantine-8/hooks';
+import { type FC, useState } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
     useAvatarDeleteMutation,
@@ -19,12 +25,30 @@ import useApp from '../../../providers/App/useApp';
 import { LightdashUserAvatar } from '../../Avatar';
 import classes from './AvatarSettings.module.css';
 
+const DEFAULT_SWATCH_COLOR = '#ced4da';
+
+const GRADIENT_SWATCH_COLORS: Record<UserAvatarGradientId, string> = {
+    lilac: '#9d7fff',
+    blush: '#ff6fc4',
+    amethyst: '#5e4cff',
+    sunrise: '#b3a0ff',
+    slate: '#2a2a2a',
+};
+
+const gradientIdForColor = (color: string): UserAvatarGradientId | null =>
+    USER_AVATAR_GRADIENT_IDS.find(
+        (id) => GRADIENT_SWATCH_COLORS[id] === color,
+    ) ?? null;
+
 const AvatarSettings: FC = () => {
     const { user } = useApp();
     const { showToastError } = useToaster();
     const uploadMutation = useAvatarUploadMutation();
     const deleteMutation = useAvatarDeleteMutation();
     const updateUserMutation = useUserUpdateMutation();
+    const [opened, { toggle, close }] = useDisclosure(false);
+    const [previewGradient, setPreviewGradient] =
+        useState<UserAvatarGradientId | null>(null);
 
     if (!user.data) return null;
 
@@ -42,6 +66,18 @@ const AvatarSettings: FC = () => {
                 });
             },
         });
+    };
+
+    const handleToggle = () => {
+        if (!opened) {
+            setPreviewGradient(avatarGradient ?? null);
+        }
+        toggle();
+    };
+
+    const handleApply = () => {
+        updateUserMutation.mutate({ avatarGradient: previewGradient });
+        close();
     };
 
     return (
@@ -82,13 +118,22 @@ const AvatarSettings: FC = () => {
                 </Button>
             )}
             {!avatarUrl && (
-                <Popover width={200} position="bottom-start" withArrow>
+                <Popover
+                    opened={opened}
+                    onChange={(isOpen) => {
+                        if (!isOpen) close();
+                    }}
+                    width={220}
+                    position="bottom-start"
+                    withArrow
+                >
                     <Popover.Target>
                         <Tooltip label="Choose color">
                             <button
                                 type="button"
                                 aria-label="Choose avatar color"
                                 className={classes.swatchButton}
+                                onClick={handleToggle}
                             >
                                 <LightdashUserAvatar
                                     size="sm"
@@ -101,57 +146,59 @@ const AvatarSettings: FC = () => {
                         </Tooltip>
                     </Popover.Target>
                     <Popover.Dropdown>
-                        <Text size="xs" c="dimmed" fw={500} mb="xs">
-                            Avatar color
-                        </Text>
-                        <Group gap="xs" wrap="wrap">
-                            <Tooltip label="No color (default)">
-                                <button
-                                    type="button"
-                                    aria-label="Use default avatar"
-                                    className={
-                                        !avatarGradient
-                                            ? `${classes.swatchButton} ${classes.swatchSelected}`
-                                            : classes.swatchButton
-                                    }
-                                    onClick={() =>
-                                        updateUserMutation.mutate({
-                                            avatarGradient: null,
-                                        })
-                                    }
+                        <Stack gap="sm">
+                            <Group justify="space-between" align="center">
+                                <Text size="xs" c="dimmed" fw={500}>
+                                    Avatar color
+                                </Text>
+                                <LightdashUserAvatar
+                                    size="sm"
+                                    userUuid={userUuid}
+                                    avatarGradient={previewGradient}
                                 >
-                                    <LightdashUserAvatar size="sm">
-                                        {initials}
-                                    </LightdashUserAvatar>
-                                </button>
-                            </Tooltip>
-                            {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
-                                <Tooltip key={gradientId} label={gradientId}>
-                                    <button
-                                        type="button"
-                                        aria-label={`Use ${gradientId} avatar color`}
-                                        className={
-                                            gradientId === avatarGradient
-                                                ? `${classes.swatchButton} ${classes.swatchSelected}`
-                                                : classes.swatchButton
-                                        }
-                                        onClick={() =>
-                                            updateUserMutation.mutate({
-                                                avatarGradient: gradientId,
-                                            })
-                                        }
-                                    >
-                                        <LightdashUserAvatar
-                                            size="sm"
-                                            userUuid={userUuid}
-                                            avatarGradient={gradientId}
-                                        >
-                                            {initials}
-                                        </LightdashUserAvatar>
-                                    </button>
-                                </Tooltip>
-                            ))}
-                        </Group>
+                                    {initials}
+                                </LightdashUserAvatar>
+                            </Group>
+                            <ColorPicker
+                                withPicker={false}
+                                format="hex"
+                                swatchesPerRow={6}
+                                swatches={[
+                                    DEFAULT_SWATCH_COLOR,
+                                    ...USER_AVATAR_GRADIENT_IDS.map(
+                                        (id) => GRADIENT_SWATCH_COLORS[id],
+                                    ),
+                                ]}
+                                value={
+                                    previewGradient
+                                        ? GRADIENT_SWATCH_COLORS[
+                                              previewGradient
+                                          ]
+                                        : DEFAULT_SWATCH_COLOR
+                                }
+                                onChange={(color) =>
+                                    setPreviewGradient(
+                                        gradientIdForColor(color),
+                                    )
+                                }
+                            />
+                            <Group justify="flex-end" gap="xs">
+                                <Button
+                                    variant="subtle"
+                                    size="xs"
+                                    onClick={close}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    loading={updateUserMutation.isLoading}
+                                    onClick={handleApply}
+                                >
+                                    Apply
+                                </Button>
+                            </Group>
+                        </Stack>
                     </Popover.Dropdown>
                 </Popover>
             )}

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -61,7 +61,7 @@ const AvatarSettings: FC = () => {
                     </Button>
                 )}
             </FileButton>
-            <Divider orientation="vertical" my="auto" h={20} />
+            {!avatarUrl && <Divider orientation="vertical" my="auto" h={20} />}
             {avatarUrl && (
                 <Button
                     variant="subtle"
@@ -73,54 +73,56 @@ const AvatarSettings: FC = () => {
                     Remove photo
                 </Button>
             )}
-            <Group gap="xs" wrap="nowrap" align="center">
-                <Tooltip label="No color (default)">
-                    <button
-                        type="button"
-                        aria-label="Use default avatar"
-                        className={
-                            !avatarGradient
-                                ? `${classes.swatchButton} ${classes.swatchSelected}`
-                                : classes.swatchButton
-                        }
-                        onClick={() =>
-                            updateUserMutation.mutate({
-                                avatarGradient: null,
-                            })
-                        }
-                    >
-                        <LightdashUserAvatar size="sm">
-                            {initials}
-                        </LightdashUserAvatar>
-                    </button>
-                </Tooltip>
-                {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
-                    <Tooltip key={gradientId} label={gradientId}>
+            {!avatarUrl && (
+                <Group gap="xs" wrap="nowrap" align="center">
+                    <Tooltip label="No color (default)">
                         <button
                             type="button"
-                            aria-label={`Use ${gradientId} avatar color`}
+                            aria-label="Use default avatar"
                             className={
-                                gradientId === avatarGradient
+                                !avatarGradient
                                     ? `${classes.swatchButton} ${classes.swatchSelected}`
                                     : classes.swatchButton
                             }
                             onClick={() =>
                                 updateUserMutation.mutate({
-                                    avatarGradient: gradientId,
+                                    avatarGradient: null,
                                 })
                             }
                         >
-                            <LightdashUserAvatar
-                                size="sm"
-                                userUuid={userUuid}
-                                avatarGradient={gradientId}
-                            >
+                            <LightdashUserAvatar size="sm">
                                 {initials}
                             </LightdashUserAvatar>
                         </button>
                     </Tooltip>
-                ))}
-            </Group>
+                    {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
+                        <Tooltip key={gradientId} label={gradientId}>
+                            <button
+                                type="button"
+                                aria-label={`Use ${gradientId} avatar color`}
+                                className={
+                                    gradientId === avatarGradient
+                                        ? `${classes.swatchButton} ${classes.swatchSelected}`
+                                        : classes.swatchButton
+                                }
+                                onClick={() =>
+                                    updateUserMutation.mutate({
+                                        avatarGradient: gradientId,
+                                    })
+                                }
+                            >
+                                <LightdashUserAvatar
+                                    size="sm"
+                                    userUuid={userUuid}
+                                    avatarGradient={gradientId}
+                                >
+                                    {initials}
+                                </LightdashUserAvatar>
+                            </button>
+                        </Tooltip>
+                    ))}
+                </Group>
+            )}
         </Group>
     );
 };

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -61,7 +61,7 @@ const AvatarSettings: FC = () => {
                     </Button>
                 )}
             </FileButton>
-            <Divider orientation="vertical" my={0} h={24} />
+            <Divider orientation="vertical" my="auto" h={20} />
             {avatarUrl && (
                 <Button
                     variant="subtle"

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,5 +1,13 @@
 import { USER_AVATAR_GRADIENT_IDS } from '@lightdash/common';
-import { Button, Divider, FileButton, Group, Tooltip } from '@mantine-8/core';
+import {
+    Button,
+    Divider,
+    FileButton,
+    Group,
+    Popover,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
 import { type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
@@ -74,54 +82,78 @@ const AvatarSettings: FC = () => {
                 </Button>
             )}
             {!avatarUrl && (
-                <Group gap="xs" wrap="nowrap" align="center">
-                    <Tooltip label="No color (default)">
-                        <button
-                            type="button"
-                            aria-label="Use default avatar"
-                            className={
-                                !avatarGradient
-                                    ? `${classes.swatchButton} ${classes.swatchSelected}`
-                                    : classes.swatchButton
-                            }
-                            onClick={() =>
-                                updateUserMutation.mutate({
-                                    avatarGradient: null,
-                                })
-                            }
-                        >
-                            <LightdashUserAvatar size="sm">
-                                {initials}
-                            </LightdashUserAvatar>
-                        </button>
-                    </Tooltip>
-                    {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
-                        <Tooltip key={gradientId} label={gradientId}>
+                <Popover width={200} position="bottom-start" withArrow>
+                    <Popover.Target>
+                        <Tooltip label="Choose color">
                             <button
                                 type="button"
-                                aria-label={`Use ${gradientId} avatar color`}
-                                className={
-                                    gradientId === avatarGradient
-                                        ? `${classes.swatchButton} ${classes.swatchSelected}`
-                                        : classes.swatchButton
-                                }
-                                onClick={() =>
-                                    updateUserMutation.mutate({
-                                        avatarGradient: gradientId,
-                                    })
-                                }
+                                aria-label="Choose avatar color"
+                                className={classes.swatchButton}
                             >
                                 <LightdashUserAvatar
                                     size="sm"
                                     userUuid={userUuid}
-                                    avatarGradient={gradientId}
+                                    avatarGradient={avatarGradient}
                                 >
                                     {initials}
                                 </LightdashUserAvatar>
                             </button>
                         </Tooltip>
-                    ))}
-                </Group>
+                    </Popover.Target>
+                    <Popover.Dropdown>
+                        <Text size="xs" c="dimmed" fw={500} mb="xs">
+                            Avatar color
+                        </Text>
+                        <Group gap="xs" wrap="wrap">
+                            <Tooltip label="No color (default)">
+                                <button
+                                    type="button"
+                                    aria-label="Use default avatar"
+                                    className={
+                                        !avatarGradient
+                                            ? `${classes.swatchButton} ${classes.swatchSelected}`
+                                            : classes.swatchButton
+                                    }
+                                    onClick={() =>
+                                        updateUserMutation.mutate({
+                                            avatarGradient: null,
+                                        })
+                                    }
+                                >
+                                    <LightdashUserAvatar size="sm">
+                                        {initials}
+                                    </LightdashUserAvatar>
+                                </button>
+                            </Tooltip>
+                            {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
+                                <Tooltip key={gradientId} label={gradientId}>
+                                    <button
+                                        type="button"
+                                        aria-label={`Use ${gradientId} avatar color`}
+                                        className={
+                                            gradientId === avatarGradient
+                                                ? `${classes.swatchButton} ${classes.swatchSelected}`
+                                                : classes.swatchButton
+                                        }
+                                        onClick={() =>
+                                            updateUserMutation.mutate({
+                                                avatarGradient: gradientId,
+                                            })
+                                        }
+                                    >
+                                        <LightdashUserAvatar
+                                            size="sm"
+                                            userUuid={userUuid}
+                                            avatarGradient={gradientId}
+                                        >
+                                            {initials}
+                                        </LightdashUserAvatar>
+                                    </button>
+                                </Tooltip>
+                            ))}
+                        </Group>
+                    </Popover.Dropdown>
+                </Popover>
             )}
         </Group>
     );

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,0 +1,136 @@
+import {
+    getUserAvatarGradient,
+    USER_AVATAR_GRADIENT_IDS,
+} from '@lightdash/common';
+import {
+    Button,
+    FileButton,
+    Group,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { type FC } from 'react';
+import useToaster from '../../../hooks/toaster/useToaster';
+import {
+    useAvatarDeleteMutation,
+    useAvatarUploadMutation,
+} from '../../../hooks/user/useAvatarMutations';
+import { useUserUpdateMutation } from '../../../hooks/user/useUserUpdateMutation';
+import useApp from '../../../providers/App/useApp';
+import { LightdashUserAvatar } from '../../Avatar';
+import classes from './AvatarSettings.module.css';
+
+const AvatarSettings: FC = () => {
+    const { user } = useApp();
+    const { showToastError } = useToaster();
+    const uploadMutation = useAvatarUploadMutation();
+    const deleteMutation = useAvatarDeleteMutation();
+    const updateUserMutation = useUserUpdateMutation();
+
+    if (!user.data) return null;
+
+    const { userUuid, firstName, lastName, avatarUrl, avatarGradient } =
+        user.data;
+    const initials = `${firstName[0] ?? ''}${lastName[0] ?? ''}`.trim();
+    const activeGradient = getUserAvatarGradient(userUuid, avatarGradient);
+    const defaultGradient = getUserAvatarGradient(userUuid, null);
+
+    const handleFile = (file: File | null) => {
+        if (!file) return;
+        uploadMutation.mutate(file, {
+            onError: (error) => {
+                showToastError({
+                    title: 'Failed to upload avatar',
+                    subtitle: error?.error?.message ?? undefined,
+                });
+            },
+        });
+    };
+
+    return (
+        <Group align="center" gap="lg">
+            <LightdashUserAvatar
+                size={64}
+                userUuid={userUuid}
+                avatarUrl={avatarUrl}
+                avatarGradient={avatarGradient}
+            >
+                {initials}
+            </LightdashUserAvatar>
+            <Stack gap="xs">
+                <Group gap="sm">
+                    <FileButton
+                        onChange={handleFile}
+                        accept="image/png,image/jpeg,image/webp"
+                    >
+                        {(fileProps) => (
+                            <Button
+                                variant="default"
+                                size="xs"
+                                loading={uploadMutation.isLoading}
+                                {...fileProps}
+                            >
+                                Upload photo
+                            </Button>
+                        )}
+                    </FileButton>
+                    {avatarUrl && (
+                        <Button
+                            variant="subtle"
+                            color="red"
+                            size="xs"
+                            loading={deleteMutation.isLoading}
+                            onClick={() => deleteMutation.mutate()}
+                        >
+                            Remove photo
+                        </Button>
+                    )}
+                </Group>
+                <Text size="xs" c="dimmed">
+                    Or pick a color — it shows when you have no photo.
+                </Text>
+                <Group gap="xs">
+                    {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
+                        <Tooltip
+                            key={gradientId}
+                            label={
+                                gradientId === defaultGradient
+                                    ? `${gradientId} (default)`
+                                    : gradientId
+                            }
+                        >
+                            <button
+                                type="button"
+                                aria-label={`Use ${gradientId} avatar color`}
+                                className={
+                                    gradientId === activeGradient
+                                        ? `${classes.swatchButton} ${classes.swatchSelected}`
+                                        : classes.swatchButton
+                                }
+                                onClick={() =>
+                                    updateUserMutation.mutate({
+                                        avatarGradient:
+                                            gradientId === defaultGradient
+                                                ? null
+                                                : gradientId,
+                                    })
+                                }
+                            >
+                                <LightdashUserAvatar
+                                    size="md"
+                                    userUuid={userUuid}
+                                    avatarGradient={gradientId}
+                                >
+                                    {initials}
+                                </LightdashUserAvatar>
+                            </button>
+                        </Tooltip>
+                    ))}
+                </Group>
+            </Stack>
+        </Group>
+    );
+};
+
+export default AvatarSettings;

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -73,7 +73,7 @@ const AvatarSettings: FC = () => {
                     Remove photo
                 </Button>
             )}
-            <Group gap="xs" wrap="nowrap">
+            <Group gap="xs" wrap="nowrap" align="center">
                 <Tooltip label="No color (default)">
                     <button
                         type="button"

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,12 +1,5 @@
 import { USER_AVATAR_GRADIENT_IDS } from '@lightdash/common';
-import {
-    Button,
-    FileButton,
-    Group,
-    Stack,
-    Text,
-    Tooltip,
-} from '@mantine-8/core';
+import { Button, FileButton, Group, Tooltip } from '@mantine-8/core';
 import { type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
@@ -44,7 +37,7 @@ const AvatarSettings: FC = () => {
     };
 
     return (
-        <Group align="center" gap="lg">
+        <Group align="center" gap="md" wrap="nowrap">
             <LightdashUserAvatar
                 size={64}
                 userUuid={userUuid}
@@ -53,87 +46,80 @@ const AvatarSettings: FC = () => {
             >
                 {initials}
             </LightdashUserAvatar>
-            <Stack gap="xs">
-                <Group gap="sm">
-                    <FileButton
-                        onChange={handleFile}
-                        accept="image/png,image/jpeg,image/webp"
+            <FileButton
+                onChange={handleFile}
+                accept="image/png,image/jpeg,image/webp"
+            >
+                {(fileProps) => (
+                    <Button
+                        variant="default"
+                        size="xs"
+                        loading={uploadMutation.isLoading}
+                        {...fileProps}
                     >
-                        {(fileProps) => (
-                            <Button
-                                variant="default"
-                                size="xs"
-                                loading={uploadMutation.isLoading}
-                                {...fileProps}
-                            >
-                                Upload photo
-                            </Button>
-                        )}
-                    </FileButton>
-                    {avatarUrl && (
-                        <Button
-                            variant="subtle"
-                            color="red"
-                            size="xs"
-                            loading={deleteMutation.isLoading}
-                            onClick={() => deleteMutation.mutate()}
-                        >
-                            Remove photo
-                        </Button>
-                    )}
-                </Group>
-                <Text size="xs" c="dimmed">
-                    Or pick a color — it shows when you have no photo.
-                </Text>
-                <Group gap="xs">
-                    <Tooltip label="No color (default)">
+                        Upload photo
+                    </Button>
+                )}
+            </FileButton>
+            {avatarUrl && (
+                <Button
+                    variant="subtle"
+                    color="red"
+                    size="xs"
+                    loading={deleteMutation.isLoading}
+                    onClick={() => deleteMutation.mutate()}
+                >
+                    Remove photo
+                </Button>
+            )}
+            <Group gap="xs" wrap="nowrap">
+                <Tooltip label="No color (default)">
+                    <button
+                        type="button"
+                        aria-label="Use default avatar"
+                        className={
+                            !avatarGradient
+                                ? `${classes.swatchButton} ${classes.swatchSelected}`
+                                : classes.swatchButton
+                        }
+                        onClick={() =>
+                            updateUserMutation.mutate({
+                                avatarGradient: null,
+                            })
+                        }
+                    >
+                        <LightdashUserAvatar size="sm">
+                            {initials}
+                        </LightdashUserAvatar>
+                    </button>
+                </Tooltip>
+                {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
+                    <Tooltip key={gradientId} label={gradientId}>
                         <button
                             type="button"
-                            aria-label="Use default avatar"
+                            aria-label={`Use ${gradientId} avatar color`}
                             className={
-                                !avatarGradient
+                                gradientId === avatarGradient
                                     ? `${classes.swatchButton} ${classes.swatchSelected}`
                                     : classes.swatchButton
                             }
                             onClick={() =>
                                 updateUserMutation.mutate({
-                                    avatarGradient: null,
+                                    avatarGradient: gradientId,
                                 })
                             }
                         >
-                            <LightdashUserAvatar size="sm">
+                            <LightdashUserAvatar
+                                size="sm"
+                                userUuid={userUuid}
+                                avatarGradient={gradientId}
+                            >
                                 {initials}
                             </LightdashUserAvatar>
                         </button>
                     </Tooltip>
-                    {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
-                        <Tooltip key={gradientId} label={gradientId}>
-                            <button
-                                type="button"
-                                aria-label={`Use ${gradientId} avatar color`}
-                                className={
-                                    gradientId === avatarGradient
-                                        ? `${classes.swatchButton} ${classes.swatchSelected}`
-                                        : classes.swatchButton
-                                }
-                                onClick={() =>
-                                    updateUserMutation.mutate({
-                                        avatarGradient: gradientId,
-                                    })
-                                }
-                            >
-                                <LightdashUserAvatar
-                                    size="sm"
-                                    userUuid={userUuid}
-                                    avatarGradient={gradientId}
-                                >
-                                    {initials}
-                                </LightdashUserAvatar>
-                            </button>
-                        </Tooltip>
-                    ))}
-                </Group>
-            </Stack>
+                ))}
+            </Group>
         </Group>
     );
 };

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -28,6 +28,7 @@ import { VerifyEmailModal } from '../../../pages/VerifyEmail';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import TimeZonePicker from '../../common/TimeZonePicker';
+import AvatarSettings from './AvatarSettings';
 
 const validationSchema = z.object({
     firstName: z.string().nonempty(),
@@ -128,6 +129,8 @@ const ProfilePanel: FC = () => {
     return (
         <form onSubmit={handleOnSubmit}>
             <Stack mt="md">
+                <AvatarSettings />
+
                 <TextInput
                     placeholder="First name"
                     label="First name"

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -371,6 +371,9 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                             size="sm"
                             radius="xl"
                             color="blue"
+                            userUuid={user.userUuid}
+                            avatarUrl={user.avatarUrl}
+                            avatarGradient={user.avatarGradient}
                         />
                         <Stack gap={2}>
                             {user.firstName || user.lastName ? (

--- a/packages/frontend/src/components/common/UserSelect/index.tsx
+++ b/packages/frontend/src/components/common/UserSelect/index.tsx
@@ -91,6 +91,8 @@ export const UserSelect: FC<UserSelectProps> = ({
                         user.email,
                     ),
                     email: user.email,
+                    avatarUrl: user.avatarUrl,
+                    avatarGradient: user.avatarGradient,
                 },
             ]),
         );
@@ -159,7 +161,13 @@ export const UserSelect: FC<UserSelectProps> = ({
 
                 return (
                     <Group gap="sm" wrap="nowrap">
-                        <LightdashUserAvatar name={userData.name} size="sm" />
+                        <LightdashUserAvatar
+                            name={userData.name}
+                            size="sm"
+                            userUuid={option.value}
+                            avatarUrl={userData.avatarUrl}
+                            avatarGradient={userData.avatarGradient}
+                        />
                         <Stack gap={2}>
                             <Text size="sm" fw={500}>
                                 {userData.name}

--- a/packages/frontend/src/ee/components/UserAccessMultiSelect.tsx
+++ b/packages/frontend/src/ee/components/UserAccessMultiSelect.tsx
@@ -167,6 +167,7 @@ export const UserAccessMultiSelect: FC<UserAccessMultiSelectProps> = ({
                         name={user.label}
                         size="sm"
                         radius="xl"
+                        userUuid={user.userUuid}
                     />
                     <Stack gap="two">
                         <Group gap="xs">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
@@ -93,9 +93,7 @@ export const ReviewAssigneeMenu: FC<Props> = ({
                                         radius="xl"
                                         userUuid={assignee.userUuid}
                                         avatarUrl={assignee.avatarUrl}
-                                        avatarGradient={
-                                            assignee.avatarGradient
-                                        }
+                                        avatarGradient={assignee.avatarGradient}
                                     />
                                 ) : (
                                     <LightdashUserAvatar

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
@@ -91,6 +91,11 @@ export const ReviewAssigneeMenu: FC<Props> = ({
                                         name={assigneeName ?? undefined}
                                         size={withName ? 18 : 'sm'}
                                         radius="xl"
+                                        userUuid={assignee.userUuid}
+                                        avatarUrl={assignee.avatarUrl}
+                                        avatarGradient={
+                                            assignee.avatarGradient
+                                        }
                                     />
                                 ) : (
                                     <LightdashUserAvatar
@@ -157,6 +162,11 @@ export const ReviewAssigneeMenu: FC<Props> = ({
                                                 name={name}
                                                 size="xs"
                                                 radius="xl"
+                                                userUuid={member.userUuid}
+                                                avatarUrl={member.avatarUrl}
+                                                avatarGradient={
+                                                    member.avatarGradient
+                                                }
                                             />
                                         }
                                         onClick={(e) => {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnOwner.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnOwner.tsx
@@ -30,7 +30,11 @@ export const MetricsCatalogColumnOwner: FC<Props> = ({ row }) => {
         <Tooltip label={owner.email} openDelay={300}>
             <Paper px="xs" w="fit-content" style={{ cursor: 'default' }}>
                 <Group gap="two" wrap="nowrap" maw="200px">
-                    <LightdashUserAvatar size={16} name={displayName} />
+                    <LightdashUserAvatar
+                        size={16}
+                        name={displayName}
+                        userUuid={owner.userUuid}
+                    />
                     <Text fz="sm" fw={600} c="ldGray.9" truncate>
                         {displayName}
                     </Text>

--- a/packages/frontend/src/hooks/user/downscaleAvatarImage.ts
+++ b/packages/frontend/src/hooks/user/downscaleAvatarImage.ts
@@ -1,0 +1,46 @@
+// Center-crop to square + downscale in-browser so uploads are ~50KB, not raw photos.
+export const downscaleAvatarImage = (
+    file: File,
+    maxSize: number = 512,
+): Promise<Blob> =>
+    new Promise((resolve, reject) => {
+        const img = new Image();
+        const objectUrl = URL.createObjectURL(file);
+        img.onload = () => {
+            URL.revokeObjectURL(objectUrl);
+            const side = Math.min(img.width, img.height);
+            const target = Math.min(maxSize, side);
+            const canvas = document.createElement('canvas');
+            canvas.width = target;
+            canvas.height = target;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) {
+                reject(new Error('Could not process image in this browser'));
+                return;
+            }
+            ctx.drawImage(
+                img,
+                (img.width - side) / 2,
+                (img.height - side) / 2,
+                side,
+                side,
+                0,
+                0,
+                target,
+                target,
+            );
+            canvas.toBlob(
+                (blob) =>
+                    blob
+                        ? resolve(blob)
+                        : reject(new Error('Could not encode image')),
+                'image/webp',
+                0.9,
+            );
+        };
+        img.onerror = () => {
+            URL.revokeObjectURL(objectUrl);
+            reject(new Error('File is not a valid image'));
+        };
+        img.src = objectUrl;
+    });

--- a/packages/frontend/src/hooks/user/useAvatarMutations.ts
+++ b/packages/frontend/src/hooks/user/useAvatarMutations.ts
@@ -1,0 +1,57 @@
+import { type ApiError, type ApiUserAvatarResponse } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+import { downscaleAvatarImage } from './downscaleAvatarImage';
+
+const uploadAvatar = async (
+    file: File,
+): Promise<ApiUserAvatarResponse['results']> => {
+    const blob = await downscaleAvatarImage(file);
+    const response = await fetch('/api/v1/user/me/avatar', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': blob.type },
+        body: blob,
+    });
+    let json: unknown;
+    try {
+        json = await response.json();
+    } catch (e) {
+        throw new Error('Unexpected response uploading avatar');
+    }
+    if (!response.ok) {
+        throw json;
+    }
+    return (json as ApiUserAvatarResponse).results;
+};
+
+export const useAvatarUploadMutation = () => {
+    const queryClient = useQueryClient();
+    return useMutation<ApiUserAvatarResponse['results'], ApiError, File>({
+        mutationKey: ['user_avatar_upload'],
+        mutationFn: uploadAvatar,
+        onSuccess: async () => {
+            await queryClient.refetchQueries(['user']);
+            await queryClient.invalidateQueries(['organization_users']);
+        },
+    });
+};
+
+const deleteAvatar = async () =>
+    lightdashApi<undefined>({
+        url: '/user/me/avatar',
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useAvatarDeleteMutation = () => {
+    const queryClient = useQueryClient();
+    return useMutation<undefined, ApiError>({
+        mutationKey: ['user_avatar_delete'],
+        mutationFn: deleteAvatar,
+        onSuccess: async () => {
+            await queryClient.refetchQueries(['user']);
+            await queryClient.invalidateQueries(['organization_users']);
+        },
+    });
+};


### PR DESCRIPTION
## Summary
Profile settings avatar section + call-site sweep (stack 4, on #25055).

- **Settings → Profile**: 64px avatar preview as the click target (hover reveals a pencil icon), photo upload (client-side canvas center-crop + downscale to ~50KB before PUT; server re-validates regardless), remove photo.
- **Color popover**: preview-then-Apply picker for the 5 curated "paint-splatter" mesh gradients (lilac, blush, amethyst, sunrise, slate) plus a no-color default. Nothing saves until Apply.
- Upload/delete mutations refetch `['user']` and invalidate `['organization_users']`.
- Sweep: share-space modal, user selects, metrics-catalog owner, AI review assignee menu now pass user identity — photos where the payload has them, brand gradients everywhere else. AI *agent* avatars intentionally untouched.

Follow-ups stacked on top: #25083 (custom color picker, gradient/solid modes), #25084 (comments + space access lists + navbar ring).

## Regression analysis
Every human initials-avatar changes appearance on day one where users pick a gradient — that's the feature. Users with no photo and no explicit gradient keep the legacy plain avatar. No new fetches added anywhere.

## Screenshots
See Graphite stack page — settings section + uploaded state verified live (upload → preview + navbar update instantly; immutable-cached GETs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qtyCMqL6tkoDoZ46bn4Q2