### PR TITLE
feat(ai-reviews): ground next-user-turn signals in a real next user prompt

### DIFF
--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -619,6 +619,8 @@ describe('AiAgentReviewClassifierService', () => {
             makeCandidate({
                 userPrompt:
                     'No, country is not available here, so use airport name.',
+                nextUserPromptUuid: '00000000-0000-0000-0000-000000000013',
+                nextUserPrompt: 'Thanks, airport name works.',
                 contextTurns: [
                     {
                         relation: 'previous',
@@ -773,5 +775,105 @@ describe('resolveReviewJudgeProvider', () => {
         expect(resolveReviewJudgeProvider(copilotWith({ openai: {} }))).toBe(
             undefined,
         );
+    });
+});
+
+describe('enforceNextUserSignalGrounding', () => {
+    const promotedWithNextUserSignal = (
+        overrides: Partial<AiAgentReviewClassifierJudgeOutput> = {},
+    ): AiAgentReviewClassifierJudgeOutput =>
+        makeJudgeOutput({
+            signal: 'implicit_correction',
+            implicitSignalSources: ['next_user_correction'],
+            promotedToFinding: true,
+            promotionReason: 'User corrected the metric.',
+            primaryRootCause: 'semantic_layer',
+            ...overrides,
+        });
+
+    it('returns the output untouched when a next user prompt exists', () => {
+        const output = promotedWithNextUserSignal();
+        expect(
+            AiAgentReviewClassifierService.enforceNextUserSignalGrounding(
+                output,
+                true,
+            ),
+        ).toBe(output);
+    });
+
+    it('returns the output untouched when no next_user_* sources were emitted', () => {
+        const output = promotedWithNextUserSignal({
+            implicitSignalSources: ['tool_error'],
+        });
+        expect(
+            AiAgentReviewClassifierService.enforceNextUserSignalGrounding(
+                output,
+                false,
+            ),
+        ).toBe(output);
+    });
+
+    it('strips fabricated next_user_* sources and demotes when nothing else supports promotion', () => {
+        const result =
+            AiAgentReviewClassifierService.enforceNextUserSignalGrounding(
+                promotedWithNextUserSignal({
+                    implicitSignalSources: [
+                        'next_user_correction',
+                        'next_user_retry',
+                    ],
+                }),
+                false,
+            );
+        expect(result.implicitSignalSources).toEqual([]);
+        expect(result.promotedToFinding).toBe(false);
+        expect(result.promotionReason).toBe(
+            'next_user_signal_without_next_user_prompt',
+        );
+    });
+
+    it('strips fabricated sources but keeps the promotion when other promotable evidence remains', () => {
+        const result =
+            AiAgentReviewClassifierService.enforceNextUserSignalGrounding(
+                promotedWithNextUserSignal({
+                    implicitSignalSources: [
+                        'next_user_correction',
+                        'tool_error',
+                    ],
+                }),
+                false,
+            );
+        expect(result.implicitSignalSources).toEqual(['tool_error']);
+        expect(result.promotedToFinding).toBe(true);
+    });
+
+    it('demotes when only output_shape_correction remains after stripping', () => {
+        const result =
+            AiAgentReviewClassifierService.enforceNextUserSignalGrounding(
+                promotedWithNextUserSignal({
+                    implicitSignalSources: [
+                        'next_user_retry',
+                        'output_shape_correction',
+                    ],
+                }),
+                false,
+            );
+        expect(result.implicitSignalSources).toEqual([
+            'output_shape_correction',
+        ]);
+        expect(result.promotedToFinding).toBe(false);
+    });
+
+    it('strips without demoting when the output was not promoted', () => {
+        const result =
+            AiAgentReviewClassifierService.enforceNextUserSignalGrounding(
+                promotedWithNextUserSignal({
+                    promotedToFinding: false,
+                    promotionReason: null,
+                }),
+                false,
+            );
+        expect(result.implicitSignalSources).toEqual([]);
+        expect(result.promotedToFinding).toBe(false);
+        expect(result.promotionReason).toBeNull();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -41,7 +41,7 @@ import { getAiCallTelemetry } from './ai/utils/aiCallTelemetry';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
-const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v10';
+const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v11';
 const WRITEBACK_TOOL_NAMES = new Set([
     'editDbtProject',
     'propose_writeback',
@@ -370,12 +370,17 @@ export class AiAgentReviewClassifierService extends BaseService {
         if (successfulWritebackEvidence) {
             return { suppressed: 'writeback_in_progress', judgeOutput: null };
         }
+        const judgeOutput = await this.judgeTurn(
+            input.candidate,
+            input.evidencePacket,
+        );
         return {
             suppressed: null,
-            judgeOutput: await this.judgeTurn(
-                input.candidate,
-                input.evidencePacket,
-            ),
+            judgeOutput:
+                AiAgentReviewClassifierService.enforceNextUserSignalGrounding(
+                    judgeOutput,
+                    input.evidencePacket.nextUserPrompt !== null,
+                ),
         };
     }
 
@@ -647,6 +652,49 @@ export class AiAgentReviewClassifierService extends BaseService {
         }
     }
 
+    /**
+     * next_user_* signals require a real next user turn. When there is none,
+     * strip them, and demote the finding when nothing else promotable remains
+     * — the promotion was built on fabricated evidence.
+     */
+    static enforceNextUserSignalGrounding(
+        judgeOutput: AiAgentReviewClassifierJudgeOutput,
+        hasNextUserPrompt: boolean,
+    ): AiAgentReviewClassifierJudgeOutput {
+        if (hasNextUserPrompt) {
+            return judgeOutput;
+        }
+        const nextUserSources = new Set([
+            'next_user_correction',
+            'next_user_dispute',
+            'next_user_retry',
+        ]);
+        const fabricatedSources = judgeOutput.implicitSignalSources.filter(
+            (source) => nextUserSources.has(source),
+        );
+        if (fabricatedSources.length === 0) {
+            return judgeOutput;
+        }
+        const implicitSignalSources = judgeOutput.implicitSignalSources.filter(
+            (source) => !nextUserSources.has(source),
+        );
+        const remainingPromotableSources = implicitSignalSources.filter(
+            (source) => source !== 'output_shape_correction',
+        );
+        const shouldDemote =
+            judgeOutput.promotedToFinding &&
+            remainingPromotableSources.length === 0;
+        if (!shouldDemote) {
+            return { ...judgeOutput, implicitSignalSources };
+        }
+        return {
+            ...judgeOutput,
+            implicitSignalSources,
+            promotedToFinding: false,
+            promotionReason: 'next_user_signal_without_next_user_prompt',
+        };
+    }
+
     private async classifyTurnWithJudge(
         candidate: AiAgentReviewClassifierTurnCandidate,
         agentConfig: AiAgentReviewAgentConfigEvidence,
@@ -683,10 +731,28 @@ export class AiAgentReviewClassifierService extends BaseService {
             candidate,
             agentConfig,
         );
-        const judgeOutput = await this.judgeTurn(
+        const rawJudgeOutput = await this.judgeTurn(
             candidate,
             reviewEvidence.evidencePacket,
         );
+        const judgeOutput =
+            AiAgentReviewClassifierService.enforceNextUserSignalGrounding(
+                rawJudgeOutput,
+                reviewEvidence.evidencePacket.nextUserPrompt !== null,
+            );
+        if (judgeOutput !== rawJudgeOutput) {
+            this.debugLog('NextUserSignalGroundingApplied', {
+                promptUuid: candidate.subject.assistantPromptUuid,
+                threadUuid: candidate.subject.threadUuid,
+                strippedSources: rawJudgeOutput.implicitSignalSources.filter(
+                    (source) =>
+                        !judgeOutput.implicitSignalSources.includes(source),
+                ),
+                demoted:
+                    rawJudgeOutput.promotedToFinding &&
+                    !judgeOutput.promotedToFinding,
+            });
+        }
         const signal: AiAgentReviewClassifierTurnSignal = {
             subject: candidate.subject,
             interactionSource: candidate.interactionSource,
@@ -1141,6 +1207,11 @@ Implicit signal definitions — set these whenever the evidence supports them:
 - tool_error: a tool call errored, timed out, or returned an empty / error result the assistant did not recover from.
 - product_capability_request: the user asked for something Lightdash cannot currently express.
 - human_intervention: an admin or engineer had to step in.
+
+Grounding rules for next_user_* signals — these override everything below:
+- The evidence packet's nextUserPrompt field is the ONLY evidence for next_user_correction, next_user_dispute, and next_user_retry. When nextUserPrompt is null there is no next user turn: never emit these signals, and never imagine or predict what the user would say next.
+- Never derive next_user_* signals from the reviewed turn's own userPrompt, from the assistant's answer, or from caveats, hedging, or self-critique inside the assistant's answer.
+- A clarifying or interrogative question asked BY THE ASSISTANT is not a user retry, correction, or dispute.
 
 Decision rules — apply in order:
 


### PR DESCRIPTION
## Summary

Phase 2 of the AI review classifier improvement plan (Linear: **ZAP-552**) — forbid fabricated next-user-turn signals. This is the single biggest false-positive driver from the analytics-org audit: ~60 of the 102 non-GOOD findings involved the judge claiming `next_user_correction`/`next_user_dispute`/`next_user_retry` on turns that had **no next user turn**, inventing what the user "would" say next or reading the assistant's own hedging as a user dispute. `implicit_correction` signals were 41% false-positive vs ~3x cleaner retry/dispute signals.

Stacked on #25065; measurable on the replay scoreboard from #25064.

## Changes

**Judge prompt v11** — new grounding block that overrides the decision rules:
- `nextUserPrompt` is the ONLY evidence for `next_user_*` signals; when it is null there is no next user turn — never emit them, never predict the user's next message.
- Never derive `next_user_*` from the reviewed turn's own prompt, the assistant's answer, or caveats/self-critique inside it.
- A clarifying question asked by the assistant is not a user retry/correction/dispute.

**Deterministic post-judge guard** (`enforceNextUserSignalGrounding`) — belt and braces for when the model ignores the prompt:
- When the packet has no next user prompt, strip `next_user_*` sources from the output.
- Demote the finding only when nothing else promotable remains (a fabricated source alongside e.g. `tool_error` keeps the promotion; `output_shape_correction` alone does not sustain it).
- Applied on both the live classify path and the scoreboard replay path, so the eval measures deployed behavior.

`JUDGE_PROMPT_HASH` bumped v10 → v11.

## Verification

- 6 new unit tests covering the guard (untouched with a real next prompt, untouched without fabricated sources, strip+demote, strip+keep on other evidence, output_shape-only demotion, strip without demote on unpromoted output).
- One existing fixture updated: it promoted on `next_user_correction` while its candidate had `nextUserPrompt: null` — exactly the fabrication this PR forbids; it now carries a real next user turn.
- Backend typecheck + full suite green (3434); lint clean.
- Next: replay the audit fixture on the scoreboard to quantify the FP drop (expected to flip most of the fabricated-repeat FPs to not-promoted).

## Regression analysis

- Turns WITH a real next user turn are untouched (guard early-returns; the prompt rules only constrain the null case).
- Findings promoted on grounded evidence (`tool_error`, `assistant_no_answer`, human feedback, etc.) are untouched even when a fabricated source is stripped alongside.
- The hash bump means new runs record `ai-agent-review-judge-v11`; existing signals/items are unaffected (hash is recorded metadata, not a dedup key).
- No API shapes, permissions, or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiTzUNSpHJkWoJGVXQ5eNV