### PR TITLE
feat(analytics): add system_explores_enabled project setting (PROD-8608)

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -28,6 +28,7 @@ import path from 'path';
 import qs from 'qs';
 import reDoc from 'redoc-express';
 import { URL } from 'url';
+import { registerAiUsageTracker } from './analytics/aiUsage';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
@@ -220,6 +221,7 @@ export default class App {
                   )
                 : undefined,
         });
+        registerAiUsageTracker((event) => this.analytics.track(event));
         this.database = knex(
             this.environment === 'production'
                 ? args.knexConfig.production

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
+import { registerAiUsageTracker } from './analytics/aiUsage';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
@@ -131,6 +132,7 @@ export default class NatsWorkerApp {
                   )
                 : undefined,
         });
+        registerAiUsageTracker((event) => this.analytics.track(event));
 
         this.database = knex(
             this.environment === 'production'

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
+import { registerAiUsageTracker } from './analytics/aiUsage';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
@@ -167,6 +168,7 @@ export default class SchedulerApp {
                   )
                 : undefined,
         });
+        registerAiUsageTracker((event) => this.analytics.track(event));
 
         this.database = knex(
             this.environment === 'production'

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -44,6 +44,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
 import { type ExternalConnectionEvent } from '../ee/analytics';
 import { VERSION } from '../version';
+import type { AiUsageEvent } from './aiUsage';
 import type { EventStreamSink } from './eventStream/EventStreamSink';
 
 type Identify = {
@@ -2534,7 +2535,8 @@ type TypedEvent =
     | AiRouterMessageRoutedEvent
     | ContentVerificationEvent
     | SchedulerOwnershipReassignedEvent
-    | ImpersonationEvent;
+    | ImpersonationEvent
+    | AiUsageEvent;
 
 type UntypedEvent<T extends BaseTrack> = Omit<BaseTrack, 'event'> &
     T & {

--- a/packages/backend/src/analytics/aiUsage.test.ts
+++ b/packages/backend/src/analytics/aiUsage.test.ts
@@ -1,0 +1,177 @@
+import Logger from '../logging/logger';
+import {
+    AiUsageEvent,
+    embeddingModelUsageToTokens,
+    emitAiUsage,
+    languageModelUsageToTokens,
+    registerAiUsageTracker,
+} from './aiUsage';
+
+vi.mock('../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+describe('languageModelUsageToTokens', () => {
+    it('maps AI SDK usage to token classes', () => {
+        expect(
+            languageModelUsageToTokens({
+                inputTokens: 1000,
+                inputTokenDetails: {
+                    noCacheTokens: 150,
+                    cacheReadTokens: 800,
+                    cacheWriteTokens: 50,
+                },
+                outputTokens: 200,
+                outputTokenDetails: {
+                    textTokens: 170,
+                    reasoningTokens: 30,
+                },
+                totalTokens: 1200,
+            }),
+        ).toEqual({
+            inputTokens: 1000,
+            outputTokens: 200,
+            cacheReadTokens: 800,
+            cacheWriteTokens: 50,
+            reasoningTokens: 30,
+            totalTokens: 1200,
+        });
+    });
+
+    it('maps unreported token classes to null', () => {
+        expect(
+            languageModelUsageToTokens({
+                inputTokens: undefined,
+                inputTokenDetails: {
+                    noCacheTokens: undefined,
+                    cacheReadTokens: undefined,
+                    cacheWriteTokens: undefined,
+                },
+                outputTokens: undefined,
+                outputTokenDetails: {
+                    textTokens: undefined,
+                    reasoningTokens: undefined,
+                },
+                totalTokens: undefined,
+            }),
+        ).toEqual({
+            inputTokens: null,
+            outputTokens: null,
+            cacheReadTokens: null,
+            cacheWriteTokens: null,
+            reasoningTokens: null,
+            totalTokens: null,
+        });
+    });
+});
+
+describe('embeddingModelUsageToTokens', () => {
+    it('maps embedding tokens to input and total', () => {
+        expect(embeddingModelUsageToTokens({ tokens: 42 })).toEqual({
+            inputTokens: 42,
+            outputTokens: null,
+            cacheReadTokens: null,
+            cacheWriteTokens: null,
+            reasoningTokens: null,
+            totalTokens: 42,
+        });
+    });
+});
+
+describe('emitAiUsage', () => {
+    const tokens = {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheReadTokens: 800,
+        cacheWriteTokens: 50,
+        reasoningTokens: 30,
+        totalTokens: 1200,
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        registerAiUsageTracker(() => {});
+    });
+
+    it('emits a structured log line and a tracked event', () => {
+        const track = vi.fn<(event: AiUsageEvent) => void>();
+        registerAiUsageTracker(track);
+
+        emitAiUsage(
+            {
+                functionId: 'generateAgentResponse',
+                metadata: {
+                    feature: 'agent',
+                    organizationUuid: 'org-1',
+                    projectUuid: 'project-1',
+                    agentUuid: 'agent-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    userUuid: 'user-1',
+                    model: 'claude-sonnet-5',
+                    provider: 'anthropic',
+                },
+            },
+            tokens,
+        );
+
+        const expectedProperties = {
+            feature: 'agent',
+            functionId: 'generateAgentResponse',
+            organizationId: 'org-1',
+            projectId: 'project-1',
+            aiAgentId: 'agent-1',
+            threadId: 'thread-1',
+            promptId: 'prompt-1',
+            model: 'claude-sonnet-5',
+            provider: 'anthropic',
+            ...tokens,
+        };
+
+        expect(Logger.info).toHaveBeenCalledWith('AI usage', {
+            event: 'ai.usage',
+            userId: 'user-1',
+            ...expectedProperties,
+        });
+        expect(track).toHaveBeenCalledWith({
+            event: 'ai.usage',
+            userId: 'user-1',
+            properties: expectedProperties,
+        });
+    });
+
+    it('falls back to an anonymous id when no user is attributed', () => {
+        const track = vi.fn<(event: AiUsageEvent) => void>();
+        registerAiUsageTracker(track);
+
+        emitAiUsage(
+            {
+                functionId: 'routeProject',
+                metadata: {
+                    feature: 'project-router',
+                    organizationUuid: 'org-1',
+                },
+            },
+            tokens,
+        );
+
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({ anonymousId: 'anonymous' }),
+        );
+        expect(track.mock.calls[0][0].userId).toBeUndefined();
+    });
+
+    it('still logs when no tracker is registered', () => {
+        emitAiUsage(
+            { functionId: 'fn', metadata: { feature: 'llm-judge' } },
+            tokens,
+        );
+        expect(Logger.info).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/analytics/aiUsage.ts
+++ b/packages/backend/src/analytics/aiUsage.ts
@@ -1,0 +1,166 @@
+import { Track as AnalyticsTrack } from '@rudderstack/rudder-sdk-node';
+import type { EmbeddingModelUsage, LanguageModelUsage } from 'ai';
+import Logger from '../logging/logger';
+
+type BaseTrack = Omit<AnalyticsTrack, 'context'>;
+
+/**
+ * Coarse feature bucket for an AI call. Lets us attribute token usage and cost
+ * to a product surface (data apps vs the agent vs metadata generation, etc.)
+ * independently of the fine-grained `functionId`.
+ */
+export type AiCallFeature =
+    | 'agent'
+    | 'agent-subtask'
+    | 'chart-metadata'
+    | 'document-summary'
+    | 'thread-title'
+    | 'tooltip'
+    | 'artifact-question'
+    | 'agent-suggestions'
+    | 'table-calc'
+    | 'formula-table-calc'
+    | 'compaction'
+    | 'embedding'
+    | 'project-router'
+    | 'agent-selector'
+    | 'review-classifier'
+    | 'llm-judge'
+    | 'data-app'
+    | 'managed-agent';
+
+/**
+ * Token counts for a single AI call, normalized across providers and call
+ * kinds (LLM text/object generation, embeddings). Null means the provider
+ * did not report that class of tokens.
+ */
+export type AiUsageTokens = {
+    inputTokens: number | null;
+    outputTokens: number | null;
+    cacheReadTokens: number | null;
+    cacheWriteTokens: number | null;
+    reasoningTokens: number | null;
+    totalTokens: number | null;
+};
+
+// Defensive against the type: providers (and test mocks) don't always report
+// usage, and a missing field must never throw into the AI call path.
+export const languageModelUsageToTokens = (
+    usage: LanguageModelUsage,
+): AiUsageTokens => ({
+    inputTokens: usage?.inputTokens ?? null,
+    outputTokens: usage?.outputTokens ?? null,
+    cacheReadTokens: usage?.inputTokenDetails?.cacheReadTokens ?? null,
+    cacheWriteTokens: usage?.inputTokenDetails?.cacheWriteTokens ?? null,
+    reasoningTokens: usage?.outputTokenDetails?.reasoningTokens ?? null,
+    totalTokens: usage?.totalTokens ?? null,
+});
+
+export const embeddingModelUsageToTokens = (
+    usage: EmbeddingModelUsage,
+): AiUsageTokens => ({
+    inputTokens: usage.tokens,
+    outputTokens: null,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    reasoningTokens: null,
+    totalTokens: usage.tokens,
+});
+
+/**
+ * One event per AI model call, emitted 100% unsampled (unlike traces) so
+ * token usage can be accounted per org/user/feature. Consumed by the usage
+ * event stream sink (`ai_usage` stream) and Rudderstack.
+ */
+export type AiUsageEvent = BaseTrack & {
+    event: 'ai.usage';
+    properties: {
+        feature: AiCallFeature;
+        functionId: string;
+        organizationId: string | null;
+        projectId: string | null;
+        aiAgentId: string | null;
+        threadId: string | null;
+        promptId: string | null;
+        model: string | null;
+        provider: string | null;
+    } & AiUsageTokens;
+};
+
+type AiUsageTrackFn = (event: AiUsageEvent) => void;
+
+let aiUsageTrackFn: AiUsageTrackFn | null = null;
+
+/**
+ * Registered once per process at app construction (API, scheduler, NATS
+ * worker). Module-level because `ai.usage` is emitted from pure helper
+ * functions (AI generators) that have no access to the LightdashAnalytics
+ * instance — same pattern as the global Logger.
+ */
+export const registerAiUsageTracker = (fn: AiUsageTrackFn): void => {
+    aiUsageTrackFn = fn;
+};
+
+/**
+ * Structural subset of the `experimental_telemetry` config built by
+ * `getAiCallTelemetry`, which every AI call site already holds — its metadata
+ * carries the feature + attribution dimensions.
+ */
+type AiCallTelemetryConfig = {
+    functionId: string;
+    metadata: Record<string, string | number | boolean>;
+};
+
+const getMetadataString = (
+    metadata: AiCallTelemetryConfig['metadata'],
+    key: string,
+): string | null => {
+    const value = metadata[key];
+    return typeof value === 'string' ? value : null;
+};
+
+/**
+ * Emits token usage for a single AI call in two forms:
+ * 1. A structured log line (marker `event: 'ai.usage'`) so any log stack can
+ *    consume it. Level `info` on purpose — prod log thresholds must include
+ *    it or usage silently vanishes from log-based consumers.
+ * 2. An `ai.usage` analytics event through `track()`, which the usage event
+ *    stream sink projects into the `ai_usage` stream.
+ */
+export const emitAiUsage = (
+    telemetry: AiCallTelemetryConfig,
+    tokens: AiUsageTokens,
+): void => {
+    try {
+        const { metadata } = telemetry;
+        const userUuid = getMetadataString(metadata, 'userUuid');
+        const properties: AiUsageEvent['properties'] = {
+            feature: metadata.feature as AiCallFeature,
+            functionId: telemetry.functionId,
+            organizationId: getMetadataString(metadata, 'organizationUuid'),
+            projectId: getMetadataString(metadata, 'projectUuid'),
+            aiAgentId: getMetadataString(metadata, 'agentUuid'),
+            threadId: getMetadataString(metadata, 'threadUuid'),
+            promptId: getMetadataString(metadata, 'promptUuid'),
+            model: getMetadataString(metadata, 'model'),
+            provider: getMetadataString(metadata, 'provider'),
+            ...tokens,
+        };
+
+        Logger.info('AI usage', {
+            event: 'ai.usage',
+            userId: userUuid,
+            ...properties,
+        });
+
+        aiUsageTrackFn?.({
+            event: 'ai.usage',
+            ...(userUuid !== null
+                ? { userId: userUuid }
+                : { anonymousId: 'anonymous' }),
+            properties,
+        });
+    } catch (error) {
+        Logger.warn(`Failed to emit AI usage: ${error}`);
+    }
+};

--- a/packages/backend/src/analytics/eventStream/aiUsageStream.test.ts
+++ b/packages/backend/src/analytics/eventStream/aiUsageStream.test.ts
@@ -1,0 +1,126 @@
+import type { AiUsageEvent } from '../aiUsage';
+import { EventStreamSink } from './EventStreamSink';
+import { EVENT_STREAM_SCHEMA_VERSION } from './projection';
+import { eventStreamRegistry } from './registry';
+import { EventStreamRow } from './types';
+
+vi.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const createWriterMock = () => ({
+    push: vi.fn<(stream: string, row: EventStreamRow) => void>(),
+    flush: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+});
+
+const aiUsageEvent: AiUsageEvent = {
+    event: 'ai.usage',
+    userId: 'user-1',
+    properties: {
+        feature: 'agent',
+        functionId: 'generateAgentResponse',
+        organizationId: 'org-1',
+        projectId: 'project-1',
+        aiAgentId: 'agent-1',
+        threadId: 'thread-1',
+        promptId: 'prompt-1',
+        model: 'claude-sonnet-5',
+        provider: 'anthropic',
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheReadTokens: 800,
+        cacheWriteTokens: 50,
+        reasoningTokens: 30,
+        totalTokens: 1200,
+    },
+};
+
+describe('ai_usage stream projection', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('projects an ai.usage event', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle(aiUsageEvent);
+        expect(writer.push).toHaveBeenCalledTimes(1);
+        const [stream, row] = writer.push.mock.calls[0];
+        expect(stream).toBe('ai_usage');
+        expect(row).toMatchObject({
+            event_name: 'ai.usage',
+            org_id: 'org-1',
+            user_id: 'user-1',
+            schema_version: EVENT_STREAM_SCHEMA_VERSION,
+            project_id: 'project-1',
+            feature: 'agent',
+            function_id: 'generateAgentResponse',
+            agent_id: 'agent-1',
+            thread_id: 'thread-1',
+            prompt_id: 'prompt-1',
+            model: 'claude-sonnet-5',
+            provider: 'anthropic',
+            input_tokens: 1000,
+            output_tokens: 200,
+            cache_read_tokens: 800,
+            cache_write_tokens: 50,
+            reasoning_tokens: 30,
+            total_tokens: 1200,
+        });
+        expect(new Date(row.event_ts).toISOString()).toBe(row.event_ts);
+    });
+
+    it('projects null dimensions and token classes as null columns', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle({
+            ...aiUsageEvent,
+            properties: {
+                ...aiUsageEvent.properties,
+                projectId: null,
+                aiAgentId: null,
+                threadId: null,
+                promptId: null,
+                model: null,
+                provider: null,
+                cacheReadTokens: null,
+                cacheWriteTokens: null,
+                reasoningTokens: null,
+            },
+        });
+        expect(writer.push).toHaveBeenCalledTimes(1);
+        const [, row] = writer.push.mock.calls[0];
+        expect(row).toMatchObject({
+            event_name: 'ai.usage',
+            project_id: null,
+            agent_id: null,
+            thread_id: null,
+            prompt_id: null,
+            model: null,
+            provider: null,
+            cache_read_tokens: null,
+            cache_write_tokens: null,
+            reasoning_tokens: null,
+        });
+    });
+
+    it('drops events without an organization id', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle({
+            ...aiUsageEvent,
+            properties: {
+                ...aiUsageEvent.properties,
+                organizationId: null,
+            },
+        });
+        expect(writer.push).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/analytics/eventStream/aiUsageStream.ts
+++ b/packages/backend/src/analytics/eventStream/aiUsageStream.ts
@@ -1,0 +1,64 @@
+import type { AiUsageEvent } from '../aiUsage';
+import { buildEnvelope, ProjectionResult } from './projection';
+import type { CompactedStreamColumn } from './types';
+
+/**
+ * Typed column list for the compacted (parquet) zone of the `ai_usage`
+ * stream, v1. Envelope columns first, then one typed column per field of the
+ * ai.usage projection below — one row per AI model call.
+ */
+export const aiUsageCompactedColumns: CompactedStreamColumn[] = [
+    { name: 'event_name', type: 'VARCHAR' },
+    { name: 'org_id', type: 'VARCHAR' },
+    { name: 'user_id', type: 'VARCHAR' },
+    { name: 'event_ts', type: 'TIMESTAMP' },
+    { name: 'schema_version', type: 'INTEGER' },
+    { name: 'project_id', type: 'VARCHAR' },
+    { name: 'feature', type: 'VARCHAR' },
+    { name: 'function_id', type: 'VARCHAR' },
+    { name: 'agent_id', type: 'VARCHAR' },
+    { name: 'thread_id', type: 'VARCHAR' },
+    { name: 'prompt_id', type: 'VARCHAR' },
+    { name: 'model', type: 'VARCHAR' },
+    { name: 'provider', type: 'VARCHAR' },
+    { name: 'input_tokens', type: 'BIGINT' },
+    { name: 'output_tokens', type: 'BIGINT' },
+    { name: 'cache_read_tokens', type: 'BIGINT' },
+    { name: 'cache_write_tokens', type: 'BIGINT' },
+    { name: 'reasoning_tokens', type: 'BIGINT' },
+    { name: 'total_tokens', type: 'BIGINT' },
+];
+
+/**
+ * Projection for the `ai_usage` stream (v1): one row per AI model call,
+ * emitted via `emitAiUsage`. Returns null when the call can't be attributed
+ * to an organization.
+ */
+const projectAiUsageEvent = (payload: AiUsageEvent): ProjectionResult => {
+    const { properties } = payload;
+    if (!properties.organizationId) return null;
+    return {
+        stream: 'ai_usage',
+        row: {
+            ...buildEnvelope(payload, properties.organizationId),
+            project_id: properties.projectId,
+            feature: properties.feature,
+            function_id: properties.functionId,
+            agent_id: properties.aiAgentId,
+            thread_id: properties.threadId,
+            prompt_id: properties.promptId,
+            model: properties.model,
+            provider: properties.provider,
+            input_tokens: properties.inputTokens,
+            output_tokens: properties.outputTokens,
+            cache_read_tokens: properties.cacheReadTokens,
+            cache_write_tokens: properties.cacheWriteTokens,
+            reasoning_tokens: properties.reasoningTokens,
+            total_tokens: properties.totalTokens,
+        },
+    };
+};
+
+export const aiUsageProjections = {
+    'ai.usage': projectAiUsageEvent,
+};

--- a/packages/backend/src/analytics/eventStream/projection.ts
+++ b/packages/backend/src/analytics/eventStream/projection.ts
@@ -3,7 +3,7 @@ import { EventStreamRow } from './types';
 
 export const EVENT_STREAM_SCHEMA_VERSION = 1;
 
-export type StreamName = 'query_events';
+export type StreamName = 'query_events' | 'ai_usage';
 
 /**
  * Common envelope stamped on every row pushed into the usage event stream.

--- a/packages/backend/src/analytics/eventStream/registry.ts
+++ b/packages/backend/src/analytics/eventStream/registry.ts
@@ -1,4 +1,6 @@
+import type { AiUsageEvent } from '../aiUsage';
 import type { QueryCompletedEvent } from '../LightdashAnalytics';
+import { aiUsageCompactedColumns, aiUsageProjections } from './aiUsageStream';
 import type { ProjectionResult, StreamName } from './projection';
 import {
     queryEventsCompactedColumns,
@@ -11,7 +13,7 @@ import type { CompactedStreamColumn } from './types';
  * Adding a new stream/event = add the event type here and a projection entry
  * below; nothing else needs to change.
  */
-export type ProjectedEvent = QueryCompletedEvent;
+export type ProjectedEvent = QueryCompletedEvent | AiUsageEvent;
 
 export type EventStreamRegistry = {
     [E in ProjectedEvent as E['event']]: (payload: E) => ProjectionResult;
@@ -23,6 +25,7 @@ export type EventStreamRegistry = {
  */
 export const eventStreamRegistry: EventStreamRegistry = {
     ...queryEventsProjections,
+    ...aiUsageProjections,
 };
 
 /**
@@ -35,6 +38,7 @@ export const compactedStreamSchemas: Record<
     CompactedStreamColumn[]
 > = {
     query_events: queryEventsCompactedColumns,
+    ai_usage: aiUsageCompactedColumns,
 };
 
 export const getCompactedStreamColumns = (

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -39,6 +39,7 @@ import {
     UpdateDefaultUserSpaces,
     UpdateMetadata,
     UpdateProjectMember,
+    UpdateSystemExplores,
     UserWarehouseCredentials,
     type ApiCalculateSubtotalsResponse,
     type ApiCreateDashboardResponse,
@@ -710,6 +711,39 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         await this.services
             .getProjectService()
             .updateMetadata(toSessionUser(req.account), projectUuid, body);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Toggle system explores (Lightdash usage analytics) for a project.
+     * When enabled, usage analytics explores are injected on the next compile.
+     * @summary Update system explores setting
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('{projectUuid}/systemExplores')
+    @OperationId('updateSystemExplores')
+    async updateSystemExplores(
+        @Path() projectUuid: string,
+        @Body() body: UpdateSystemExplores,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.services
+            .getProjectService()
+            .updateSystemExplores(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+            );
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -35,6 +35,7 @@ export type DbProject = {
     scheduler_failure_contact_override: string | null;
     created_by_user_uuid: string | null;
     has_default_user_spaces: boolean;
+    system_explores_enabled: boolean;
     project_defaults: ProjectDefaults | null;
     color_palette_uuid: string | null;
     table_groups: Record<string, GroupType> | null;
@@ -77,6 +78,7 @@ type UpdateDbProject = Partial<
         | 'scheduler_failure_include_contact'
         | 'scheduler_failure_contact_override'
         | 'has_default_user_spaces'
+        | 'system_explores_enabled'
         | 'project_defaults'
         | 'color_palette_uuid'
         | 'table_groups'

--- a/packages/backend/src/database/migrations/20260702120243_add_system_explores_enabled_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260702120243_add_system_explores_enabled_to_projects.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+const ProjectTableName = 'projects';
+const ColumnName = 'system_explores_enabled';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ProjectTableName, (table) => {
+        table.boolean(ColumnName).defaultTo(false).notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ProjectTableName, (table) => {
+        table.dropColumn(ColumnName);
+    });
+}

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
@@ -14,6 +14,7 @@ vi.mock('./ai/models', () => ({ getModel: vi.fn() }));
 vi.mock('./ai/agents/agentV2', () => ({ defaultAgentOptions: {} }));
 vi.mock('./ai/utils/aiCallTelemetry', () => ({
     getAiCallTelemetry: () => ({}),
+    getLanguageModelAttribution: () => ({}),
 }));
 
 const generateObjectMock = vi.mocked(generateObject);

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -33,6 +33,10 @@ import {
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { createHash } from 'crypto';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../analytics/aiUsage';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { type CatalogModel } from '../../models/CatalogModel/CatalogModel';
@@ -45,7 +49,10 @@ import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassi
 import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
-import { getAiCallTelemetry } from './ai/utils/aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from './ai/utils/aiCallTelemetry';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
@@ -1545,20 +1552,22 @@ export class AiAgentReviewClassifierService extends BaseService {
                 evidencePacket.suggestedEvidenceExcerpts.length,
         });
 
+        const telemetry = getAiCallTelemetry({
+            functionId: 'aiAgentReviewClassifierJudge',
+            feature: 'review-classifier',
+            organizationUuid: candidate.subject.organizationUuid,
+            projectUuid: candidate.subject.projectUuid,
+            agentUuid: candidate.subject.agentUuid,
+            threadUuid: candidate.subject.threadUuid,
+            promptUuid: candidate.subject.assistantPromptUuid,
+            ...getLanguageModelAttribution(model.model),
+        });
         const result = await generateObject({
             model: model.model,
             ...defaultAgentOptions,
             ...model.callOptions,
             providerOptions: model.providerOptions,
-            experimental_telemetry: getAiCallTelemetry({
-                functionId: 'aiAgentReviewClassifierJudge',
-                feature: 'review-classifier',
-                organizationUuid: candidate.subject.organizationUuid,
-                projectUuid: candidate.subject.projectUuid,
-                agentUuid: candidate.subject.agentUuid,
-                threadUuid: candidate.subject.threadUuid,
-                promptUuid: candidate.subject.assistantPromptUuid,
-            }),
+            experimental_telemetry: telemetry,
             schema: aiAgentReviewClassifierJudgeOutputSchema,
             messages: [
                 {
@@ -1670,6 +1679,7 @@ Existing review items — dedup rules. The evidence packet field existingReviewI
                 },
             ],
         });
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
         return result.object as AiAgentReviewClassifierJudgeOutput;
     }

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -73,6 +73,10 @@ import { PassThrough, Readable } from 'node:stream';
 import { extract, pack as tarPack, type Headers } from 'tar-stream';
 import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../analytics/aiUsage';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
 import { resolveS3Credentials } from '../../../clients/Aws/S3BaseClient';
@@ -104,7 +108,10 @@ import { type ExternalConnectionModel } from '../../models/ExternalConnectionMod
 import type { SandboxRegistryModel } from '../../models/SandboxRegistryModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
-import { getAiCallTelemetry } from '../ai/utils/aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../ai/utils/aiCallTelemetry';
 import {
     createSandboxManager,
     S3SnapshotStore,
@@ -3333,6 +3340,33 @@ export class AppGenerateService extends BaseService {
                 )}, numTurns=${generationUsage.numTurns}, inputTokens=${generationUsage.inputTokens}, outputTokens=${generationUsage.outputTokens}, cacheReadTokens=${generationUsage.cacheReadInputTokens}, cacheCreationTokens=${generationUsage.cacheCreationInputTokens}, costUsd=${generationUsage.costUsd})`,
         );
 
+        // Aggregated across every `claude` CLI invocation in the pipeline;
+        // the CLI reports inputTokens excluding cache reads/writes.
+        emitAiUsage(
+            getAiCallTelemetry({
+                functionId: 'appClaudeGeneration',
+                feature: 'data-app',
+                organizationUuid: payload.organizationUuid,
+                projectUuid,
+                userUuid: payload.userUuid,
+                model: claudeModel,
+                provider: 'anthropic',
+                extra: { appUuid },
+            }),
+            {
+                inputTokens: generationUsage.inputTokens,
+                outputTokens: generationUsage.outputTokens,
+                cacheReadTokens: generationUsage.cacheReadInputTokens,
+                cacheWriteTokens: generationUsage.cacheCreationInputTokens,
+                reasoningTokens: null,
+                totalTokens:
+                    generationUsage.inputTokens +
+                    generationUsage.cacheReadInputTokens +
+                    generationUsage.cacheCreationInputTokens +
+                    generationUsage.outputTokens,
+            },
+        );
+
         this.analytics.track({
             event: 'data_app.version.completed',
             userId: payload.userUuid,
@@ -3693,19 +3727,21 @@ export class AppGenerateService extends BaseService {
         const CLARIFY_TIMEOUT_MS = 15_000;
 
         const start = performance.now();
+        const telemetry = getAiCallTelemetry({
+            functionId: 'clarifyApp',
+            feature: 'data-app',
+            organizationUuid,
+            projectUuid,
+            userUuid: user.userUuid,
+            ...getLanguageModelAttribution(modelOptions.model),
+        });
         let result;
         try {
             result = await generateObject({
                 model: modelOptions.model,
                 ...modelOptions.callOptions,
                 providerOptions: modelOptions.providerOptions,
-                experimental_telemetry: getAiCallTelemetry({
-                    functionId: 'clarifyApp',
-                    feature: 'data-app',
-                    organizationUuid,
-                    projectUuid,
-                    userUuid: user.userUuid,
-                }),
+                experimental_telemetry: telemetry,
                 schema: clarifySchema,
                 abortSignal: AbortSignal.timeout(CLARIFY_TIMEOUT_MS),
                 messages: [
@@ -3761,6 +3797,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             );
             return { questions: [] };
         }
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
         const elapsedMs = AppGenerateService.elapsed(start);
 
         const questions = result.object.questions

--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -1,7 +1,14 @@
 import { AiAgentWithContext } from '@lightdash/common';
 import { generateObject, LanguageModel } from 'ai';
 import { z } from 'zod';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 const AgentSelectionSchema = z.object({
     agentUuid: z
@@ -146,12 +153,14 @@ export async function selectAgent({
         buildAdminInstructionsSection(instructions),
     );
 
+    const telemetry = getAiCallTelemetry({
+        functionId: 'selectAgent',
+        feature: 'agent-selector',
+        ...getLanguageModelAttribution(model),
+    });
     const result = await generateObject({
         model,
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'selectAgent',
-            feature: 'agent-selector',
-        }),
+        experimental_telemetry: telemetry,
         schema: AgentSelectionSchema,
         messages: [
             { role: 'system', content: systemPrompt },
@@ -161,6 +170,7 @@ export async function selectAgent({
             },
         ],
     });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     const selection = result.object;
     const exists = candidates.some((c) => c.uuid === selection.agentUuid);

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -15,6 +15,10 @@ import {
     type Output,
     type ToolSet,
 } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import Logger from '../../../../logging/logger';
 import { getSystemPromptV2 } from '../prompts/systemV2';
 import { getAnalyzeFieldImpact } from '../tools/analyzeFieldImpact';
@@ -834,6 +838,10 @@ export const generateAgentResponse = async ({
             tools,
             logger,
         });
+        const telemetry = getAgentTelemetryConfig(
+            'generateAgentResponse',
+            args,
+        );
         const result = await generateText({
             ...defaultAgentOptions,
             ...args.callOptions,
@@ -961,11 +969,10 @@ export const generateAgentResponse = async ({
                     promptUuid: args.promptUuid,
                 });
             },
-            experimental_telemetry: getAgentTelemetryConfig(
-                'generateAgentResponse',
-                args,
-            ),
+            experimental_telemetry: telemetry,
         });
+
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.totalUsage));
 
         logger(
             'Generate Agent Response',
@@ -1094,6 +1101,7 @@ export const streamAgentResponse = async ({
             }
             return interrupted;
         };
+        const telemetry = getAgentTelemetryConfig('streamAgentResponse', args);
         const result = streamText({
             ...defaultAgentOptions,
             ...args.callOptions,
@@ -1303,7 +1311,14 @@ export const streamAgentResponse = async ({
                         });
                 }
             },
-            onFinish: async ({ usage, steps, reasoning, finishReason }) => {
+            onFinish: async ({
+                usage,
+                totalUsage,
+                steps,
+                reasoning,
+                finishReason,
+            }) => {
+                emitAiUsage(telemetry, languageModelUsageToTokens(totalUsage));
                 logger(
                     'On Finish',
                     `Stream finished. Updating prompt with response. finishReason: ${finishReason}, steps: ${steps.length}`,
@@ -1402,10 +1417,7 @@ export const streamAgentResponse = async ({
 
                 void cleanupMcpClients();
             },
-            experimental_telemetry: getAgentTelemetryConfig(
-                'streamAgentResponse',
-                args,
-            ),
+            experimental_telemetry: telemetry,
         });
 
         logger('Stream Agent Response', 'Returning stream result.');

--- a/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
@@ -1,6 +1,10 @@
 import { Field, Filters } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -63,16 +67,17 @@ export async function generateChartMetadata(
 ): Promise<GeneratedChartMetadata> {
     const fieldLabelMap = buildFieldLabelMap(context.fieldsContext);
 
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateChartMetadata',
+        'chart-metadata',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
         schema: ChartMetadataSchema,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateChartMetadata',
-            'chart-metadata',
-        ),
+        experimental_telemetry: telemetry,
         messages: [
             {
                 role: 'system',
@@ -102,5 +107,6 @@ ${
             },
         ],
     });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/agents/compactionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/compactionGenerator.ts
@@ -1,4 +1,8 @@
 import { generateText } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -12,15 +16,16 @@ export async function generateCompactionSummary(
         conversation: string;
     },
 ): Promise<string> {
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateCompactionSummary',
+        'compaction',
+    );
     const result = await generateText({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateCompactionSummary',
-            'compaction',
-        ),
+        experimental_telemetry: telemetry,
         messages: [
             {
                 role: 'system',
@@ -55,6 +60,8 @@ Requirements:
             },
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.totalUsage));
 
     return result.text.trim();
 }

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -9,6 +9,10 @@ import {
     type ModelMessage,
     type StreamTextResult,
 } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../../analytics/aiUsage';
 import Logger from '../../../../../logging/logger';
 import { getFindExplores } from '../../tools/findExplores';
 import { getFindFields } from '../../tools/findFields';
@@ -113,6 +117,11 @@ export const runDiscoverFieldsAgent = (
 
     const inflightWrites: Array<Promise<void>> = [];
 
+    const telemetry = getAgentTelemetryConfig(
+        'discoverFieldsSubagent',
+        args.telemetry,
+        'agent-subtask',
+    );
     const stream = streamText({
         model: args.model,
         ...args.callOptions,
@@ -127,11 +136,10 @@ export const runDiscoverFieldsAgent = (
             delayInMs: 40,
             chunking: 'line',
         }),
-        experimental_telemetry: getAgentTelemetryConfig(
-            'discoverFieldsSubagent',
-            args.telemetry,
-            'agent-subtask',
-        ),
+        experimental_telemetry: telemetry,
+        onFinish: ({ totalUsage }) => {
+            emitAiUsage(telemetry, languageModelUsageToTokens(totalUsage));
+        },
         onChunk: ({ chunk }) => {
             if (chunk.type === 'tool-call') {
                 if (!isSubagentPersistedToolName(chunk.toolName)) return;

--- a/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
@@ -4,6 +4,10 @@ import {
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { renderAvailableExplores } from '../prompts/availableExplores';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
@@ -81,15 +85,16 @@ export async function generateDocumentSummary(
         projectExplores: Explore[];
     },
 ): Promise<AiAgentDocumentStructuredSummary> {
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateDocumentSummary',
+        'document-summary',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateDocumentSummary',
-            'document-summary',
-        ),
+        experimental_telemetry: telemetry,
         schema: DocumentSummarySchema,
         messages: [
             {
@@ -113,6 +118,8 @@ Output the structured fields per the schema. Pay attention to the \`relevance\` 
             },
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
@@ -1,5 +1,9 @@
 import { ParameterError } from '@lightdash/common';
 import { embed, EmbeddingModel } from 'ai';
+import {
+    embeddingModelUsageToTokens,
+    emitAiUsage,
+} from '../../../../analytics/aiUsage';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import { getAzureProvider } from '../models/azure-openai-gpt-4.1';
 import { getBedrockEmbeddingModel } from '../models/bedrock';
@@ -74,16 +78,23 @@ export async function generateEmbedding(
     }
     const { model, provider, modelName } = embeddingModelConfig;
 
-    let { embedding } = await embed({
+    const telemetry = getAiCallTelemetry({
+        functionId: 'generateEmbedding',
+        feature: 'embedding',
+        model: modelName,
+        provider,
+        extra: metadata,
+    });
+    const result = await embed({
         model,
         value: trimmedText,
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'generateEmbedding',
-            feature: 'embedding',
-            extra: metadata,
-        }),
+        experimental_telemetry: telemetry,
         // TODO :: provider options to set dimensions
     });
+
+    emitAiUsage(telemetry, embeddingModelUsageToTokens(result.usage));
+
+    let { embedding } = result;
 
     if (embedding.length !== EMBEDDING_DIMENSIONS) {
         console.warn(

--- a/packages/backend/src/ee/services/ai/agents/formulaTableCalculationGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/formulaTableCalculationGenerator.ts
@@ -8,6 +8,10 @@ import {
 import { FUNCTION_CATALOG, parse } from '@lightdash/formula';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import Logger from '../../../../logging/logger';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
@@ -340,15 +344,16 @@ export async function generateFormulaTableCalculation(
             content: string;
         }> = [],
     ) => {
+        const telemetry = getGeneratorTelemetry(
+            modelOptions,
+            'generateFormulaTableCalculation',
+            'formula-table-calc',
+        );
         const result = await generateObject({
             model: modelOptions.model,
             ...modelOptions.callOptions,
             providerOptions: modelOptions.providerOptions,
-            experimental_telemetry: getGeneratorTelemetry(
-                modelOptions,
-                'generateFormulaTableCalculation',
-                'formula-table-calc',
-            ),
+            experimental_telemetry: telemetry,
             schema: FormulaTableCalculationSchema,
             messages: [
                 { role: 'system', content: systemPrompt },
@@ -356,6 +361,7 @@ export async function generateFormulaTableCalculation(
                 ...extraMessages,
             ],
         });
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
         return result.object;
     };
 

--- a/packages/backend/src/ee/services/ai/agents/projectRouter.ts
+++ b/packages/backend/src/ee/services/ai/agents/projectRouter.ts
@@ -1,6 +1,13 @@
 import { generateObject, LanguageModel } from 'ai';
 import { z } from 'zod';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 const ProjectRoutingSchema = z.object({
     reasoning: z
@@ -40,12 +47,14 @@ export async function routeProjectForSlack(
         )
         .join('\n');
 
+    const telemetry = getAiCallTelemetry({
+        functionId: 'routeProjectForSlack',
+        feature: 'project-router',
+        ...getLanguageModelAttribution(model),
+    });
     const result = await generateObject({
         model,
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'routeProjectForSlack',
-            feature: 'project-router',
-        }),
+        experimental_telemetry: telemetry,
         schema: ProjectRoutingSchema,
         messages: [
             {
@@ -68,6 +77,7 @@ Rules:
             },
         ],
     });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     const { projectUuid } = result.object;
     if (

--- a/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
@@ -1,7 +1,14 @@
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 const QUESTION_MAX_LENGTH_CHARS = 200;
 const QuestionSchema = z.object({
@@ -23,6 +30,12 @@ export async function generateArtifactQuestion(
     description: string | null,
     metadata: Record<string, string> = {},
 ): Promise<string> {
+    const telemetry = getAiCallTelemetry({
+        functionId: 'generateArtifactQuestion',
+        feature: 'artifact-question',
+        ...getLanguageModelAttribution(modelOptions.model),
+        extra: metadata,
+    });
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
@@ -50,12 +63,10 @@ Title: ${title || 'N/A'}
 Description: ${description || 'N/A'}`,
             },
         ],
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'generateArtifactQuestion',
-            feature: 'artifact-question',
-            extra: metadata,
-        }),
+        experimental_telemetry: telemetry,
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object.question;
 }

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -5,8 +5,15 @@ import {
     type AgentSuggestionsModelObject,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 const EMPTY_STATE_PROMPT = `You write 3-6 starter "chips" that appear above an empty AI agent chat input in a business-intelligence tool.
 
@@ -225,6 +232,15 @@ export async function generateAgentSuggestions(
         canManageContent: context.canManageContent,
     });
 
+    const telemetry = getAiCallTelemetry({
+        functionId: 'generateAgentSuggestions',
+        feature: 'agent-suggestions',
+        ...getLanguageModelAttribution(modelOptions.model),
+        extra: {
+            ...metadata,
+            mode: isPostResponse ? 'post-response' : 'empty-state',
+        },
+    });
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
@@ -242,15 +258,10 @@ export async function generateAgentSuggestions(
                     : `Generate empty-state suggestion chips for this agent.\n\nContext:\n${userContent}`,
             },
         ],
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'generateAgentSuggestions',
-            feature: 'agent-suggestions',
-            extra: {
-                ...metadata,
-                mode: isPostResponse ? 'post-response' : 'empty-state',
-            },
-        }),
+        experimental_telemetry: telemetry,
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/agents/tableCalculationGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/tableCalculationGenerator.ts
@@ -12,6 +12,10 @@ import {
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -261,15 +265,16 @@ export async function generateTableCalculation(
 ): Promise<GeneratedTableCalculation> {
     const fieldReferenceGuide = buildFieldReferenceGuide(context.fieldsContext);
 
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateTableCalculation',
+        'table-calc',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateTableCalculation',
-            'table-calc',
-        ),
+        experimental_telemetry: telemetry,
         schema: TableCalculationSchema,
         messages: [
             {
@@ -411,6 +416,8 @@ export async function generateTableCalculation(
             },
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/agents/telemetry.ts
+++ b/packages/backend/src/ee/services/ai/agents/telemetry.ts
@@ -1,5 +1,9 @@
 import type { AiAgentArgs } from '../types/aiAgent';
-import { AiCallFeature, getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    AiCallFeature,
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 export const getAiAgentModelName = (model: AiAgentArgs['model']) =>
     typeof model === 'string' ? model : model.modelId;
@@ -48,6 +52,6 @@ export const getAgentTelemetryConfig = (
         threadUuid,
         promptUuid,
         userUuid: userId,
-        model: getAiAgentModelName(model),
+        ...getLanguageModelAttribution(model),
         recordIO: telemetryEnabled,
     });

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -1,5 +1,9 @@
 import { generateObject, ModelMessage } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -21,15 +25,16 @@ export async function generateThreadTitle(
     modelOptions: GeneratorModelOptions,
     messages: ModelMessage[],
 ): Promise<string> {
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateThreadTitle',
+        'thread-title',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateThreadTitle',
-            'thread-title',
-        ),
+        experimental_telemetry: telemetry,
         schema: TitleSchema,
         messages: [
             {
@@ -54,6 +59,8 @@ The title should be clear, specific, and helpful for someone browsing a list of 
             ...messages,
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object.title;
 }

--- a/packages/backend/src/ee/services/ai/agents/tooltipGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/tooltipGenerator.ts
@@ -1,6 +1,10 @@
 import { GenerateTooltipRequest, TooltipFieldContext } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -36,15 +40,16 @@ export async function generateTooltip(
 ): Promise<GeneratedTooltip> {
     const fieldReferenceGuide = buildFieldReferenceGuide(context.fieldsContext);
 
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateTooltip',
+        'tooltip',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateTooltip',
-            'tooltip',
-        ),
+        experimental_telemetry: telemetry,
         schema: TooltipSchema,
         messages: [
             {
@@ -107,6 +112,8 @@ ${
             },
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
+++ b/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
@@ -1,27 +1,7 @@
-/**
- * Coarse feature bucket for an AI call. Lets us attribute token usage and cost
- * to a product surface (data apps vs the agent vs metadata generation, etc.) in
- * tracing, independently of the fine-grained `functionId`.
- */
-export type AiCallFeature =
-    | 'agent'
-    | 'agent-subtask'
-    | 'chart-metadata'
-    | 'document-summary'
-    | 'thread-title'
-    | 'tooltip'
-    | 'artifact-question'
-    | 'agent-suggestions'
-    | 'table-calc'
-    | 'formula-table-calc'
-    | 'compaction'
-    | 'embedding'
-    | 'project-router'
-    | 'agent-selector'
-    | 'review-classifier'
-    | 'llm-judge'
-    | 'data-app'
-    | 'managed-agent';
+import type { LanguageModel } from 'ai';
+import type { AiCallFeature } from '../../../../analytics/aiUsage';
+
+export type { AiCallFeature };
 
 /**
  * Attribution dimensions stamped on an AI-call span. All optional because not
@@ -37,7 +17,26 @@ export type AiCallAttribution = {
     promptUuid?: string | null;
     userUuid?: string | null;
     model?: string | null;
+    provider?: string | null;
 };
+
+/**
+ * Model name + provider attribution derived from an AI SDK model object.
+ * The SDK provider id is dot-namespaced (e.g. `azure.chat`,
+ * `bedrock.anthropic.messages`); the first segment matches our configured
+ * provider names (openai/azure/anthropic/bedrock/openrouter), which is what
+ * cost accounting joins on — the same model name bills differently per
+ * provider. Bare string models carry no provider information.
+ */
+export const getLanguageModelAttribution = (
+    model: LanguageModel,
+): Pick<AiCallAttribution, 'model' | 'provider'> =>
+    typeof model === 'string'
+        ? { model, provider: null }
+        : {
+              model: model.modelId,
+              provider: model.provider?.split('.')[0] ?? null,
+          };
 
 export type AiCallTelemetryOptions = AiCallAttribution & {
     functionId: string;
@@ -60,6 +59,7 @@ const ATTRIBUTION_KEYS: (keyof AiCallAttribution)[] = [
     'promptUuid',
     'userUuid',
     'model',
+    'provider',
 ];
 
 /**
@@ -111,12 +111,15 @@ export const getAiCallTelemetry = ({
  * avoid an import cycle with the models package.
  */
 export const getGeneratorTelemetry = (
-    modelOptions: { telemetry?: AiCallAttribution },
+    modelOptions: { model?: LanguageModel; telemetry?: AiCallAttribution },
     functionId: string,
     feature: AiCallFeature,
 ) =>
     getAiCallTelemetry({
         functionId,
         feature,
+        ...(modelOptions.model != null
+            ? getLanguageModelAttribution(modelOptions.model)
+            : {}),
         ...(modelOptions.telemetry ?? {}),
     });

--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -2,9 +2,16 @@ import { assertUnreachable } from '@lightdash/common';
 import { generateObject, LanguageModel } from 'ai';
 import { JSONDiff, Score } from 'autoevals';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { defaultAgentOptions } from '../agents/agentV2';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
-import { getAiCallTelemetry } from './aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from './aiCallTelemetry';
 
 export const factualityScores = {
     A: 0.4,
@@ -179,14 +186,16 @@ export async function llmAsAJudge({
       ************`
                     : '';
 
-            const { object } = await generateObject({
+            const telemetry = getAiCallTelemetry({
+                functionId: 'llmAsAJudge',
+                feature: 'llm-judge',
+                ...getLanguageModelAttribution(judge),
+            });
+            const result = await generateObject({
                 model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
-                experimental_telemetry: getAiCallTelemetry({
-                    functionId: 'llmAsAJudge',
-                    feature: 'llm-judge',
-                }),
+                experimental_telemetry: telemetry,
                 schema: z.object({
                     answer: z
                         .enum(['A', 'B', 'C', 'D', 'E'])
@@ -231,6 +240,8 @@ ${
       (E) The answers differ, but these differences don't matter from the perspective of factuality.
       `,
             });
+            emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+            const { object } = result;
 
             const factualityResult = {
                 answer: object.answer,
@@ -261,14 +272,16 @@ ${
                 throw new Error('context is required for contextRelevancy');
             }
 
-            const { object } = await generateObject({
+            const telemetry = getAiCallTelemetry({
+                functionId: 'llmAsAJudge',
+                feature: 'llm-judge',
+                ...getLanguageModelAttribution(judge),
+            });
+            const result = await generateObject({
                 model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
-                experimental_telemetry: getAiCallTelemetry({
-                    functionId: 'llmAsAJudge',
-                    feature: 'llm-judge',
-                }),
+                experimental_telemetry: telemetry,
                 schema: z.object({
                     score: z
                         .number()
@@ -301,6 +314,8 @@ Evaluate how relevant the provided context is to answering the query. Consider:
 Provide a relevancy score between 0 (not relevant at all) and 1 (highly relevant), and explain your reasoning.
                 `,
             });
+            emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+            const { object } = result;
 
             const contextResult = {
                 score: object.score,

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -7,10 +7,17 @@ import { generateObject } from 'ai';
 import { JSONDiff } from 'autoevals';
 import { compact, differenceWith } from 'lodash';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { DbAiAgentToolCall } from '../../../database/entities/ai';
 import { defaultAgentOptions } from '../agents/agentV2';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
-import { getAiCallTelemetry } from './aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from './aiCallTelemetry';
 
 const TOOL_NAME_TO_DB_TOOL_NAME = {
     findExplores: 'find_explores',
@@ -285,14 +292,16 @@ export const evaluateToolCallSequence = async (
         .map((score) => score.description)
         .join('\n\n');
 
-    const { object: evaluationResult } = await generateObject({
+    const telemetry = getAiCallTelemetry({
+        functionId: 'evaluateToolCallSequence',
+        feature: 'llm-judge',
+        ...getLanguageModelAttribution(judge),
+    });
+    const result = await generateObject({
         model: judge,
         ...defaultAgentOptions,
         ...callOptions,
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'evaluateToolCallSequence',
-            feature: 'llm-judge',
-        }),
+        experimental_telemetry: telemetry,
         schema: toolEvaluationSchema,
         prompt: `
 You are evaluating AI agent tool usage for business logic testing. Here is the data:
@@ -368,8 +377,9 @@ For passed, return true if effectiveness is excellent/good AND appropriateTools 
 Use empty arrays for suggestions, missingTools, unnecessaryTools, validationErrors, and expectedArgsValidation when not applicable.
         `,
     });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
-    return evaluationResult;
+    return result.object;
 };
 
 export const llmAsJudgeForTools = async ({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15227,17 +15227,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15327,18 +15327,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15351,10 +15339,22 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                             },
@@ -15501,21 +15501,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -15534,6 +15519,21 @@ const models: TsoaRoute.Models = {
                                                                                                 enums: [
                                                                                                     'success',
                                                                                                 ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
                                                                                             },
                                                                                             {
                                                                                                 dataType:
@@ -15625,17 +15625,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15851,29 +15851,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15894,7 +15871,30 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -15905,12 +15905,12 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                name: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                table: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -15981,18 +15981,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16005,10 +15993,22 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                         },
@@ -16201,10 +16201,6 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
@@ -16212,13 +16208,17 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
+                                                href: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 slug: {
                                                     dataType: 'string',
+                                                    required: true,
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 uuid: {
@@ -16569,13 +16569,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -16771,17 +16771,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -16800,14 +16800,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
@@ -25123,11 +25123,57 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiProviderApiKeysSet: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                openai: { dataType: 'boolean', required: true },
+                anthropic: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiProviderApiKeyHints: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                openai: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                anthropic: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiOrganizationSettings: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                providerApiKeyHints: {
+                    ref: 'AiProviderApiKeyHints',
+                    required: true,
+                },
+                providerApiKeysSet: {
+                    ref: 'AiProviderApiKeysSet',
+                    required: true,
+                },
                 defaultAiAgentModelConfig: {
                     dataType: 'union',
                     subSchemas: [
@@ -25209,38 +25255,23 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiOrganizationSettings_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Omit_AiOrganizationSettings.organizationUuid__': {
+    UpdateAiProviderApiKeys: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                aiAgentsVisible: {
+                openai: {
                     dataType: 'union',
                     subSchemas: [
-                        { dataType: 'boolean' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                aiAgentReviewsEnabled: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'boolean' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                mcpContentWritesEnabled: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'boolean' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                defaultAiAgentModelConfig: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'AiAgentModelConfig' },
+                        { dataType: 'string' },
                         { dataType: 'enum', enums: [null] },
-                        { dataType: 'undefined' },
+                    ],
+                },
+                anthropic: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
                     ],
                 },
             },
@@ -25251,7 +25282,20 @@ const models: TsoaRoute.Models = {
     UpdateAiOrganizationSettings: {
         dataType: 'refAlias',
         type: {
-            ref: 'Partial_Omit_AiOrganizationSettings.organizationUuid__',
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                providerApiKeys: { ref: 'UpdateAiProviderApiKeys' },
+                defaultAiAgentModelConfig: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentModelConfig' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                mcpContentWritesEnabled: { dataType: 'boolean' },
+                aiAgentReviewsEnabled: { dataType: 'boolean' },
+                aiAgentsVisible: { dataType: 'boolean' },
+            },
             validators: {},
         },
     },
@@ -31219,6 +31263,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 projectDefaults: { ref: 'ProjectDefaults' },
+                systemExploresEnabled: { dataType: 'boolean', required: true },
                 hasDefaultUserSpaces: { dataType: 'boolean', required: true },
                 organizationWarehouseCredentialsUuid: { dataType: 'string' },
                 createdByUserUuid: {
@@ -31684,6 +31729,17 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: [null] },
                     ],
                 },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateSystemExplores: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                systemExploresEnabled: { dataType: 'boolean', required: true },
             },
             validators: {},
         },
@@ -32835,7 +32891,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32845,7 +32901,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32855,7 +32911,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -32868,7 +32924,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -33530,7 +33586,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33540,7 +33596,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33550,7 +33606,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -33563,7 +33619,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -68295,6 +68351,71 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateProjectMetadata',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_updateSystemExplores: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateSystemExplores',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/systemExplores',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.updateSystemExplores,
+        ),
+
+        async function ProjectController_updateSystemExplores(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_updateSystemExplores,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateSystemExplores',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16691,10 +16691,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -16703,8 +16703,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -16727,28 +16727,28 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
-                                                                                    },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "operator": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "required",
-                                                                                    "tableName",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "operator"
+                                                                                    "tableName",
+                                                                                    "operator",
+                                                                                    "required"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -16830,15 +16830,15 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "status": {
                                                                             "type": "string",
                                                                             "enum": [
                                                                                 "error",
                                                                                 "success"
                                                                             ]
+                                                                        },
+                                                                        "error": {
+                                                                            "type": "string"
                                                                         },
                                                                         "results": {
                                                                             "items": {
@@ -16861,10 +16861,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -16873,8 +16873,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -16985,27 +16985,27 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "label": {
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "metric",
+                                                                                        "dimension"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "table": {
+                                                                                "name": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
@@ -17014,12 +17014,12 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "fieldType",
                                                                                 "description",
-                                                                                "label",
+                                                                                "fieldType",
+                                                                                "table",
                                                                                 "fieldId",
-                                                                                "name",
-                                                                                "table"
+                                                                                "label",
+                                                                                "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -17039,28 +17039,28 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
-                                                                                        },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
                                                                                         },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "operator": {
                                                                                             "type": "string"
+                                                                                        },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
-                                                                                        "required",
-                                                                                        "tableName",
                                                                                         "fieldRef",
                                                                                         "fieldId",
-                                                                                        "operator"
+                                                                                        "tableName",
+                                                                                        "operator",
+                                                                                        "required"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -17200,22 +17200,22 @@
                                                         ],
                                                         "type": "object"
                                                     },
-                                                    "href": {
-                                                        "type": "string"
-                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
                                                     },
+                                                    "href": {
+                                                        "type": "string"
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     },
                                                     "uuid": {
                                                         "type": "string"
@@ -17226,10 +17226,10 @@
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "href",
                                                     "warnings",
-                                                    "status",
+                                                    "href",
                                                     "slug",
+                                                    "status",
                                                     "uuid",
                                                     "name"
                                                 ],
@@ -17332,13 +17332,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -17346,8 +17346,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -17408,10 +17408,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17420,8 +17420,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -17431,8 +17431,8 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "dimension",
                                                                     "metric",
+                                                                    "dimension",
                                                                     null
                                                                 ],
                                                                 "nullable": true
@@ -25311,8 +25311,40 @@
             "UpdateAiReviewNotificationSettings": {
                 "$ref": "#/components/schemas/Pick_AiReviewNotificationSettings.enabled-or-slackChannelId_"
             },
+            "AiProviderApiKeysSet": {
+                "properties": {
+                    "openai": {
+                        "type": "boolean"
+                    },
+                    "anthropic": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["openai", "anthropic"],
+                "type": "object"
+            },
+            "AiProviderApiKeyHints": {
+                "properties": {
+                    "openai": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "anthropic": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["openai", "anthropic"],
+                "type": "object"
+            },
             "AiOrganizationSettings": {
                 "properties": {
+                    "providerApiKeyHints": {
+                        "$ref": "#/components/schemas/AiProviderApiKeyHints"
+                    },
+                    "providerApiKeysSet": {
+                        "$ref": "#/components/schemas/AiProviderApiKeysSet"
+                    },
                     "defaultAiAgentModelConfig": {
                         "allOf": [
                             {
@@ -25335,6 +25367,8 @@
                     }
                 },
                 "required": [
+                    "providerApiKeyHints",
+                    "providerApiKeysSet",
                     "defaultAiAgentModelConfig",
                     "mcpContentWritesEnabled",
                     "aiAgentReviewsEnabled",
@@ -25406,16 +25440,23 @@
             "ApiUpdateAiOrganizationSettingsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiOrganizationSettings_"
             },
-            "Partial_Omit_AiOrganizationSettings.organizationUuid__": {
+            "UpdateAiProviderApiKeys": {
                 "properties": {
-                    "aiAgentsVisible": {
-                        "type": "boolean"
+                    "openai": {
+                        "type": "string",
+                        "nullable": true
                     },
-                    "aiAgentReviewsEnabled": {
-                        "type": "boolean"
-                    },
-                    "mcpContentWritesEnabled": {
-                        "type": "boolean"
+                    "anthropic": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateAiOrganizationSettings": {
+                "properties": {
+                    "providerApiKeys": {
+                        "$ref": "#/components/schemas/UpdateAiProviderApiKeys"
                     },
                     "defaultAiAgentModelConfig": {
                         "allOf": [
@@ -25424,13 +25465,18 @@
                             }
                         ],
                         "nullable": true
+                    },
+                    "mcpContentWritesEnabled": {
+                        "type": "boolean"
+                    },
+                    "aiAgentReviewsEnabled": {
+                        "type": "boolean"
+                    },
+                    "aiAgentsVisible": {
+                        "type": "boolean"
                     }
                 },
-                "type": "object",
-                "description": "Make all properties in T optional"
-            },
-            "UpdateAiOrganizationSettings": {
-                "$ref": "#/components/schemas/Partial_Omit_AiOrganizationSettings.organizationUuid__"
+                "type": "object"
             },
             "ApiJobScheduledResponse": {
                 "properties": {
@@ -31746,6 +31792,9 @@
                     "projectDefaults": {
                         "$ref": "#/components/schemas/ProjectDefaults"
                     },
+                    "systemExploresEnabled": {
+                        "type": "boolean"
+                    },
                     "hasDefaultUserSpaces": {
                         "type": "boolean"
                     },
@@ -31807,6 +31856,7 @@
                 "required": [
                     "expiresAt",
                     "colorPaletteUuid",
+                    "systemExploresEnabled",
                     "hasDefaultUserSpaces",
                     "createdByUserUuid",
                     "schedulerFailureContactOverride",
@@ -32260,6 +32310,15 @@
                         "nullable": true
                     }
                 },
+                "type": "object"
+            },
+            "UpdateSystemExplores": {
+                "properties": {
+                    "systemExploresEnabled": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["systemExploresEnabled"],
                 "type": "object"
             },
             "UpdateDefaultUserSpaces": {
@@ -33372,22 +33431,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -33951,22 +34010,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -43393,7 +43452,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3320.0",
+        "version": "0.3321.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -58597,6 +58656,57 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/UpdateMetadata"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/systemExplores": {
+            "patch": {
+                "operationId": "updateSystemExplores",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Toggle system explores (Lightdash usage analytics) for a project.\nWhen enabled, usage analytics explores are injected on the next compile.",
+                "summary": "Update system explores setting",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateSystemExplores"
                             }
                         }
                     }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -64,6 +64,7 @@ export const projectMock = {
     scheduler_failure_include_contact: false,
     scheduler_failure_contact_override: null,
     has_default_user_spaces: false,
+    system_explores_enabled: false,
 };
 
 export const tableSelectionMock: Pick<
@@ -117,6 +118,7 @@ export const expectedProject: Project = {
     schedulerFailureContactOverride: null,
     createdByUserUuid: null,
     hasDefaultUserSpaces: false,
+    systemExploresEnabled: false,
     colorPaletteUuid: null,
     expiresAt: null,
 };

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -842,6 +842,7 @@ export class ProjectModel {
                   created_by_user_uuid: string | null;
                   organization_warehouse_credentials_uuid: string | null;
                   has_default_user_spaces: boolean;
+                  system_explores_enabled: boolean;
                   project_defaults: ProjectDefaults | null;
                   color_palette_uuid: string | null;
                   expires_at: Date | null;
@@ -865,6 +866,7 @@ export class ProjectModel {
                   created_by_user_uuid: string | null;
                   organization_warehouse_credentials_uuid: string | null;
                   has_default_user_spaces: boolean;
+                  system_explores_enabled: boolean;
                   project_defaults: ProjectDefaults | null;
                   color_palette_uuid: string | null;
                   expires_at: Date | null;
@@ -944,6 +946,9 @@ export class ProjectModel {
                             .ref('has_default_user_spaces')
                             .withSchema(ProjectTableName),
                         this.database
+                            .ref('system_explores_enabled')
+                            .withSchema(ProjectTableName),
+                        this.database
                             .ref('project_defaults')
                             .withSchema(ProjectTableName),
                         this.database
@@ -1001,6 +1006,7 @@ export class ProjectModel {
                         project.organization_warehouse_credentials_uuid ??
                         undefined,
                     hasDefaultUserSpaces: project.has_default_user_spaces,
+                    systemExploresEnabled: project.system_explores_enabled,
                     projectDefaults: project.project_defaults ?? undefined,
                     colorPaletteUuid: project.color_palette_uuid ?? null,
                     expiresAt: project.expires_at ?? null,
@@ -1230,6 +1236,7 @@ export class ProjectModel {
             organizationWarehouseCredentialsUuid:
                 project.organizationWarehouseCredentialsUuid,
             hasDefaultUserSpaces: project.hasDefaultUserSpaces,
+            systemExploresEnabled: project.systemExploresEnabled,
             projectDefaults: project.projectDefaults,
             colorPaletteUuid: project.colorPaletteUuid ?? null,
             expiresAt: project.expiresAt,
@@ -1814,6 +1821,15 @@ export class ProjectModel {
             .update({
                 copied_from_project_uuid: data.upstreamProjectUuid, // if upstreamProjectUuid is undefined, it will do nothing, if it is null, it will be unset
             })
+            .where('project_uuid', projectUuid);
+    }
+
+    async updateSystemExplores(
+        projectUuid: string,
+        systemExploresEnabled: boolean,
+    ): Promise<void> {
+        await this.database(ProjectTableName)
+            .update({ system_explores_enabled: systemExploresEnabled })
             .where('project_uuid', projectUuid);
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -383,6 +383,7 @@ export const projectWithSensitiveFields: Project = {
     schedulerFailureContactOverride: null,
     createdByUserUuid: sessionAccount.user.id,
     hasDefaultUserSpaces: false,
+    systemExploresEnabled: false,
     colorPaletteUuid: null,
     expiresAt: null,
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -182,6 +182,7 @@ import {
     UpdateProjectMember,
     UpdateQueryTimezoneSettings,
     UpdateSchedulerSettings,
+    UpdateSystemExplores,
     UpdateVirtualViewPayload,
     UserAccessControls,
     UserAttributeValueMap,
@@ -7954,6 +7955,32 @@ export class ProjectService extends BaseService {
         }
 
         await this.projectModel.updateMetadata(projectUuid, data);
+    }
+
+    async updateSystemExplores(
+        user: SessionUser,
+        projectUuid: string,
+        data: UpdateSystemExplores,
+    ): Promise<void> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        await this.projectModel.updateSystemExplores(
+            projectUuid,
+            data.systemExploresEnabled,
+        );
     }
 
     async updateDefaultUserSpaces(

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -327,6 +327,10 @@ export type UpdateMetadata = {
 export type UpdateDefaultUserSpaces = {
     hasDefaultUserSpaces: boolean;
 };
+
+export type UpdateSystemExplores = {
+    systemExploresEnabled: boolean;
+};
 export type ApiFormulaValidationResults =
     | { valid: true; compiledSql: string }
     | { valid: false; error: string };
@@ -681,6 +685,7 @@ export type CreateProject = Omit<
     | 'schedulerFailureContactOverride'
     | 'createdByUserUuid'
     | 'hasDefaultUserSpaces'
+    | 'systemExploresEnabled'
     | 'colorPaletteUuid'
     | 'expiresAt'
 > & {
@@ -719,6 +724,7 @@ export type UpdateProject = Omit<
     | 'schedulerFailureContactOverride'
     | 'createdByUserUuid'
     | 'hasDefaultUserSpaces'
+    | 'systemExploresEnabled'
     | 'colorPaletteUuid'
     | 'expiresAt'
 > & {

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1030,6 +1030,7 @@ export type Project = {
     createdByUserUuid: string | null;
     organizationWarehouseCredentialsUuid?: string;
     hasDefaultUserSpaces: boolean;
+    systemExploresEnabled: boolean;
     projectDefaults?: ProjectDefaults;
     colorPaletteUuid: string | null;
     expiresAt: Date | null;


### PR DESCRIPTION
## What

Adds a per-project boolean setting `system_explores_enabled` (default `false`) that will gate the injection of Lightdash usage-analytics ("system") explores, plus a `PATCH /api/v1/projects/{projectUuid}/systemExplores` endpoint to toggle it.

- Knex migration adding `projects.system_explores_enabled boolean not null default false`
- `DbProject` / `UpdateDbProject` entity types, `ProjectModel` read mapping + `updateSystemExplores`
- `Project.systemExploresEnabled` in common types (omitted from `CreateProject`/`UpdateProject` — managed via its own endpoint, mirroring `hasDefaultUserSpaces`)
- `ProjectService.updateSystemExplores` gated on `manage:Project`
- Generated TSOA routes/swagger

## Why

Part of the usage-analytics read layer (PROD-8608): system explores are opt-in per project. This is PR 1 of 3 — the toggle does nothing until the injection PR lands on top.

Linear: https://linear.app/lightdash/issue/PROD-8608

## Stack

Depends on #25047 (compaction). Followed by #25062 (SYSTEM explore injection) and #25063 (scope gating + DuckDB routing).

## Judgment calls

- Mirrored the `hasDefaultUserSpaces` PATCH-endpoint pattern rather than widening `UpdateProject` — smallest surface, no frontend change needed.
- Backend-only toggle for v1 (settable via API); frontend settings switch deferred as follow-up.

## Testing

- `pnpm -F common lint/typecheck/test`, `pnpm -F backend lint/typecheck/test:dev:nowatch` all pass
- E2E: `PATCH .../systemExplores {"systemExploresEnabled":true}` → 200, column flips in `projects` (verified via psql)

https://claude.ai/code/session_011AsrrbU7h5qFRayP3iWyGF
