### PR TITLE
fix(external-connections): allow Authorization as an api_key header name

### DIFF
--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
@@ -296,15 +296,17 @@ describe('serializeRequestBody', () => {
 });
 
 describe('assertSafeApiKeyHeaderName', () => {
-    it('accepts a normal api key header', () => {
-        expect(() => assertSafeApiKeyHeaderName('X-Api-Key')).not.toThrow();
-    });
+    it.each([['X-Api-Key'], ['Authorization'], ['authorization']])(
+        'accepts the api key header %s',
+        (name) => {
+            expect(() => assertSafeApiKeyHeaderName(name)).not.toThrow();
+        },
+    );
 
     it.each([
         ['Host'],
         ['host'],
         ['Cookie'],
-        ['Authorization'],
         ['Content-Length'],
         ['Transfer-Encoding'],
         ['Connection'],

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
@@ -196,13 +196,17 @@ export function serializeRequestBody(body: unknown): {
 
 // Header names an api_key must never be injected under: they let stored config
 // control request routing/framing or overwrite the proxy's own security
-// headers (host pinning, content-type, auth). The api_key header name is
+// headers (host pinning, content-type). The api_key header name is
 // admin-supplied config, and the proxy is where it becomes an outbound
 // request — so reject sensitive and hop-by-hop headers here, even though
 // write-time validation also runs.
+//
+// `authorization` is intentionally allowed: some APIs (e.g. Linear) expect the
+// key directly in the Authorization header rather than as `Bearer <token>`.
+// The proxy only sets its own Authorization header on the mutually-exclusive
+// `bearer_token` path, so an api_key injected here can never clobber it.
 const FORBIDDEN_API_KEY_HEADERS = new Set([
     'host',
-    'authorization',
     'cookie',
     'content-length',
     'content-type',


### PR DESCRIPTION
### Description:
Some APIs (e.g. Linear) expect the key directly in the Authorization header rather than as `Bearer <token>`. The proxy blocked this via FORBIDDEN_API_KEY_HEADERS, so api_key connections could not target them.
