### PR TITLE
feat(ai): pass requesting-user context (name, role, teams) to the agent system prompt

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -16,6 +16,7 @@ export type DbAiAgent = {
     enable_data_access: boolean;
     enable_self_improvement: boolean;
     enable_content_tools: boolean;
+    enable_user_context: boolean;
     admin_only: boolean;
     model_config: AiAgentModelConfig | null;
     /**

--- a/packages/backend/src/ee/database/migrations/20260702160000_add_enable_user_context_to_ai_agent.ts
+++ b/packages/backend/src/ee/database/migrations/20260702160000_add_enable_user_context_to_ai_agent.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const AIAgentTableName = 'ai_agent';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AIAgentTableName))) return;
+
+    await knex.schema.alterTable(AIAgentTableName, (table) => {
+        table.boolean('enable_user_context').defaultTo(false).notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AIAgentTableName))) return;
+
+    await knex.schema.alterTable(AIAgentTableName, (table) => {
+        table.dropColumn('enable_user_context');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -293,6 +293,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     contentVerificationModel:
                         models.getContentVerificationModel(),
                     groupsModel: models.getGroupsModel(),
+                    rolesModel: models.getRolesModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     slackClient: clients.getSlackClient(),
                     projectService: repository.getProjectService(),

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -448,6 +448,7 @@ export class AiAgentModel {
                 enableDataAccess: `${AiAgentTableName}.enable_data_access`,
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
                 enableContentTools: `${AiAgentTableName}.enable_content_tools`,
+                enableUserContext: `${AiAgentTableName}.enable_user_context`,
                 adminOnly: `${AiAgentTableName}.admin_only`,
                 modelConfig: `${AiAgentTableName}.model_config`,
                 version: `${AiAgentTableName}.version`,
@@ -585,6 +586,7 @@ export class AiAgentModel {
                 enableDataAccess: `${AiAgentTableName}.enable_data_access`,
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
                 enableContentTools: `${AiAgentTableName}.enable_content_tools`,
+                enableUserContext: `${AiAgentTableName}.enable_user_context`,
                 adminOnly: `${AiAgentTableName}.admin_only`,
                 modelConfig: `${AiAgentTableName}.model_config`,
                 version: `${AiAgentTableName}.version`,
@@ -1745,6 +1747,7 @@ export class AiAgentModel {
             | 'enableDataAccess'
             | 'enableSelfImprovement'
             | 'enableContentTools'
+            | 'enableUserContext'
             | 'adminOnly'
             | 'modelConfig'
             | 'version'
@@ -1774,6 +1777,7 @@ export class AiAgentModel {
                     enable_data_access: args.enableDataAccess,
                     enable_self_improvement: args.enableSelfImprovement,
                     enable_content_tools: args.enableContentTools ?? false,
+                    enable_user_context: args.enableUserContext ?? false,
                     admin_only: args.adminOnly ?? false,
                     model_config: args.modelConfig ?? null,
                     version: args.version,
@@ -1877,6 +1881,7 @@ export class AiAgentModel {
                 enableDataAccess: agent.enable_data_access,
                 enableSelfImprovement: agent.enable_self_improvement,
                 enableContentTools: agent.enable_content_tools,
+                enableUserContext: agent.enable_user_context,
                 adminOnly: agent.admin_only,
                 modelConfig: agent.model_config,
                 version: agent.version,
@@ -1931,6 +1936,7 @@ export class AiAgentModel {
                 enableDataAccess: true,
                 enableSelfImprovement: false,
                 enableContentTools: false,
+                enableUserContext: false,
                 modelConfig: null,
                 version: 1,
                 mcpServerUuids: [],
@@ -1991,6 +1997,9 @@ export class AiAgentModel {
                         : {}),
                     ...(args.enableContentTools !== undefined
                         ? { enable_content_tools: args.enableContentTools }
+                        : {}),
+                    ...(args.enableUserContext !== undefined
+                        ? { enable_user_context: args.enableUserContext }
                         : {}),
                     ...(args.adminOnly !== undefined
                         ? { admin_only: args.adminOnly }
@@ -2165,6 +2174,7 @@ export class AiAgentModel {
                 enableDataAccess: agent.enable_data_access,
                 enableSelfImprovement: agent.enable_self_improvement,
                 enableContentTools: agent.enable_content_tools,
+                enableUserContext: agent.enable_user_context,
                 adminOnly: agent.admin_only,
                 modelConfig: agent.model_config,
                 version: agent.version,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2729,6 +2729,7 @@ export class AiAgentService extends BaseService {
             enableSelfImprovement: body.enableSelfImprovement,
             enableContentTools:
                 body.enableDataAccess && (body.enableContentTools ?? false),
+            enableUserContext: body.enableUserContext ?? false,
             adminOnly: body.adminOnly ?? false,
             modelConfig: body.modelConfig ?? null,
             version: body.version,
@@ -3645,6 +3646,7 @@ export class AiAgentService extends BaseService {
             enableContentTools: nextEnableDataAccess
                 ? body.enableContentTools
                 : false,
+            enableUserContext: body.enableUserContext,
             adminOnly: body.adminOnly,
             modelConfig: body.modelConfig,
             version: body.version,
@@ -7405,7 +7407,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         // Slack without aiRequireOAuth resolves the actor to the workspace
         // installer, not the requester — omit rather than describe the wrong person.
         let requestingUser: AiAgentRequestingUser | null = null;
-        if (hasTrustedPromptUserIdentity && user.organizationUuid) {
+        if (
+            agentSettings.enableUserContext &&
+            hasTrustedPromptUserIdentity &&
+            user.organizationUuid
+        ) {
             const userGroups = await this.groupsModel.findUserGroups({
                 userUuid: user.userUuid,
                 organizationUuid: user.organizationUuid,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -172,6 +172,7 @@ import { GroupsModel } from '../../../models/GroupsModel';
 import { OpenIdIdentityModel } from '../../../models/OpenIdIdentitiesModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { PullRequestsModel } from '../../../models/PullRequestsModel';
+import { RolesModel } from '../../../models/RolesModel';
 import { SearchModel } from '../../../models/SearchModel';
 import { SlackUnfurlImageModel } from '../../../models/SlackUnfurlImageModel';
 import { SpaceModel } from '../../../models/SpaceModel';
@@ -236,6 +237,10 @@ import {
     getModel,
 } from '../ai/models';
 import { matchesPreset } from '../ai/models/presets';
+import {
+    requestingUserRoleFromCustomRole,
+    requestingUserRoleFromSystemRole,
+} from '../ai/prompts/systemV2RequestingUser';
 import { parseRepoTarget, runShellCommandOnFs } from '../ai/repoFs/bashShell';
 import {
     createGithubRepoSource,
@@ -255,6 +260,7 @@ import {
     AiAgentDependencies,
     type AiAgentMcpServer,
     type AiAgentRequestingUser,
+    type AiAgentRequestingUserRole,
 } from '../ai/types/aiAgent';
 import {
     DiscoverReposFn,
@@ -362,6 +368,7 @@ type AiAgentServiceDependencies = {
     searchService: SearchService;
     featureFlagService: FeatureFlagService;
     groupsModel: GroupsModel;
+    rolesModel: RolesModel;
     lightdashConfig: LightdashConfig;
     openIdIdentityModel: OpenIdIdentityModel;
     projectService: ProjectService;
@@ -587,6 +594,8 @@ export class AiAgentService extends BaseService {
     private readonly featureFlagService: FeatureFlagService;
 
     private readonly groupsModel: GroupsModel;
+
+    private readonly rolesModel: RolesModel;
 
     private readonly lightdashConfig: LightdashConfig;
 
@@ -908,6 +917,7 @@ export class AiAgentService extends BaseService {
         this.searchService = dependencies.searchService;
         this.featureFlagService = dependencies.featureFlagService;
         this.groupsModel = dependencies.groupsModel;
+        this.rolesModel = dependencies.rolesModel;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.openIdIdentityModel = dependencies.openIdIdentityModel;
         this.projectService = dependencies.projectService;
@@ -7416,9 +7426,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 userUuid: user.userUuid,
                 organizationUuid: user.organizationUuid,
             });
+            // A custom org role stores 'member' as a placeholder in user.role,
+            // so resolve the real role (and its register) from roleUuid first.
+            let role: AiAgentRequestingUserRole | null = null;
+            if (user.roleUuid) {
+                const customRole =
+                    await this.rolesModel.getRoleWithScopesByUuid(
+                        user.roleUuid,
+                    );
+                role = requestingUserRoleFromCustomRole(customRole);
+            } else if (user.role) {
+                role = requestingUserRoleFromSystemRole(user.role);
+            }
             requestingUser = {
                 name: [user.firstName, user.lastName].filter(Boolean).join(' '),
-                role: user.role ?? null,
+                role,
                 groups: userGroups.map((group) => group.name),
             };
         }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -254,6 +254,7 @@ import {
     AiAgentArgs,
     AiAgentDependencies,
     type AiAgentMcpServer,
+    type AiAgentRequestingUser,
 } from '../ai/types/aiAgent';
 import {
     DiscoverReposFn,
@@ -7401,6 +7402,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                       },
                   )));
 
+        // Slack without aiRequireOAuth resolves the actor to the workspace
+        // installer, not the requester — omit rather than describe the wrong person.
+        let requestingUser: AiAgentRequestingUser | null = null;
+        if (hasTrustedPromptUserIdentity && user.organizationUuid) {
+            const userGroups = await this.groupsModel.findUserGroups({
+                userUuid: user.userUuid,
+                organizationUuid: user.organizationUuid,
+            });
+            requestingUser = {
+                name: [user.firstName, user.lastName].filter(Boolean).join(' '),
+                role: user.role ?? null,
+                groups: userGroups.map((group) => group.name),
+            };
+        }
+
         const args: AiAgentArgs = {
             organizationId: user.organizationUuid,
             userId: user.userUuid,
@@ -7408,6 +7424,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ...modelProperties,
 
             agentSettings,
+            requestingUser,
             knowledgeDocuments,
             projectContext,
             projectContextEnabled,

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -62,6 +62,7 @@ const createCandidate = (
     enableDataAccess: true,
     enableSelfImprovement: true,
     enableContentTools: true,
+    enableUserContext: false,
     adminOnly: false,
     modelConfig: null,
     version: 1,

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -97,6 +97,7 @@ const selectedAgent: AiAgentWithContext = {
     enableDataAccess: true,
     enableSelfImprovement: true,
     enableContentTools: true,
+    enableUserContext: false,
     adminOnly: false,
     modelConfig: null,
     version: 1,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -682,6 +682,7 @@ const getAgentMessages = (
         getSystemPromptV2({
             agentName: args.agentSettings.name,
             instructions: args.agentSettings.instruction || undefined,
+            requestingUser: args.requestingUser,
             availableExplores,
             availableSkills: args.availableSkills,
             knowledgeDocuments: args.knowledgeDocuments,

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -1,5 +1,9 @@
 import { OrganizationMemberRole } from '@lightdash/common';
 import { getSystemPromptV2 } from './systemV2';
+import {
+    requestingUserRoleFromCustomRole,
+    requestingUserRoleFromSystemRole,
+} from './systemV2RequestingUser';
 
 const promptText = (args: Parameters<typeof getSystemPromptV2>[0]): string => {
     const { content } = getSystemPromptV2(args);
@@ -40,7 +44,9 @@ describe('getSystemPromptV2 requesting user', () => {
             availableExplores: [],
             requestingUser: {
                 name: 'Ada Lovelace',
-                role: OrganizationMemberRole.VIEWER,
+                role: requestingUserRoleFromSystemRole(
+                    OrganizationMemberRole.VIEWER,
+                ),
                 groups: ['Finance', 'Ops'],
             },
         });
@@ -58,7 +64,9 @@ describe('getSystemPromptV2 requesting user', () => {
             availableExplores: [],
             requestingUser: {
                 name: 'Grace Hopper',
-                role: OrganizationMemberRole.DEVELOPER,
+                role: requestingUserRoleFromSystemRole(
+                    OrganizationMemberRole.DEVELOPER,
+                ),
                 groups: [],
             },
         });
@@ -81,6 +89,36 @@ describe('getSystemPromptV2 requesting user', () => {
         expect(content).toContain('Sam Service');
         expect(content).not.toContain('organization role:');
         expect(content).toContain('business user');
+    });
+
+    test('renders a custom role name and derives the register from its scopes', () => {
+        const technical = promptText({
+            availableExplores: [],
+            requestingUser: {
+                name: 'Grace Hopper',
+                role: requestingUserRoleFromCustomRole({
+                    name: 'Analytics Engineer',
+                    scopes: ['view:Dashboard', 'manage:SqlRunner'],
+                }),
+                groups: [],
+            },
+        });
+        expect(technical).toContain('organization role: Analytics Engineer');
+        expect(technical).toContain('technical detail is appropriate');
+
+        const business = promptText({
+            availableExplores: [],
+            requestingUser: {
+                name: 'Ada Lovelace',
+                role: requestingUserRoleFromCustomRole({
+                    name: 'Finance Viewer',
+                    scopes: ['view:Dashboard', 'manage:Explore'],
+                }),
+                groups: [],
+            },
+        });
+        expect(business).toContain('organization role: Finance Viewer');
+        expect(business).toContain('business user');
     });
 
     test('omits the section entirely when the requesting user is unknown', () => {

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -1,3 +1,4 @@
+import { OrganizationMemberRole } from '@lightdash/common';
 import { getSystemPromptV2 } from './systemV2';
 
 const promptText = (args: Parameters<typeof getSystemPromptV2>[0]): string => {
@@ -30,6 +31,76 @@ describe('getSystemPromptV2 project context', () => {
     test('leaves no unfilled project_context placeholder', () => {
         const content = promptText({ availableExplores: [] });
         expect(content).not.toContain('{{project_context}}');
+    });
+});
+
+describe('getSystemPromptV2 requesting user', () => {
+    test('renders identity and non-technical guidance for a viewer', () => {
+        const content = promptText({
+            availableExplores: [],
+            requestingUser: {
+                name: 'Ada Lovelace',
+                role: OrganizationMemberRole.VIEWER,
+                groups: ['Finance', 'Ops'],
+            },
+        });
+        expect(content).toContain('## Who you are talking to');
+        expect(content).toContain('Ada Lovelace');
+        expect(content).toContain('organization role: Viewer');
+        expect(content).toContain('member of: Finance, Ops');
+        expect(content).toContain('business user');
+        expect(content).toContain('Never advise them to use a different table');
+        expect(content).toContain("user's team(s)");
+    });
+
+    test('renders technical guidance for a developer', () => {
+        const content = promptText({
+            availableExplores: [],
+            requestingUser: {
+                name: 'Grace Hopper',
+                role: OrganizationMemberRole.DEVELOPER,
+                groups: [],
+            },
+        });
+        expect(content).toContain('organization role: Developer');
+        expect(content).toContain('technical detail is appropriate');
+        expect(content).not.toContain('business user');
+        // no team-disambiguation guidance without groups
+        expect(content).not.toContain("user's team(s)");
+    });
+
+    test('defaults to the non-technical register when the role is unknown', () => {
+        const content = promptText({
+            availableExplores: [],
+            requestingUser: {
+                name: 'Sam Service',
+                role: null,
+                groups: [],
+            },
+        });
+        expect(content).toContain('Sam Service');
+        expect(content).not.toContain('organization role:');
+        expect(content).toContain('business user');
+    });
+
+    test('omits the section entirely when the requesting user is unknown', () => {
+        const contentNull = promptText({
+            availableExplores: [],
+            requestingUser: null,
+        });
+        const contentOmitted = promptText({ availableExplores: [] });
+        for (const content of [contentNull, contentOmitted]) {
+            expect(content).not.toContain('## Who you are talking to');
+            expect(content).not.toContain('{{requesting_user_section}}');
+        }
+    });
+
+    test('omits the section when all identity fields are empty', () => {
+        const content = promptText({
+            availableExplores: [],
+            requestingUser: { name: '', role: null, groups: [] },
+        });
+        expect(content).not.toContain('## Who you are talking to');
     });
 });
 

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -8,6 +8,7 @@ import {
 import { SystemModelMessage } from 'ai';
 import moment from 'moment';
 import { AiAgentSkillReference } from '../skills/types';
+import { AiAgentRequestingUser } from '../types/aiAgent';
 import { xmlBuilder } from '../xmlBuilder';
 import { renderAvailableExplores } from './availableExplores';
 import { getAiWritebackSection } from './systemV2AiWriteback';
@@ -19,6 +20,7 @@ import {
     repoFsRootHint,
     repoFsSearchCaveat,
 } from './systemV2RepoFs';
+import { getRequestingUserSection } from './systemV2RequestingUser';
 import { getRunSqlSection } from './systemV2RunSql';
 import { SEARCH_SEMANTIC_LAYER_SECTION } from './systemV2SearchSemanticLayer';
 import { renderAvailableSkills } from './systemV2Skills';
@@ -31,6 +33,7 @@ export const getSystemPromptV2 = (args: {
     hasProjectContext?: boolean;
     instructions?: string;
     agentName?: string;
+    requestingUser?: AiAgentRequestingUser | null;
     date?: string;
     enableDataAccess?: boolean;
     enableSearchSemanticLayer?: boolean;
@@ -54,6 +57,7 @@ export const getSystemPromptV2 = (args: {
     const {
         instructions,
         agentName = 'Lightdash AI Analyst',
+        requestingUser = null,
         date = moment().utc().format('YYYY-MM-DD'),
         enableDataAccess = false,
         enableSearchSemanticLayer = false,
@@ -186,6 +190,10 @@ export const getSystemPromptV2 = (args: {
         .replace(
             '{{instructions}}',
             instructions ? `Special instructions: ${instructions}` : '',
+        )
+        .replace(
+            '{{requesting_user_section}}',
+            getRequestingUserSection(requestingUser),
         )
         .replace('{{date}}', date)
         .replace('{{available_explores}}', availableExploresContent)

--- a/packages/backend/src/ee/services/ai/prompts/systemV2RequestingUser.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2RequestingUser.ts
@@ -1,14 +1,47 @@
 import {
+    getAllScopesForRole,
     OrganizationMemberRole,
     OrganizationMemberRoleLabels,
+    ProjectMemberRole,
 } from '@lightdash/common';
-import { AiAgentRequestingUser } from '../types/aiAgent';
+import {
+    AiAgentRequestingUser,
+    AiAgentRequestingUserRole,
+} from '../types/aiAgent';
 
 const TECHNICAL_ROLES = new Set<OrganizationMemberRole>([
     OrganizationMemberRole.EDITOR,
     OrganizationMemberRole.DEVELOPER,
     OrganizationMemberRole.ADMIN,
 ]);
+
+// Scopes exclusive to editor tier and above — the same threshold TECHNICAL_ROLES
+// draws for system roles, applied to a custom role's scope list.
+const TECHNICAL_SCOPES = (() => {
+    const interactiveViewerScopes = new Set(
+        getAllScopesForRole(ProjectMemberRole.INTERACTIVE_VIEWER),
+    );
+    return new Set(
+        getAllScopesForRole(ProjectMemberRole.ADMIN).filter(
+            (scope) => !interactiveViewerScopes.has(scope),
+        ),
+    );
+})();
+
+export const requestingUserRoleFromSystemRole = (
+    role: OrganizationMemberRole,
+): AiAgentRequestingUserRole => ({
+    name: OrganizationMemberRoleLabels[role],
+    isTechnical: TECHNICAL_ROLES.has(role),
+});
+
+export const requestingUserRoleFromCustomRole = (customRole: {
+    name: string;
+    scopes: string[];
+}): AiAgentRequestingUserRole => ({
+    name: customRole.name,
+    isTechnical: customRole.scopes.some((scope) => TECHNICAL_SCOPES.has(scope)),
+});
 
 const BUSINESS_USER_GUIDANCE = `Assume a business user consuming data, not someone who maintains it:
 - Answer in plain language. Avoid data-modeling jargon (dbt, semantic layer, joins, table/model names as recommendations).
@@ -26,19 +59,15 @@ export const getRequestingUserSection = (
 
     const identityParts: string[] = [];
     if (name) identityParts.push(name);
-    if (role)
-        identityParts.push(
-            `organization role: ${OrganizationMemberRoleLabels[role]}`,
-        );
+    if (role) identityParts.push(`organization role: ${role.name}`);
     if (groups.length > 0)
         identityParts.push(`member of: ${groups.join(', ')}`);
     if (identityParts.length === 0) return '';
 
     // Unknown role → default to the safe, non-technical register.
-    const guidance =
-        role && TECHNICAL_ROLES.has(role)
-            ? TECHNICAL_USER_GUIDANCE
-            : BUSINESS_USER_GUIDANCE;
+    const guidance = role?.isTechnical
+        ? TECHNICAL_USER_GUIDANCE
+        : BUSINESS_USER_GUIDANCE;
 
     const teamGuidance =
         groups.length > 0

--- a/packages/backend/src/ee/services/ai/prompts/systemV2RequestingUser.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2RequestingUser.ts
@@ -1,0 +1,54 @@
+import {
+    OrganizationMemberRole,
+    OrganizationMemberRoleLabels,
+} from '@lightdash/common';
+import { AiAgentRequestingUser } from '../types/aiAgent';
+
+const TECHNICAL_ROLES = new Set<OrganizationMemberRole>([
+    OrganizationMemberRole.EDITOR,
+    OrganizationMemberRole.DEVELOPER,
+    OrganizationMemberRole.ADMIN,
+]);
+
+const BUSINESS_USER_GUIDANCE = `Assume a business user consuming data, not someone who maintains it:
+- Answer in plain language. Avoid data-modeling jargon (dbt, semantic layer, joins, table/model names as recommendations).
+- Never advise them to use a different table or explore, fix the data model, or change the agent's configuration — they cannot act on that. Pick the best data source yourself and just answer.
+- If the available data cannot answer the question, say so simply and suggest they raise it with their data team.`;
+
+const TECHNICAL_USER_GUIDANCE = `They maintain this project, so technical detail is appropriate: naming explores or fields, explaining modeling limitations, and suggesting semantic-layer changes are all fine when relevant.`;
+
+export const getRequestingUserSection = (
+    requestingUser: AiAgentRequestingUser | null,
+): string => {
+    if (!requestingUser) return '';
+
+    const { name, role, groups } = requestingUser;
+
+    const identityParts: string[] = [];
+    if (name) identityParts.push(name);
+    if (role)
+        identityParts.push(
+            `organization role: ${OrganizationMemberRoleLabels[role]}`,
+        );
+    if (groups.length > 0)
+        identityParts.push(`member of: ${groups.join(', ')}`);
+    if (identityParts.length === 0) return '';
+
+    // Unknown role → default to the safe, non-technical register.
+    const guidance =
+        role && TECHNICAL_ROLES.has(role)
+            ? TECHNICAL_USER_GUIDANCE
+            : BUSINESS_USER_GUIDANCE;
+
+    const teamGuidance =
+        groups.length > 0
+            ? "\nWhen a question is ambiguous, prefer the interpretation, metrics, and terminology most relevant to the user's team(s)."
+            : '';
+
+    return `## Who you are talking to
+
+The user you are speaking with is ${identityParts.join(', ')}.
+
+${guidance}${teamGuidance}
+Do not recite this profile back to the user or mention that you were given it; just let it shape your answers.`;
+};

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -130,6 +130,8 @@ See the CRITICAL section at the top of this prompt: reasoning is user-visible. D
 Today is {{date}}.
 {{instructions}}
 
+{{requesting_user_section}}
+
 ## Available explores
 {{available_explores}}
 

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -4,7 +4,6 @@ import {
     AiMcpServer,
     AiMcpServerConnectionStatus,
     AiWritebackAttribution,
-    OrganizationMemberRole,
     ProjectContextEntry,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -82,9 +81,14 @@ export type UnavailableMcpServer = {
     status: AiMcpServerConnectionStatus;
 };
 
+export type AiAgentRequestingUserRole = {
+    name: string;
+    isTechnical: boolean;
+};
+
 export type AiAgentRequestingUser = {
     name: string;
-    role: OrganizationMemberRole | null;
+    role: AiAgentRequestingUserRole | null;
     groups: string[];
 };
 

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -4,6 +4,7 @@ import {
     AiMcpServer,
     AiMcpServerConnectionStatus,
     AiWritebackAttribution,
+    OrganizationMemberRole,
     ProjectContextEntry,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -81,8 +82,15 @@ export type UnavailableMcpServer = {
     status: AiMcpServerConnectionStatus;
 };
 
+export type AiAgentRequestingUser = {
+    name: string;
+    role: OrganizationMemberRole | null;
+    groups: string[];
+};
+
 export type AiAgentArgs = AnyAiModel & {
     agentSettings: AiAgent;
+    requestingUser: AiAgentRequestingUser | null;
     knowledgeDocuments: AiAgentDocumentSummary[];
     projectContext: ProjectContextEntry[];
     // Whether the project_context feature is on for this turn (Control = off).

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12343,7 +12343,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version_':
+    'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -12438,6 +12438,7 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     enableContentTools: { dataType: 'boolean', required: true },
+                    enableUserContext: { dataType: 'boolean', required: true },
                     adminOnly: { dataType: 'boolean', required: true },
                     modelConfig: {
                         dataType: 'union',
@@ -12456,7 +12457,7 @@ const models: TsoaRoute.Models = {
     AiAgentSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version_',
+            ref: 'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_',
             validators: {},
         },
     },
@@ -12991,7 +12992,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -13086,6 +13087,7 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     enableContentTools: { dataType: 'boolean', required: true },
+                    enableUserContext: { dataType: 'boolean', required: true },
                     adminOnly: { dataType: 'boolean', required: true },
                     modelConfig: {
                         dataType: 'union',
@@ -13104,7 +13106,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_',
             validators: {},
         },
     },
@@ -13700,6 +13702,7 @@ const models: TsoaRoute.Models = {
                             array: { dataType: 'string' },
                         },
                         adminOnly: { dataType: 'boolean' },
+                        enableUserContext: { dataType: 'boolean' },
                         enableContentTools: { dataType: 'boolean' },
                     },
                 },
@@ -13708,7 +13711,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version__':
         {
             dataType: 'refAlias',
             type: {
@@ -13837,6 +13840,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    enableUserContext: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     adminOnly: {
                         dataType: 'union',
                         subSchemas: [
@@ -13870,7 +13880,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -15773,6 +15783,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15895,25 +15924,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -16298,11 +16308,6 @@ const models: TsoaRoute.Models = {
                                                                     'nestedObjectLiteral',
                                                                 nestedProperties:
                                                                     {
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
                                                                         kind: {
                                                                             dataType:
                                                                                 'union',
@@ -16344,6 +16349,11 @@ const models: TsoaRoute.Models = {
                                                                                         ],
                                                                                     },
                                                                                 ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
                                                                             required: true,
                                                                         },
                                                                     },
@@ -32741,7 +32751,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32751,7 +32761,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32761,7 +32771,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -32774,7 +32784,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -33436,7 +33446,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33446,7 +33456,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33456,7 +33466,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -33469,7 +33479,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13954,7 +13954,7 @@
                 "required": ["modelProvider", "modelName"],
                 "type": "object"
             },
-            "Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version_": {
+            "Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -14044,6 +14044,9 @@
                     "enableContentTools": {
                         "type": "boolean"
                     },
+                    "enableUserContext": {
+                        "type": "boolean"
+                    },
                     "adminOnly": {
                         "type": "boolean"
                     },
@@ -14079,6 +14082,7 @@
                     "enableDataAccess",
                     "enableSelfImprovement",
                     "enableContentTools",
+                    "enableUserContext",
                     "adminOnly",
                     "modelConfig",
                     "version"
@@ -14087,7 +14091,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgentSummary": {
-                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version_"
+                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_"
             },
             "ApiAiAgentSummaryResponse": {
                 "properties": {
@@ -14580,7 +14584,7 @@
             "ApiAiAgentProjectThreadSummaryListResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_AiAgentProjectThreadSummary-Array__"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -14670,6 +14674,9 @@
                     "enableContentTools": {
                         "type": "boolean"
                     },
+                    "enableUserContext": {
+                        "type": "boolean"
+                    },
                     "adminOnly": {
                         "type": "boolean"
                     },
@@ -14705,6 +14712,7 @@
                     "enableDataAccess",
                     "enableSelfImprovement",
                     "enableContentTools",
+                    "enableUserContext",
                     "adminOnly",
                     "modelConfig",
                     "version"
@@ -14713,7 +14721,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -15317,6 +15325,9 @@
                             "adminOnly": {
                                 "type": "boolean"
                             },
+                            "enableUserContext": {
+                                "type": "boolean"
+                            },
                             "enableContentTools": {
                                 "type": "boolean"
                             }
@@ -15325,7 +15336,7 @@
                     }
                 ]
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version__": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -15396,6 +15407,9 @@
                     "enableContentTools": {
                         "type": "boolean"
                     },
+                    "enableUserContext": {
+                        "type": "boolean"
+                    },
                     "adminOnly": {
                         "type": "boolean"
                     },
@@ -15418,7 +15432,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-modelConfig-or-version__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version__"
                     },
                     {
                         "properties": {
@@ -16937,6 +16951,10 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -16996,10 +17014,6 @@
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -17071,8 +17085,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "fields",
                                                                     "rationale",
+                                                                    "fields",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -17212,9 +17226,6 @@
                                                     "steps": {
                                                         "items": {
                                                             "properties": {
-                                                                "label": {
-                                                                    "type": "string"
-                                                                },
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
@@ -17224,11 +17235,14 @@
                                                                         "compile",
                                                                         "stage"
                                                                     ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
                                                                 }
                                                             },
                                                             "required": [
-                                                                "label",
-                                                                "kind"
+                                                                "kind",
+                                                                "label"
                                                             ],
                                                             "type": "object"
                                                         },
@@ -33267,22 +33281,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -33846,22 +33860,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -43206,7 +43220,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3301.0",
+        "version": "0.3303.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -277,6 +277,43 @@ export class GroupsModel {
         }));
     }
 
+    async findUserGroups(filters: {
+        userUuid: string;
+        organizationUuid: string;
+    }): Promise<Pick<Group, 'uuid' | 'name'>[]> {
+        const rows = await this.database(GroupMembershipTableName)
+            .innerJoin(
+                UserTableName,
+                `${GroupMembershipTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            )
+            .innerJoin(
+                GroupTableName,
+                `${GroupMembershipTableName}.group_uuid`,
+                `${GroupTableName}.group_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${GroupTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .where(`${UserTableName}.user_uuid`, filters.userUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                filters.organizationUuid,
+            )
+            .select<Pick<DbGroup, 'group_uuid' | 'name'>[]>(
+                `${GroupTableName}.group_uuid`,
+                `${GroupTableName}.name`,
+            )
+            .orderBy(`${GroupTableName}.name`);
+
+        return rows.map((row) => ({
+            uuid: row.group_uuid,
+            name: row.name,
+        }));
+    }
+
     async createGroup({
         createdByUserUuid,
         createGroup,

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -145,6 +145,7 @@ export const baseAgentSchema = z.object({
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
+    enableUserContext: z.boolean(),
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
@@ -172,6 +173,7 @@ export type AiAgent = Pick<
     | 'enableDataAccess'
     | 'enableSelfImprovement'
     | 'enableContentTools'
+    | 'enableUserContext'
     | 'adminOnly'
     | 'modelConfig'
     | 'version'
@@ -197,6 +199,7 @@ export type AiAgentSummary = Pick<
     | 'enableDataAccess'
     | 'enableSelfImprovement'
     | 'enableContentTools'
+    | 'enableUserContext'
     | 'adminOnly'
     | 'modelConfig'
     | 'version'
@@ -348,6 +351,7 @@ export type ApiCreateAiAgent = Pick<
     | 'version'
 > & {
     enableContentTools?: boolean;
+    enableUserContext?: boolean;
     adminOnly?: boolean;
     mcpServerUuids?: string[];
     modelConfig?: AiAgentModelConfig | null;
@@ -369,6 +373,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'enableDataAccess'
         | 'enableSelfImprovement'
         | 'enableContentTools'
+        | 'enableUserContext'
         | 'adminOnly'
         | 'modelConfig'
         | 'version'

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -85,6 +85,7 @@ const formSchema = z.object({
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
+    enableUserContext: z.boolean(),
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
@@ -798,6 +799,34 @@ export const AiAgentFormSetup = ({
                                     type: 'checkbox',
                                 })}
                                 disabled={!form.values.enableDataAccess}
+                            />
+                            <Switch
+                                variant="subtle"
+                                label={
+                                    <Group gap="xs">
+                                        <Text fz="sm" fw={500}>
+                                            Pass user information
+                                        </Text>
+                                        <Tooltip
+                                            label="Only applies when the agent knows who is asking — on Slack this requires the OAuth requirement to be enabled in the organization's Slack settings."
+                                            withArrow
+                                            withinPortal
+                                            multiline
+                                            position="right"
+                                            maw="300px"
+                                        >
+                                            <MantineIcon
+                                                icon={IconInfoCircle}
+                                            />
+                                        </Tooltip>
+                                    </Group>
+                                }
+                                description={
+                                    "Shares the requesting user's name, role, and group memberships with the agent so it can tailor answers to who is asking."
+                                }
+                                {...form.getInputProps('enableUserContext', {
+                                    type: 'checkbox',
+                                })}
                             />
                         </Stack>
                     </Paper>

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -96,6 +96,7 @@ const formSchema = z.object({
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
+    enableUserContext: z.boolean(),
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
@@ -151,6 +152,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             enableDataAccess: true,
             enableSelfImprovement: false,
             enableContentTools: true,
+            enableUserContext: false,
             adminOnly: false,
             modelConfig: null,
             version: 2, // INFO: Default to v2 for now
@@ -184,6 +186,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 enableContentTools:
                     (agent.enableDataAccess ?? false) &&
                     (agent.enableContentTools ?? false),
+                enableUserContext: agent.enableUserContext ?? false,
                 adminOnly: agent.adminOnly ?? false,
                 modelConfig: agent.modelConfig ?? null,
                 version: agent.version ?? 2, // INFO: Default to v2 for now


### PR DESCRIPTION
## Summary

The agent has no idea who it's talking to. When a business user asks a question, it can answer like it's addressing a data developer — "use this table instead", modeling jargon, semantic-layer caveats — which is meaningless to a viewer who just wants a number.

This PR lets each agent receive the requesting user's identity in its system prompt, behind a new per-agent setting, so answers are shaped to the audience.

### Prompt injection

- **`GroupsModel.findUserGroups`** — new helper returning a user's group names within an org.
- **`AiAgentArgs.requestingUser`** — `{ name, role, groups }`, built in `AiAgentService` next to the rest of the prompt args. `role` is a display-ready `{ name, isTechnical }` resolved by the service, so the prompt renderer stays pure.
- **`## Who you are talking to` prompt section** (`systemV2RequestingUser.ts`) — renders the identity line plus register guidance:
  - Viewer / Interactive Viewer / Member / unknown role → plain language, no modeling jargon, never advise switching tables or fixing the model; if the data can't answer, suggest raising it with their data team.
  - Editor / Developer / Admin → technical detail is appropriate.
  - When the user belongs to teams, ambiguous questions should prefer the interpretation/terminology of their team.

### Custom org roles

A custom org role stores `role = 'member'` as a placeholder on the membership row, so reading `user.role` alone would describe every custom-role user as "Member" and always use the non-technical register. Instead, when `user.roleUuid` is set the service resolves the role via `RolesModel.getRoleWithScopesByUuid` and:

- renders the actual role name (e.g. `organization role: Analytics Engineer`) — the name itself is a useful audience signal;
- derives the register from the role's scopes: technical if it holds any scope exclusive to editor tier and above (computed from `roleToScopeMapping` as admin's cumulative scopes minus interactive viewer's), mirroring the Editor+ threshold used for system roles.

### Per-agent toggle (opt-in)

New `enableUserContext` agent setting, **off by default**:

- Migration adds `ai_agent.enable_user_context` (boolean, default false, not nullable).
- Flows through `AiAgent` types / create / update APIs (TSOA routes regenerated).
- Frontend: "Pass user information" switch in the agent's Data access settings section, with a tooltip noting the Slack OAuth caveat below.

### Trust guard

On Slack without `aiRequireOAuth`, the prompt actor is the workspace installer, not the requester — the same reason runSql/writeback/repo-discovery fail closed there. In that case `requestingUser` is `null` and the section is omitted entirely (even when the toggle is on), rather than describing the wrong person.

Web and MCP prompts (OAuth, PAT, service account) always carry the real `SessionUser`, so MCP flows work with just the toggle.

### Out of scope (follow-ups)

- Passing the same context to the AI Router's agent-selection prompt (next PR).
- Team-scoped knowledge documents (needs a doc↔group mapping).
- User attributes: deliberately not exposed — they are row-level-security values already enforced in query execution and say nothing about audience.

## Testing

- Unit tests in `systemV2.test.ts` cover: viewer rendering (identity + non-technical guidance), developer rendering (technical guidance, no team hint without groups), unknown role defaulting to the non-technical register, custom-role rendering (name + scope-derived register in both directions), and full omission when `requestingUser` is null/empty.
- `pnpm -F backend typecheck:fast`, `pnpm -F frontend typecheck:fast`, `pnpm -F common typecheck:fast` and the backend test suite pass.

Relates: ZAP-472
Relates: #23758
