### PR TITLE
feat(frontend): add alertdialog role to MantineModal

### DIFF
--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -27,6 +27,15 @@ import classes from './MantineModal.module.css';
  */
 export type MantineModalVariant = 'default' | 'delete';
 
+/**
+ * Semantic role of the modal, driving both its ARIA role and dismissal behavior.
+ * - `dialog`: standard modal, dismissible by clicking outside / pressing Escape
+ * - `alertdialog`: interrupts and requires an explicit decision; not dismissible
+ *   by click-outside or Escape, guarding against accidental dismissal. Use for
+ *   destructive confirmations and other choices that must be answered.
+ */
+export type MantineModalRole = 'dialog' | 'alertdialog';
+
 const VARIANT_CONFIG: Record<
     MantineModalVariant,
     { icon?: IconType; color?: string; confirmLabel: string }
@@ -68,6 +77,17 @@ export type MantineModalProps = {
      * @default 'default'
      */
     variant?: MantineModalVariant;
+    /**
+     * Semantic role of the modal.
+     * - `alertdialog`: sets `role="alertdialog"` and disables click-outside /
+     *   Escape dismissal so a confirmation can't be lost by a stray click.
+     *   Override the dismissal defaults per-case via `modalRootProps`.
+     * Defaults to `alertdialog` for `variant="delete"` (destructive actions
+     * shouldn't be dismissed by accident), otherwise `dialog`. Set explicitly
+     * to opt a delete modal back into `dialog`, or to mark a non-delete modal
+     * (e.g. a revoke/regenerate confirmation) as an alert.
+     */
+    role?: MantineModalRole;
     /**
      * The type of resource being acted upon (e.g., "chart", "dashboard", "space").
      * Used with `variant="delete"` to auto-generate description.
@@ -184,6 +204,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
     onClose,
     title,
     variant = 'default',
+    role = variant === 'delete' ? 'alertdialog' : 'dialog',
     resourceType,
     resourceLabel,
     icon,
@@ -204,6 +225,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
     onCancel,
     confirmBeforeClose = false,
     modalRootProps,
+    modalContentProps,
     modalHeaderProps,
     modalBodyProps,
     modalActionsProps,
@@ -229,6 +251,8 @@ const MantineModal: React.FC<MantineModalProps> = ({
     }, [confirmBeforeClose, onClose, openConfirmClose]);
 
     const config = VARIANT_CONFIG[variant];
+
+    const isAlertDialog = role === 'alertdialog';
 
     const effectiveIcon = icon ?? config.icon;
 
@@ -290,12 +314,18 @@ const MantineModal: React.FC<MantineModalProps> = ({
                 onClose={handleClose}
                 size={fullScreen ? 'auto' : size}
                 centered
+                closeOnClickOutside={isAlertDialog ? false : undefined}
+                closeOnEscape={isAlertDialog ? false : undefined}
                 {...modalRootProps}
             >
                 <Modal.Overlay />
                 <Modal.Content
+                    {...modalContentProps}
+                    role={isAlertDialog ? 'alertdialog' : undefined}
                     className={
-                        fullScreen ? classes.fullScreenContent : undefined
+                        fullScreen
+                            ? classes.fullScreenContent
+                            : modalContentProps?.className
                     }
                 >
                     <Modal.Header
@@ -377,7 +407,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
                     centered
                 >
                     <Modal.Overlay />
-                    <Modal.Content>
+                    <Modal.Content role="alertdialog">
                         <Modal.Header
                             className={classes.header}
                             px="xl"

--- a/packages/frontend/src/stories/Modal.stories.tsx
+++ b/packages/frontend/src/stories/Modal.stories.tsx
@@ -92,6 +92,28 @@ export const DeleteWithWarning: Story = {
 };
 
 /**
+ * Alert dialog that can't be dismissed by accident.
+ * Set `role="alertdialog"` for confirmations that must be answered — it disables
+ * click-outside and Escape dismissal and sets the `alertdialog` ARIA role, so the
+ * user must choose Cancel or the confirm action.
+ *
+ * `variant="delete"` already defaults to `role="alertdialog"`, so you only set
+ * `role` explicitly here because this destructive confirmation isn't a delete.
+ */
+export const AlertDialog: Story = {
+    args: {
+        opened: true,
+        onClose: () => {},
+        title: 'Regenerate secret',
+        role: 'alertdialog',
+        description:
+            'This invalidates the current secret and breaks any embeds using it. Clicking outside won’t dismiss this dialog.',
+        confirmLabel: 'Regenerate',
+        onConfirm: () => {},
+    },
+};
+
+/**
  * Modal with left-side actions (e.g., "New Space" button).
  * Uses the `leftActions` prop to position secondary actions on the left.
  */


### PR DESCRIPTION
### Description

Adds a semantic `role` prop to the shared `MantineModal` component so we can distinguish a plain dialog from an alert dialog (a confirmation that must be answered and shouldn't be dismissed by accident).

- New optional prop: `role: 'dialog' | 'alertdialog'`.
- `role="alertdialog"` disables click-outside **and** Escape dismissal, and sets ARIA `role="alertdialog"` on the content.
- **The default is derived from `variant`**: `variant="delete"` defaults to `alertdialog`, everything else to `dialog`. Still overridable per call (set `role` explicitly, or `modalRootProps` for the close flags).
- Also wires up the previously-dead `modalContentProps` and adds a Storybook example (`AlertDialog`).

#### Behaviour change

All existing `variant="delete"` modals now block click-outside / Escape dismissal automatically — this is intentional, destructive confirmations shouldn't be lost to a stray click. Non-delete destructive modals are migrated in the stacked PR.

#### Verification

Props verified against `@mantine/core@8.0.0` type defs (`role`, `closeOnClickOutside`, `closeOnEscape`). Backwards-compatible: `role` is optional and the default preserves today's behaviour for every non-delete modal.

Linear: PROD-8654
