### PR TITLE
fix(embed): retry transient network failures when loading embedded dashboards

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.test.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { vi, type Mock } from 'vitest';
+import { createQueryClient } from '../../../../providers/ReactQuery/createQueryClient';
+import { useEmbedDashboard } from './hooks';
+
+vi.mock('./api', () => ({
+    postEmbedDashboard: vi.fn(),
+}));
+
+import { postEmbedDashboard } from './api';
+
+const mockPostEmbedDashboard = postEmbedDashboard as unknown as Mock;
+
+// Mirrors the NetworkError shape `handleError` (src/api.ts) synthesizes for a
+// transient transport failure; `shouldRetryQuery` matches on `error.name`.
+const transientNetworkError = {
+    status: 'error',
+    error: {
+        name: 'NetworkError',
+        statusCode: 500,
+        message:
+            'We are currently unable to reach the Lightdash server. Please try again in a few moments.',
+        data: {},
+    },
+};
+
+const dashboard = { name: 'My dashboard', tiles: [], tabs: [] };
+
+// Uses the production QueryClient defaults so the test exercises the same
+// retry policy the app ships with.
+function createWrapper() {
+    const queryClient = createQueryClient({
+        queries: { retryDelay: () => 0 },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+}
+
+describe('useEmbedDashboard', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('recovers from a single transient NetworkError instead of surfacing a terminal error', async () => {
+        mockPostEmbedDashboard
+            .mockRejectedValueOnce(transientNetworkError)
+            .mockResolvedValue(dashboard);
+
+        const { result } = renderHook(() => useEmbedDashboard('project-uuid'), {
+            wrapper: createWrapper(),
+        });
+
+        // A single transient blip must not strand the embed on
+        // "unable to reach the Lightdash server" — the global retry
+        // policy should re-attempt and succeed.
+        await waitFor(() => expect(result.current.isSuccess).toBe(true), {
+            timeout: 3000,
+        });
+        expect(result.current.data).toEqual(dashboard);
+        expect(mockPostEmbedDashboard).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces a real API error immediately without retrying', async () => {
+        const forbiddenError = {
+            status: 'error',
+            error: {
+                name: 'ForbiddenError',
+                statusCode: 403,
+                message: 'Your embed token has expired.',
+                data: {},
+            },
+        };
+        mockPostEmbedDashboard.mockRejectedValue(forbiddenError);
+
+        const { result } = renderHook(() => useEmbedDashboard('project-uuid'), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error).toEqual(forbiddenError);
+        expect(mockPostEmbedDashboard).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces the error after exhausting retries during a persistent outage', async () => {
+        mockPostEmbedDashboard.mockRejectedValue(transientNetworkError);
+
+        const { result } = renderHook(() => useEmbedDashboard('project-uuid'), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true), {
+            timeout: 3000,
+        });
+        // initial attempt + MAX_QUERY_RETRIES (5) retries
+        expect(mockPostEmbedDashboard).toHaveBeenCalledTimes(6);
+    });
+});

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
@@ -11,6 +11,7 @@ export const useEmbedDashboard = (
         queryKey: ['embed-dashboard', projectUuid, paletteUuid],
         queryFn: () => postEmbedDashboard(projectUuid!, { paletteUuid }),
         enabled: !!projectUuid && enabled,
-        retry: false,
+        // Inherits the app-wide retry policy: transient NetworkErrors retry
+        // with backoff; real API errors (e.g. expired JWT) surface at once.
     });
 };


### PR DESCRIPTION
Closes #25077

## Summary

Embedded dashboards (React SDK `Lightdash.Dashboard` and direct `/embed/` links) intermittently showed "Error loading dashboard / We are currently unable to reach the Lightdash server. Please try again in a few moments." on first load, then worked after a manual refresh. One transient transport blip was enough to strand the embed on that error for the lifetime of the mount.

## Root cause

A single failed `POST /embed/:projectUuid/dashboard` — a dropped fetch, or an LB 502 whose non-JSON body makes `r.json()` throw — is flattened by `handleError` (`src/api.ts`) into a `NetworkError` carrying the generic copy. The dashboard query then never recovers:

```ts
// packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
useQuery<EmbedDashboard, ApiError>({
    queryKey: ['embed-dashboard', projectUuid, paletteUuid],
    queryFn: () => postEmbedDashboard(projectUuid!, { paletteUuid }),
    enabled: !!projectUuid && enabled,
    retry: false, // <-- opts out of the app-wide transient retry
});
```

`retry: false` predates #23831. Back then the react-query default retried *all* errors 3× — including 403s — so opting out was correct. #23831 replaced the app default with `shouldRetryQuery`, which retries only transient `NetworkError`s (5×, exponential backoff) and surfaces real API errors immediately. From that point the opt-out provided nothing and only disabled the recovery safety net:

```
one transient blip on POST /embed/:projectUuid/dashboard
   │
   ├─ main app (global policy) ─ retry 1s → 2s → 4s … ─ self-heals, user sees nothing
   │
   └─ embed (retry: false) ───── terminal error state ─ "unable to reach the Lightdash
                                                         server" until full page reload
```

The error is terminal because nothing refetches it: `staleTime` 30s, `refetchOnWindowFocus: false`, no invalidation. A hard refresh works only because it recreates the per-mount `QueryClient`. The failure also leaves no server-side trace when the request never lands, so it is invisible to backend logs and metrics.

## Fix

- `packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts` — drop `retry: false`; the hook inherits the app-wide policy: transient `NetworkError`s retry with backoff, real API errors (e.g. expired JWT) still surface immediately with zero retries.
- `packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.test.tsx` — regression tests under the production `createQueryClient()` defaults: transient failure recovers (2 calls), 403 fails fast (1 call, error unshaped), persistent outage terminates after exactly 6 attempts.
- `SettingsEmbed/index.tsx` keeps its `retry: false` — admin settings surface, not the embed load path.

## Notes for review

- In a genuine outage the error UI now appears after the retry budget (~23s cumulative backoff) instead of instantly — same tradeoff the rest of the app made in #23831.
- `EmbedService.getDashboard` tracks a dashboard-view analytics event, so a retry after a response-lost failure can double-count that event. Analytics-only, no data mutation.

## Test plan

- [x] `npx vitest run src/ee/features/embed/EmbedDashboard/` — 2 files, 16 tests pass (added regression suite `useEmbedDashboard`)
- [x] `npx vitest run src/ee/features/embed/` — 5 files, 61 tests pass; `src/providers/ReactQuery/` — 4 pass
- [x] `pnpm -F frontend typecheck:fast` + oxlint on the touched folder — clean
- [x] Manual: local embed page with an injected transport failure of the first dashboard POST recovers without a reload; dashboard renders (was: terminal error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)