### PR TITLE
fix(backend): apply manifest name/description on app code upload [GLITCH-583]

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -65,6 +65,7 @@ function buildService() {
         createVersion: vi.fn().mockResolvedValue({ version: 1 }),
         getLatestVersion: vi.fn().mockResolvedValue(null),
         countInProgressVersionsForProject: vi.fn().mockResolvedValue(0),
+        updateApp: vi.fn().mockResolvedValue({}),
     };
 
     const schedulerClient = {
@@ -186,6 +187,8 @@ describe('AppGenerateService.importAppCode', () => {
             space_uuid: null,
             created_by_user_uuid: USER_UUID,
             organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
         };
         appModel.findApp.mockResolvedValue(existingApp);
         appModel.getLatestVersion.mockResolvedValue({ version: 4 });
@@ -310,6 +313,61 @@ describe('AppGenerateService.importAppCode', () => {
         expect(result.action).toBe('create');
         expect(appModel.createWithVersion).toHaveBeenCalledOnce();
         expect(schedulerClient.appBuildFromSource).toHaveBeenCalledOnce();
+    });
+
+    it('append mode: calls updateApp when manifest name and description differ from existing app', async () => {
+        const { service, appModel } = buildService();
+
+        const existingApp = {
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: null,
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Old Name',
+            description: 'Old description',
+        };
+        appModel.findApp.mockResolvedValue(existingApp);
+        appModel.getLatestVersion.mockResolvedValue({ version: 1 });
+
+        const updatedCode = makeCode();
+        updatedCode.manifest.name = 'New Name';
+        updatedCode.manifest.description = 'New description';
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: updatedCode,
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        expect(appModel.updateApp).toHaveBeenCalledOnce();
+        expect(appModel.updateApp).toHaveBeenCalledWith(
+            EXISTING_APP_UUID,
+            PROJECT_UUID,
+            { name: 'New Name', description: 'New description' },
+        );
+    });
+
+    it('append mode: does not call updateApp when manifest name and description are unchanged', async () => {
+        const { service, appModel } = buildService();
+
+        const existingApp = {
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: null,
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
+        };
+        appModel.findApp.mockResolvedValue(existingApp);
+        appModel.getLatestVersion.mockResolvedValue({ version: 1 });
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(),
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        expect(appModel.updateApp).not.toHaveBeenCalled();
     });
 
     it('create mode: source.tar contains only src/ entries when bundle has mixed files', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -402,6 +402,29 @@ describe('AppGenerateService.getAppCode', () => {
         expect(semanticContent).toContain('# Semantic layer unavailable');
     });
 
+    it('passes limit: 100 to getAppWithVersions when assembling prompt history', async () => {
+        const fakeS3 = makeFakeS3(sourceTarBuffer);
+
+        const getAppWithVersionsSpy = vi
+            .fn()
+            .mockResolvedValue({ versions: [], hasMore: false });
+
+        const appModel = {
+            getApp: vi.fn().mockResolvedValue(fakeApp),
+            getLatestReadyVersion: vi.fn().mockResolvedValue(fakeAppVersion),
+            getAppWithVersions: getAppWithVersionsSpy,
+        };
+
+        const svc = buildService({ appModel, s3ClientOverride: fakeS3 });
+        await svc.getAppCode(fakeUser, PROJECT_UUID, APP_UUID);
+
+        expect(getAppWithVersionsSpy).toHaveBeenCalledWith(
+            APP_UUID,
+            PROJECT_UUID,
+            { limit: 100 },
+        );
+    });
+
     it('assembles context: semantic layer, null parameters (empty), prompt history, and empty theme', async () => {
         const fakeS3 = makeFakeS3(sourceTarBuffer);
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -6991,6 +6991,19 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 existingApp,
                 'You do not have access to update this app',
             );
+            const nameChanged = code.manifest.name !== existingApp.name;
+            const descChanged =
+                code.manifest.description !== existingApp.description;
+            if (nameChanged || descChanged) {
+                const update: Partial<Pick<DbApp, 'name' | 'description'>> = {};
+                if (nameChanged) update.name = code.manifest.name;
+                if (descChanged) update.description = code.manifest.description;
+                await this.appModel.updateApp(
+                    existingApp.app_id,
+                    projectUuid,
+                    update,
+                );
+            }
             newAppUuid = existingApp.app_id;
             const latestVersion = await this.appModel.getLatestVersion(
                 existingApp.app_id,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -6894,6 +6894,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 const withVersions = await this.appModel.getAppWithVersions(
                     app.app_id,
                     projectUuid,
+                    { limit: 100 },
                 );
                 const promptMd = promptHistoryToMarkdown(
                     withVersions.versions.map((v) => ({


### PR DESCRIPTION
Two small backend fixes for the data-apps-as-code upload/download loop.

- **Manifest `name`/`description` now apply on update**: `importAppCode`'s append branch previously only created a version row, so editing them in `lightdash-app.yml` and re-uploading had no effect. It now diffs against the existing app and calls the existing `AppModel.updateApp` with only the changed fields.
- **Prompt-history cap raised**: `assembleAppContext` used `getAppWithVersions`' default 20-version limit, silently truncating `.lightdash/context/prompt-history.md` for long-lived apps. Now passes an explicit `{ limit: 100 }`.

Closes: GLITCH-583
Closes: GLITCH-573

🤖 Generated with [Claude Code](https://claude.com/claude-code)