### PR TITLE
feat(ai-reviews): admin API endpoint to capture judge replay inputs for the eval scoreboard

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -2,12 +2,14 @@ import {
     AiAgentAdminFilters,
     AiAgentAdminSort,
     AiAgentReviewItemStatus,
+    AiAgentReviewReplayCaptureRequest,
     ApiAiAgentAdminConversationsResponse,
     ApiAiAgentAdminPromptActivityResponse,
     ApiAiAgentReviewItemActivityResponse,
     ApiAiAgentReviewItemPrDiffResponse,
     ApiAiAgentReviewItemResponse,
     ApiAiAgentReviewItemsResponse,
+    ApiAiAgentReviewReplayCaptureResponse,
     ApiAiAgentReviewSignalsResponse,
     ApiAiAgentSummaryResponse,
     ApiAiOrganizationSettingsResponse,
@@ -247,6 +249,31 @@ export class AiAgentAdminController extends BaseController {
                 toSessionUser(req.account),
                 fingerprint,
             ),
+        };
+    }
+
+    /**
+     * Rebuild judge replay inputs for historical review signals so the eval
+     * scoreboard can replay the judge offline. Read-only; feature-flag gated.
+     * @summary Capture AI review judge replay inputs
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/review-replay-capture')
+    @OperationId('captureAiAgentReviewReplayInputs')
+    async captureReviewReplayInputs(
+        @Request() req: express.Request,
+        @Body() body: AiAgentReviewReplayCaptureRequest,
+    ): Promise<ApiAiAgentReviewReplayCaptureResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().captureReviewReplayInputs(
+                    toSessionUser(req.account),
+                    body,
+                ),
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -346,6 +346,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentModel: models.getAiAgentModel(),
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    aiAgentReviewClassifierService:
+                        repository.getAiAgentReviewClassifierService<AiAgentReviewClassifierService>(),
                     aiAgentReviewNotificationModel:
                         models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>(),
                     aiAgentReviewNotificationService:

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -974,6 +974,34 @@ export class AiAgentReviewClassifierModel {
         }));
     }
 
+    async findTurnSignalSubjects(args: {
+        organizationUuid: string;
+        signalUuids: string[];
+    }): Promise<
+        { signalUuid: string; promptUuid: string; threadUuid: string }[]
+    > {
+        const rows = await this.database(AiAgentTurnSignalTableName)
+            .select<
+                {
+                    ai_agent_review_turn_signal_uuid: string;
+                    ai_prompt_uuid: string;
+                    ai_thread_uuid: string;
+                }[]
+            >(
+                'ai_agent_review_turn_signal_uuid',
+                'ai_prompt_uuid',
+                'ai_thread_uuid',
+            )
+            .where('organization_uuid', args.organizationUuid)
+            .whereIn('ai_agent_review_turn_signal_uuid', args.signalUuids);
+
+        return rows.map((row) => ({
+            signalUuid: row.ai_agent_review_turn_signal_uuid,
+            promptUuid: row.ai_prompt_uuid,
+            threadUuid: row.ai_thread_uuid,
+        }));
+    }
+
     async getAgentMcpCapabilities(
         agentUuid: string,
     ): Promise<AiAgentMcpServerSnapshot[]> {

--- a/packages/backend/src/ee/repl/scripts/reviewClassifierScoreboard.ts
+++ b/packages/backend/src/ee/repl/scripts/reviewClassifierScoreboard.ts
@@ -509,6 +509,93 @@ export function getReviewClassifierScoreboardScripts(
         return { captured, missing, failed };
     }
 
+    /**
+     * Capture via the deployed admin API instead of a direct DB connection —
+     * needs the AiReviewReplayCapture feature flag enabled for the org and an
+     * org-admin PAT. Produces the same fixture format as the DB capture.
+     */
+    async function captureReviewScoreboardFixtureFromApi(args: {
+        siteUrl: string;
+        apiKey: string;
+        verdictsCsvPath: string;
+        outPath: string;
+        batchSize?: number;
+    }): Promise<{ captured: number; missing: number; failed: number }> {
+        const labels = parseVerdictsCsv(
+            await readFile(args.verdictsCsvPath, 'utf8'),
+        );
+        const labelsBySignalUuid = new Map(
+            labels.map((label) => [label.signalUuid, label]),
+        );
+        const batchSize = Math.min(args.batchSize ?? 25, 50);
+        const entries: ScoreboardFixtureEntry[] = [];
+
+        for (let start = 0; start < labels.length; start += batchSize) {
+            const batch = labels.slice(start, start + batchSize);
+            // eslint-disable-next-line no-await-in-loop
+            const response = await fetch(
+                `${args.siteUrl}/api/v1/aiAgents/admin/review-replay-capture`,
+                {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `ApiKey ${args.apiKey}`,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        signalUuids: batch.map((label) => label.signalUuid),
+                    }),
+                },
+            );
+            if (!response.ok) {
+                throw new Error(
+                    `Capture request failed (${response.status}): ${
+                        // eslint-disable-next-line no-await-in-loop
+                        await response.text()
+                    }`,
+                );
+            }
+            // eslint-disable-next-line no-await-in-loop
+            const payload = (await response.json()) as {
+                results: {
+                    signalUuid: string;
+                    promptUuid: string | null;
+                    threadUuid: string | null;
+                    captureError: string | null;
+                    input: AiAgentReviewJudgeReplayInput | null;
+                }[];
+            };
+            payload.results.forEach((result) => {
+                const label = labelsBySignalUuid.get(result.signalUuid);
+                if (!label) {
+                    return;
+                }
+                entries.push({
+                    label,
+                    promptUuid: result.promptUuid,
+                    threadUuid: result.threadUuid,
+                    input: result.input,
+                    captureError: result.captureError,
+                });
+            });
+            console.log(
+                `Captured ${Math.min(start + batchSize, labels.length)}/${
+                    labels.length
+                }`,
+            );
+        }
+
+        await writeFile(args.outPath, JSON.stringify(entries, null, 2));
+        const captured = entries.filter((e) => e.input !== null).length;
+        const missing = entries.filter(
+            (e) => e.captureError === 'signal not found',
+        ).length;
+        const failed = entries.length - captured - missing;
+        console.log(
+            `Captured ${captured}/${entries.length} judge inputs to ${args.outPath} (${missing} signals missing, ${failed} failed)`,
+        );
+        return { captured, missing, failed };
+    }
+
     async function scoreReviewScoreboard(args: {
         fixturePath: string;
         outPath?: string;
@@ -613,6 +700,7 @@ export function getReviewClassifierScoreboardScripts(
     return {
         printReviewScoreboardBaseline,
         captureReviewScoreboardFixture,
+        captureReviewScoreboardFixtureFromApi,
         scoreReviewScoreboard,
     };
 }

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -202,6 +202,7 @@ const makeOrgViewerUser = (): SessionUser => ({
 const makeService = ({
     aiAgentModel = {},
     aiAgentReviewClassifierModel = {},
+    aiAgentReviewClassifierService = {},
     aiAgentReviewNotificationModel = {},
     featureFlagService = {},
     aiOrganizationSettingsService = {},
@@ -219,6 +220,7 @@ const makeService = ({
 }: {
     aiAgentModel?: Record<string, unknown>;
     aiAgentReviewClassifierModel?: Record<string, unknown>;
+    aiAgentReviewClassifierService?: Record<string, unknown>;
     aiAgentReviewNotificationModel?: Record<string, unknown>;
     featureFlagService?: Record<string, unknown>;
     aiOrganizationSettingsService?: Record<string, unknown>;
@@ -297,6 +299,10 @@ const makeService = ({
                 slackChannelId: 'C123',
             }),
             ...aiAgentReviewNotificationModel,
+        },
+        aiAgentReviewClassifierService: {
+            captureJudgeReplayInput: vi.fn().mockResolvedValue(null),
+            ...aiAgentReviewClassifierService,
         },
         featureFlagService: {
             get: vi.fn().mockResolvedValue({ enabled: true }),
@@ -458,6 +464,88 @@ describe('AiAgentAdminService review access', () => {
             'Insufficient permissions to access AI agent reviews',
         );
         expect(listReviewSignals).not.toHaveBeenCalled();
+    });
+});
+
+describe('AiAgentAdminService.captureReviewReplayInputs', () => {
+    it('rejects when the feature flag is disabled', async () => {
+        const service = makeService({
+            featureFlagService: {
+                get: vi.fn().mockResolvedValue({ enabled: false }),
+            },
+        });
+
+        await expect(
+            service.captureReviewReplayInputs(makeAdminUser(), {
+                signalUuids: ['signal-1'],
+            }),
+        ).rejects.toThrow('Review replay capture is not enabled');
+    });
+
+    it('rejects non org admins', async () => {
+        const service = makeService();
+
+        await expect(
+            service.captureReviewReplayInputs(makeDeveloperUser(), {
+                signalUuids: ['signal-1'],
+            }),
+        ).rejects.toThrow();
+    });
+
+    it('rejects batches over 50 signals', async () => {
+        const service = makeService();
+
+        await expect(
+            service.captureReviewReplayInputs(makeAdminUser(), {
+                signalUuids: Array.from({ length: 51 }, (_, i) => `s-${i}`),
+            }),
+        ).rejects.toThrow('at most 50 signals');
+    });
+
+    it('resolves signals to prompts and returns captured inputs', async () => {
+        const replayInput = { candidate: {}, evidencePacket: {} };
+        const captureJudgeReplayInput = vi.fn().mockResolvedValue(replayInput);
+        const findTurnSignalSubjects = vi.fn().mockResolvedValue([
+            {
+                signalUuid: 'signal-1',
+                promptUuid: 'prompt-1',
+                threadUuid: 'thread-1',
+            },
+        ]);
+        const service = makeService({
+            aiAgentReviewClassifierModel: { findTurnSignalSubjects },
+            aiAgentReviewClassifierService: { captureJudgeReplayInput },
+        });
+
+        const results = await service.captureReviewReplayInputs(
+            makeAdminUser(),
+            { signalUuids: ['signal-1', 'signal-2'] },
+        );
+
+        expect(findTurnSignalSubjects).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            signalUuids: ['signal-1', 'signal-2'],
+        });
+        expect(captureJudgeReplayInput).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            promptUuid: 'prompt-1',
+        });
+        expect(results).toEqual([
+            {
+                signalUuid: 'signal-1',
+                promptUuid: 'prompt-1',
+                threadUuid: 'thread-1',
+                captureError: null,
+                input: replayInput,
+            },
+            {
+                signalUuid: 'signal-2',
+                promptUuid: null,
+                threadUuid: null,
+                captureError: 'signal not found',
+                input: null,
+            },
+        ]);
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -12,6 +12,8 @@ import {
     AiAgentReviewRemediationCompileJobPayload,
     AiAgentReviewRemediationPreviewJobPayload,
     AiAgentReviewRemediationRunJobPayload,
+    AiAgentReviewReplayCaptureEntry,
+    AiAgentReviewReplayCaptureRequest,
     AiAgentReviewSignalSummary,
     AiAgentReviewWritebackJobPayload,
     AiAgentSummary,
@@ -77,6 +79,7 @@ import {
     planReviewWriteback,
     PROJECT_CONTEXT_WORK_THREAD_INSTRUCTION,
 } from './ai/reviewWriteback/buildReviewWritebackPrompt';
+import { type AiAgentReviewClassifierService } from './AiAgentReviewClassifierService';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 import { type AiAgentService } from './AiAgentService/AiAgentService';
 import { type AiOrganizationSettingsService } from './AiOrganizationSettingsService';
@@ -87,6 +90,10 @@ type AiAgentAdminServiceDependencies = {
     analytics: LightdashAnalytics;
     aiAgentModel: AiAgentModel;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    aiAgentReviewClassifierService: Pick<
+        AiAgentReviewClassifierService,
+        'captureJudgeReplayInput'
+    >;
     aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
     aiAgentReviewNotificationService: AiAgentReviewNotificationService;
     aiAgentService: AiAgentService;
@@ -315,6 +322,11 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
 
+    private readonly aiAgentReviewClassifierService: Pick<
+        AiAgentReviewClassifierService,
+        'captureJudgeReplayInput'
+    >;
+
     private readonly aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
 
     private readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
@@ -351,6 +363,8 @@ export class AiAgentAdminService extends BaseService {
         this.aiAgentModel = dependencies.aiAgentModel;
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
+        this.aiAgentReviewClassifierService =
+            dependencies.aiAgentReviewClassifierService;
         this.aiAgentReviewNotificationModel =
             dependencies.aiAgentReviewNotificationModel;
         this.aiAgentReviewNotificationService =
@@ -1078,6 +1092,92 @@ export class AiAgentAdminService extends BaseService {
         return this.aiAgentReviewClassifierModel.listReviewSignals({
             organizationUuid,
         });
+    }
+
+    /**
+     * Rebuilds the judge inputs (candidate + evidence packet) for historical
+     * turn signals so the eval scoreboard can replay the judge offline.
+     * Read-only; gated behind the AiReviewReplayCapture feature flag.
+     */
+    async captureReviewReplayInputs(
+        user: SessionUser,
+        body: AiAgentReviewReplayCaptureRequest,
+    ): Promise<AiAgentReviewReplayCaptureEntry[]> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+        const { enabled } = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiReviewReplayCapture,
+            user,
+        });
+        if (!enabled) {
+            throw new ForbiddenError('Review replay capture is not enabled');
+        }
+        if (body.signalUuids.length === 0) {
+            return [];
+        }
+        if (body.signalUuids.length > 50) {
+            throw new ParameterError(
+                'Capture at most 50 signals per request; batch larger sets',
+            );
+        }
+
+        const subjects =
+            await this.aiAgentReviewClassifierModel.findTurnSignalSubjects({
+                organizationUuid,
+                signalUuids: body.signalUuids,
+            });
+        const subjectsBySignalUuid = new Map(
+            subjects.map((subjectRow) => [subjectRow.signalUuid, subjectRow]),
+        );
+
+        return Promise.all(
+            body.signalUuids.map(
+                async (
+                    signalUuid,
+                ): Promise<AiAgentReviewReplayCaptureEntry> => {
+                    const subjectRow = subjectsBySignalUuid.get(signalUuid);
+                    if (!subjectRow) {
+                        return {
+                            signalUuid,
+                            promptUuid: null,
+                            threadUuid: null,
+                            captureError: 'signal not found',
+                            input: null,
+                        };
+                    }
+                    try {
+                        const input =
+                            await this.aiAgentReviewClassifierService.captureJudgeReplayInput(
+                                {
+                                    organizationUuid,
+                                    promptUuid: subjectRow.promptUuid,
+                                },
+                            );
+                        return {
+                            signalUuid,
+                            promptUuid: subjectRow.promptUuid,
+                            threadUuid: subjectRow.threadUuid,
+                            captureError: input ? null : 'candidate not found',
+                            input,
+                        };
+                    } catch (error) {
+                        return {
+                            signalUuid,
+                            promptUuid: subjectRow.promptUuid,
+                            threadUuid: subjectRow.threadUuid,
+                            captureError:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error),
+                            input: null,
+                        };
+                    }
+                },
+            ),
+        );
     }
 
     async updateReviewItemStatus(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14950,11 +14950,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14969,11 +14969,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14988,11 +14988,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15007,11 +15007,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15156,7 +15156,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -15164,7 +15164,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15179,7 +15183,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -15187,11 +15191,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15320,11 +15320,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15349,6 +15349,21 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 pagination:
                                                                                     {
                                                                                         dataType:
@@ -15391,21 +15406,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -15415,14 +15415,14 @@ const models: TsoaRoute.Models = {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'error',
+                                                                                                    'success',
                                                                                                 ],
                                                                                             },
                                                                                             {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'success',
+                                                                                                    'error',
                                                                                                 ],
                                                                                             },
                                                                                             {
@@ -15557,11 +15557,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15576,11 +15576,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15595,11 +15595,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15642,11 +15642,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15685,149 +15685,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
-                                                                    required: true,
-                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -15910,6 +15767,12 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -15918,12 +15781,6 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -15937,6 +15794,149 @@ const models: TsoaRoute.Models = {
                                                                                 required: true,
                                                                             },
                                                                         },
+                                                                    required: true,
+                                                                },
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -16129,11 +16129,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16148,11 +16148,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16167,11 +16167,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16186,11 +16186,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16200,6 +16200,77 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16277,77 +16348,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16379,12 +16379,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -16392,6 +16386,12 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16431,11 +16431,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16496,11 +16496,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16515,11 +16515,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16532,6 +16532,14 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'union',
                                                     subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['rejected'],
+                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
@@ -16540,14 +16548,6 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: ['timeout'],
                                                         },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['rejected'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
                                                     ],
                                                     required: true,
                                                 },
@@ -16561,11 +16561,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16582,25 +16582,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16681,6 +16662,25 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 type: {
                                                                     dataType:
                                                                         'union',
@@ -16723,11 +16723,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16742,11 +16742,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16761,11 +16761,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16780,11 +16780,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16799,11 +16799,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -22316,11 +22316,63 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiWritebackDbtSourceOption: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectSubPath: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                branch: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                repository: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                isPrimary: { dataType: 'boolean', required: true },
+                name: { dataType: 'string', required: true },
+                projectDbtSourceUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiWritebackRunResult: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                dbtSourceOptions: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiWritebackDbtSourceOption',
+                    },
+                },
+                needsDbtSourceSelection: { dataType: 'boolean' },
+                dbtSourceUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 steps: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'AiWritebackStep' },
@@ -22397,6 +22449,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                dbtSourceUuid: { dataType: 'string' },
                 prompt: { dataType: 'string', required: true },
             },
             validators: {},
@@ -23666,6 +23719,84 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 title: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewReplayCaptureEntry: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                input: { dataType: 'any', required: true },
+                captureError: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                threadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                promptUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                signalUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiAgentReviewReplayCaptureEntry-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentReviewReplayCaptureEntry',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewReplayCaptureResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiAgentReviewReplayCaptureEntry-Array_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewReplayCaptureRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                signalUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
             },
             validators: {},
         },
@@ -57493,6 +57624,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getReviewItem',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_captureReviewReplayInputs: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'AiAgentReviewReplayCaptureRequest',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/admin/review-replay-capture',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.captureReviewReplayInputs,
+        ),
+
+        async function AiAgentAdminController_captureReviewReplayInputs(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_captureReviewReplayInputs,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'captureReviewReplayInputs',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16556,8 +16556,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16612,16 +16612,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "requiredFilters": {
@@ -16686,8 +16686,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16701,6 +16701,9 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "pagination": {
                                                                             "properties": {
                                                                                 "totalPageCount": {
@@ -16728,14 +16731,11 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "status": {
                                                                             "type": "string",
                                                                             "enum": [
-                                                                                "error",
-                                                                                "success"
+                                                                                "success",
+                                                                                "error"
                                                                             ]
                                                                         },
                                                                         "results": {
@@ -16800,8 +16800,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16835,8 +16835,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
                                                             "success",
+                                                            "error",
                                                             "not_found"
                                                         ]
                                                     }
@@ -16863,70 +16863,6 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
-                                                                    },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "description",
-                                                                                "label",
-                                                                                "fieldId",
-                                                                                "name",
-                                                                                "table"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "requiredFilters": {
@@ -16964,14 +16900,14 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -16981,12 +16917,76 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "joinedTables",
                                                                             "baseTable",
+                                                                            "joinedTables",
                                                                             "label",
                                                                             "name"
                                                                         ],
                                                                         "type": "object"
+                                                                    },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "fieldValueType",
+                                                                                "caseSensitiveFilters",
+                                                                                "isFromJoinedTable",
+                                                                                "fieldFilterType",
+                                                                                "fieldType",
+                                                                                "description",
+                                                                                "label",
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -16997,9 +16997,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "rationale",
-                                                                    "fields",
                                                                     "explore",
+                                                                    "fields",
+                                                                    "rationale",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -17135,6 +17135,32 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "read",
+                                                                        "edit",
+                                                                        "search",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17162,32 +17188,6 @@
                                                         ],
                                                         "nullable": true
                                                     },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17207,9 +17207,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
-                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
+                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -17259,8 +17259,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -17272,10 +17272,10 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "timeout",
+                                                            "success",
                                                             "rejected",
-                                                            "success"
+                                                            "error",
+                                                            "timeout"
                                                         ]
                                                     }
                                                 },
@@ -17286,10 +17286,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17326,6 +17322,10 @@
                                                                 },
                                                                 "type": "array"
                                                             },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
@@ -17337,8 +17337,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -17346,8 +17346,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -22664,8 +22664,59 @@
                 "type": "object",
                 "description": "One action the writeback sandbox took, in a generic shape the chat UI can\ngroup and render as step rows without knowing anything about writeback.\n`kind` buckets the action (consecutive same-kind steps are grouped, e.g.\n\"Read 3 files\"); `label` is the file basename or a stage description."
             },
+            "AiWritebackDbtSourceOption": {
+                "properties": {
+                    "projectSubPath": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "branch": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "repository": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "isPrimary": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectDbtSourceUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "projectSubPath",
+                    "branch",
+                    "repository",
+                    "isPrimary",
+                    "name",
+                    "projectDbtSourceUuid"
+                ],
+                "type": "object",
+                "description": "One dbt source a writeback run can target, surfaced when a project has more\nthan one and the run needs the caller to choose. `projectDbtSourceUuid` is\nthe project's own uuid for the primary source and a row uuid for additional\nsources — the same identifier the project's dbt-sources list returns, so the\ncaller can echo it straight back as `dbtSourceUuid`."
+            },
             "AiWritebackRunResult": {
                 "properties": {
+                    "dbtSourceOptions": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiWritebackDbtSourceOption"
+                        },
+                        "type": "array",
+                        "description": "The dbt sources to choose from when `needsDbtSourceSelection` is set."
+                    },
+                    "needsDbtSourceSelection": {
+                        "type": "boolean",
+                        "description": "Set when the project has several dbt sources and the run could not decide\nwhich one the prompt targets. No sandbox is started and no pull request is\nopened; `dbtSourceOptions` lists the choices and the caller should re-run\nwith `dbtSourceUuid` set to one of them. Absent on a normal run."
+                    },
+                    "dbtSourceUuid": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The dbt source this run targeted: a `project_dbt_sources` row uuid for an\nadditional source, or `null` for the project's primary dbt connection. A\nthread stays bound to this source across resumes — one thread, one PR.\nOptional so an older server's response (which omits it) doesn't surface as\n`undefined` on a newer typed client."
+                    },
                     "steps": {
                         "items": {
                             "$ref": "#/components/schemas/AiWritebackStep"
@@ -22748,13 +22799,17 @@
             },
             "AiWritebackRequestBody": {
                 "properties": {
+                    "dbtSourceUuid": {
+                        "type": "string",
+                        "description": "Which of the project's dbt sources to target, when it has more than one\n(see {@link AiWritebackDbtSourceOption}). Pass the project's own uuid (or\nomit) to target the primary dbt connection. When omitted and the project\nhas several sources, the run infers the target from the prompt and asks\nthe caller to choose if it can't (see `needsDbtSourceSelection`)."
+                    },
                     "prompt": {
                         "type": "string"
                     }
                 },
                 "required": ["prompt"],
                 "type": "object",
-                "description": "Body for kicking off an AI writeback run. The target repository is\ncloned into a sandbox, the prompt is executed by the Claude Code CLI, and a\npull request is opened against the repo if the agent changes any files.\n\nThe target repository (owner, repo) and the dbt project sub-folder are\nresolved server-side from the Lightdash project's dbt connection — identified\nby the `projectUuid` path parameter — so the caller only supplies the prompt."
+                "description": "Body for kicking off an AI writeback run. The target repository is\ncloned into a sandbox, the prompt is executed by the Claude Code CLI, and a\npull request is opened against the repo if the agent changes any files.\n\nThe target repository (owner, repo) and the dbt project sub-folder are\nresolved server-side from the chosen dbt source — by default the Lightdash\nproject's primary dbt connection (identified by the `projectUuid` path\nparameter), or the source named by `dbtSourceUuid` when the project has more\nthan one dbt source."
             },
             "ProjectCiStatus": {
                 "properties": {
@@ -23935,6 +23990,66 @@
                     "description",
                     "title"
                 ],
+                "type": "object"
+            },
+            "AiAgentReviewReplayCaptureEntry": {
+                "properties": {
+                    "input": {},
+                    "captureError": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "threadUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "promptUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "signalUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "input",
+                    "captureError",
+                    "threadUuid",
+                    "promptUuid",
+                    "signalUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentReviewReplayCaptureEntry-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReviewReplayCaptureEntry"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewReplayCaptureResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewReplayCaptureEntry-Array_"
+            },
+            "AiAgentReviewReplayCaptureRequest": {
+                "properties": {
+                    "signalUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["signalUuids"],
                 "type": "object"
             },
             "AiAgentReviewRemediationEventDetail": {
@@ -42985,7 +43100,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3296.0",
+        "version": "0.3298.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -50154,6 +50269,47 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/UpdateAiAgentReviewItemStatus"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/aiAgents/admin/review-replay-capture": {
+            "post": {
+                "operationId": "captureAiAgentReviewReplayInputs",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewReplayCaptureResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Rebuild judge replay inputs for historical review signals so the eval\nscoreboard can replay the judge offline. Read-only; feature-flag gated.",
+                "summary": "Capture AI review judge replay inputs",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AiAgentReviewReplayCaptureRequest"
                             }
                         }
                     }

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -948,6 +948,25 @@ export type ApiAiAgentReviewSignalsResponse = ApiSuccess<
     AiAgentReviewSignalSummary[]
 >;
 
+export type AiAgentReviewReplayCaptureRequest = {
+    signalUuids: string[];
+};
+
+export type AiAgentReviewReplayCaptureEntry = {
+    signalUuid: string;
+    promptUuid: string | null;
+    threadUuid: string | null;
+    captureError: string | null;
+    // Opaque judge replay payload (candidate + evidence packet). Its shape is
+    // owned by the backend classifier service and consumed verbatim by the
+    // eval scoreboard's replayJudge — it is not a stable API contract.
+    input: unknown;
+};
+
+export type ApiAiAgentReviewReplayCaptureResponse = ApiSuccess<
+    AiAgentReviewReplayCaptureEntry[]
+>;
+
 export type AiAgentReviewClassifierRunStatus =
     | 'queued'
     | 'running'

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -186,6 +186,13 @@ export enum FeatureFlags {
     AiWriteback = 'ai-writeback',
 
     /**
+     * Enable the admin API endpoint that captures AI review judge replay
+     * inputs (candidate + evidence packet) for the offline eval scoreboard.
+     * Off by default — intended only for orgs running classifier evals.
+     */
+    AiReviewReplayCapture = 'ai-review-replay-capture',
+
+    /**
      * Enable the `searchSemanticLayer` agent tool, which lets the AI agent
      * list/search metrics and dimensions across ALL explores at once (backed
      * by the catalog search index) to answer project-wide questions like


### PR DESCRIPTION
## Summary

Enables the classifier eval without direct prod DB access ("Option B"): an admin API endpoint that rebuilds the judge's replay inputs for historical review signals, so the scoreboard (#25064) can capture over HTTPS with a PAT and then run all scoring **offline**. Tops the classifier stack (#25064→#25080).

## How the eval flow works after this deploys

1. Enable the new `ai-review-replay-capture` feature flag for the analytics org only.
2. From a local repl: `captureReviewScoreboardFixtureFromApi({ siteUrl: 'https://analytics.lightdash.cloud', apiKey: PAT, verdictsCsvPath, outPath })` — batches the 170 labeled signal uuids through the endpoint and writes a local JSON fixture.
3. Offline forever after (Anthropic key only): `scoreReviewScoreboard({ fixturePath, escalation: false })` vs `{ escalation: true }` vs the stored v10 baseline — the full A/B without another deploy or prod touch.

## Changes

- `POST /api/v1/aiAgents/admin/review-replay-capture` on `AiAgentAdminController`: takes ≤50 signal uuids, resolves them **org-scoped** to their prompts (`findTurnSignalSubjects`), and returns each turn's judge inputs rebuilt through the current packet builder. Read-only — persists nothing.
- **Double-gated**: `checkOrganizationAdminAccess` + the new `AiReviewReplayCapture` feature flag (off by default everywhere).
- The replay payload is an intentionally opaque `input: unknown` field — its shape is owned by the backend classifier service and consumed verbatim by the scoreboard's `replayJudge`; documented as not a stable API contract.
- `captureReviewScoreboardFixtureFromApi` added to the repl scoreboard scripts, producing the identical fixture format as the DB-direct capture.
- `generate-api` regenerated.

## Verification

- 4 new unit tests: flag-off → Forbidden, non-admin → Forbidden, >50 batch → ParameterError, happy path (signal→prompt resolution, per-entry capture, missing-signal entries).
- Backend typecheck + full suite green (3446), common green, lint clean.

## Regression analysis

- Pure addition: new route + new service method + new model read; no existing endpoint or behavior changes.
- Data exposure is bounded: org-admin only (same ability that already sees review signals/threads in the admin UI), flag-gated dark by default, org-scoped signal resolution prevents cross-org reads by uuid guessing.
- Batch cap (50) + read-only queries bound the per-request load; the client batches sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiTzUNSpHJkWoJGVXQ5eNV