### PR TITLE
feat(cli): --skip-charts/--skip-dashboards for apps-only downloads [GLITCH-585]

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -18,6 +18,7 @@ import {
     getErrorMessage,
     isMalformedEmptyDashboardFilter,
     LightdashError,
+    ParameterError,
     Project,
     PromotionAction,
     PromotionChanges,
@@ -86,6 +87,9 @@ export type DownloadHandlerOptions = {
     includeCharts: boolean;
     nested: boolean; // Use nested folder structure (projectName/spaceSlug/charts|dashboards)
     skipSpaces: boolean; // Skip writing space metadata files during download
+    skipCharts: boolean; // Skip downloading charts and SQL charts
+    skipDashboards: boolean; // Skip downloading dashboards
+    appsOnly?: boolean; // download only: implies skipCharts + skipDashboards + skipSpaces
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
     validate?: boolean; // Validate charts and dashboards after upload
     concurrency: number;
@@ -839,6 +843,21 @@ export const downloadHandler = async (
 ): Promise<void> => {
     GlobalState.setVerbose(options.verbose);
 
+    if (options.appsOnly) {
+        const appsOnlySelection = selectAppsToDownload({
+            apps: Array.isArray(options.apps) ? options.apps : undefined,
+            includeApps: options.includeApps === true,
+        });
+        if (appsOnlySelection.mode === 'none') {
+            throw new ParameterError(
+                'Nothing to download: --apps-only requires --apps <appUuids...> or --include-apps.',
+            );
+        }
+        options.skipCharts = true;
+        options.skipDashboards = true;
+        options.skipSpaces = true;
+    }
+
     await checkLightdashVersion();
 
     const config = await getConfig();
@@ -896,14 +915,19 @@ export const downloadHandler = async (
         let allMetadataEntries: MetadataEntry[] = [];
         let allSpaces: SpaceAsCode[] = [];
 
-        // Download regular charts
-        if (hasFilters && options.charts.length === 0) {
-            console.info(
-                styles.warning(`No charts filters provided, skipping`),
-            );
-        } else {
-            const [regularChartTotal, , regularChartMeta, regularChartSpaces] =
-                await downloadContent(
+        // Download regular charts and SQL charts
+        if (!options.skipCharts) {
+            if (hasFilters && options.charts.length === 0) {
+                console.info(
+                    styles.warning(`No charts filters provided, skipping`),
+                );
+            } else {
+                const [
+                    regularChartTotal,
+                    ,
+                    regularChartMeta,
+                    regularChartSpaces,
+                ] = await downloadContent(
                     options.charts,
                     'charts',
                     projectId,
@@ -914,65 +938,78 @@ export const downloadHandler = async (
                     skipSpaces,
                     options.stripPivotSeries,
                 );
-            spinner.succeed(`Downloaded ${regularChartTotal} charts`);
-            allMetadataEntries = [...allMetadataEntries, ...regularChartMeta];
-            allSpaces = [...allSpaces, ...regularChartSpaces];
+                spinner.succeed(`Downloaded ${regularChartTotal} charts`);
+                allMetadataEntries = [
+                    ...allMetadataEntries,
+                    ...regularChartMeta,
+                ];
+                allSpaces = [...allSpaces, ...regularChartSpaces];
 
-            // Download SQL charts
-            spinner.start(`Downloading SQL charts`);
-            const [sqlChartTotal, , sqlChartMeta, sqlChartSpaces] =
-                await downloadContent(
-                    options.charts,
-                    'sqlCharts',
-                    projectId,
-                    projectName,
-                    options.path,
-                    options.languageMap,
-                    options.nested,
-                    skipSpaces,
-                    false,
-                );
-            spinner.succeed(`Downloaded ${sqlChartTotal} SQL charts`);
-            allMetadataEntries = [...allMetadataEntries, ...sqlChartMeta];
-            allSpaces = [...allSpaces, ...sqlChartSpaces];
+                // Download SQL charts
+                spinner.start(`Downloading SQL charts`);
+                const [sqlChartTotal, , sqlChartMeta, sqlChartSpaces] =
+                    await downloadContent(
+                        options.charts,
+                        'sqlCharts',
+                        projectId,
+                        projectName,
+                        options.path,
+                        options.languageMap,
+                        options.nested,
+                        skipSpaces,
+                        false,
+                    );
+                spinner.succeed(`Downloaded ${sqlChartTotal} SQL charts`);
+                allMetadataEntries = [...allMetadataEntries, ...sqlChartMeta];
+                allSpaces = [...allSpaces, ...sqlChartSpaces];
 
-            chartTotal = regularChartTotal + sqlChartTotal;
+                chartTotal = regularChartTotal + sqlChartTotal;
+            }
         }
 
         // Download dashboards
-        if (hasFilters && options.dashboards.length === 0) {
-            console.info(
-                styles.warning(`No dashboards filters provided, skipping`),
-            );
-        } else {
-            let chartSlugs: string[] = [];
-
-            let dashMeta: MetadataEntry[];
-            let dashSpaces: SpaceAsCode[];
-            [dashboardTotal, chartSlugs, dashMeta, dashSpaces] =
-                await downloadContent(
-                    options.dashboards,
-                    'dashboards',
-                    projectId,
-                    projectName,
-                    options.path,
-                    options.languageMap,
-                    options.nested,
-                    skipSpaces,
-                    false,
+        if (!options.skipDashboards) {
+            if (hasFilters && options.dashboards.length === 0) {
+                console.info(
+                    styles.warning(`No dashboards filters provided, skipping`),
                 );
-            allMetadataEntries = [...allMetadataEntries, ...dashMeta];
-            allSpaces = [...allSpaces, ...dashSpaces];
+            } else {
+                let chartSlugs: string[] = [];
 
-            spinner.succeed(`Downloaded ${dashboardTotal} dashboards`);
-
-            if (hasFilters && chartSlugs.length > 0) {
-                spinner.start(
-                    `Downloading ${chartSlugs.length} charts linked to dashboards`,
-                );
-
-                const [regularCharts, , linkedChartMeta, linkedChartSpaces] =
+                let dashMeta: MetadataEntry[];
+                let dashSpaces: SpaceAsCode[];
+                [dashboardTotal, chartSlugs, dashMeta, dashSpaces] =
                     await downloadContent(
+                        options.dashboards,
+                        'dashboards',
+                        projectId,
+                        projectName,
+                        options.path,
+                        options.languageMap,
+                        options.nested,
+                        skipSpaces,
+                        false,
+                    );
+                allMetadataEntries = [...allMetadataEntries, ...dashMeta];
+                allSpaces = [...allSpaces, ...dashSpaces];
+
+                spinner.succeed(`Downloaded ${dashboardTotal} dashboards`);
+
+                if (
+                    hasFilters &&
+                    chartSlugs.length > 0 &&
+                    !options.skipCharts
+                ) {
+                    spinner.start(
+                        `Downloading ${chartSlugs.length} charts linked to dashboards`,
+                    );
+
+                    const [
+                        regularCharts,
+                        ,
+                        linkedChartMeta,
+                        linkedChartSpaces,
+                    ] = await downloadContent(
                         chartSlugs,
                         'charts',
                         projectId,
@@ -983,31 +1020,35 @@ export const downloadHandler = async (
                         skipSpaces,
                         options.stripPivotSeries,
                     );
-                allMetadataEntries = [
-                    ...allMetadataEntries,
-                    ...linkedChartMeta,
-                ];
-                allSpaces = [...allSpaces, ...linkedChartSpaces];
+                    allMetadataEntries = [
+                        ...allMetadataEntries,
+                        ...linkedChartMeta,
+                    ];
+                    allSpaces = [...allSpaces, ...linkedChartSpaces];
 
-                const [sqlCharts, , linkedSqlMeta, linkedSqlSpaces] =
-                    await downloadContent(
-                        chartSlugs,
-                        'sqlCharts',
-                        projectId,
-                        projectName,
-                        options.path,
-                        options.languageMap,
-                        options.nested,
-                        skipSpaces,
+                    const [sqlCharts, , linkedSqlMeta, linkedSqlSpaces] =
+                        await downloadContent(
+                            chartSlugs,
+                            'sqlCharts',
+                            projectId,
+                            projectName,
+                            options.path,
+                            options.languageMap,
+                            options.nested,
+                            skipSpaces,
+                        );
+                    allMetadataEntries = [
+                        ...allMetadataEntries,
+                        ...linkedSqlMeta,
+                    ];
+                    allSpaces = [...allSpaces, ...linkedSqlSpaces];
+
+                    spinner.succeed(
+                        `Downloaded ${
+                            regularCharts + sqlCharts
+                        } charts linked to dashboards`,
                     );
-                allMetadataEntries = [...allMetadataEntries, ...linkedSqlMeta];
-                allSpaces = [...allSpaces, ...linkedSqlSpaces];
-
-                spinner.succeed(
-                    `Downloaded ${
-                        regularCharts + sqlCharts
-                    } charts linked to dashboards`,
-                );
+                }
             }
         }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -754,6 +754,8 @@ program
         'skip writing space metadata files during download',
         false,
     )
+    .option('--skip-charts', 'skip downloading charts', false)
+    .option('--skip-dashboards', 'skip downloading dashboards', false)
     .option(
         '--strip-pivot-series',
         'strip per-value pivot series config from chart YAML for portable downloads',
@@ -766,6 +768,11 @@ program
     .option(
         '--include-apps',
         'Include the project\'s data apps (enterprise), capped at the first 10. Only lists apps that are in a space; use "--apps <uuids>" for the rest.',
+        false,
+    )
+    .option(
+        '--apps-only',
+        'Download only data apps (implies --skip-charts --skip-dashboards --skip-spaces). Requires --apps <appUuids...> or --include-apps.',
         false,
     )
     .action(downloadHandler);


### PR DESCRIPTION
Adds `--skip-charts`, `--skip-dashboards`, and an `--apps-only` convenience flag to `lightdash download`, following the existing `--skip-spaces` precedent, so an apps-only checkout is one flag:

```
lightdash download --apps-only --apps <uuid>
# equivalent to: --apps <uuid> --skip-charts --skip-dashboards --skip-spaces
```

`--apps-only` without `--apps`/`--include-apps` errors ("Nothing to download"). Previously every app download also pulled all charts/dashboards/spaces — noisy, and risky since a later `upload --force` from that folder would rewrite project content.

Verified live: apps-only download writes only `apps/`, and a subsequent no-force upload from that folder updates just the app (`Total data apps updated: 1`, 0 charts/dashboards found).

Closes: GLITCH-585

🤖 Generated with [Claude Code](https://claude.com/claude-code)