### PR TITLE
feat(ai-reviews): phase-1 quick wins for the review classifier evidence packet

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -406,6 +406,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
                     aiAgentModel: models.getAiAgentModel<AiAgentModel>(),
+                    aiAgentDocumentModel:
+                        models.getAiAgentDocumentModel<AiAgentDocumentModel>(),
                     aiOrganizationSettingsModel:
                         models.getAiOrganizationSettingsModel(),
                     catalogModel: models.getCatalogModel(),

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -334,21 +334,31 @@ type ToolCallEvidenceRow = {
 
 const TOOL_NAME_PRIORITY = new Map<string, number>([
     ['editDbtProject', 95],
+    ['proposeWriteback', 95],
     ['propose_writeback', 95],
     ['runAiWriteback', 95],
     ['run_ai_writeback', 95],
     ['findFields', 80],
     ['find_fields', 80],
+    ['editContent', 75],
+    ['createContent', 75],
     ['findExplores', 70],
     ['find_explores', 70],
+    ['repoShell', 70],
+    ['exploreRepo', 70],
     ['runQuery', 65],
     ['run_metric_query', 65],
     ['runSql', 60],
     ['run_sql', 60],
+    ['generateVisualization', 60],
     ['searchFieldValues', 55],
     ['search_field_values', 55],
+    ['getDashboardCharts', 55],
     ['discoverFields', 50],
 ]);
+
+const MCP_TOOL_NAME_PREFIX = 'mcp_';
+const MCP_TOOL_NAME_SCORE = 50;
 
 const TOOL_RESULT_ERROR_PATTERN =
     /no match|no relevant|not found|empty|error|failed/i;
@@ -397,7 +407,11 @@ const rankToolCallEvidence = ({
                     ? (100 * overlapCount) / queryTokens.size
                     : 0;
 
-            const nameScore = TOOL_NAME_PRIORITY.get(row.tool_name) ?? 10;
+            const nameScore =
+                TOOL_NAME_PRIORITY.get(row.tool_name) ??
+                (row.tool_name.startsWith(MCP_TOOL_NAME_PREFIX)
+                    ? MCP_TOOL_NAME_SCORE
+                    : 10);
             const parentBonus = row.parent_tool_call_id ? 15 : 0;
             const errorBonus = TOOL_RESULT_ERROR_PATTERN.test(resultText)
                 ? 25
@@ -959,6 +973,10 @@ export class AiAgentReviewClassifierModel {
                     .whereIn(
                         'tool_call.tool_name',
                         Array.from(TOOL_NAME_PRIORITY.keys()),
+                    )
+                    .orWhereILike(
+                        'tool_call.tool_name',
+                        `${MCP_TOOL_NAME_PREFIX.replace('_', '\\_')}%`,
                     )
                     .orWhereNotNull('tool_call.parent_tool_call_id');
             });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -292,6 +292,9 @@ describe('AiAgentReviewClassifierService', () => {
     const aiAgentModel = {
         getAgent: vi.fn(),
     };
+    const aiAgentDocumentModel = {
+        findAllForAgent: vi.fn().mockResolvedValue([]),
+    };
     const aiOrganizationSettingsModel = {
         findByOrganizationUuid: vi.fn(),
     } as unknown as import('vitest').Mocked<AiOrganizationSettingsModel>;
@@ -309,6 +312,7 @@ describe('AiAgentReviewClassifierService', () => {
     const service = new AiAgentReviewClassifierService({
         aiAgentReviewClassifierModel: model,
         aiAgentModel: aiAgentModel as never,
+        aiAgentDocumentModel,
         aiOrganizationSettingsModel,
         catalogModel: catalogModel as never,
         projectModel: projectModel as never,
@@ -339,6 +343,7 @@ describe('AiAgentReviewClassifierService', () => {
         aiAgentReviewNotificationService.notifyNeedsReview.mockResolvedValue(
             undefined,
         );
+        aiAgentDocumentModel.findAllForAgent.mockResolvedValue([]);
         aiAgentModel.getAgent.mockResolvedValue({
             uuid: AGENT_UUID,
             organizationUuid: ORGANIZATION_UUID,

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -31,6 +31,7 @@ import { type CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
+import { type AiAgentDocumentModel } from '../models/AiAgentDocumentModel';
 import { type AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
@@ -75,6 +76,7 @@ type AiAgentReviewClassifierJudgeTargetRef =
 type AiAgentReviewClassifierServiceDependencies = {
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     aiAgentModel: AiAgentModel;
+    aiAgentDocumentModel: Pick<AiAgentDocumentModel, 'findAllForAgent'>;
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
     catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
     projectModel: Pick<ProjectModel, 'getSummary'>;
@@ -235,6 +237,11 @@ export class AiAgentReviewClassifierService extends BaseService {
 
     private readonly aiAgentModel: AiAgentModel;
 
+    private readonly aiAgentDocumentModel: Pick<
+        AiAgentDocumentModel,
+        'findAllForAgent'
+    >;
+
     private readonly catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
 
     private readonly projectModel: Pick<ProjectModel, 'getSummary'>;
@@ -254,6 +261,7 @@ export class AiAgentReviewClassifierService extends BaseService {
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
         this.aiAgentModel = dependencies.aiAgentModel;
+        this.aiAgentDocumentModel = dependencies.aiAgentDocumentModel;
         this.catalogModel = dependencies.catalogModel;
         this.projectModel = dependencies.projectModel;
         this.aiOrganizationSettingsModel =
@@ -918,11 +926,18 @@ export class AiAgentReviewClassifierService extends BaseService {
                 projectUuid: candidate.subject.projectUuid,
                 agentUuid: candidate.subject.agentUuid,
             });
+            const knowledgeDocuments =
+                await this.aiAgentDocumentModel.findAllForAgent({
+                    organizationUuid: candidate.subject.organizationUuid,
+                    agentUuid: candidate.subject.agentUuid,
+                    projectUuid: candidate.subject.projectUuid,
+                });
 
             const instruction = agent.instruction ?? null;
             const settings = [
                 instruction ? 'instructions' : null,
-                'data_access',
+                knowledgeDocuments.length > 0 ? 'knowledge_documents' : null,
+                agent.enableDataAccess ? 'data_access' : null,
                 agent.enableSelfImprovement ? 'self_improvement' : null,
                 agent.spaceAccess.length > 0 ? 'space_access' : null,
                 agent.groupAccess.length > 0 || agent.userAccess.length > 0
@@ -952,9 +967,14 @@ export class AiAgentReviewClassifierService extends BaseService {
                 availableCapabilities,
                 instructionHash: instruction ? hashText(instruction) : null,
                 instructionSummary: instruction
-                    ? truncate(instruction, 500)
+                    ? truncate(instruction, 2000)
                     : null,
-                knowledgeDocuments: [],
+                knowledgeDocuments: knowledgeDocuments.map((document) => ({
+                    uuid: document.uuid,
+                    name: document.name,
+                    updatedAt: document.updatedAt.toISOString(),
+                    summary: document.summary,
+                })),
             };
             const snapshotHash = getAiAgentConfigSnapshotHash(snapshot);
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -376,6 +376,62 @@ describe('aiAgentReviewClassifierJudgeOutputSchema', () => {
             }).success,
         ).toBe(true);
     });
+
+    it.each([
+        'normal_refinement',
+        'output_shape_correction',
+        'new_question',
+        'acceptance_or_continuation',
+    ] as const)('rejects a promoted finding with signal %s', (signal) => {
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse({
+                ...baseJudgeOutput,
+                signal,
+            }).success,
+        ).toBe(false);
+    });
+
+    it('accepts a non-failure signal when not promoted', () => {
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse({
+                ...baseJudgeOutput,
+                signal: 'acceptance_or_continuation',
+                promotedToFinding: false,
+                primaryRootCause: 'not_a_failure',
+            }).success,
+        ).toBe(true);
+    });
+
+    it('rejects a promoted finding whose recommendation is no_action', () => {
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse({
+                ...baseJudgeOutput,
+                recommendation: {
+                    actionType: 'no_action',
+                    title: 'Nothing to do',
+                    rationale: 'n/a',
+                    targetRefs: [],
+                },
+            }).success,
+        ).toBe(false);
+    });
+
+    it('accepts a no_action recommendation when not promoted', () => {
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse({
+                ...baseJudgeOutput,
+                promotedToFinding: false,
+                primaryRootCause: 'not_a_failure',
+                signal: 'new_question',
+                recommendation: {
+                    actionType: 'no_action',
+                    title: 'Nothing to do',
+                    rationale: 'n/a',
+                    targetRefs: [],
+                },
+            }).success,
+        ).toBe(true);
+    });
 });
 
 describe('getAiAgentConfigSnapshotHash', () => {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -480,6 +480,14 @@ export type AiAgentJudgeProjectContextEntry = {
     objects: string[];
 };
 
+// Signals that describe a healthy turn — mutually exclusive with promotion.
+const NOT_A_FAILURE_SIGNALS: ReadonlySet<string> = new Set([
+    'normal_refinement',
+    'output_shape_correction',
+    'new_question',
+    'acceptance_or_continuation',
+]);
+
 export const aiAgentReviewClassifierJudgeOutputSchema = z
     .object({
         signal: z.enum([
@@ -606,6 +614,27 @@ export const aiAgentReviewClassifierJudgeOutputSchema = z
                 message:
                     'promotedToFinding must be false when primaryRootCause is not_a_failure',
                 path: ['promotedToFinding'],
+            });
+        }
+        if (
+            output.promotedToFinding &&
+            NOT_A_FAILURE_SIGNALS.has(output.signal)
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `promotedToFinding must be false when signal is ${output.signal}; promoted findings need a failure signal`,
+                path: ['signal'],
+            });
+        }
+        if (
+            output.promotedToFinding &&
+            output.recommendation?.actionType === 'no_action'
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                    'promoted findings must carry an actionable recommendation, not no_action',
+                path: ['recommendation', 'actionType'],
             });
         }
     });


### PR DESCRIPTION
## Summary

Phase 1 of the AI review classifier improvement plan (Linear: **ZAP-553** part, **ZAP-560** part, **ZAP-563**) — three independent, near-zero-risk fixes from the analytics-org audit, each addressing a distinct evidence-packet/output defect. Stacked on the replay scoreboard (#25064) they'll be measured against.

## Changes

### Tool-evidence ranking — ZAP-553 (part)
The audit found the evidence packet was *success-blind*: the eligibility whitelist only covered discovery/query tools plus snake_case writeback names, so successful content edits, repo inspection, visualizations, and all MCP tool traces never reached the judge — which then read recovered turns as unrecovered failures.

- `proposeWriteback` (legacy camelCase rows persisted before the tool rename) now ranks at writeback priority (95) instead of falling to the default 10.
- `editContent`, `createContent`, `repoShell`, `exploreRepo`, `generateVisualization`, `getDashboardCharts` added to eligibility + ranking.
- `mcp_*` tools eligible via ILIKE with a moderate default score (50).

### Agent-config evidence — ZAP-560 (part)
- `knowledgeDocuments` in the config snapshot is now the agent's real document list (`AiAgentDocumentModel.findAllForAgent`) instead of a hardcoded `[]` — the judge was recommending "add a knowledge document" for agents that already had one.
- `data_access` in settings is gated on `enableDataAccess` instead of always claimed.
- Instruction summary budget raised 500 → 2000 chars.

### Judge output self-consistency — ZAP-563
Schema-level `superRefine` guardrails (model-free; `generateObject` retries on violation):
- `promotedToFinding: true` + a non-failure signal (`normal_refinement`, `output_shape_correction`, `new_question`, `acceptance_or_continuation`) is rejected.
- `promotedToFinding: true` + `recommendation.actionType: no_action` is rejected.

This removes the 18 self-contradictory findings observed in the audit at the output boundary.

## Verification

- 7 new schema tests in common; service/model suites updated for the new dependency.
- `common` build + tests green (2613), backend typecheck + full suite green (3428), lint clean.
- Next: replay the judge over the captured audit fixture (scoreboard from #25064) to measure the FP-rate drop.

## Regression analysis

- The config-snapshot changes alter `agentConfigSnapshotHash` for agents whose snapshot previously misreported (`data_access` claimed but disabled, missing knowledge docs, >500-char instructions). That hash is an evidence fingerprint, not a dedup key for review items — new runs simply record a more truthful snapshot.
- The schema guardrails only reject outputs that were already self-contradictory; consistent judge outputs are unaffected.
- Tool-eligibility widening only adds candidate evidence rows; the packet still caps supporting evidence at the top 5 by relevance.
- No API shapes, permissions, or persisted schemas change; no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiTzUNSpHJkWoJGVXQ5eNV