### PR TITLE
feat(analytics): gate system explores behind view:SystemAnalytics and route to DuckDB (PROD-8608)

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -272,7 +272,10 @@ type QueryExecutionEvent = BaseTrack & {
     );
 };
 
-type QueryExecutionSource = 'warehouse' | 'pre_aggregate_duckdb';
+export type QueryExecutionSource =
+    | 'warehouse'
+    | 'pre_aggregate_duckdb'
+    | 'system_duckdb';
 
 type QueryReadyEvent = BaseTrack & {
     event: 'query.ready';

--- a/packages/backend/src/analytics/eventStream/UsageEventsCompactor.ts
+++ b/packages/backend/src/analytics/eventStream/UsageEventsCompactor.ts
@@ -11,7 +11,7 @@ import { getCompactedStreamColumns } from './registry';
 import { CompactedStreamColumn } from './types';
 
 const RAW_KEY_PREFIX = 'events/raw/';
-const COMPACTED_KEY_PREFIX = 'events/compacted';
+export const COMPACTED_KEY_PREFIX = 'events/compacted';
 export const MAX_PARTITIONS_PER_RUN = 500;
 const DELETE_BATCH_SIZE = 1000;
 export const DELETE_MAX_ATTEMPTS = 3;

--- a/packages/backend/src/analytics/systemExplores/buildSystemExplores.test.ts
+++ b/packages/backend/src/analytics/systemExplores/buildSystemExplores.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
     buildSystemExplores,
     getSystemExploresForProject,
+    isSystemExploreName,
 } from './buildSystemExplores';
 
 const ORGANIZATION_UUID = '172a2270-000f-42be-9c68-c4752c23ae51';
@@ -143,5 +144,16 @@ describe('getSystemExploresForProject', () => {
                 systemExploresEnabled: false,
             }),
         ).toEqual([]);
+    });
+});
+
+describe('isSystemExploreName', () => {
+    it('matches generated system explore names', () => {
+        expect(isSystemExploreName('lightdash_query_events')).toBe(true);
+    });
+
+    it('does not match other explore names', () => {
+        expect(isSystemExploreName('query_events')).toBe(false);
+        expect(isSystemExploreName('orders')).toBe(false);
     });
 });

--- a/packages/backend/src/analytics/systemExplores/buildSystemExplores.ts
+++ b/packages/backend/src/analytics/systemExplores/buildSystemExplores.ts
@@ -23,6 +23,7 @@ import type {
     CompactedColumnType,
     CompactedStreamColumn,
 } from '../eventStream/types';
+import { COMPACTED_KEY_PREFIX } from '../eventStream/UsageEventsCompactor';
 
 export const SYSTEM_EXPLORE_GROUP = 'Usage analytics';
 
@@ -30,6 +31,11 @@ const SYSTEM_EXPLORE_NAME_PREFIX = 'lightdash_';
 
 export const getSystemExploreName = (stream: string): string =>
     `${SYSTEM_EXPLORE_NAME_PREFIX}${stream}`;
+
+export const isSystemExploreName = (exploreName: string): boolean =>
+    Object.keys(compactedStreamSchemas).some(
+        (stream) => getSystemExploreName(stream) === exploreName,
+    );
 
 type SystemMetricDef = Pick<Metric, 'name' | 'description' | 'percentile'> & {
     type: MetricType;
@@ -241,7 +247,11 @@ const buildSqlTable = (args: {
     organizationUuid: string;
     stream: string;
 }): string =>
-    `read_parquet('s3://${args.bucket}/events/compacted/org_id=${args.organizationUuid}/stream=${args.stream}/**/*.parquet', hive_partitioning=true, union_by_name=true)`;
+    `read_parquet('s3://${args.bucket}/${COMPACTED_KEY_PREFIX}/org_id=${args.organizationUuid}/stream=${args.stream}/**/*.parquet', hive_partitioning=true, union_by_name=true)`;
+
+/** URI prefix that system explore queries are allowed to read from. */
+export const getSystemExploreAllowedUriPrefix = (bucket: string): string =>
+    `s3://${bucket}/${COMPACTED_KEY_PREFIX}/`;
 
 export type BuildSystemExploresArgs = {
     organizationUuid: string;

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -326,7 +326,7 @@ export default class PrometheusMetrics {
                 this.warehouseDurationHistogram = new prometheus.Histogram({
                     name: 'lightdash_query_warehouse_duration_seconds',
                     help: 'Warehouse query execution duration',
-                    labelNames: ['warehouse_type', 'context'],
+                    labelNames: ['warehouse_type', 'context', 'source'],
                     buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
                     ...rest,
                 });
@@ -1161,7 +1161,7 @@ export default class PrometheusMetrics {
 
     public observeS3ResultsUploadDuration(
         durationMs: number,
-        source: 'warehouse' | 'pre_aggregate_duckdb',
+        source: 'warehouse' | 'pre_aggregate_duckdb' | 'system_duckdb',
     ) {
         this.s3ResultsUploadDurationHistogram?.observe(
             { source },
@@ -1255,11 +1255,13 @@ export default class PrometheusMetrics {
         durationMs: number,
         warehouseType: string,
         context: string,
+        source: 'warehouse' | 'pre_aggregate_duckdb' | 'system_duckdb',
     ) {
         this.warehouseDurationHistogram?.observe(
             {
                 warehouse_type: warehouseType,
                 context: getQueryContextLabel(context),
+                source,
             },
             durationMs / 1000,
         );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -86,6 +86,7 @@ import {
     S3Error,
     SchedulerFormat,
     SqlChart,
+    SupportedDbtAdapter,
     TrialExpiredError,
     UnexpectedServerError,
     UserAccessControls,
@@ -124,12 +125,21 @@ import {
     type WarehouseResults,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
-import { SshTunnel, warehouseSqlBuilderFromType } from '@lightdash/warehouses';
+import {
+    DuckdbWarehouseClient,
+    SshTunnel,
+    warehouseSqlBuilderFromType,
+} from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
 import { createInterface } from 'readline';
 import { Readable, Writable } from 'stream';
 import { v4 as uuidv4 } from 'uuid';
 import { DownloadCsv } from '../../analytics/LightdashAnalytics';
+import type { QueryExecutionSource } from '../../analytics/LightdashAnalytics';
+import {
+    getSystemExploreAllowedUriPrefix,
+    isSystemExploreName,
+} from '../../analytics/systemExplores/buildSystemExplores';
 import { transformAndExportResults } from '../../clients/Aws/transformAndExportResults';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import type { INatsClient } from '../../clients/NatsClient';
@@ -284,6 +294,8 @@ type ResolvedWarehouseCredentials = CreateWarehouseCredentials & {
     userWarehouseCredentialsUuid: string | undefined;
 };
 
+const SYSTEM_EXPLORE_QUERY_INSTANCE_CACHE_KEY = 'system-explore-query-instance';
+
 export class AsyncQueryService extends ProjectService {
     private static sleep(ms: number, signal?: AbortSignal) {
         if (signal?.aborted) {
@@ -368,6 +380,8 @@ export class AsyncQueryService extends ProjectService {
     private readonly organizationAccessService: OrganizationAccessService;
 
     protected readonly preAggregateStrategy: PreAggregateStrategy;
+
+    private cachedSystemExploreWarehouseClient: WarehouseClient | null = null;
 
     constructor(args: AsyncQueryServiceArguments) {
         super(args);
@@ -572,6 +586,83 @@ export class AsyncQueryService extends ProjectService {
         });
     }
 
+    /**
+     * SYSTEM (usage analytics) explores are compiled for DuckDB regardless
+     * of the project warehouse — they execute over the compacted usage
+     * events parquet zone, not the project warehouse.
+     */
+    private static getWarehouseSqlBuilderForExplore(
+        explore: Explore,
+        warehouseCredentials: Pick<
+            ResolvedWarehouseCredentials,
+            'type' | 'startOfWeek'
+        >,
+    ): WarehouseSqlBuilder {
+        if (explore.type === ExploreType.SYSTEM) {
+            return warehouseSqlBuilderFromType(
+                SupportedDbtAdapter.DUCKDB,
+                warehouseCredentials.startOfWeek,
+            );
+        }
+        return warehouseSqlBuilderFromType(
+            warehouseCredentials.type,
+            warehouseCredentials.startOfWeek,
+        );
+    }
+
+    private getSystemExploreWarehouseClient(): WarehouseClient {
+        if (!this.cachedSystemExploreWarehouseClient) {
+            const usageEventsS3 = this.lightdashConfig.usageEvents.s3;
+            const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
+                usageEventsS3 ?? undefined,
+            );
+            if (!usageEventsS3 || !duckdbRuntimeConfig) {
+                throw new UnexpectedServerError(
+                    'System explore execution is unavailable: missing usage events S3 configuration',
+                );
+            }
+            this.cachedSystemExploreWarehouseClient = new DuckdbWarehouseClient(
+                { type: 'duckdb_s3', s3Config: duckdbRuntimeConfig },
+                {
+                    instanceCacheKey: SYSTEM_EXPLORE_QUERY_INSTANCE_CACHE_KEY,
+                    logger: Logger,
+                    allowedReadParquetUriPrefixes: [
+                        getSystemExploreAllowedUriPrefix(usageEventsS3.bucket),
+                    ],
+                },
+            );
+        }
+        return this.cachedSystemExploreWarehouseClient;
+    }
+
+    /**
+     * Detects queries against SYSTEM explores and returns the DuckDB
+     * client that executes them over the usage events bucket. Detection
+     * happens here (rather than at enqueue time) so both the inline and
+     * queued (NATS worker) execution paths route consistently.
+     */
+    private async getSystemExploreClientOverride(
+        projectUuid: string,
+        queryTags: RunQueryTags,
+    ): Promise<WarehouseClient | null> {
+        const exploreName = queryTags.explore_name;
+        if (
+            !this.lightdashConfig.usageEvents.enabled ||
+            !exploreName ||
+            !isSystemExploreName(exploreName)
+        ) {
+            return null;
+        }
+        const explore = await this.projectModel.getExploreFromCache(
+            projectUuid,
+            exploreName,
+        );
+        if (isExploreError(explore) || explore.type !== ExploreType.SYSTEM) {
+            return null;
+        }
+        return this.getSystemExploreWarehouseClient();
+    }
+
     private getResultsStorageClientForContext(
         context?: QueryExecutionContext | null,
     ): S3ResultsFileStorageClient {
@@ -645,6 +736,19 @@ export class AsyncQueryService extends ProjectService {
             ability.cannot(
                 'manage',
                 subject('PreAggregation', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new NotFoundError(`Explore "${exploreName}" does not exist.`);
+        }
+
+        if (
+            explore.type === ExploreType.SYSTEM &&
+            ability.cannot(
+                'view',
+                subject('SystemAnalytics', {
                     organizationUuid,
                     projectUuid,
                 }),
@@ -2544,13 +2648,23 @@ export class AsyncQueryService extends ProjectService {
             },
         };
 
-        const executionSource: 'warehouse' | 'pre_aggregate_duckdb' =
-            warehouseClientOverride ? 'pre_aggregate_duckdb' : 'warehouse';
+        const systemExploreClientOverride = warehouseClientOverride
+            ? null
+            : await this.getSystemExploreClientOverride(projectUuid, queryTags);
+        const clientOverride =
+            warehouseClientOverride ?? systemExploreClientOverride;
+
+        let executionSource: QueryExecutionSource = 'warehouse';
+        if (warehouseClientOverride) {
+            executionSource = 'pre_aggregate_duckdb';
+        } else if (systemExploreClientOverride) {
+            executionSource = 'system_duckdb';
+        }
         let queryStartTime = Date.now();
 
         try {
-            if (warehouseClientOverride) {
-                warehouseClient = warehouseClientOverride;
+            if (clientOverride) {
+                warehouseClient = clientOverride;
                 warehouseCredentialsType =
                     warehouseCredentialsTypeOverride ??
                     warehouseClient.credentials.type;
@@ -2701,6 +2815,7 @@ export class AsyncQueryService extends ProjectService {
                 durationMs,
                 warehouseCredentialsType,
                 queryTags.query_context,
+                executionSource,
             );
 
             this.prometheusMetrics?.observeWarehousePhaseDurations(
@@ -2779,6 +2894,7 @@ export class AsyncQueryService extends ProjectService {
                 );
                 if (
                     executionSource === 'pre_aggregate_duckdb' ||
+                    executionSource === 'system_duckdb' ||
                     this.lightdashConfig.prometheus.allQueryMetricsEnabled
                 ) {
                     this.prometheusMetrics?.observeS3ResultsUploadDuration(
@@ -3660,10 +3776,11 @@ export class AsyncQueryService extends ProjectService {
                         );
                     }
 
-                    const warehouseSqlBuilder = warehouseSqlBuilderFromType(
-                        warehouseCredentialsType,
-                        warehouseCredentials.startOfWeek,
-                    );
+                    const warehouseSqlBuilder =
+                        AsyncQueryService.getWarehouseSqlBuilderForExplore(
+                            explore,
+                            warehouseCredentials,
+                        );
 
                     let pivotedQuery = null;
                     if (pivotConfiguration) {
@@ -3775,7 +3892,7 @@ export class AsyncQueryService extends ProjectService {
                         },
                     };
                     const trackQueryExecuted = (
-                        executionSource?: 'warehouse' | 'pre_aggregate_duckdb',
+                        executionSource?: QueryExecutionSource,
                     ) =>
                         this.analytics.trackAccount(account, {
                             event: 'query.executed',
@@ -4388,10 +4505,11 @@ export class AsyncQueryService extends ProjectService {
             );
         }
 
-        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
-            warehouseCredentials.type,
-            warehouseCredentials.startOfWeek,
-        );
+        const warehouseSqlBuilder =
+            AsyncQueryService.getWarehouseSqlBuilderForExplore(
+                explore,
+                warehouseCredentials,
+            );
 
         // Combine default parameter values with request parameters first
         const combinedParameters = await this.combineParameters(
@@ -4639,10 +4757,11 @@ export class AsyncQueryService extends ProjectService {
             isServiceAccount: account.isServiceAccount(),
         });
 
-        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
-            warehouseCredentials.type,
-            warehouseCredentials.startOfWeek,
-        );
+        const warehouseSqlBuilder =
+            AsyncQueryService.getWarehouseSqlBuilderForExplore(
+                explore,
+                warehouseCredentials,
+            );
 
         const combinedParameters = await this.combineParameters(
             projectUuid,
@@ -4913,10 +5032,11 @@ export class AsyncQueryService extends ProjectService {
             isServiceAccount: account.isServiceAccount(),
         });
 
-        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
-            warehouseCredentials.type,
-            warehouseCredentials.startOfWeek,
-        );
+        const warehouseSqlBuilder =
+            AsyncQueryService.getWarehouseSqlBuilderForExplore(
+                explore,
+                warehouseCredentials,
+            );
 
         // Combine default parameter values, saved chart parameters, and request parameters first
         const combinedParameters = await this.combineParameters(
@@ -5356,10 +5476,11 @@ export class AsyncQueryService extends ProjectService {
                 this.projectParametersModel.find(projectUuid),
         ]);
 
-        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
-            warehouseCredentials.type,
-            warehouseCredentials.startOfWeek,
-        );
+        const warehouseSqlBuilder =
+            AsyncQueryService.getWarehouseSqlBuilderForExplore(
+                explore,
+                warehouseCredentials,
+            );
 
         const dashboardParameters = convertDashboardParametersToValuesMap(
             rawDashboardParameters,
@@ -5564,11 +5685,6 @@ export class AsyncQueryService extends ProjectService {
             isServiceAccount: account.isServiceAccount(),
         });
 
-        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
-            warehouseCredentials.type,
-            warehouseCredentials.startOfWeek,
-        );
-
         const { metricQuery, fields: metricQueryFields } =
             await this.queryHistoryModel.get(
                 underlyingDataSourceQueryUuid,
@@ -5584,6 +5700,12 @@ export class AsyncQueryService extends ProjectService {
                 projectUuid,
                 exploreName,
                 organizationUuid,
+            );
+
+        const warehouseSqlBuilder =
+            AsyncQueryService.getWarehouseSqlBuilderForExplore(
+                explore,
+                warehouseCredentials,
             );
 
         // Combine parameters early so we can filter dimensions by parameter availability
@@ -6807,10 +6929,11 @@ export class AsyncQueryService extends ProjectService {
             isServiceAccount: account.isServiceAccount(),
         });
 
-        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
-            warehouseCredentials.type,
-            warehouseCredentials.startOfWeek,
-        );
+        const warehouseSqlBuilder =
+            AsyncQueryService.getWarehouseSqlBuilderForExplore(
+                explore,
+                warehouseCredentials,
+            );
 
         const {
             sql,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6914,6 +6914,25 @@ export class ProjectService extends BaseService {
         );
     }
 
+    private canViewSystemExplores(
+        account: Account,
+        organizationUuid: string,
+        projectUuid: string,
+    ): boolean {
+        if (!this.lightdashConfig.usageEvents.enabled) {
+            return false;
+        }
+
+        const auditedAbility = this.createAuditedAbility(account);
+        return auditedAbility.can(
+            'view',
+            subject('SystemAnalytics', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+    }
+
     async getAllExploresSummary(
         account: Account,
         projectUuid: string,
@@ -6947,11 +6966,22 @@ export class ProjectService extends BaseService {
                 organizationUuid,
                 projectUuid,
             );
-        const visibleExploreSummaries = shouldIncludePreAggregateExplores
-            ? allExploreSummaries
-            : allExploreSummaries.filter(
-                  (explore) => explore.type !== ExploreType.PRE_AGGREGATE,
-              );
+        const canViewSystemExplores = this.canViewSystemExplores(
+            account,
+            organizationUuid,
+            projectUuid,
+        );
+        const visibleExploreSummaries = allExploreSummaries.filter(
+            (explore) => {
+                if (explore.type === ExploreType.PRE_AGGREGATE) {
+                    return shouldIncludePreAggregateExplores;
+                }
+                if (explore.type === ExploreType.SYSTEM) {
+                    return canViewSystemExplores;
+                }
+                return true;
+            },
+        );
 
         if (filtered) {
             const {
@@ -6962,6 +6992,7 @@ export class ProjectService extends BaseService {
                     (explore) =>
                         hasIntersection(explore.tags || [], value || []) ||
                         explore.type === ExploreType.VIRTUAL || // Custom explores/Virtual views are included by default
+                        explore.type === ExploreType.SYSTEM || // System explores are not selectable via dbt tables
                         (shouldIncludePreAggregateExplores &&
                             explore.type === ExploreType.PRE_AGGREGATE),
                 );
@@ -6971,6 +7002,7 @@ export class ProjectService extends BaseService {
                     (explore) =>
                         (value || []).includes(explore.name) ||
                         explore.type === ExploreType.VIRTUAL || // Custom explores/Virtual views are included by default
+                        explore.type === ExploreType.SYSTEM || // System explores are not selectable via dbt tables
                         (shouldIncludePreAggregateExplores &&
                             explore.type === ExploreType.PRE_AGGREGATE),
                 );
@@ -7126,6 +7158,11 @@ export class ProjectService extends BaseService {
                         project.organizationUuid,
                         projectUuid,
                     );
+                const canViewSystemExplores = this.canViewSystemExplores(
+                    account,
+                    project.organizationUuid,
+                    projectUuid,
+                );
 
                 const filteredExplores = Object.values(explores).reduce<
                     Record<string, Explore | ExploreError>
@@ -7133,6 +7170,12 @@ export class ProjectService extends BaseService {
                     if (
                         explore.type === ExploreType.PRE_AGGREGATE &&
                         !canViewPreAggregateExplores
+                    ) {
+                        return acc;
+                    }
+                    if (
+                        explore.type === ExploreType.SYSTEM &&
+                        !canViewSystemExplores
                     ) {
                         return acc;
                     }

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -74,6 +74,26 @@ describe('Organization member permissions', () => {
                 ).toEqual(true);
             });
 
+            it('can view system analytics in their own organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SystemAnalytics', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SystemAnalytics', {
+                            organizationUuid: 'another-org',
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
             it('can manage member profiles', () => {
                 expect(
                     ability.can('manage', 'OrganizationMemberProfile'),
@@ -591,6 +611,18 @@ describe('Organization member permissions', () => {
 
             it('cannot manage organizations', () => {
                 expect(ability.can('manage', 'Organization')).toEqual(false);
+            });
+
+            it('cannot view system analytics', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SystemAnalytics', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
             });
 
             it('can view and manage public & accessable dashboards', () => {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -447,6 +447,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('view', 'Analytics', {
             organizationUuid: member.organizationUuid,
         });
+        can('view', 'SystemAnalytics', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'OrganizationMemberProfile', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -181,6 +181,7 @@ const BASE_ROLE_SCOPES = {
         'manage:GitIntegration',
         'manage:OrganizationWarehouseCredentials',
         'manage:Organization',
+        'view:SystemAnalytics',
         'impersonate:User',
 
         // PAT management. Granted dynamically at runtime via

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -80,6 +80,7 @@ const ENTERPRISE_SUBJECTS = new Set([
     'AiAgentThread',
     'ContentAsCode',
     'PreAggregation',
+    'SystemAnalytics',
     'ExternalConnection',
     // The matching scopes (`view:` + `manage:OrganizationWarehouseCredentials`)
     // are `isEnterprise: true` in scopes.ts, so the scope-build path
@@ -138,6 +139,7 @@ const PROJECT_PARITY_IGNORE = new Set([
     '*:GitIntegration',
     '*:OrganizationWarehouseCredentials',
     '*:User', // impersonate:User
+    '*:SystemAnalytics', // org-admin only, granted at org-level assignment
 
     // Case 2: granular actions subsumed by project's broader `manage:X`.
     'create:Job',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1106,6 +1106,14 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'view:SystemAnalytics',
+        description: 'View and query Lightdash usage analytics explores',
+        isEnterprise: true,
+        group: ScopeGroup.DATA,
+        dependencies: [{ name: 'view:Project' }],
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:ExportCsv',
         description: 'Export data to CSV',
         isEnterprise: false,

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -246,6 +246,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'PreAggregation', {
             organizationUuid,
         });
+        can('view', 'SystemAnalytics', {
+            organizationUuid,
+        });
         can('manage', 'VirtualView', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -63,6 +63,7 @@ export type CaslSubjectNames =
     | 'Space'
     | 'SpotlightTableConfig'
     | 'SqlRunner'
+    | 'SystemAnalytics'
     | 'Tags'
     | 'UnderlyingData'
     | 'User'

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -697,6 +697,100 @@ describe('DuckdbWarehouseClient', () => {
             expect(streamMock).not.toHaveBeenCalled();
         });
 
+        describe('allowedReadParquetUriPrefixes', () => {
+            const ALLOWED_PREFIX = 's3://bucket/events/compacted/';
+            const newClientWithPrefix = () =>
+                new DuckdbWarehouseClient(undefined, {
+                    allowedReadParquetUriPrefixes: [ALLOWED_PREFIX],
+                });
+
+            it('should allow read_parquet with a literal uri under an allowed prefix', async () => {
+                const streamMock = vi.fn(async () =>
+                    getMockStreamResult(
+                        [[{ val: 1 }]],
+                        [DUCKDB_TYPE_IDS.INTEGER],
+                    ),
+                );
+                createInstanceMock.mockResolvedValue(
+                    createMockConnection(streamMock),
+                );
+
+                const client = newClientWithPrefix();
+                await client.runQuery(
+                    "SELECT * FROM read_parquet('s3://bucket/events/compacted/org_id=abc/**/*.parquet', hive_partitioning=true, union_by_name=true) AS t",
+                );
+                expect(streamMock).toHaveBeenCalled();
+            });
+
+            it('should reject read_parquet with a literal uri outside allowed prefixes', async () => {
+                const streamMock = vi.fn();
+                createInstanceMock.mockResolvedValue(
+                    createMockConnection(streamMock),
+                );
+
+                const client = newClientWithPrefix();
+                await expect(
+                    client.runQuery(
+                        "SELECT * FROM read_parquet('s3://bucket/other/file.parquet')",
+                    ),
+                ).rejects.toThrow(
+                    "SQL validation error: function 'read_parquet' is not allowed",
+                );
+                expect(streamMock).not.toHaveBeenCalled();
+            });
+
+            it('should reject read_parquet with a non-literal uri even when prefixed', async () => {
+                const streamMock = vi.fn();
+                createInstanceMock.mockResolvedValue(
+                    createMockConnection(streamMock),
+                );
+
+                const client = newClientWithPrefix();
+                await expect(
+                    client.runQuery(
+                        "SELECT * FROM read_parquet('s3://bucket/events/compacted/' || secret)",
+                    ),
+                ).rejects.toThrow(
+                    "SQL validation error: function 'read_parquet' is not allowed",
+                );
+                expect(streamMock).not.toHaveBeenCalled();
+            });
+
+            it('should reject read_parquet with a list uri argument', async () => {
+                const streamMock = vi.fn();
+                createInstanceMock.mockResolvedValue(
+                    createMockConnection(streamMock),
+                );
+
+                const client = newClientWithPrefix();
+                await expect(
+                    client.runQuery(
+                        "SELECT * FROM read_parquet(['s3://bucket/events/compacted/a.parquet'])",
+                    ),
+                ).rejects.toThrow(
+                    "SQL validation error: function 'read_parquet' is not allowed",
+                );
+                expect(streamMock).not.toHaveBeenCalled();
+            });
+
+            it('should still reject other file readers when prefixes are configured', async () => {
+                const streamMock = vi.fn();
+                createInstanceMock.mockResolvedValue(
+                    createMockConnection(streamMock),
+                );
+
+                const client = newClientWithPrefix();
+                await expect(
+                    client.runQuery(
+                        "SELECT * FROM read_csv('s3://bucket/events/compacted/a.csv')",
+                    ),
+                ).rejects.toThrow(
+                    "SQL validation error: function 'read_csv' is not allowed",
+                );
+                expect(streamMock).not.toHaveBeenCalled();
+            });
+        });
+
         it('should reject user queries that use file table paths', async () => {
             const streamMock = vi.fn(async () =>
                 getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -138,6 +138,13 @@ export type DuckdbWarehouseClientOptions = {
     instanceCacheKey?: string;
     logger?: DuckdbLogger;
     onQueryProfile?: (profile: DuckdbQueryProfileMetrics) => void;
+    /**
+     * Server-generated `read_parquet('<uri>', ...)` FROM targets whose uri is
+     * a single string literal starting with one of these prefixes pass the
+     * user-SQL file access validation. Everything else (other file readers,
+     * non-literal uris, other prefixes) stays blocked.
+     */
+    allowedReadParquetUriPrefixes?: string[];
 };
 
 export const mapFieldTypeFromTypeId = (typeId: number): DimensionType => {
@@ -327,6 +334,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         profile: DuckdbQueryProfileMetrics,
     ) => void;
 
+    private readonly allowedReadParquetUriPrefixes: string[];
+
     constructor(
         credentials?: CreateDuckdbCredentials | DuckdbConnectionCredentials,
         options?: DuckdbWarehouseClientOptions,
@@ -415,6 +424,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             options?.instanceCacheKey ?? ducklakeAutoCacheKey;
         this.logger = options?.logger;
         this.onQueryProfile = options?.onQueryProfile;
+        this.allowedReadParquetUriPrefixes =
+            options?.allowedReadParquetUriPrefixes ?? [];
     }
 
     private static hashDucklakeConfig(
@@ -1443,8 +1454,32 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         }
     }
 
-    private static validateUserSqlFileAccess(sql: string): void {
-        const stripped = DuckdbWarehouseClient.stripSqlComments(sql);
+    /**
+     * Blanks out `read_parquet('<literal uri>' [,...)])` calls whose uri
+     * starts with an allowed prefix so the file-access blocklist below does
+     * not reject server-generated FROM targets (e.g. system usage-analytics
+     * explores). The literal must be the complete first argument — dynamic
+     * uris (concatenation, subqueries, lists) are never allowed.
+     */
+    private sanitizeAllowedReadParquetCalls(sql: string): string {
+        if (this.allowedReadParquetUriPrefixes.length === 0) {
+            return sql;
+        }
+        return sql.replace(
+            /\bread_parquet(\s*\(\s*'([^']*)')(?=\s*[,)])/gi,
+            (match, rest, uri) =>
+                this.allowedReadParquetUriPrefixes.some((prefix) =>
+                    uri.startsWith(prefix),
+                )
+                    ? `allowed_read_parquet${rest}`
+                    : match,
+        );
+    }
+
+    private validateUserSqlFileAccess(sql: string): void {
+        const stripped = this.sanitizeAllowedReadParquetCalls(
+            DuckdbWarehouseClient.stripSqlComments(sql),
+        );
         const functionMatch = stripped.match(
             BLOCKED_USER_SQL_FILE_FUNCTION_PATTERN,
         );
@@ -1466,7 +1501,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         sql: string,
     ): Promise<void> {
         DuckdbWarehouseClient.validateSqlFunctions(sql);
-        DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
+        this.validateUserSqlFileAccess(sql);
 
         const extracted = await db.extractStatements(sql);
 


### PR DESCRIPTION
## What

Access control and execution routing for SYSTEM (usage analytics) explores.

**Org scope (`view:SystemAnalytics`)**
- New CASL subject `SystemAnalytics`, scope `view:SystemAnalytics` (`isEnterprise: true`, `ScopeGroup.DATA`)
- Granted to **org admins only**: `organizationMemberAbility.admin`, service-account `ORG_ADMIN`, and `roleToScopeMapping` ADMIN (org-management section — no-op at project assignment). Developer access is a separate ticket (PROD-2758).
- Filtering at both explore chokepoints, mirroring the `manage:PreAggregation` pattern: `getAllExploresSummary` and `findExploresWithUserAccessControls` (the latter covers `getExploreWithUserAccessControls`, so direct query execution 404s for users without the scope; the materialization-role variant in `AsyncQueryService.getExploreForMetricQueryExecution` gets an explicit check).

**DuckDB execution routing**
- Compile: `getWarehouseSqlBuilderForExplore` swaps in the DuckDB SQL builder for SYSTEM explores at all seven explore-driven compile sites (metric query, saved chart, dashboard chart, underlying data, field-value search, totals, prepared query).
- Execute: `runAsyncWarehouseQuery` detects SYSTEM-explore queries (cheap name check, confirmed against the cached explore) and swaps in a cached `DuckdbWarehouseClient` over `lightdashConfig.usageEvents.s3` — a single chokepoint covering both the inline and queued (NATS worker) paths. No warehouse fallback: system query errors mark the query as errored. New `executionSource: 'system_duckdb'` label on query analytics.
- `DuckdbWarehouseClient` gets `allowedReadParquetUriPrefixes`: the user-SQL file-access blocklist from #24919 now permits `read_parquet('<literal uri>')` when the uri literal is the complete first argument and starts with an allowed prefix (`s3://<bucket>/events/compacted/` for the system client). Dynamic uris (concat/lists), other prefixes, and other file readers stay blocked; clients without the option are unchanged.

## Why

A user without the scope must neither see a SYSTEM explore nor run a query against it by hitting the API directly, and queries must execute on DuckDB over the compacted zone instead of the project warehouse. Linear: https://linear.app/lightdash/issue/PROD-8608

## Stack

Depends on #25062 (explore injection). Top of the PROD-8608 stack.

## Judgment calls

- **Type-check over `requiredScope` field**: gating keys off `explore.type === SYSTEM` at the existing chokepoints rather than a generic `requiredScope` field on the explore — one mechanism, mirrors pre-agg exactly; a `requiredScope` field can be introduced later if a second scoped explore type appears.
- Scope named `view:SystemAnalytics` (distinct from the existing `view:Analytics` usage-dashboards scope).
- Detection at `runAsyncWarehouseQuery` (not a new routing target) keeps the NATS enqueue/worker protocol untouched.
- Multi-org instances never inject system explores (see #25062), so the singleton DuckDB client + compacted-zone prefix are safe.

## Testing

- `roleToScopeParity` passes; new ability tests (org admin can view own-org SystemAnalytics, not another org; editor cannot)
- New `DuckdbWarehouseClient` validation tests: allowed-prefix literal passes; other prefixes, concatenated uris, list args, and other file readers still blocked
- All quality gates green: common/backend/warehouses lint + typecheck + tests, frontend typecheck

## E2E evidence (dev stack, real MinIO compacted partition)

Admin query `event_name` + `total_events` against `lightdash_query_events` (v2 async query API):

```json
[{"event_name": "query.executed", "total_events": 1},
 {"event_name": "query.ready", "total_events": 1}]
```

`query_history.compiled_sql` confirms DuckDB dialect over the org-pinned compacted zone (`FROM read_parquet('s3://default/events/compacted/org_id=172a2270-.../stream=query_events/**/*.parquet', hive_partitioning=true, union_by_name=true)`), 2 rows in 85ms.

Gating: org editor (`demo2@`) sees 60 explores (no system) vs admin's 61; direct query → 404 `Explore "lightdash_query_events" does not exist.` SQL Runner tables endpoint only lists the project Postgres catalog — no system source.

## Deferred

- Frontend settings switch for the project toggle
- Developer-role access (PROD-2758)
- Legacy sync query path (`runQuery` v1) does not route SYSTEM explores; Explorer/dashboards use the async path (same situation as pre-aggregates)

https://claude.ai/code/session_011AsrrbU7h5qFRayP3iWyGF
