### PR TITLE
feat(ai-reviews): two-tier judge — fast promotion gate, strong-model verdict on promoted turns

### DIFF
--- a/packages/backend/src/ee/repl/scripts/reviewClassifierScoreboard.ts
+++ b/packages/backend/src/ee/repl/scripts/reviewClassifierScoreboard.ts
@@ -514,6 +514,8 @@ export function getReviewClassifierScoreboardScripts(
         outPath?: string;
         limit?: number;
         concurrency?: number;
+        /** false = A/B the fast gate tier alone (no strong-model escalation) */
+        escalation?: boolean;
     }): Promise<ScoreboardMetrics> {
         const service = getService();
         let entries: ScoreboardFixtureEntry[];
@@ -553,7 +555,9 @@ export function getReviewClassifierScoreboardScripts(
                     };
                 }
                 try {
-                    const result = await service.replayJudge(entry.input);
+                    const result = await service.replayJudge(entry.input, {
+                        escalationEnabled: args.escalation ?? true,
+                    });
                     console.log(
                         `[${index + 1}/${entries.length}] ${
                             entry.label.signalUuid

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
@@ -1,0 +1,242 @@
+import {
+    type AiAgentReviewClassifierJudgeOutput,
+    type AiAgentReviewClassifierTurnCandidate,
+} from '@lightdash/common';
+import { generateObject } from 'ai';
+import { getModel } from './ai/models';
+import {
+    AiAgentReviewClassifierService,
+    type AiAgentReviewJudgeReplayInput,
+} from './AiAgentReviewClassifierService';
+
+vi.mock('ai', () => ({ generateObject: vi.fn() }));
+vi.mock('./ai/models', () => ({ getModel: vi.fn() }));
+vi.mock('./ai/agents/agentV2', () => ({ defaultAgentOptions: {} }));
+vi.mock('./ai/utils/aiCallTelemetry', () => ({
+    getAiCallTelemetry: () => ({}),
+}));
+
+const generateObjectMock = vi.mocked(generateObject);
+const getModelMock = vi.mocked(getModel);
+
+const GATE_MODEL = {
+    model: { modelId: 'claude-haiku-4-5' },
+    callOptions: {},
+    providerOptions: {},
+};
+const ESCALATION_MODEL = {
+    model: { modelId: 'claude-sonnet-4-6' },
+    callOptions: {},
+    providerOptions: {},
+};
+
+const candidate = {
+    subject: {
+        type: 'turn_review',
+        assistantPromptUuid: 'prompt-1',
+        threadUuid: 'thread-1',
+        agentUuid: 'agent-1',
+        projectUuid: 'project-1',
+        organizationUuid: 'org-1',
+    },
+    interactionSource: 'app',
+    sourceRef: {
+        source: 'app',
+        threadUuid: 'thread-1',
+        promptUuid: 'prompt-1',
+        appUrl: null,
+    },
+    targetTurn: {
+        promptUuid: 'prompt-1',
+        userPrompt: 'question',
+        assistantResponse: 'answer',
+        errorMessage: null,
+        createdAt: new Date('2026-06-01T10:00:00.000Z'),
+        respondedAt: new Date('2026-06-01T10:00:05.000Z'),
+    },
+    contextTurns: [],
+    userPrompt: 'question',
+    assistantResponse: 'answer',
+    errorMessage: null,
+    humanScore: null,
+    humanFeedback: null,
+    createdAt: new Date('2026-06-01T10:00:00.000Z'),
+    respondedAt: new Date('2026-06-01T10:00:05.000Z'),
+    nextUserPromptUuid: null,
+    nextUserPrompt: null,
+    modelMetadata: { provider: 'anthropic', model: 'claude' },
+    tokenUsageTotal: null,
+    queryHistory: [],
+    supportingEvidence: [],
+    toolOutcomes: [],
+    pendingApprovalTimeout: false,
+} satisfies AiAgentReviewClassifierTurnCandidate;
+
+const replayInput: AiAgentReviewJudgeReplayInput = {
+    candidate,
+    evidencePacket: {
+        subject: candidate.subject,
+        interactionSource: candidate.interactionSource,
+        targetTurn: candidate.targetTurn,
+        humanFeedback: { score: null, comment: null },
+        agentConfig: {
+            snapshotHash: null,
+            settings: [],
+            availableCapabilities: [],
+            dataAccessEnabled: null,
+            selfImprovementEnabled: null,
+            contentToolsEnabled: null,
+            instructionSummary: null,
+            knowledgeDocumentCount: 0,
+            knowledgeDocuments: [],
+            mcpServers: [],
+        },
+        semanticContext: {
+            queriedExploreNames: [],
+            queriedFieldNames: [],
+            catalogMatches: [],
+        },
+        nextUserPrompt: null,
+        previousTurns: [],
+        queryHistory: [],
+        supportingEvidence: [],
+        suggestedEvidenceExcerpts: [],
+        threadWritebackPullRequests: [],
+        toolOutcomes: [],
+        pendingApprovalTimeout: false,
+    },
+};
+
+const judgeOutput = (
+    overrides: Partial<AiAgentReviewClassifierJudgeOutput> = {},
+): AiAgentReviewClassifierJudgeOutput => ({
+    signal: 'implicit_correction',
+    implicitSignalSources: ['tool_error'],
+    confidence: 'high',
+    promotedToFinding: true,
+    promotionReason: 'Tool errored.',
+    primaryRootCause: 'runtime_reliability',
+    secondaryRootCauses: [],
+    subcategories: [],
+    fixTargets: [],
+    targetRefs: [],
+    agentConfigurationSettings: [],
+    ownerType: 'unknown',
+    evidenceExcerpts: [],
+    recommendation: null,
+    projectContextEntry: null,
+    reviewItem: { title: 'Fix it', description: 'why' },
+    ...overrides,
+});
+
+const makeService = () =>
+    new AiAgentReviewClassifierService({
+        aiAgentReviewClassifierModel: {} as never,
+        aiAgentModel: {} as never,
+        aiAgentDocumentModel: { findAllForAgent: vi.fn() },
+        aiOrganizationSettingsModel: {} as never,
+        catalogModel: { getCatalogItemsSummary: vi.fn() },
+        projectModel: {
+            getSummary: vi.fn(),
+            findExploresFromCache: vi.fn(),
+        } as never,
+        featureFlagService: {} as never,
+        lightdashConfig: {
+            ai: { copilot: { providers: {}, defaultProvider: 'openai' } },
+        } as never,
+        aiAgentReviewNotificationService: {} as never,
+    });
+
+describe('two-tier judge escalation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getModelMock.mockImplementation(
+            (_config, options) =>
+                (options?.useFastModel
+                    ? GATE_MODEL
+                    : ESCALATION_MODEL) as never,
+        );
+    });
+
+    it('returns the gate output without escalating when not promoted', async () => {
+        const gateOutput = judgeOutput({
+            promotedToFinding: false,
+            promotionReason: null,
+            primaryRootCause: 'not_a_failure',
+            signal: 'acceptance_or_continuation',
+            implicitSignalSources: [],
+        });
+        generateObjectMock.mockResolvedValueOnce({
+            object: gateOutput,
+        } as never);
+
+        const result = await makeService().replayJudge(replayInput);
+
+        expect(generateObjectMock).toHaveBeenCalledTimes(1);
+        expect(generateObjectMock).toHaveBeenCalledWith(
+            expect.objectContaining({ model: GATE_MODEL.model }),
+        );
+        expect(result.judgeOutput).toEqual(gateOutput);
+    });
+
+    it('escalates promoted turns to the strong model and returns its verdict', async () => {
+        const escalatedOutput = judgeOutput({
+            primaryRootCause: 'agent_configuration',
+        });
+        generateObjectMock
+            .mockResolvedValueOnce({ object: judgeOutput() } as never)
+            .mockResolvedValueOnce({ object: escalatedOutput } as never);
+
+        const result = await makeService().replayJudge(replayInput);
+
+        expect(generateObjectMock).toHaveBeenCalledTimes(2);
+        expect(generateObjectMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({ model: ESCALATION_MODEL.model }),
+        );
+        expect(result.judgeOutput).toEqual(escalatedOutput);
+    });
+
+    it('lets the strong model demote a gate promotion', async () => {
+        const demoted = judgeOutput({
+            promotedToFinding: false,
+            promotionReason: null,
+            primaryRootCause: 'not_a_failure',
+            signal: 'acceptance_or_continuation',
+            implicitSignalSources: [],
+        });
+        generateObjectMock
+            .mockResolvedValueOnce({ object: judgeOutput() } as never)
+            .mockResolvedValueOnce({ object: demoted } as never);
+
+        const result = await makeService().replayJudge(replayInput);
+
+        expect(result.judgeOutput?.promotedToFinding).toBe(false);
+    });
+
+    it('skips escalation when disabled via options', async () => {
+        const gateOutput = judgeOutput();
+        generateObjectMock.mockResolvedValueOnce({
+            object: gateOutput,
+        } as never);
+
+        const result = await makeService().replayJudge(replayInput, {
+            escalationEnabled: false,
+        });
+
+        expect(generateObjectMock).toHaveBeenCalledTimes(1);
+        expect(result.judgeOutput).toEqual(gateOutput);
+    });
+
+    it('skips escalation when the strong model is the same as the gate model', async () => {
+        getModelMock.mockImplementation(() => GATE_MODEL as never);
+        const gateOutput = judgeOutput();
+        generateObjectMock.mockResolvedValueOnce({
+            object: gateOutput,
+        } as never);
+
+        const result = await makeService().replayJudge(replayInput);
+
+        expect(generateObjectMock).toHaveBeenCalledTimes(1);
+        expect(result.judgeOutput).toEqual(gateOutput);
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -71,9 +71,16 @@ export const resolveReviewJudgeProvider = (
 ): LightdashConfig['ai']['copilot']['defaultProvider'] | undefined =>
     copilot.providers.anthropic ? 'anthropic' : undefined;
 
+export type AiAgentReviewJudgeOptions = {
+    // Escalate promoted turns to the strong (non-fast) model. Defaults to
+    // true; the replay scoreboard passes false to A/B the gate tier alone.
+    escalationEnabled?: boolean;
+};
+
 type AiAgentReviewClassifierJudge = (
     candidate: AiAgentReviewClassifierTurnCandidate,
     evidencePacket: AiAgentReviewJudgeEvidencePacket,
+    opts?: AiAgentReviewJudgeOptions,
 ) => Promise<AiAgentReviewClassifierJudgeOutput>;
 
 type AiAgentReviewClassifierJudgeTargetRef =
@@ -291,8 +298,8 @@ export class AiAgentReviewClassifierService extends BaseService {
         this.lightdashConfig = dependencies.lightdashConfig;
         this.judgeTurn =
             dependencies.judgeTurn ??
-            ((candidate, evidencePacket) =>
-                this.judgeTurnWithLlm(candidate, evidencePacket));
+            ((candidate, evidencePacket, opts) =>
+                this.judgeTurnWithLlm(candidate, evidencePacket, opts));
     }
 
     private debugLog(context: string, payload: Record<string, unknown>): void {
@@ -381,6 +388,7 @@ export class AiAgentReviewClassifierService extends BaseService {
      */
     async replayJudge(
         input: AiAgentReviewJudgeReplayInput,
+        opts?: AiAgentReviewJudgeOptions,
     ): Promise<AiAgentReviewJudgeReplayResult> {
         const successfulWritebackEvidence =
             AiAgentReviewClassifierService.getSuccessfulWritebackEvidence(
@@ -392,6 +400,7 @@ export class AiAgentReviewClassifierService extends BaseService {
         const judgeOutput = await this.judgeTurn(
             input.candidate,
             input.evidencePacket,
+            opts,
         );
         return {
             suppressed: null,
@@ -1240,17 +1249,23 @@ export class AiAgentReviewClassifierService extends BaseService {
     private async judgeTurnWithLlm(
         candidate: AiAgentReviewClassifierTurnCandidate,
         evidencePacket: AiAgentReviewJudgeEvidencePacket,
+        opts?: AiAgentReviewJudgeOptions & {
+            tier?: 'gate' | 'escalation';
+        },
     ): Promise<AiAgentReviewClassifierJudgeOutput> {
+        const tier = opts?.tier ?? 'gate';
         const model = getModel(this.lightdashConfig.ai.copilot, {
             provider: resolveReviewJudgeProvider(
                 this.lightdashConfig.ai.copilot,
             ),
-            useFastModel: true,
+            useFastModel: tier === 'gate',
         });
 
         this.debugLog('JudgeRequest', {
             promptUuid: candidate.subject.assistantPromptUuid,
             threadUuid: candidate.subject.threadUuid,
+            tier,
+            judgeModelId: model.model.modelId,
             modelProvider: candidate.modelMetadata.provider,
             modelName: candidate.modelMetadata.model,
             previousTurnCount: evidencePacket.previousTurns.length,
@@ -1273,7 +1288,10 @@ export class AiAgentReviewClassifierService extends BaseService {
             ...model.callOptions,
             providerOptions: model.providerOptions,
             experimental_telemetry: getAiCallTelemetry({
-                functionId: 'aiAgentReviewClassifierJudge',
+                functionId:
+                    tier === 'gate'
+                        ? 'aiAgentReviewClassifierJudge'
+                        : 'aiAgentReviewClassifierJudgeEscalation',
                 feature: 'review-classifier',
                 organizationUuid: candidate.subject.organizationUuid,
                 projectUuid: candidate.subject.projectUuid,
@@ -1388,7 +1406,49 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
             ],
         });
 
-        return result.object as AiAgentReviewClassifierJudgeOutput;
+        const output = result.object as AiAgentReviewClassifierJudgeOutput;
+
+        // Two-tier judge: the fast model is a promotion gate; turns it wants
+        // to promote re-run through the strong model, whose verdict wins —
+        // root cause and targetRefs are what mint review items and route PRs.
+        const escalationEnabled = opts?.escalationEnabled ?? true;
+        if (
+            tier === 'gate' &&
+            escalationEnabled &&
+            output.promotedToFinding &&
+            this.hasDistinctEscalationJudgeModel(model.model.modelId)
+        ) {
+            const escalatedOutput = await this.judgeTurnWithLlm(
+                candidate,
+                evidencePacket,
+                { tier: 'escalation' },
+            );
+            this.debugLog('JudgeEscalationCompleted', {
+                promptUuid: candidate.subject.assistantPromptUuid,
+                threadUuid: candidate.subject.threadUuid,
+                gatePromoted: output.promotedToFinding,
+                gateRootCause: output.primaryRootCause,
+                escalatedPromoted: escalatedOutput.promotedToFinding,
+                escalatedRootCause: escalatedOutput.primaryRootCause,
+            });
+            return escalatedOutput;
+        }
+
+        return output;
+    }
+
+    private hasDistinctEscalationJudgeModel(gateModelId: string): boolean {
+        try {
+            const escalationModel = getModel(this.lightdashConfig.ai.copilot, {
+                provider: resolveReviewJudgeProvider(
+                    this.lightdashConfig.ai.copilot,
+                ),
+                useFastModel: false,
+            });
+            return escalationModel.model.modelId !== gateModelId;
+        } catch {
+            return false;
+        }
     }
 
     private async isEnabled(args: {


### PR DESCRIPTION
## Summary

Phase 5 — the last phase — of the AI review classifier improvement plan (Linear: **ZAP-556**): a two-tier judge. The audit showed the fast-tier model (`gpt-5-mini`/`claude-haiku-4-5`) is out of its depth on root-cause classification (wrong >50% of the time; one turn produced 3 findings with 3 different root causes), while the promotion gate — "is there a promotable problem?" — is the easy, high-volume half (70%+ of turns are acceptance/refinement). Stacked on #25079.

## Design

- **Gate (fast model, every turn):** unchanged full judge.
- **Escalation (strong model, promoted turns only — ~17% of volume):** the same evidence packet re-runs through the provider's default (non-fast) model — `claude-sonnet-4-6` on Anthropic — and its verdict wins **wholesale**, including `promotedToFinding: false`. Escalation therefore doubles as a false-positive filter on exactly the turns that mint review items and open writeback PRs.
- Escalation is skipped when the resolved strong model equals the gate model (e.g. a config pinned to one model), and per-call disableable via `{escalationEnabled: false}`.
- Escalated calls carry their own telemetry functionId (`aiAgentReviewClassifierJudgeEscalation`), so cost/latency per tier is separable in traces.

Deliberately **no confidence gate** — the audit showed confidence is miscalibrated (`high` = 43% good vs `medium` = 24%).

## A/B harness

`scoreReviewScoreboard({ fixturePath, escalation: false })` replays the gate tier alone; `escalation: true` (default) replays the two-tier pipeline — same fixture, same labels (the 170 human-validated audit verdicts), per the ticket's "don't guess — A/B it". The post-judge grounding guard applies on both paths, so the eval measures deployed behavior.

## Verification

- 5 unit tests over the escalation seam (mocked `generateObject`/`getModel`): no escalation when not promoted, strong-model verdict wins, strong model can demote, per-call disable, same-model skip.
- Backend typecheck + full suite green (3442), lint clean.
- Pending: the actual A/B numbers on the replay fixture (needs the prod-proxy capture session).

## Regression analysis

- Turns the gate does not promote (~83%) behave exactly as before — one fast-model call.
- Promoted turns cost one extra strong-model call over the same packet; given ~17% escalation volume this roughly doubles spend on that slice only, in exchange for root-cause reliability on the findings that drive PRs.
- Configs where fast and default models resolve identically see no behavior change (escalation self-skips).
- No prompt change (`JUDGE_PROMPT_HASH` stays v13), no API/permission/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiTzUNSpHJkWoJGVXQ5eNV