### PR TITLE
feat(ai-reviews): guaranteed tool outcomes, approval-timeout carve-out, preview-thread exclusion

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -553,11 +553,27 @@ describe('AiAgentReviewClassifierModel', () => {
                 prompt_slack_ts: null,
                 query_history_summaries: [],
                 supporting_evidence_summaries: [],
+                tool_outcomes: [
+                    {
+                        toolCallId: 'tool-call-1',
+                        toolName: 'proposeWriteback',
+                        status: 'success',
+                    },
+                ],
+                pending_approval_timeout: true,
             });
 
             expect(result.subject.assistantPromptUuid).toBe(PROMPT_UUID);
             expect(result.interactionSource).toBe('app');
             expect(result.tokenUsageTotal).toBe(123);
+            expect(result.toolOutcomes).toEqual([
+                {
+                    toolCallId: 'tool-call-1',
+                    toolName: 'proposeWriteback',
+                    status: 'success',
+                },
+            ]);
+            expect(result.pendingApprovalTimeout).toBe(true);
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -17,6 +17,7 @@ import type {
     AiAgentReviewClassifierRunStatus,
     AiAgentReviewClassifierSignalFinding,
     AiAgentReviewClassifierSupportingEvidence,
+    AiAgentReviewClassifierToolOutcome,
     AiAgentReviewClassifierTurnCandidate,
     AiAgentReviewClassifierTurnSignal,
     AiAgentReviewItemDismissedReason,
@@ -321,6 +322,8 @@ type TurnReviewCandidateRow = BaseCandidateRow & {
               createdAt: string;
           })[]
         | null;
+    tool_outcomes: AiAgentReviewClassifierToolOutcome[] | null;
+    pending_approval_timeout: boolean;
 };
 
 type ToolCallEvidenceRow = {
@@ -359,6 +362,25 @@ const TOOL_NAME_PRIORITY = new Map<string, number>([
 
 const MCP_TOOL_NAME_PREFIX = 'mcp_';
 const MCP_TOOL_NAME_SCORE = 50;
+
+// Tools whose success/failure the judge must always see, independent of the
+// relevance-ranked top-5 supportingEvidence selection.
+const TOOL_OUTCOME_NAMES = new Set([
+    'editDbtProject',
+    'proposeWriteback',
+    'propose_writeback',
+    'runAiWriteback',
+    'run_ai_writeback',
+    'editContent',
+    'createContent',
+    'setupPreviewDeploy',
+]);
+
+const isToolOutcomeName = (toolName: string): boolean =>
+    TOOL_OUTCOME_NAMES.has(toolName) ||
+    toolName.startsWith(MCP_TOOL_NAME_PREFIX);
+
+const SQL_APPROVAL_TIMEOUT_PATTERN = /sql approval timed out/i;
 
 const TOOL_RESULT_ERROR_PATTERN =
     /no match|no relevant|not found|empty|error|failed/i;
@@ -630,6 +652,8 @@ export class AiAgentReviewClassifierModel {
                     createdAt: new Date(evidence.createdAt),
                 }),
             ),
+            toolOutcomes: row.tool_outcomes ?? [],
+            pendingApprovalTimeout: row.pending_approval_timeout,
         };
     }
 
@@ -709,6 +733,7 @@ export class AiAgentReviewClassifierModel {
                     previousTurnContext,
                     queryHistorySummaries,
                     supportingEvidenceSummaries,
+                    turnToolOutcomes,
                 ] = await Promise.all([
                     this.fetchNextPrompt(
                         base.ai_thread_uuid,
@@ -730,6 +755,7 @@ export class AiAgentReviewClassifierModel {
                         base.human_feedback,
                         base.error_message,
                     ),
+                    this.fetchTurnToolOutcomes(base.ai_prompt_uuid),
                 ]);
 
                 const row: TurnReviewCandidateRow = {
@@ -739,6 +765,9 @@ export class AiAgentReviewClassifierModel {
                     previous_turn_context: previousTurnContext,
                     query_history_summaries: queryHistorySummaries,
                     supporting_evidence_summaries: supportingEvidenceSummaries,
+                    tool_outcomes: turnToolOutcomes.toolOutcomes,
+                    pending_approval_timeout:
+                        turnToolOutcomes.pendingApprovalTimeout,
                 };
 
                 return AiAgentReviewClassifierModel.mapTurnReviewCandidate(row);
@@ -797,14 +826,15 @@ export class AiAgentReviewClassifierModel {
             // Preview projects host writeback verification threads — reviewing
             // them would feed the reviewer's own output back into itself.
             .whereNot('project.project_type', ProjectType.PREVIEW)
-            // Remediation build-fix threads are the reviewer's own output;
-            // reviewing them would open a review item on the fix it just made.
+            // Remediation build-fix and preview-verification threads are the
+            // reviewer's own output; reviewing them would open a review item
+            // on the fix it just made.
             .whereNotExists((builder) => {
                 void builder
                     .select(this.database.raw('1'))
                     .from(`${AiAgentReviewRemediationTableName} as remediation`)
                     .whereRaw(
-                        'remediation.work_thread_uuid = thread.ai_thread_uuid',
+                        'remediation.work_thread_uuid = thread.ai_thread_uuid OR remediation.preview_thread_uuid = thread.ai_thread_uuid',
                     );
             })
             .whereIn('thread.created_from', ['web_app', 'slack'])
@@ -934,6 +964,59 @@ export class AiAgentReviewClassifierModel {
                 sorts: row.metric_query?.sorts ?? [],
             },
         }));
+    }
+
+    private async fetchTurnToolOutcomes(promptUuid: string): Promise<{
+        toolOutcomes: AiAgentReviewClassifierToolOutcome[];
+        pendingApprovalTimeout: boolean;
+    }> {
+        const rows = await this.database(
+            `${AiAgentToolCallTableName} as tool_call`,
+        )
+            .leftJoin(
+                `${AiAgentToolResultTableName} as tool_result`,
+                function joinToolResult() {
+                    this.on(
+                        'tool_result.ai_prompt_uuid',
+                        '=',
+                        'tool_call.ai_prompt_uuid',
+                    ).andOn(
+                        'tool_result.tool_call_id',
+                        '=',
+                        'tool_call.tool_call_id',
+                    );
+                },
+            )
+            .select<
+                {
+                    tool_call_id: string;
+                    tool_name: string;
+                    created_at: Date;
+                    result: string | null;
+                }[]
+            >({
+                tool_call_id: 'tool_call.tool_call_id',
+                tool_name: 'tool_call.tool_name',
+                created_at: 'tool_call.created_at',
+                result: 'tool_result.result',
+            })
+            .where('tool_call.ai_prompt_uuid', promptUuid)
+            .orderBy('tool_call.created_at', 'asc');
+
+        return {
+            toolOutcomes: rows
+                .filter((row) => isToolOutcomeName(row.tool_name))
+                .map((row) => ({
+                    toolCallId: row.tool_call_id,
+                    toolName: row.tool_name,
+                    status: TOOL_RESULT_ERROR_PATTERN.test(row.result ?? '')
+                        ? ('error' as const)
+                        : ('success' as const),
+                })),
+            pendingApprovalTimeout: rows.some((row) =>
+                SQL_APPROVAL_TIMEOUT_PATTERN.test(row.result ?? ''),
+            ),
+        };
     }
 
     private async fetchSupportingEvidence(

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -65,6 +65,8 @@ const makeCandidate = (
     tokenUsageTotal: 123,
     queryHistory: [],
     supportingEvidence: [],
+    toolOutcomes: [],
+    pendingApprovalTimeout: false,
     ...overrides,
 });
 
@@ -554,6 +556,42 @@ describe('AiAgentReviewClassifierService', () => {
         expect(judgeTurn).toHaveBeenCalledTimes(1);
         expect(result.findingCount).toBe(1);
         expect(result.reviewItemCount).toBe(1);
+    });
+
+    it('passes tool outcomes and the approval-timeout flag through to the judge packet', async () => {
+        judgeTurn.mockResolvedValueOnce(makeJudgeOutput());
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({
+                toolOutcomes: [
+                    {
+                        toolCallId: 'content-tool-call-1',
+                        toolName: 'editContent',
+                        status: 'success',
+                    },
+                ],
+                pendingApprovalTimeout: true,
+            }),
+        ]);
+
+        await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+        });
+
+        expect(judgeTurn).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                toolOutcomes: [
+                    {
+                        toolCallId: 'content-tool-call-1',
+                        toolName: 'editContent',
+                        status: 'success',
+                    },
+                ],
+                pendingApprovalTimeout: true,
+            }),
+        );
     });
 
     it('drops project context entries when AI writeback is disabled', async () => {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -15,6 +15,7 @@ import {
     type AiAgentReviewClassifierJudgeOutput,
     type AiAgentReviewClassifierRunScope,
     type AiAgentReviewClassifierSignalFinding,
+    type AiAgentReviewClassifierToolOutcome,
     type AiAgentReviewClassifierTurnCandidate,
     type AiAgentReviewClassifierTurnSignal,
     type AiAgentRootCause,
@@ -41,7 +42,7 @@ import { getAiCallTelemetry } from './ai/utils/aiCallTelemetry';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
-const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v11';
+const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v12';
 const WRITEBACK_TOOL_NAMES = new Set([
     'editDbtProject',
     'propose_writeback',
@@ -137,6 +138,11 @@ export type AiAgentReviewJudgeEvidencePacket = {
     // PRs the agent already opened in this thread via writeback tools. Non-empty
     // means a real PR exists — the judge should only promote if it failed/was wrong.
     threadWritebackPullRequests: { prUrl: string | null; createdAt: Date }[];
+    // Complete success/error outcome per content-mutating/writeback/preview/MCP
+    // tool call in the turn — never truncated by the top-5 evidence ranking.
+    toolOutcomes: AiAgentReviewClassifierToolOutcome[];
+    // A human SQL-approval gate expired during the turn (user stepped away).
+    pendingApprovalTimeout: boolean;
 };
 
 type AiAgentReviewAgentConfigEvidence =
@@ -1204,7 +1210,7 @@ Implicit signal definitions — set these whenever the evidence supports them:
 - next_user_dispute: the next user prompt explicitly says the previous answer was wrong.
 - next_user_retry: the next user prompt asks the same unresolved question again or asks to try a different approach after a failed, empty, non-substantive, or off-target answer. Do not use this for normal iterative exploration after a useful answer.
 - output_shape_correction: the next user prompt asks for a different chart / format / grouping with no semantic change.
-- tool_error: a tool call errored, timed out, or returned an empty / error result the assistant did not recover from.
+- tool_error: a tool call errored, timed out, or returned an empty / error result the assistant did not recover from. A human SQL-approval gate expiring (evidence packet pendingApprovalTimeout=true, or a result saying the SQL approval timed out / the user may have stepped away) is NOT a tool_error — it is expected behavior when the user steps away, not a runtime or warehouse defect. Do not promote it as runtime_reliability; when it is the only issue in the turn use promotedToFinding=false (or feedback_quality at most), especially when humanFeedback.score is not negative.
 - product_capability_request: the user asked for something Lightdash cannot currently express.
 - human_intervention: an admin or engineer had to step in.
 
@@ -1217,7 +1223,7 @@ Decision rules — apply in order:
 
 1. First, populate implicitSignalSources by inspecting the evidence packet. Do not skip this step.
 
-2. If the evidence shows the assistant successfully called a writeback tool (for example editDbtProject or runAiWriteback) and opened or updated a pull request, do not promote this as a semantic_layer or project_context finding. The remediation is already in progress; use promotedToFinding=false, signal=acceptance_or_continuation, primaryRootCause=not_a_failure, and promotionReason=writeback_tool_already_started. The evidence packet field threadWritebackPullRequests lists PRs the agent has already opened in this thread — when it is non-empty a real pull request exists, so do not infer from prose that the assistant fabricated it. Only consider writeback turns promotable when the tool failed, opened no pull request despite a clear requested change, or the user later says the PR is wrong.
+2. The evidence packet field toolOutcomes lists the success/error outcome of EVERY content-mutating, writeback, preview-deploy, and MCP tool call in the turn — it is complete even when the corresponding trace is not in supportingEvidence. A success there means the action really happened: never claim the assistant lacks a capability, fabricated an action, or failed to execute when toolOutcomes shows that tool succeeding. If the evidence shows the assistant successfully called a writeback tool (for example editDbtProject or runAiWriteback) and opened or updated a pull request, do not promote this as a semantic_layer or project_context finding. The remediation is already in progress; use promotedToFinding=false, signal=acceptance_or_continuation, primaryRootCause=not_a_failure, and promotionReason=writeback_tool_already_started. The evidence packet field threadWritebackPullRequests lists PRs the agent has already opened in this thread — when it is non-empty a real pull request exists, so do not infer from prose that the assistant fabricated it. Only consider writeback turns promotable when the tool failed, opened no pull request despite a clear requested change, or the user later says the PR is wrong.
 
 3. Treat implicitSignalSources as strong evidence of unresolved user intent, not as decoration. Promote when the implicit signal points to likely assistant failure:
    - Always promote assistant_no_answer, next_user_dispute, tool_error, product_capability_request, and human_intervention.
@@ -1447,6 +1453,8 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
             suggestedEvidenceExcerpts:
                 AiAgentReviewClassifierService.buildEvidenceExcerpts(candidate),
             threadWritebackPullRequests,
+            toolOutcomes: candidate.toolOutcomes,
+            pendingApprovalTimeout: candidate.pendingApprovalTimeout,
         };
     }
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -1024,6 +1024,17 @@ export type AiAgentReviewClassifierTurnCandidate = {
     tokenUsageTotal: number | null;
     queryHistory: AiAgentReviewClassifierQueryHistorySummary[];
     supportingEvidence: AiAgentReviewClassifierSupportingEvidence[];
+    toolOutcomes: AiAgentReviewClassifierToolOutcome[];
+    pendingApprovalTimeout: boolean;
+};
+
+// Compact outcome line for every content-mutating / writeback / preview-deploy
+// / MCP tool call in the turn — guaranteed visible to the judge regardless of
+// the relevance-ranked (top-5) supportingEvidence selection.
+export type AiAgentReviewClassifierToolOutcome = {
+    toolCallId: string;
+    toolName: string;
+    status: 'success' | 'error';
 };
 
 export type AiAgentReviewClassifierQueryHistorySummary = {


### PR DESCRIPTION
## Summary

Phase 3 of the AI review classifier improvement plan (Linear: **ZAP-553** finish, **ZAP-555**, **ZAP-557** residual) — structural evidence filters that don't depend on prompt wording. Stacked on #25066; measurable on the replay scoreboard from #25064.

## Changes

### Guaranteed `toolOutcomes[]` — ZAP-553 (finish)
The audit's failure mode #2 (success-as-failure): `rankToolCallEvidence` adds +25 for error-looking results and caps at top-5, so on busy turns successful writeback/content traces get evicted by unrelated errors and the judge claims the action never happened.

- New `fetchTurnToolOutcomes`: one query over ALL tool calls in the turn, producing a compact `{toolCallId, toolName, status: success|error}` per content-mutating / writeback / preview-deploy / `mcp_*` call — carried on the candidate and packet independently of the ranked top-5.
- Prompt rule 2 extended: `toolOutcomes` is complete; never claim a missing capability, fabricated action, or failed execution when it shows the tool succeeding.

### SQL-approval-gate timeout carve-out — ZAP-555
The blanket "timeout → runtime_reliability" rule fired on the human SQL-approval gate ('SQL approval timed out after 5 minutes… the user may have stepped away'), some on thumbs-up turns. These inflate the runtime_reliability bucket humans never action (0/40).

- Derived `pendingApprovalTimeout` flag (matches the `SQL approval timed out` result signature from `runSql.ts`/`slackSqlAggregate.ts`) on candidate + packet, so the judge doesn't pattern-match prose.
- `tool_error` definition updated: an expired approval gate is expected behavior, not a runtime/warehouse defect — don't promote as runtime_reliability; weight non-negative human feedback against promotion.

### Self-referential thread exclusion — ZAP-557 (residual)
Candidate selection excluded remediation `work_thread_uuid` threads (#24517) and preview projects (#24239) but a remediation's `preview_thread_uuid` in a non-preview project could slip through. The `whereNotExists` now matches either column (belt-and-suspenders).

Still to verify against prod data (during the scoreboard replay session): that the audit's ~11 'Review fix' findings predate #24239/#24517 — if so ZAP-557 closes with just this gap plug.

`JUDGE_PROMPT_HASH` bumped v11 → v12.

## Verification

- New tests: candidate mapping of `tool_outcomes`/`pending_approval_timeout`; packet propagation of both fields to the judge.
- Backend typecheck + full suite green (3435), common suite green, lint clean.

## Regression analysis

- `toolOutcomes`/`pendingApprovalTimeout` are additive packet fields; turns without matching tool calls get `[]`/`false` and behave as before.
- One extra indexed-by-prompt query per candidate in `listTurnReviewCandidates` (runs alongside the existing four in `Promise.all`).
- The `preview_thread_uuid` exclusion only removes the reviewer's own preview-verification threads from candidate selection — the same class already excluded by project type in preview projects.
- No API shapes, permissions, or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiTzUNSpHJkWoJGVXQ5eNV