### PR TITLE
feat(frontend): mark destructive modals as alertdialog

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -419,6 +419,7 @@ const SavedChartsHeader: FC = () => {
                     onClose={() => {
                         blocker.reset();
                     }}
+                    role="alertdialog"
                     title="Unsaved changes"
                     icon={IconAlertCircle}
                     cancelLabel="Stay"

--- a/packages/frontend/src/components/ProjectAccess/RemoveProjectAccessModal.tsx
+++ b/packages/frontend/src/components/ProjectAccess/RemoveProjectAccessModal.tsx
@@ -15,6 +15,7 @@ const RemoveProjectAccessModal: FC<Props> = ({ user, onDelete, onClose }) => {
         <MantineModal
             opened
             onClose={onClose}
+            role="alertdialog"
             title="Revoke project access"
             icon={IconKey}
             description={`Are you sure you want to revoke project access for "${

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/CreateTokenModal.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/CreateTokenModal.tsx
@@ -60,6 +60,7 @@ export const CreateTokenModal: FC<{
         <MantineModal
             opened
             onClose={onBackClick}
+            role="alertdialog"
             title={data ? 'Your token has been generated' : 'New token'}
             cancelLabel={isSuccess ? 'Close' : 'Cancel'}
             icon={IconKey}

--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/CreateOAuthClientModal.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/CreateOAuthClientModal.tsx
@@ -64,6 +64,7 @@ export const CreateOAuthClientModal: FC<{
         <MantineModal
             opened
             onClose={onClose}
+            role="alertdialog"
             title={
                 isSuccess
                     ? 'Application registered'

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/AzureAdSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/AzureAdSsoPanel.tsx
@@ -336,6 +336,7 @@ const AzureAdSsoPanel: FC = () => {
                 <MantineModal
                     opened
                     onClose={() => setDeleteOpen(false)}
+                    role="alertdialog"
                     title="Remove Azure AD configuration"
                     icon={IconShieldCheck}
                     cancelLabel="Cancel"

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx
@@ -352,6 +352,7 @@ const GenericOidcSsoPanel: FC = () => {
                 <MantineModal
                     opened
                     onClose={() => setDeleteOpen(false)}
+                    role="alertdialog"
                     title="Remove OpenID Connect configuration"
                     icon={IconShieldCheck}
                     cancelLabel="Cancel"

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GoogleSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GoogleSsoPanel.tsx
@@ -304,6 +304,7 @@ const GoogleSsoPanel: FC = () => {
                 <MantineModal
                     opened
                     onClose={() => setDeleteOpen(false)}
+                    role="alertdialog"
                     title="Remove Google configuration"
                     icon={IconShieldCheck}
                     cancelLabel="Cancel"

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/OktaSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/OktaSsoPanel.tsx
@@ -379,6 +379,7 @@ const OktaSsoPanel: FC = () => {
                 <MantineModal
                     opened
                     onClose={() => setDeleteOpen(false)}
+                    role="alertdialog"
                     title="Remove Okta configuration"
                     icon={IconShieldCheck}
                     cancelLabel="Cancel"

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx
@@ -334,6 +334,7 @@ const OneLoginSsoPanel: FC = () => {
                 <MantineModal
                     opened
                     onClose={() => setDeleteOpen(false)}
+                    role="alertdialog"
                     title="Remove OneLogin configuration"
                     icon={IconShieldCheck}
                     cancelLabel="Cancel"

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
@@ -252,6 +252,7 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                 onClose={() =>
                     !isDeleting ? setIsDeleteDialogOpen(false) : undefined
                 }
+                role="alertdialog"
                 title="Delete user"
                 icon={IconTrash}
                 cancelDisabled={isDeleting}

--- a/packages/frontend/src/components/UserSettings/VerifiedDomains/VerifiedDomainsPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/VerifiedDomains/VerifiedDomainsPanel.tsx
@@ -137,6 +137,7 @@ const VerifiedDomainsPanel: FC = () => {
                 <MantineModal
                     opened
                     onClose={() => setDomainToDelete(null)}
+                    role="alertdialog"
                     title="Remove verified domain"
                     icon={IconWorldCheck}
                     cancelLabel="Cancel"

--- a/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
+++ b/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
@@ -301,6 +301,7 @@ const VerifiedContentPanel: FC<Props> = ({ projectUuid }) => {
             <MantineModal
                 opened={unverifyModalOpened}
                 onClose={closeUnverifyModal}
+                role="alertdialog"
                 title="Remove verification?"
                 description="This will remove the verified badge from this content. You can verify it again later."
                 actions={

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
@@ -393,6 +393,7 @@ export const VerifiedArtifactsTable: FC<Props> = ({
             <MantineModal
                 opened={unverifyModalOpened}
                 onClose={closeUnverifyModal}
+                role="alertdialog"
                 title="Remove from verified answers?"
                 description="This answer will no longer be used as a reference in future conversations. You can verify it again later."
                 actions={

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -498,6 +498,7 @@ export const AiChartQuickOptions = ({
             <MantineModal
                 opened={verifyModalOpened}
                 onClose={closeVerifyModal}
+                role="alertdialog"
                 title="Remove from verified answers"
                 icon={IconCircleCheck}
                 size="sm"

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/CreateTokenModal.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/CreateTokenModal.tsx
@@ -84,6 +84,7 @@ export const CreateTokenModal: FC<{
         <MantineModal
             opened
             onClose={onBackClick}
+            role="alertdialog"
             title={isSuccess ? 'Your token has been generated' : 'New token'}
             icon={IconKey}
             size="lg"

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
@@ -252,6 +252,7 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
         <MantineModal
             opened={isOpen}
             onClose={closeModal}
+            role="alertdialog"
             title="New Service Account"
             icon={IconKey}
             cancelLabel={token ? false : 'Cancel'}

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsRotateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsRotateModal.tsx
@@ -151,6 +151,7 @@ export const ServiceAccountsRotateModal: FC<Props> = ({
         <MantineModal
             opened={isOpen}
             onClose={handleClose}
+            role="alertdialog"
             title="Rotate token"
             icon={IconRefresh}
             size="md"

--- a/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
+++ b/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
@@ -258,6 +258,8 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
     const handleRevertChange = (changeUuid: string, entityName: string) => {
         modals.openConfirmModal({
             title: 'Revert change',
+            closeOnClickOutside: false,
+            closeOnEscape: false,
             children: (
                 <Text>
                     Are you sure you want to revert the change to{' '}
@@ -293,6 +295,8 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
     const handleRevertAllChanges = () => {
         modals.openConfirmModal({
             title: 'Revert all changes',
+            closeOnClickOutside: false,
+            closeOnEscape: false,
             children: (
                 <Text>
                     Are you sure you want to revert all{' '}

--- a/packages/frontend/src/features/dashboardTabs/DeleteTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabs/DeleteTabModal.tsx
@@ -185,6 +185,7 @@ export const TabDeleteModal: FC<DeleteProps> = ({
         <MantineModal
             opened={opened}
             onClose={onClose}
+            role="alertdialog"
             title="Remove tab"
             icon={IconTrash}
             actions={

--- a/packages/frontend/src/features/projectGroupAccess/components/RevokeProjectGroupAccessModal.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/RevokeProjectGroupAccessModal.tsx
@@ -20,6 +20,7 @@ const RevokeProjectGroupAccessModal: FC<RevokeProjectGroupAccessModalProps> = ({
         <MantineModal
             opened
             onClose={onClose}
+            role="alertdialog"
             title="Revoke group project access"
             icon={IconKey}
             description={`Are you sure you want to revoke project access for this group "${group.name}"?`}

--- a/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
+++ b/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
@@ -220,6 +220,7 @@ export const PromotionConfirmDialog: FC<Props> = ({
         <MantineModal
             opened
             onClose={onClose}
+            role="alertdialog"
             title={`Promoting ${type}`}
             icon={IconRocket}
             size="lg"

--- a/packages/frontend/src/features/sourceCodeEditor/components/UnsavedChangesModal.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/UnsavedChangesModal.tsx
@@ -15,6 +15,7 @@ const UnsavedChangesModal: FC<UnsavedChangesModalProps> = ({
     <MantineModal
         opened={opened}
         onClose={onClose}
+        role="alertdialog"
         title="Unsaved changes"
         icon={IconAlertTriangle}
         description="You have unsaved changes. Are you sure you want to discard them?"

--- a/packages/frontend/src/features/sync/components/SyncModalDelete.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalDelete.tsx
@@ -41,6 +41,7 @@ export const SyncModalDelete = () => {
         <MantineModal
             opened
             onClose={() => setAction(SyncModalAction.VIEW)}
+            role="alertdialog"
             title="Delete"
             icon={IconTrash}
             size="lg"

--- a/packages/frontend/src/features/virtualView/components/EditVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/EditVirtualViewModal.tsx
@@ -84,6 +84,7 @@ export const EditVirtualViewModal: FC<Props> = ({
             <MantineModal
                 opened={opened}
                 onClose={onClose}
+                role="alertdialog"
                 title="You have unsaved changes"
                 icon={IconAlertCircle}
                 description="Are you sure you want to leave this page? Changes you've made to your query will not be saved."

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -896,6 +896,7 @@ const Dashboard: FC = () => {
                     onClose={() => {
                         blocker.reset();
                     }}
+                    role="alertdialog"
                     title="Unsaved changes"
                     icon={IconAlertCircle}
                     cancelLabel="Stay"


### PR DESCRIPTION
### Description

Stacked on the `MantineModal` `role` prop PR. Applies `role="alertdialog"` to non-delete destructive / irreversible confirmations so they can't be dismissed by an accidental click-outside or Escape.

Covered (24 modals + 2 raw confirmations):

- **Access / integration removal**: 5 SSO configs (Okta, Azure AD, Google, OIDC, OneLogin), verified domain, project access, group project access, content verification, delete user, delete Google Sheets sync, remove dashboard tab, remove verified answer (admin table + chat quick-options).
- **One-time secrets** (accidental dismissal loses the secret permanently): PAT, SCIM token, service-account token, OAuth client secret, token rotation.
- **Unsaved-changes prompts**: source-code editor, saved chart header, dashboard, virtual-view editor.
- **Irreversible writes**: content promotion.
- **Raw revert confirmations** (mantine `modals` manager, can't inherit the prop): "Revert change" / "Revert all changes" — guarded with `closeOnClickOutside: false` + `closeOnEscape: false`.

`variant="delete"` modals are already covered by the derived default in the parent PR and are untouched here.

**Not changed:** `SyncModalView` — its trash icon just opens the separate `SyncModalDelete` (already covered); the list modal itself is non-destructive, so making it non-dismissable would be wrong.

Each change is a single prop addition; no logic or import changes.

Linear: PROD-8654
