### PR TITLE
feat(ai-reviews): root-cause accuracy — real agent capabilities, agent-scoped catalog, query-construction carve-out

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -286,6 +286,11 @@ export const AiAgentMcpServerToolPermissionModes = [
 export type DbAiAgentMcpServerToolPermissionMode =
     (typeof AiAgentMcpServerToolPermissionModes)[number];
 
+export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW: DbAiAgentMcpServerToolPermissionMode =
+    'always_allow';
+export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY: DbAiAgentMcpServerToolPermissionMode =
+    'always_deny';
+
 export type DbAiAgentMcpServerTool = {
     ai_agent_uuid: string;
     ai_mcp_server_uuid: string;

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -128,6 +128,8 @@ import {
     type AiSqlApprovalDecision,
 } from '../database/entities/ai';
 import {
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
     AiAgentGroupAccessTableName,
     AiAgentInstructionVersionsTableName,
     AiAgentIntegrationTableName,
@@ -182,10 +184,10 @@ type Dependencies = {
     encryptionUtil: EncryptionUtil;
 };
 
-export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW: DbAiAgentMcpServerToolPermissionMode =
-    'always_allow';
-export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY: DbAiAgentMcpServerToolPermissionMode =
-    'always_deny';
+export {
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
+};
 
 export type AiAgentMcpServerToolPermissionSetting = AiMcpServerTool & {
     agentUuid: string;

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -39,6 +39,7 @@ const snapshot = {
     instructionHash: 'hash',
     instructionSummary: 'Use finance definitions.',
     knowledgeDocuments: [],
+    mcpServers: [],
 };
 
 const makeRunRow = (overrides: Partial<Record<string, unknown>> = {}) => ({

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -8,6 +8,7 @@ import type {
     AiAgentEvidenceExcerpt,
     AiAgentFixTarget,
     AiAgentImplicitSignalSource,
+    AiAgentMcpServerSnapshot,
     AiAgentRecommendation,
     AiAgentReviewClassifierConfidence,
     AiAgentReviewClassifierContextTurn,
@@ -52,6 +53,13 @@ import {
     AiThreadTableName,
     AiWritebackThreadTableName,
 } from '../database/entities/ai';
+import {
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
+    AiAgentMcpServerTableName,
+    AiAgentMcpServerToolTableName,
+    AiMcpServerTableName,
+    AiMcpServerToolTableName,
+} from '../database/entities/aiAgent';
 import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemEventsTableName,
@@ -963,6 +971,60 @@ export class AiAgentReviewClassifierModel {
                 filters: row.metric_query?.filters ?? {},
                 sorts: row.metric_query?.sorts ?? [],
             },
+        }));
+    }
+
+    async getAgentMcpCapabilities(
+        agentUuid: string,
+    ): Promise<AiAgentMcpServerSnapshot[]> {
+        const servers = await this.database(AiAgentMcpServerTableName)
+            .innerJoin(
+                AiMcpServerTableName,
+                `${AiAgentMcpServerTableName}.ai_mcp_server_uuid`,
+                `${AiMcpServerTableName}.ai_mcp_server_uuid`,
+            )
+            .select<{ ai_mcp_server_uuid: string; name: string }[]>({
+                ai_mcp_server_uuid: `${AiMcpServerTableName}.ai_mcp_server_uuid`,
+                name: `${AiMcpServerTableName}.name`,
+            })
+            .where(`${AiAgentMcpServerTableName}.ai_agent_uuid`, agentUuid)
+            .orderBy(`${AiMcpServerTableName}.name`, 'asc');
+
+        if (servers.length === 0) {
+            return [];
+        }
+
+        const toolRows = await this.database(AiAgentMcpServerToolTableName)
+            .innerJoin(
+                AiMcpServerToolTableName,
+                `${AiAgentMcpServerToolTableName}.ai_mcp_server_tool_uuid`,
+                `${AiMcpServerToolTableName}.ai_mcp_server_tool_uuid`,
+            )
+            .select<{ ai_mcp_server_uuid: string; tool_name: string }[]>({
+                ai_mcp_server_uuid: `${AiAgentMcpServerToolTableName}.ai_mcp_server_uuid`,
+                tool_name: `${AiMcpServerToolTableName}.tool_name`,
+            })
+            .where(`${AiAgentMcpServerToolTableName}.ai_agent_uuid`, agentUuid)
+            .andWhere(
+                `${AiAgentMcpServerToolTableName}.permission_mode`,
+                AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
+            )
+            .orderBy(`${AiMcpServerToolTableName}.tool_name`, 'asc');
+
+        const toolsByServer = toolRows.reduce<Map<string, string[]>>(
+            (acc, row) => {
+                const tools = acc.get(row.ai_mcp_server_uuid) ?? [];
+                tools.push(row.tool_name);
+                acc.set(row.ai_mcp_server_uuid, tools);
+                return acc;
+            },
+            new Map(),
+        );
+
+        return servers.map((server) => ({
+            name: server.name,
+            enabledToolNames:
+                toolsByServer.get(server.ai_mcp_server_uuid) ?? [],
         }));
     }
 

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -290,6 +290,7 @@ describe('AiAgentReviewClassifierService', () => {
         updateRun: vi.fn(),
         createTurnSignal: vi.fn(),
         getThreadWritebackPullRequests: vi.fn().mockResolvedValue(new Map()),
+        getAgentMcpCapabilities: vi.fn().mockResolvedValue([]),
     } as unknown as import('vitest').Mocked<AiAgentReviewClassifierModel>;
     const aiAgentModel = {
         getAgent: vi.fn(),
@@ -305,6 +306,7 @@ describe('AiAgentReviewClassifierService', () => {
     };
     const projectModel = {
         getSummary: vi.fn(),
+        findExploresFromCache: vi.fn(),
     };
     const aiAgentReviewNotificationService = {
         notifyNeedsReview: vi.fn(),
@@ -346,6 +348,7 @@ describe('AiAgentReviewClassifierService', () => {
             undefined,
         );
         aiAgentDocumentModel.findAllForAgent.mockResolvedValue([]);
+        model.getAgentMcpCapabilities.mockResolvedValue([]);
         aiAgentModel.getAgent.mockResolvedValue({
             uuid: AGENT_UUID,
             organizationUuid: ORGANIZATION_UUID,
@@ -360,6 +363,7 @@ describe('AiAgentReviewClassifierService', () => {
             imageUrl: null,
             enableDataAccess: true,
             enableSelfImprovement: false,
+            enableContentTools: false,
             version: 'v1',
             groupAccess: [],
             userAccess: [],
@@ -590,6 +594,125 @@ describe('AiAgentReviewClassifierService', () => {
                     },
                 ],
                 pendingApprovalTimeout: true,
+            }),
+        );
+    });
+
+    it('surfaces MCP servers and content tools as agent capabilities in the judge packet', async () => {
+        judgeTurn.mockResolvedValueOnce(makeJudgeOutput());
+        model.getAgentMcpCapabilities.mockResolvedValue([
+            { name: 'Linear', enabledToolNames: ['list_issues'] },
+        ]);
+        model.listTurnReviewCandidates.mockResolvedValue([makeCandidate()]);
+
+        await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+        });
+
+        expect(judgeTurn).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                agentConfig: expect.objectContaining({
+                    availableCapabilities: expect.arrayContaining([
+                        'mcp_tools',
+                    ]),
+                    mcpServers: [
+                        { name: 'Linear', enabledToolNames: ['list_issues'] },
+                    ],
+                    settings: expect.arrayContaining(['mcp_servers']),
+                }),
+            }),
+        );
+    });
+
+    it('scopes the catalog to the agent explore tags before matching', async () => {
+        judgeTurn.mockResolvedValueOnce(makeJudgeOutput());
+        aiAgentModel.getAgent.mockResolvedValue({
+            uuid: AGENT_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            name: 'Jaffle Shop',
+            description: null,
+            tags: ['sales'],
+            integrations: [],
+            updatedAt: NOW,
+            createdAt: NOW,
+            instruction: null,
+            imageUrl: null,
+            enableDataAccess: true,
+            enableSelfImprovement: false,
+            enableContentTools: false,
+            version: 'v1',
+            groupAccess: [],
+            userAccess: [],
+            spaceAccess: [],
+        });
+        catalogModel.getCatalogItemsSummary.mockResolvedValue([
+            {
+                catalogSearchUuid: 'catalog-1',
+                cachedExploreUuid: 'explore-1',
+                projectUuid: PROJECT_UUID,
+                name: 'flightcount',
+                type: 'field',
+                label: 'Flight count',
+                description: null,
+                tableName: 'orders',
+                fieldType: 'metric',
+            },
+            {
+                catalogSearchUuid: 'catalog-2',
+                cachedExploreUuid: 'explore-2',
+                projectUuid: PROJECT_UUID,
+                name: 'flightcount',
+                type: 'field',
+                label: 'Flight count (staff)',
+                description: null,
+                tableName: 'staff',
+                fieldType: 'metric',
+            },
+        ]);
+        projectModel.findExploresFromCache.mockResolvedValue({
+            orders: {
+                name: 'orders',
+                tags: ['sales'],
+                baseTable: 'orders',
+                tables: {
+                    orders: {
+                        dimensions: {},
+                        metrics: { flightcount: {} },
+                    },
+                },
+            },
+            staff: {
+                name: 'staff',
+                tags: [],
+                baseTable: 'staff',
+                tables: {
+                    staff: {
+                        dimensions: {},
+                        metrics: { flightcount: {} },
+                    },
+                },
+            },
+        });
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({ userPrompt: 'what is the flightcount?' }),
+        ]);
+
+        await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+        });
+
+        const evidencePacket = judgeTurn.mock.calls[0][1];
+        expect(evidencePacket.semanticContext.catalogMatches).toHaveLength(1);
+        expect(evidencePacket.semanticContext.catalogMatches[0]).toEqual(
+            expect.objectContaining({
+                name: 'flightcount',
+                tableName: 'orders',
             }),
         );
     });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -3,14 +3,18 @@ import {
     aiAgentReviewClassifierJudgeOutputSchema,
     CatalogType,
     FeatureFlags,
+    filterExploreByTags,
     ForbiddenError,
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
+    isExploreError,
     ProjectType,
     type AiAgentAvailableCapability,
     type AiAgentConfigSnapshot,
     type AiAgentConfigurationSetting,
     type AiAgentEvidenceExcerpt,
+    type AiAgentKnowledgeDocumentSnapshot,
+    type AiAgentMcpServerSnapshot,
     type AiAgentReviewClassifierEventType,
     type AiAgentReviewClassifierJudgeOutput,
     type AiAgentReviewClassifierRunScope,
@@ -22,6 +26,7 @@ import {
     type AiAgentTargetRef,
     type AiAgentTurnSignal,
     type CatalogItemSummary,
+    type Explore,
     type QueryHistoryStatus,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
@@ -42,7 +47,7 @@ import { getAiCallTelemetry } from './ai/utils/aiCallTelemetry';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
-const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v12';
+const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v13';
 const WRITEBACK_TOOL_NAMES = new Set([
     'editDbtProject',
     'propose_writeback',
@@ -80,7 +85,7 @@ type AiAgentReviewClassifierServiceDependencies = {
     aiAgentDocumentModel: Pick<AiAgentDocumentModel, 'findAllForAgent'>;
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
     catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
-    projectModel: Pick<ProjectModel, 'getSummary'>;
+    projectModel: Pick<ProjectModel, 'getSummary' | 'findExploresFromCache'>;
     featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
     aiAgentReviewNotificationService: AiAgentReviewNotificationService;
@@ -110,8 +115,11 @@ export type AiAgentReviewJudgeEvidencePacket = {
         availableCapabilities: AiAgentAvailableCapability[];
         dataAccessEnabled: boolean | null;
         selfImprovementEnabled: boolean | null;
+        contentToolsEnabled: boolean | null;
         instructionSummary: string | null;
         knowledgeDocumentCount: number;
+        knowledgeDocuments: AiAgentKnowledgeDocumentSnapshot[];
+        mcpServers: AiAgentMcpServerSnapshot[];
     };
     semanticContext: {
         queriedExploreNames: string[];
@@ -149,6 +157,8 @@ type AiAgentReviewAgentConfigEvidence =
     AiAgentReviewJudgeEvidencePacket['agentConfig'] & {
         snapshot: AiAgentConfigSnapshot | null;
         agentUpdatedAt: Date | null;
+        // Agent explore-tag restriction, used to agent-scope the catalog.
+        exploreTags: string[] | null;
     };
 
 type RunArgs = {
@@ -250,7 +260,10 @@ export class AiAgentReviewClassifierService extends BaseService {
 
     private readonly catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
 
-    private readonly projectModel: Pick<ProjectModel, 'getSummary'>;
+    private readonly projectModel: Pick<
+        ProjectModel,
+        'getSummary' | 'findExploresFromCache'
+    >;
 
     private readonly aiOrganizationSettingsModel: AiOrganizationSettingsModel;
 
@@ -969,7 +982,10 @@ export class AiAgentReviewClassifierService extends BaseService {
         evidencePacket: AiAgentReviewJudgeEvidencePacket;
         agentConfig: AiAgentReviewAgentConfigEvidence;
     }> {
-        const semanticContext = await this.buildSemanticContext(candidate);
+        const semanticContext = await this.buildSemanticContext(
+            candidate,
+            agentConfig.exploreTags,
+        );
         const threadWritebackPullRequests =
             (
                 await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
@@ -998,12 +1014,16 @@ export class AiAgentReviewClassifierService extends BaseService {
                 projectUuid: candidate.subject.projectUuid,
                 agentUuid: candidate.subject.agentUuid,
             });
-            const knowledgeDocuments =
-                await this.aiAgentDocumentModel.findAllForAgent({
+            const [knowledgeDocuments, mcpServers] = await Promise.all([
+                this.aiAgentDocumentModel.findAllForAgent({
                     organizationUuid: candidate.subject.organizationUuid,
                     agentUuid: candidate.subject.agentUuid,
                     projectUuid: candidate.subject.projectUuid,
-                });
+                }),
+                this.aiAgentReviewClassifierModel.getAgentMcpCapabilities(
+                    candidate.subject.agentUuid,
+                ),
+            ]);
 
             const instruction = agent.instruction ?? null;
             const settings = [
@@ -1011,6 +1031,8 @@ export class AiAgentReviewClassifierService extends BaseService {
                 knowledgeDocuments.length > 0 ? 'knowledge_documents' : null,
                 agent.enableDataAccess ? 'data_access' : null,
                 agent.enableSelfImprovement ? 'self_improvement' : null,
+                mcpServers.length > 0 ? 'mcp_servers' : null,
+                agent.tags && agent.tags.length > 0 ? 'explore_tags' : null,
                 agent.spaceAccess.length > 0 ? 'space_access' : null,
                 agent.groupAccess.length > 0 || agent.userAccess.length > 0
                     ? 'user_or_group_access'
@@ -1021,6 +1043,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             const availableCapabilities: AiAgentAvailableCapability[] = [
                 'semantic_query',
                 'chart_generation',
+                'dashboard_generation',
                 'data_value_search',
                 ...(agent.enableDataAccess
                     ? (['chart_data_access'] as const)
@@ -1028,6 +1051,10 @@ export class AiAgentReviewClassifierService extends BaseService {
                 ...(agent.enableSelfImprovement
                     ? (['context_improvement'] as const)
                     : []),
+                ...(agent.enableContentTools
+                    ? (['content_editing'] as const)
+                    : []),
+                ...(mcpServers.length > 0 ? (['mcp_tools'] as const) : []),
             ];
 
             const snapshot: AiAgentConfigSnapshot = {
@@ -1047,6 +1074,7 @@ export class AiAgentReviewClassifierService extends BaseService {
                     updatedAt: document.updatedAt.toISOString(),
                     summary: document.summary,
                 })),
+                mcpServers,
             };
             const snapshotHash = getAiAgentConfigSnapshotHash(snapshot);
 
@@ -1060,8 +1088,12 @@ export class AiAgentReviewClassifierService extends BaseService {
                 availableCapabilities: snapshot.availableCapabilities,
                 dataAccessEnabled: agent.enableDataAccess,
                 selfImprovementEnabled: agent.enableSelfImprovement,
+                contentToolsEnabled: agent.enableContentTools,
                 instructionSummary: snapshot.instructionSummary,
                 knowledgeDocumentCount: snapshot.knowledgeDocuments.length,
+                knowledgeDocuments: snapshot.knowledgeDocuments,
+                mcpServers: snapshot.mcpServers,
+                exploreTags: agent.tags,
             };
         } catch (error) {
             this.debugLog('AgentConfigSnapshotFailed', {
@@ -1084,13 +1116,72 @@ export class AiAgentReviewClassifierService extends BaseService {
             availableCapabilities: [],
             dataAccessEnabled: null,
             selfImprovementEnabled: null,
+            contentToolsEnabled: null,
             instructionSummary: null,
             knowledgeDocumentCount: 0,
+            knowledgeDocuments: [],
+            mcpServers: [],
+            exploreTags: null,
         };
+    }
+
+    /**
+     * Restricts the catalog to what the reviewed agent can actually see,
+     * mirroring the runtime filterExploreByTags scoping. Without this the
+     * judge cannot distinguish "field is missing" (semantic_layer) from
+     * "field exists but this agent cannot access it" (agent_configuration).
+     */
+    private async scopeCatalogToAgent(
+        catalogItems: CatalogItemSummary[],
+        projectUuid: string,
+        exploreTags: string[] | null,
+    ): Promise<CatalogItemSummary[]> {
+        if (!exploreTags || exploreTags.length === 0) {
+            return catalogItems;
+        }
+
+        const explores = Object.values(
+            await this.projectModel.findExploresFromCache(projectUuid, 'name'),
+        );
+        const visibleTables = new Set<string>();
+        const visibleFields = new Set<string>();
+        explores
+            .filter((explore): explore is Explore => !isExploreError(explore))
+            .forEach((explore) => {
+                const filtered = filterExploreByTags({
+                    explore,
+                    availableTags: exploreTags,
+                });
+                if (!filtered) {
+                    return;
+                }
+                Object.entries(filtered.tables).forEach(
+                    ([tableName, table]) => {
+                        const fieldNames = [
+                            ...Object.keys(table.dimensions),
+                            ...Object.keys(table.metrics),
+                        ];
+                        if (fieldNames.length === 0) {
+                            return;
+                        }
+                        visibleTables.add(tableName);
+                        fieldNames.forEach((fieldName) =>
+                            visibleFields.add(`${tableName}.${fieldName}`),
+                        );
+                    },
+                );
+            });
+
+        return catalogItems.filter((item) =>
+            item.type === CatalogType.Table
+                ? visibleTables.has(item.name)
+                : visibleFields.has(`${item.tableName}.${item.name}`),
+        );
     }
 
     private async buildSemanticContext(
         candidate: AiAgentReviewClassifierTurnCandidate,
+        exploreTags: string[] | null,
     ): Promise<AiAgentReviewJudgeEvidencePacket['semanticContext']> {
         const queriedExploreNames = [
             ...new Set(
@@ -1111,8 +1202,12 @@ export class AiAgentReviewClassifierService extends BaseService {
         ];
 
         try {
-            const catalogItems = await this.catalogModel.getCatalogItemsSummary(
+            const catalogItems = await this.scopeCatalogToAgent(
+                await this.catalogModel.getCatalogItemsSummary(
+                    candidate.subject.projectUuid,
+                ),
                 candidate.subject.projectUuid,
+                exploreTags,
             );
 
             return {
@@ -1240,6 +1335,7 @@ When promoting, pick primaryRootCause by mapping the dominant signal:
    - next_user_correction or next_user_dispute about a field, metric, dimension, join, or filter definition within the right explore → semantic_layer.
    - next_user_retry after a failed or empty answer → runtime_reliability or agent_configuration depending on cause.
    - tool_error → runtime_reliability.
+   - Query-construction failures are NOT missing data: when queryHistory shows a filter-validation error, or degenerate filters that guarantee empty or partial results (an isNull filter on the requested date dimension, equality on a single date, stacked over-restrictive filters), attribute the empty/sparse result to the agent's own query construction → runtime_reliability (or agent_configuration when instructions caused it), NOT semantic_layer. Do not emit semantic_yaml_patch or dbt_modeling_ticket fixTargets for it. Do not accept the assistant's own "we don't have this data" prose as ground truth when its queries were malformed — inspect metricQuery.filters yourself.
    - product_capability_request → product_capability.
    - human_intervention → agent_configuration unless evidence clearly points elsewhere.
    - Tiebreaker for semantic_layer vs project_context: if the durable fix is a fact the agent should KNOW — what a term/acronym/entity refers to, or which explore answers a kind of question → project_context. If the durable fix is a CHANGE to the semantic YAML — a model, dimension, metric, join, or filter definition → semantic_layer. Do not default to semantic_layer when the real gap is missing routing or knowledge about which explore to use.
@@ -1249,6 +1345,16 @@ When promoting, pick primaryRootCause by mapping the dominant signal:
 5. Successful queries can still be findings even without implicit signals when the user asked broad business language and the semantic / catalog context does not clearly support the selected field, explore, or metric. Promote those as semantic_layer or project_context when a model definition, AI hint, or project context rule would prevent future ambiguity, choosing between them with the explore-vs-definition tiebreaker above.
 
 6. Use agentConfig to catch Lightdash-layer fixes: missing instructions, disabled data access, missing knowledge docs, access restrictions, or capability settings. Promote those as agent_configuration when the answer quality depends on agent setup.
+   agentConfig.availableCapabilities glossary — what this specific agent can do:
+   - semantic_query: run governed metric/dimension queries over the semantic layer.
+   - chart_generation / dashboard_generation: create charts and dashboards from query results.
+   - data_value_search: search actual values of dimensions.
+   - chart_data_access: read the underlying data of existing charts.
+   - context_improvement: propose project-context improvements.
+   - content_editing: edit or create saved charts/dashboards via content-as-code (editContent/createContent). Some product features exist ONLY through this path — for example big-number tiles and dashboard tab management — so whether a "not supported" claim is true depends on whether this agent has it.
+   - mcp_tools: external MCP servers listed in agentConfig.mcpServers together with their enabled tools (for example Linear or GitHub). Successful mcp_* calls in toolOutcomes are real integrations, not hallucinations.
+   Capability routing: when the assistant claims something is "not supported" but availableCapabilities/mcpServers show the capability DOES exist for this agent → agent_configuration (stale agent knowledge or missing instructions), not product_capability. Use product_capability only when the capability genuinely does not exist for this agent. The semanticContext catalog is already scoped to what this agent can access — a field absent there may still exist in the project but be outside the agent's explore tags; prefer agent_configuration (access/tags) over semantic_layer when the user names data the agent cannot see.
+   agentConfig.knowledgeDocuments lists the agent's actual knowledge documents (with summaries) — never recommend adding a knowledge document that already exists; recommend updating the existing one instead.
 
 7. If you would promote but cannot pick one primaryRootCause confidently, set primaryRootCause=ambiguous with confidence=low or medium and still promote.
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -457,6 +457,12 @@ describe('getAiAgentConfigSnapshotHash', () => {
                 },
             },
         ],
+        mcpServers: [
+            {
+                name: 'Linear',
+                enabledToolNames: ['list_issues', 'create_issue'],
+            },
+        ],
     };
 
     it('is stable when unordered snapshot arrays are reordered', () => {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -99,6 +99,7 @@ export type AiAgentAvailableCapability =
     | 'sql_runner'
     | 'context_improvement'
     | 'semantic_change_proposals'
+    | 'content_editing'
     | 'mcp_tools';
 
 export type AiAgentKnowledgeDocumentSnapshot = {
@@ -106,6 +107,11 @@ export type AiAgentKnowledgeDocumentSnapshot = {
     name: string;
     updatedAt: string;
     summary: AiAgentDocumentStructuredSummary;
+};
+
+export type AiAgentMcpServerSnapshot = {
+    name: string;
+    enabledToolNames: string[];
 };
 
 export type AiAgentConfigSnapshot = {
@@ -116,6 +122,7 @@ export type AiAgentConfigSnapshot = {
     instructionHash: string | null;
     instructionSummary: string | null;
     knowledgeDocuments: AiAgentKnowledgeDocumentSnapshot[];
+    mcpServers: AiAgentMcpServerSnapshot[];
 };
 
 const normalizeForHash = (value: unknown): unknown => {


### PR DESCRIPTION
## Summary

Phase 4 of the AI review classifier improvement plan (Linear: **ZAP-554**, **ZAP-559**, **ZAP-560** partial) — the root-cause accuracy phase, targeting the categories that drive writeback PRs: semantic_layer (35% precision in the audit) and project_context (9%). Stacked on #25067; measurable on the replay scoreboard from #25064.

## Changes

### Query construction ≠ missing data — ZAP-554
The audit's worst failure mode: the agent builds a broken query (malformed date filters, `isNull` on the requested date dimension, stacked over-restrictive filters), gets zero/sparse rows, says "we don't have this data", and the judge enshrines it as a semantic_layer finding — producing **real dbt PRs against data gaps that don't exist** (e.g. PR #105).

New decision rule: filter-validation errors and degenerate filters in `queryHistory` attribute the empty result to the agent's own query construction → `runtime_reliability`/`agent_configuration`, never `semantic_layer`; no `semantic_yaml_patch`/`dbt_modeling_ticket` fixTargets; and the judge must inspect `metricQuery.filters` itself instead of trusting the assistant's prose.

### Real toolset + capability glossary — ZAP-559
`availableCapabilities` was a hardcoded 3–5 item enum (verified identical across all 1,110 run snapshots) — the judge rubber-stamped false "not supported" claims and treated successful Linear MCP calls as hallucinations.

- Config snapshot now reflects reality: `dashboard_generation`, `content_editing` (from `enableContentTools`), `mcp_tools` + the attached MCP servers with enabled tool names (new `AiAgentReviewClassifierModel.getAgentMcpCapabilities`, always-allow tools only — mirroring the runtime).
- Packet `agentConfig` gains `mcpServers`, `contentToolsEnabled`, and the full `knowledgeDocuments` list (previously only a count).
- Prompt: capability glossary (incl. the conditional-features nuance — big-number tiles / tab management exist only via the content-as-code path) + routing rule: a false "not supported" claim where the capability exists → `agent_configuration`, not `product_capability`; never recommend adding a knowledge doc that already exists.

### Agent-scoped catalog — ZAP-560 (partial)
The judge previously saw a lexical top-20 of the **whole project** catalog even for tag-restricted agents, making "field is missing" vs "field exists but this agent can't see it" undecidable.

`buildSemanticContext` now scopes the catalog through the same `filterExploreByTags` the live agent gets (explore-level and field-level tag modes), before relevance matching. Untagged agents are unchanged (early return, no explore fetch).

`JUDGE_PROMPT_HASH` v12 → v13. Also moves the MCP permission-mode constants into the entities module to break an import cycle (re-exported from `AiAgentModel`, no caller changes).

### Deliberately not included from ZAP-560
Deterministic targetRef existence-verification and embedding-based catalog matching — both need replay-scoreboard numbers to justify their design (verification changes finding semantics; embeddings add infra). Tracked on the ticket.

## Verification

- New tests: MCP servers/capabilities propagate to the judge packet; tag-scoped catalog filters an out-of-scope field with the same name as an in-scope one.
- Backend typecheck + full suite green (3437), common suite green, lint clean.

## Regression analysis

- Untagged agents (the common case) get identical catalog behavior — the scoping path early-returns.
- The snapshot hash changes for agents with MCP servers/content tools/knowledge docs (snapshot is recorded metadata, not a dedup key).
- `getAgentMcpCapabilities` runs once per classifier run (not per candidate) alongside the existing agent fetch; returns `[]` for agents without MCP.
- Moving the permission-mode constants is a pure re-export refactor; all existing importers keep working via `AiAgentModel`.
- No API shapes, permissions, or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiTzUNSpHJkWoJGVXQ5eNV