### PR TITLE
fix(ai-agents): skip eval context-relevancy judge when context is empty

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -12608,12 +12608,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
      * TODO: Consider adding explores information for extra context relevancy assessment
      * @param resultUuid
      * @param canAccessData - Indicates whether the agent can access data (data access is enabled) which means the assessment will be including the data in the context.
-     * @returns boolean - Indicates whether the result is correct or not.
+     * @returns boolean - Indicates whether the result is correct, or null when there wasn't enough information to assess it.
      */
     async assessResult(
         resultUuid: string,
         canAccessData: boolean,
-    ): Promise<boolean> {
+    ): Promise<boolean | null> {
         Logger.info(`Assessing result ${resultUuid}`);
         const { query, response, expectedAnswer, artifact, toolResults } =
             await this.aiAgentModel.getEvalResultDataForAssessment(resultUuid);
@@ -12668,7 +12668,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             : null;
 
         const contextRelevancyScore =
-            artifact || toolResults.length > 0
+            contextParts.length > 0
                 ? await llmAsAJudge({
                       query,
                       response,
@@ -12701,9 +12701,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             passed = passed && contextRelevancyScore.meta.passed;
         }
 
+        // No scorers ran (no expected answer and no context) — leave the result unassessed (N/A) instead of failing it
         if (reasoning.length === 0) {
-            reasoning.push('Not enough information to assess this result');
-            passed = false;
+            Logger.info(
+                `Skipping assessment for result ${resultUuid}: not enough information to assess`,
+            );
+            return null;
         }
 
         await this.aiAgentModel.createLlmAssessment({


### PR DESCRIPTION
## Problem

Eval results were marked **Failed** even when the agent's answer was correct, whenever the context-relevancy judge received an empty context.

`assessResult` grades each eval result with up to two LLM judges AND-ed together (factuality + context relevancy). The context fed to the relevancy judge is built only from artifact configs and `runQuery` tool results — the latter dropped entirely when the agent has data access disabled. The factuality call guards against an empty context, but the context-relevancy call ran whenever *any* tool call or artifact existed and passed the empty array straight through, rendering a blank `[Context]:` block in the judge prompt. The judge scores that ~0 (threshold 0.7) and fails the whole eval, regardless of answer quality. Reported by a customer with examples of correct plain-text answers marked Failed "because the context section is empty".

## Fix

- The context-relevancy scorer now only runs when there is actual context to evaluate (`contextParts.length > 0`), mirroring the factuality guard.
- When no scorers ran at all (no expected response and no context), the result is left **unassessed** — no `llm_assessment` row is created, so the UI shows **N/A** instead of a hard **Failed** with "Not enough information to assess this result". `assessResult` returns `null` in that case (return value is not consumed by the eval runner).

## Who is affected

- Agents with data access disabled, or prompts answered in plain text without a chart artifact, or answers where the correct result is an absence ("that id doesn't exist") — these previously auto-failed and now grade on factuality alone (or show N/A when there's also no expected response).
- Evals that previously passed are unaffected: passing required every scorer that ran to pass, and this change only removes a scorer invocation that could not receive meaningful input.

## Out of scope (follow-ups tracked on the issue)

- Widening context to non-`runQuery` tool results
- Per-scorer verdicts in the UI
- Relevancy grading for legitimately-empty query results (PROD-8372's remaining slice)

Closes: PROD-8653
Closes: #25058
Relates: PROD-8372