### PR TITLE
fix(cli): count app uploads in summary; guard cross-project app creates [GLITCH-584 GLITCH-581]

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -2,9 +2,12 @@ import { type DataAppCodeDownload } from '@lightdash/common';
 import {
     appsDownloadSummary,
     capListedApps,
+    classifyAppUpload,
+    computeUpsertedTotal,
     ensureDownloadedAppContext,
     MAX_INCLUDE_APPS,
     selectAppsToDownload,
+    shouldWarnAllSkipped,
 } from './appsDownload';
 
 const makeDownload = (): DataAppCodeDownload =>
@@ -93,6 +96,73 @@ describe('ensureDownloadedAppContext', () => {
                 withoutContext as DataAppCodeDownload,
             ),
         ).toThrow(/does not support app context downloads/i);
+    });
+});
+
+describe('computeUpsertedTotal', () => {
+    it('sums only keys that are neither skipped nor failed', () => {
+        const changes = {
+            'charts created': 2,
+            'charts skipped': 3,
+            'charts failed': 1,
+            'dashboards updated': 4,
+        };
+        expect(computeUpsertedTotal(changes)).toBe(6); // 2 + 4
+    });
+
+    it('returns 0 when all keys are skipped or failed', () => {
+        const changes = {
+            'charts skipped': 5,
+            'data apps failed': 1,
+        };
+        expect(computeUpsertedTotal(changes)).toBe(0);
+    });
+
+    it('returns 0 for empty changes', () => {
+        expect(computeUpsertedTotal({})).toBe(0);
+    });
+});
+
+describe('shouldWarnAllSkipped', () => {
+    it('returns true when everything was skipped', () => {
+        expect(shouldWarnAllSkipped({ 'charts skipped': 3 })).toBe(true);
+    });
+
+    it('returns false when some content was upserted', () => {
+        expect(
+            shouldWarnAllSkipped({
+                'charts skipped': 3,
+                'data apps created': 1,
+            }),
+        ).toBe(false);
+    });
+
+    it('returns false when only failures exist (no skipped)', () => {
+        expect(shouldWarnAllSkipped({ 'data apps failed': 1 })).toBe(false);
+    });
+
+    it('returns false when nothing was skipped', () => {
+        expect(shouldWarnAllSkipped({ 'charts created': 2 })).toBe(false);
+    });
+
+    it('returns false for empty changes', () => {
+        expect(shouldWarnAllSkipped({})).toBe(false);
+    });
+});
+
+describe('classifyAppUpload', () => {
+    it('proceeds when createNew is true regardless of project mismatch', () => {
+        expect(classifyAppUpload('proj-a', 'proj-b', true)).toBe('proceed');
+    });
+
+    it('proceeds when manifest project matches target project', () => {
+        expect(classifyAppUpload('proj-a', 'proj-a', false)).toBe('proceed');
+    });
+
+    it('needs-confirmation when projects differ and createNew is false', () => {
+        expect(classifyAppUpload('proj-a', 'proj-b', false)).toBe(
+            'needs-confirmation',
+        );
     });
 });
 

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -50,6 +50,48 @@ export const ensureDownloadedAppContext = (
 
 export type AppDownloadFailure = { appUuid: string; message: string };
 
+/**
+ * Sums changes entries that represent actual upserts — excluding both
+ * 'skipped' and 'failed' keys so that failures don't suppress the
+ * "all content was skipped" warning.
+ */
+export const computeUpsertedTotal = (changes: Record<string, number>): number =>
+    Object.entries(changes)
+        .filter(([key]) => !key.includes('skipped') && !key.includes('failed'))
+        .reduce((sum, [, value]) => sum + value, 0);
+
+/**
+ * Returns true when there is at least one skipped item and zero upserted
+ * items — the condition that should display the "all skipped" warning.
+ */
+export const shouldWarnAllSkipped = (
+    changes: Record<string, number>,
+): boolean => {
+    const totalSkipped = Object.entries(changes)
+        .filter(([key]) => key.includes('skipped'))
+        .reduce((sum, [, value]) => sum + value, 0);
+    return totalSkipped > 0 && computeUpsertedTotal(changes) === 0;
+};
+
+/**
+ * Determines how an app upload should proceed given a potential project
+ * mismatch between the manifest and the upload target.
+ *
+ * 'proceed'            — upload immediately (same project, or --create-new).
+ * 'needs-confirmation' — projects differ and --create-new was not passed;
+ *                        caller must prompt (TTY) or reject (non-TTY).
+ */
+export const classifyAppUpload = (
+    manifestProjectUuid: string,
+    targetProjectUuid: string,
+    createNew: boolean,
+): 'proceed' | 'needs-confirmation' => {
+    if (createNew || manifestProjectUuid === targetProjectUuid) {
+        return 'proceed';
+    }
+    return 'needs-confirmation';
+};
+
 export const appsDownloadSummary = (
     successCount: number,
     total: number,

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -49,9 +49,11 @@ import {
 import {
     appsDownloadSummary,
     capListedApps,
+    classifyAppUpload,
     ensureDownloadedAppContext,
     MAX_INCLUDE_APPS,
     selectAppsToDownload,
+    shouldWarnAllSkipped,
     type AppDownloadFailure,
 } from './apps/appsDownload';
 import { buildStaticAuthoringFiles } from './apps/scaffolding';
@@ -1262,14 +1264,7 @@ const logUploadChanges = (changes: Record<string, number>) => {
         console.info(`Total ${key}: ${value} `);
     });
 
-    const totalSkipped = Object.entries(changes)
-        .filter(([key]) => key.includes('skipped'))
-        .reduce((sum, [, value]) => sum + value, 0);
-    const totalUpserted = Object.entries(changes)
-        .filter(([key]) => !key.includes('skipped'))
-        .reduce((sum, [, value]) => sum + value, 0);
-
-    if (totalSkipped > 0 && totalUpserted === 0) {
+    if (shouldWarnAllSkipped(changes)) {
         console.warn(
             styles.warning(
                 `\nAll content was skipped (no local changes detected). Use --force to upload all content, e.g. when uploading to a new project.`,
@@ -1864,6 +1859,11 @@ export const uploadHandler = async (
             appsOption !== false &&
             appsOption !== undefined;
 
+        let appsCreated = 0;
+        let appsUpdated = 0;
+        let appsFailed = 0;
+        let appsSkipped = 0;
+
         if (shouldUploadApps) {
             const filterUuids: Set<string> | null =
                 Array.isArray(appsOption) && appsOption.length > 0
@@ -1916,6 +1916,46 @@ export const uploadHandler = async (
                         continue;
                     }
 
+                    // Guard: cross-project create
+                    const uploadDecision = classifyAppUpload(
+                        code.manifest.projectUuid,
+                        projectId,
+                        options.createNew === true,
+                    );
+
+                    if (uploadDecision === 'needs-confirmation') {
+                        if (process.stdin.isTTY && process.stdout.isTTY) {
+                            // eslint-disable-next-line no-await-in-loop
+                            const { confirmed } = await inquirer.prompt<{
+                                confirmed: boolean;
+                            }>([
+                                {
+                                    type: 'confirm',
+                                    name: 'confirmed',
+                                    message: `"${subDir.name}" was downloaded from project ${code.manifest.projectUuid}, but you are uploading to project ${projectId}. This will CREATE a new app. Continue?`,
+                                    default: false,
+                                },
+                            ]);
+                            if (!confirmed) {
+                                GlobalState.log(
+                                    `Skipped "${subDir.name}" (cross-project create declined). Pass --create-new to make this explicit.`,
+                                );
+                                appsSkipped += 1;
+                                // eslint-disable-next-line no-continue
+                                continue;
+                            }
+                        } else {
+                            GlobalState.log(
+                                styles.error(
+                                    `Cannot upload "${subDir.name}": its manifest targets project ${code.manifest.projectUuid} but you are uploading to project ${projectId}. Pass --create-new to create a new app in the target project.`,
+                                ),
+                            );
+                            appsFailed += 1;
+                            // eslint-disable-next-line no-continue
+                            continue;
+                        }
+                    }
+
                     const body = buildImportBody(code, projectId, {
                         createNew: options.createNew === true,
                     });
@@ -1928,6 +1968,12 @@ export const uploadHandler = async (
                         url: `/api/v1/ee/projects/${projectId}/apps/upload`,
                         body: JSON.stringify(body),
                     });
+
+                    if (action === 'create') {
+                        appsCreated += 1;
+                    } else {
+                        appsUpdated += 1;
+                    }
 
                     const actionLabel =
                         action === 'create' ? 'created' : 'updated';
@@ -1975,6 +2021,7 @@ export const uploadHandler = async (
                         }
                     }
                 } catch (appErr) {
+                    appsFailed += 1;
                     const status =
                         appErr instanceof LightdashError
                             ? appErr.statusCode
@@ -1992,6 +2039,11 @@ export const uploadHandler = async (
                     );
                 }
             }
+
+            if (appsCreated > 0) changes['data apps created'] = appsCreated;
+            if (appsUpdated > 0) changes['data apps updated'] = appsUpdated;
+            if (appsFailed > 0) changes['data apps failed'] = appsFailed;
+            if (appsSkipped > 0) changes['data apps skipped'] = appsSkipped;
         }
 
         const end = Date.now();


### PR DESCRIPTION
Two upload UX fixes from Phase 2 manual testing.

- **App uploads now count in the summary** (`data apps created/updated/failed/skipped` totals), so a successful app upload no longer ends with the false "All content was skipped (no local changes detected)" warning. Failed uploads are excluded from the upserted total so a failure alone doesn't suppress the warning either.
- **Cross-project create guard**: the target project comes from `--project`/CLI config, never the manifest — so a stale active project silently created a duplicate app. Now, when the manifest's `projectUuid` differs from the target and `--create-new` wasn't passed, a TTY gets an explicit confirm (default no) and non-TTY errors with guidance to pass `--create-new`.

Closes: GLITCH-584
Closes: GLITCH-581

🤖 Generated with [Claude Code](https://claude.com/claude-code)