### PR TITLE
feat(avatars): custom color picker with gradient/solid modes

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1673,7 +1673,6 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['none'] },
                 { dataType: 'enum', enums: ['api_key'] },
                 { dataType: 'enum', enums: ['bearer_token'] },
-                { dataType: 'enum', enums: ['google_service_account'] },
             ],
             validators: {},
         },
@@ -1730,14 +1729,6 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 hasSecret: { dataType: 'boolean', required: true },
-                oauthScopes: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'array', array: { dataType: 'string' } },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
                 apiKeyLocation: {
                     dataType: 'union',
                     subSchemas: [
@@ -1823,13 +1814,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                },
-                oauthScopes: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'enum', enums: [null] },
                     ],
                 },
@@ -2014,14 +1998,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { ref: 'ApiKeyLocation' },
-                        { dataType: 'enum', enums: [null] },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                oauthScopes: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'enum', enums: [null] },
                         { dataType: 'undefined' },
                     ],
@@ -9917,13 +9893,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                vizSchema: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'DataAppVizSchema' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                },
                 design: {
                     dataType: 'union',
                     subSchemas: [
@@ -15685,6 +15654,130 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 rationale: {
                                                                     dataType:
                                                                         'union',
@@ -15813,130 +15906,6 @@ const models: TsoaRoute.Models = {
                                                                                 required: true,
                                                                             },
                                                                         },
-                                                                    required: true,
-                                                                },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -25348,14 +25317,34 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'union',
             subSchemas: [
-                { dataType: 'enum', enums: ['dusk'] },
-                { dataType: 'enum', enums: ['ocean'] },
-                { dataType: 'enum', enums: ['ember'] },
-                { dataType: 'enum', enums: ['meadow'] },
-                { dataType: 'enum', enums: ['tide'] },
-                { dataType: 'enum', enums: ['plum'] },
-                { dataType: 'enum', enums: ['sand'] },
+                { dataType: 'enum', enums: ['lilac'] },
+                { dataType: 'enum', enums: ['blush'] },
+                { dataType: 'enum', enums: ['amethyst'] },
+                { dataType: 'enum', enums: ['sunrise'] },
                 { dataType: 'enum', enums: ['slate'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HexColor: {
+        dataType: 'refAlias',
+        type: { dataType: 'string', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SolidColor: {
+        dataType: 'refAlias',
+        type: { dataType: 'string', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAvatarColorValue: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'UserAvatarGradientId' },
+                { ref: 'HexColor' },
+                { ref: 'SolidColor' },
             ],
             validators: {},
         },
@@ -25403,7 +25392,7 @@ const models: TsoaRoute.Models = {
             avatarGradient: {
                 dataType: 'union',
                 subSchemas: [
-                    { ref: 'UserAvatarGradientId' },
+                    { ref: 'UserAvatarColorValue' },
                     { dataType: 'enum', enums: [null] },
                 ],
                 required: true,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -35291,7 +35291,7 @@ const models: TsoaRoute.Models = {
                 avatarGradient: {
                     dataType: 'union',
                     subSchemas: [
-                        { ref: 'UserAvatarGradientId' },
+                        { ref: 'UserAvatarColorValue' },
                         { dataType: 'enum', enums: [null] },
                     ],
                     required: true,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1673,6 +1673,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['none'] },
                 { dataType: 'enum', enums: ['api_key'] },
                 { dataType: 'enum', enums: ['bearer_token'] },
+                { dataType: 'enum', enums: ['google_service_account'] },
             ],
             validators: {},
         },
@@ -1729,6 +1730,14 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 hasSecret: { dataType: 'boolean', required: true },
+                oauthScopes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 apiKeyLocation: {
                     dataType: 'union',
                     subSchemas: [
@@ -1814,6 +1823,13 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                oauthScopes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'enum', enums: [null] },
                     ],
                 },
@@ -1998,6 +2014,14 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { ref: 'ApiKeyLocation' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                oauthScopes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'enum', enums: [null] },
                         { dataType: 'undefined' },
                     ],
@@ -9893,6 +9917,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                vizSchema: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DataAppVizSchema' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 design: {
                     dataType: 'union',
                     subSchemas: [
@@ -25322,6 +25353,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['amethyst'] },
                 { dataType: 'enum', enums: ['sunrise'] },
                 { dataType: 'enum', enums: ['slate'] },
+                { dataType: 'enum', enums: ['pearl'] },
             ],
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -35594,7 +35594,7 @@
                     "avatarGradient": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/UserAvatarGradientId"
+                                "$ref": "#/components/schemas/UserAvatarColorValue"
                             }
                         ],
                         "nullable": true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1662,12 +1662,7 @@
             },
             "ExternalConnectionAuthType": {
                 "type": "string",
-                "enum": [
-                    "none",
-                    "api_key",
-                    "bearer_token",
-                    "google_service_account"
-                ]
+                "enum": ["none", "api_key", "bearer_token"]
             },
             "ExternalConnectionMethod": {
                 "type": "string",
@@ -1697,13 +1692,6 @@
                     },
                     "hasSecret": {
                         "type": "boolean"
-                    },
-                    "oauthScopes": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "nullable": true
                     },
                     "apiKeyLocation": {
                         "allOf": [
@@ -1781,7 +1769,6 @@
                     "updatedByUserUuid",
                     "createdByUserUuid",
                     "hasSecret",
-                    "oauthScopes",
                     "apiKeyLocation",
                     "apiKeyName",
                     "rateLimitPerMinute",
@@ -1820,13 +1807,6 @@
                 "properties": {
                     "secret": {
                         "type": "string",
-                        "nullable": true
-                    },
-                    "oauthScopes": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
                         "nullable": true
                     },
                     "apiKeyLocation": {
@@ -1979,13 +1959,6 @@
                                 "$ref": "#/components/schemas/ApiKeyLocation"
                             }
                         ],
-                        "nullable": true
-                    },
-                    "oauthScopes": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
                         "nullable": true
                     },
                     "secret": {
@@ -11283,14 +11256,6 @@
             },
             "AppVersionResources": {
                 "properties": {
-                    "vizSchema": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DataAppVizSchema"
-                            }
-                        ],
-                        "nullable": true
-                    },
                     "design": {
                         "allOf": [
                             {
@@ -16863,6 +16828,66 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "fieldType",
+                                                                                "description",
+                                                                                "label",
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "rationale": {
                                                                         "type": "string",
                                                                         "nullable": true
@@ -16928,66 +16953,6 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "description",
-                                                                                "label",
-                                                                                "fieldId",
-                                                                                "name",
-                                                                                "table"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -16997,9 +16962,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "fields",
                                                                     "rationale",
                                                                     "explore",
-                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -25528,15 +25493,25 @@
             },
             "UserAvatarGradientId": {
                 "type": "string",
-                "enum": [
-                    "dusk",
-                    "ocean",
-                    "ember",
-                    "meadow",
-                    "tide",
-                    "plum",
-                    "sand",
-                    "slate"
+                "enum": ["lilac", "blush", "amethyst", "sunrise", "slate"]
+            },
+            "HexColor": {
+                "type": "string"
+            },
+            "SolidColor": {
+                "type": "string"
+            },
+            "UserAvatarColorValue": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/UserAvatarGradientId"
+                    },
+                    {
+                        "$ref": "#/components/schemas/HexColor"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SolidColor"
+                    }
                 ]
             },
             "LightdashUser": {
@@ -25604,7 +25579,7 @@
                     "avatarGradient": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/UserAvatarGradientId"
+                                "$ref": "#/components/schemas/UserAvatarColorValue"
                             }
                         ],
                         "nullable": true
@@ -42926,7 +42901,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3295.0",
+        "version": "0.3292.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1662,7 +1662,12 @@
             },
             "ExternalConnectionAuthType": {
                 "type": "string",
-                "enum": ["none", "api_key", "bearer_token"]
+                "enum": [
+                    "none",
+                    "api_key",
+                    "bearer_token",
+                    "google_service_account"
+                ]
             },
             "ExternalConnectionMethod": {
                 "type": "string",
@@ -1692,6 +1697,13 @@
                     },
                     "hasSecret": {
                         "type": "boolean"
+                    },
+                    "oauthScopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
                     },
                     "apiKeyLocation": {
                         "allOf": [
@@ -1769,6 +1781,7 @@
                     "updatedByUserUuid",
                     "createdByUserUuid",
                     "hasSecret",
+                    "oauthScopes",
                     "apiKeyLocation",
                     "apiKeyName",
                     "rateLimitPerMinute",
@@ -1807,6 +1820,13 @@
                 "properties": {
                     "secret": {
                         "type": "string",
+                        "nullable": true
+                    },
+                    "oauthScopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
                         "nullable": true
                     },
                     "apiKeyLocation": {
@@ -1959,6 +1979,13 @@
                                 "$ref": "#/components/schemas/ApiKeyLocation"
                             }
                         ],
+                        "nullable": true
+                    },
+                    "oauthScopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
                         "nullable": true
                     },
                     "secret": {
@@ -11256,6 +11283,14 @@
             },
             "AppVersionResources": {
                 "properties": {
+                    "vizSchema": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DataAppVizSchema"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "design": {
                         "allOf": [
                             {
@@ -25493,7 +25528,14 @@
             },
             "UserAvatarGradientId": {
                 "type": "string",
-                "enum": ["lilac", "blush", "amethyst", "sunrise", "slate"]
+                "enum": [
+                    "lilac",
+                    "blush",
+                    "amethyst",
+                    "sunrise",
+                    "slate",
+                    "pearl"
+                ]
             },
             "HexColor": {
                 "type": "string"
@@ -42901,7 +42943,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3292.1",
+        "version": "0.3295.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -1,6 +1,6 @@
 import {
     getUserAvatarUrl,
-    isUserAvatarGradientId,
+    isUserAvatarColorValue,
     KnexPaginateArgs,
     KnexPaginatedData,
     NotFoundError,
@@ -131,7 +131,7 @@ export class OrganizationMemberProfileModel {
                 : null,
             avatarGradient:
                 member.avatar_gradient &&
-                isUserAvatarGradientId(member.avatar_gradient)
+                isUserAvatarColorValue(member.avatar_gradient)
                     ? member.avatar_gradient
                     : null,
         };

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -13,7 +13,7 @@ import {
     getUserAvatarUrl,
     InvalidUser,
     isOpenIdUser,
-    isUserAvatarGradientId,
+    isUserAvatarColorValue,
     LightdashMode,
     LightdashUser,
     LightdashUserWithAbilityRules,
@@ -122,7 +122,7 @@ export const mapDbUserDetailsToLightdashUser = (
         ? getUserAvatarUrl(user.user_uuid, user.avatar_content_hash)
         : null,
     avatarGradient:
-        user.avatar_gradient && isUserAvatarGradientId(user.avatar_gradient)
+        user.avatar_gradient && isUserAvatarColorValue(user.avatar_gradient)
             ? user.avatar_gradient
             : null,
     isPending: !hasAuthentication,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -24,7 +24,7 @@ import {
     InviteLink,
     isOpenIdIdentityIssuerType,
     isOpenIdUser,
-    isUserAvatarGradientId,
+    isUserAvatarColorValue,
     isUserWithOrg,
     isValidTimezone,
     LightdashMode,
@@ -1452,7 +1452,7 @@ export class UserService extends BaseService {
         if (
             data.avatarGradient !== undefined &&
             data.avatarGradient !== null &&
-            !isUserAvatarGradientId(data.avatarGradient)
+            !isUserAvatarColorValue(data.avatarGradient)
         ) {
             throw new ParameterError(
                 `Invalid avatar gradient: ${data.avatarGradient}`,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -273,7 +273,7 @@ import {
     type LoginOptions,
     type UserAllowedOrganization,
 } from './user';
-import { type UserAvatarGradientId } from './userAvatars';
+import { type UserAvatarColorValue } from './userAvatars';
 import { type UserWarehouseCredentials } from './userWarehouseCredentials';
 import {
     type ApiChartValidationResponse,
@@ -901,7 +901,7 @@ export type UpdateUserArgs = {
        default. Null clears the preference and falls back to the project. */
     timezone: string | null;
     /* Explicit gradient placeholder override; null falls back to the deterministic gradient. */
-    avatarGradient: UserAvatarGradientId | null;
+    avatarGradient: UserAvatarColorValue | null;
 };
 
 export type ApiUserAvatarResponse = {

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -1,6 +1,6 @@
 import { type Group } from './groups';
 import { type KnexPaginatedData } from './knex-paginate';
-import { type UserAvatarGradientId } from './userAvatars';
+import { type UserAvatarColorValue } from './userAvatars';
 
 export enum OrganizationMemberRole {
     MEMBER = 'member',
@@ -70,7 +70,7 @@ export type OrganizationMemberProfile = {
     /**
      * Explicit gradient placeholder override; null falls back to the deterministic gradient
      */
-    avatarGradient: UserAvatarGradientId | null;
+    avatarGradient: UserAvatarColorValue | null;
 };
 
 export type OrganizationMemberProfileWithGroups = OrganizationMemberProfile & {

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -3,7 +3,7 @@ import { type MemberAbility } from '../authorization/types';
 import { type AnyType } from './any';
 import { type OpenIdIdentityIssuerType } from './openIdIdentity';
 import { type OrganizationMemberRole } from './organizationMemberProfile';
-import { type UserAvatarGradientId } from './userAvatars';
+import { type UserAvatarColorValue } from './userAvatars';
 
 export type AccountUser = {
     /**
@@ -43,7 +43,7 @@ export interface LightdashUser {
     /* Content-addressed path to the uploaded avatar image; null when none uploaded. */
     avatarUrl: string | null;
     /* Explicit gradient placeholder override; null falls back to the deterministic gradient. */
-    avatarGradient: UserAvatarGradientId | null;
+    avatarGradient: UserAvatarColorValue | null;
     /* Whether the user doesn't have an authentication method (password or openId) */
     isPending?: boolean;
 }
@@ -64,7 +64,7 @@ export interface LightdashSessionUser extends AccountUser {
     updatedAt: Date;
     timezone: string | null;
     avatarUrl: string | null;
-    avatarGradient: UserAvatarGradientId | null;
+    avatarGradient: UserAvatarColorValue | null;
     /* Whether the user doesn't have an authentication method (password or openId) */
     isPending?: boolean;
     /* Set only when an admin is impersonating this user via session auth */

--- a/packages/common/src/types/userAvatars.test.ts
+++ b/packages/common/src/types/userAvatars.test.ts
@@ -1,6 +1,13 @@
 import {
+    generateAvatarMeshBackgroundImage,
+    generateAvatarMeshBorderColor,
+    getAvatarMeshClassName,
+    getContrastTextColor,
     getUserAvatarGradient,
     getUserAvatarUrl,
+    hexToRgba,
+    isHexColorString,
+    isUserAvatarColorValue,
     isUserAvatarGradientId,
     USER_AVATAR_GRADIENT_IDS,
 } from './userAvatars';
@@ -62,5 +69,64 @@ describe('getUserAvatarUrl', () => {
         expect(getUserAvatarUrl('some-uuid', 'abc123')).toBe(
             '/api/v1/users/some-uuid/avatar/abc123',
         );
+    });
+});
+
+describe('isHexColorString', () => {
+    it('accepts 6-digit hex colors and rejects everything else', () => {
+        expect(isHexColorString('#5e4cff')).toBe(true);
+        expect(isHexColorString('#5E4CFF')).toBe(true);
+        expect(isHexColorString('#fff')).toBe(false);
+        expect(isHexColorString('5e4cff')).toBe(false);
+        expect(isHexColorString('not-a-color')).toBe(false);
+    });
+});
+
+describe('isUserAvatarColorValue', () => {
+    it('accepts preset ids and hex colors, rejects everything else', () => {
+        expect(isUserAvatarColorValue('lilac')).toBe(true);
+        expect(isUserAvatarColorValue('#5e4cff')).toBe(true);
+        expect(isUserAvatarColorValue('not-a-color')).toBe(false);
+    });
+});
+
+describe('hexToRgba', () => {
+    it('converts a hex color to an rgba string with the given alpha', () => {
+        expect(hexToRgba('#5e4cff', 0.4)).toBe('rgba(94, 76, 255, 0.4)');
+    });
+});
+
+describe('generateAvatarMeshBackgroundImage', () => {
+    it('produces a layered background-image using the base hex color', () => {
+        const result = generateAvatarMeshBackgroundImage('#5e4cff');
+        expect(result).toContain('#5e4cff');
+        expect(result).toContain('radial-gradient');
+        expect(result).toContain('linear-gradient');
+    });
+});
+
+describe('generateAvatarMeshBorderColor', () => {
+    it('returns an rgba border color derived from the base hex', () => {
+        expect(generateAvatarMeshBorderColor('#5e4cff')).toBe(
+            'rgba(94, 76, 255, 0.4)',
+        );
+    });
+});
+
+describe('getAvatarMeshClassName', () => {
+    it('derives a stable, lowercase class name from the hex color', () => {
+        expect(getAvatarMeshClassName('#5E4CFF')).toBe('avatar-mesh-5e4cff');
+    });
+});
+
+describe('getContrastTextColor', () => {
+    it('picks white text on dark backgrounds', () => {
+        expect(getContrastTextColor('#5e4cff')).toBe('white');
+        expect(getContrastTextColor('#0a0a0a')).toBe('white');
+    });
+
+    it('picks black text on light backgrounds', () => {
+        expect(getContrastTextColor('#f5f5f5')).toBe('black');
+        expect(getContrastTextColor('#ffe680')).toBe('black');
     });
 });

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -4,6 +4,7 @@ export const USER_AVATAR_GRADIENT_IDS = [
     'amethyst',
     'sunrise',
     'slate',
+    'pearl',
 ] as const;
 
 export type UserAvatarGradientId = (typeof USER_AVATAR_GRADIENT_IDS)[number];

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -29,3 +29,143 @@ export const getUserAvatarUrl = (
     userUuid: string,
     contentHash: string,
 ): string => `/api/v1/users/${userUuid}/avatar/${contentHash}`;
+
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+
+/* Not a template literal type: tsoa's OpenAPI generator can't resolve those. */
+export type HexColor = string;
+
+export const isHexColorString = (value: string): value is HexColor =>
+    HEX_COLOR_REGEX.test(value);
+
+const SOLID_COLOR_REGEX = /^solid:#[0-9a-fA-F]{6}$/;
+
+export type SolidColor = string;
+
+export const isSolidColorString = (value: string): value is SolidColor =>
+    SOLID_COLOR_REGEX.test(value);
+
+export const toSolidColor = (hex: HexColor): SolidColor => `solid:${hex}`;
+
+export const getHexFromSolidColor = (value: SolidColor): HexColor =>
+    value.slice('solid:'.length);
+
+/* A curated preset id, a user-picked custom mesh hex color, or a flat solid hex color. */
+export type UserAvatarColorValue = UserAvatarGradientId | HexColor | SolidColor;
+
+export const isUserAvatarColorValue = (
+    value: string,
+): value is UserAvatarColorValue =>
+    isUserAvatarGradientId(value) ||
+    isHexColorString(value) ||
+    isSolidColorString(value);
+
+type Hsl = { h: number; s: number; l: number };
+
+const hexToHsl = (hex: HexColor): Hsl => {
+    const r = parseInt(hex.slice(1, 3), 16) / 255;
+    const g = parseInt(hex.slice(3, 5), 16) / 255;
+    const b = parseInt(hex.slice(5, 7), 16) / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    if (max === min) return { h: 0, s: 0, l: l * 100 };
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h: number;
+    switch (max) {
+        case r:
+            h = (g - b) / d + (g < b ? 6 : 0);
+            break;
+        case g:
+            h = (b - r) / d + 2;
+            break;
+        default:
+            h = (r - g) / d + 4;
+    }
+    return { h: h * 60, s: s * 100, l: l * 100 };
+};
+
+const hslToHex = ({ h, s, l }: Hsl): HexColor => {
+    const sNorm = Math.min(100, Math.max(0, s)) / 100;
+    const lNorm = Math.min(100, Math.max(0, l)) / 100;
+    const hNorm = ((h % 360) + 360) % 360;
+    const c = (1 - Math.abs(2 * lNorm - 1)) * sNorm;
+    const x = c * (1 - Math.abs(((hNorm / 60) % 2) - 1));
+    const m = lNorm - c / 2;
+    let rp = 0;
+    let gp = 0;
+    let bp = 0;
+    if (hNorm < 60) [rp, gp, bp] = [c, x, 0];
+    else if (hNorm < 120) [rp, gp, bp] = [x, c, 0];
+    else if (hNorm < 180) [rp, gp, bp] = [0, c, x];
+    else if (hNorm < 240) [rp, gp, bp] = [0, x, c];
+    else if (hNorm < 300) [rp, gp, bp] = [x, 0, c];
+    else [rp, gp, bp] = [c, 0, x];
+    const toHex = (v: number) =>
+        Math.round((v + m) * 255)
+            .toString(16)
+            .padStart(2, '0');
+    return `#${toHex(rp)}${toHex(gp)}${toHex(bp)}`;
+};
+
+const shiftHsl = (
+    hex: HexColor,
+    { hueShift = 0, satShift = 0, lightShift = 0 },
+): HexColor => {
+    const { h, s, l } = hexToHsl(hex);
+    return hslToHex({
+        h: h + hueShift,
+        s: s + satShift,
+        l: l + lightShift,
+    });
+};
+
+export const hexToRgba = (hex: HexColor, alpha: number): string => {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+/* Generates the same "paint splatter" mesh recipe used by the curated
+   gradients (bright corner, subtle opposite corner, two saturated spots,
+   diagonal wash) but parameterized from an arbitrary base hex color. */
+export const generateAvatarMeshBackgroundImage = (hex: HexColor): string => {
+    const spotA = shiftHsl(hex, { hueShift: 24, satShift: 15, lightShift: 0 });
+    const spotB = shiftHsl(hex, {
+        hueShift: -24,
+        satShift: 10,
+        lightShift: -8,
+    });
+    const washLight = shiftHsl(hex, { satShift: -20, lightShift: 32 });
+    return [
+        'radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.9) 0%, transparent 40%)',
+        'radial-gradient(circle at 85% 90%, rgba(255, 255, 255, 0.3) 0%, transparent 36%)',
+        `radial-gradient(circle at 72% 25%, ${spotA} 0%, transparent 32%)`,
+        `radial-gradient(circle at 25% 75%, ${spotB} 0%, transparent 34%)`,
+        `linear-gradient(135deg, ${washLight} 0%, ${hex} 100%)`,
+    ].join(', ');
+};
+
+export const generateAvatarMeshBorderColor = (hex: HexColor): string =>
+    hexToRgba(hex, 0.4);
+
+export const getAvatarMeshClassName = (hex: HexColor): string =>
+    `avatar-mesh-${hex.slice(1).toLowerCase()}`;
+
+/* Relative luminance (WCAG) decides whether initials read better in black or white. */
+export const getContrastTextColor = (hex: HexColor): 'black' | 'white' => {
+    const toLinear = (channel: number) => {
+        const c = channel / 255;
+        return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    };
+    const r = toLinear(parseInt(hex.slice(1, 3), 16));
+    const g = toLinear(parseInt(hex.slice(3, 5), 16));
+    const b = toLinear(parseInt(hex.slice(5, 7), 16));
+    const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    return luminance > 0.55 ? 'black' : 'white';
+};
+
+export const getAvatarSolidClassName = (hex: HexColor): string =>
+    `avatar-solid-${hex.slice(1).toLowerCase()}`;

--- a/packages/frontend/src/components/Avatar.module.css
+++ b/packages/frontend/src/components/Avatar.module.css
@@ -95,3 +95,22 @@
         linear-gradient(135deg, #4a4a4a 0%, #0a0a0a 100%);
     box-shadow: inset 0 0 3px rgba(90, 90, 90, 0.5);
 }
+.root[data-avatar-gradient='pearl'] .placeholder {
+    background-image:
+        radial-gradient(
+            circle at 18% 12%,
+            rgba(255, 255, 255, 0.95) 0%,
+            transparent 40%
+        ),
+        radial-gradient(
+            circle at 85% 90%,
+            rgba(255, 255, 255, 0.6) 0%,
+            transparent 35%
+        ),
+        radial-gradient(circle at 75% 25%, #f4f4f6 0%, transparent 32%),
+        radial-gradient(circle at 25% 75%, #b9b9c2 0%, transparent 34%),
+        linear-gradient(135deg, #ffffff 0%, #cfcfd7 100%);
+    box-shadow: inset 0 0 3px rgba(160, 160, 170, 0.5);
+    /* Background is always light regardless of color scheme — fixed dark text. */
+    color: #35353a;
+}

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -1,6 +1,18 @@
-import { type UserAvatarGradientId } from '@lightdash/common';
+import {
+    generateAvatarMeshBackgroundImage,
+    generateAvatarMeshBorderColor,
+    getAvatarMeshClassName,
+    getAvatarSolidClassName,
+    getContrastTextColor,
+    getHexFromSolidColor,
+    hexToRgba,
+    isHexColorString,
+    isSolidColorString,
+    isUserAvatarGradientId,
+    type UserAvatarColorValue,
+} from '@lightdash/common';
 import { Avatar, type AvatarProps } from '@mantine-8/core';
-import { forwardRef } from 'react';
+import { forwardRef, Fragment } from 'react';
 import classes from './Avatar.module.css';
 
 type AvatarClassNames = Partial<
@@ -10,14 +22,21 @@ type AvatarClassNames = Partial<
 type Props = Omit<AvatarProps, 'classNames'> & {
     userUuid?: string;
     avatarUrl?: string | null;
-    avatarGradient?: UserAvatarGradientId | null;
+    avatarGradient?: UserAvatarColorValue | null;
     classNames?: AvatarClassNames;
 };
 
-const mergeClassNames = (extra?: AvatarClassNames): AvatarClassNames => ({
+const mergeClassNames = (
+    extra?: AvatarClassNames,
+    extraPlaceholderClass?: string,
+): AvatarClassNames => ({
     ...extra,
     root: [classes.root, extra?.root].filter(Boolean).join(' '),
-    placeholder: [classes.placeholder, extra?.placeholder]
+    placeholder: [
+        classes.placeholder,
+        extraPlaceholderClass,
+        extra?.placeholder,
+    ]
         .filter(Boolean)
         .join(' '),
 });
@@ -38,7 +57,11 @@ export const LightdashUserAvatar = forwardRef<HTMLDivElement, Props>(
                 />
             );
         }
-        if (userUuid && avatarGradient) {
+        if (
+            userUuid &&
+            avatarGradient &&
+            isUserAvatarGradientId(avatarGradient)
+        ) {
             return (
                 <Avatar
                     ref={ref}
@@ -48,6 +71,52 @@ export const LightdashUserAvatar = forwardRef<HTMLDivElement, Props>(
                     classNames={mergeClassNames(classNames)}
                     {...props}
                 />
+            );
+        }
+        if (userUuid && avatarGradient && isHexColorString(avatarGradient)) {
+            const meshClassName = getAvatarMeshClassName(avatarGradient);
+            const textColor = getContrastTextColor(avatarGradient);
+            return (
+                <Fragment>
+                    <style>
+                        {`.${meshClassName} { background-image: ${generateAvatarMeshBackgroundImage(
+                            avatarGradient,
+                        )}; box-shadow: inset 0 0 3px ${generateAvatarMeshBorderColor(
+                            avatarGradient,
+                        )}; color: ${textColor}; }`}
+                    </style>
+                    <Avatar
+                        ref={ref}
+                        radius="100%"
+                        color="initials"
+                        data-avatar-gradient="custom"
+                        classNames={mergeClassNames(classNames, meshClassName)}
+                        {...props}
+                    />
+                </Fragment>
+            );
+        }
+        if (userUuid && avatarGradient && isSolidColorString(avatarGradient)) {
+            const hex = getHexFromSolidColor(avatarGradient);
+            const solidClassName = getAvatarSolidClassName(hex);
+            const textColor = getContrastTextColor(hex);
+            return (
+                <Fragment>
+                    <style>
+                        {`.${solidClassName} { background-image: none; background-color: ${hex}; box-shadow: inset 0 0 3px ${hexToRgba(
+                            hex,
+                            0.4,
+                        )}; color: ${textColor}; }`}
+                    </style>
+                    <Avatar
+                        ref={ref}
+                        radius="100%"
+                        color="initials"
+                        data-avatar-gradient="custom"
+                        classNames={mergeClassNames(classNames, solidClassName)}
+                        {...props}
+                    />
+                </Fragment>
             );
         }
         return (

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -79,7 +79,7 @@ export const LightdashUserAvatar = forwardRef<HTMLDivElement, Props>(
             return (
                 <Fragment>
                     <style>
-                        {`.${meshClassName} { background-image: ${generateAvatarMeshBackgroundImage(
+                        {`.${classes.root}[data-avatar-gradient='custom'] .${classes.placeholder}.${meshClassName} { background-image: ${generateAvatarMeshBackgroundImage(
                             avatarGradient,
                         )}; box-shadow: inset 0 0 3px ${generateAvatarMeshBorderColor(
                             avatarGradient,
@@ -103,7 +103,7 @@ export const LightdashUserAvatar = forwardRef<HTMLDivElement, Props>(
             return (
                 <Fragment>
                     <style>
-                        {`.${solidClassName} { background-image: none; background-color: ${hex}; box-shadow: inset 0 0 3px ${hexToRgba(
+                        {`.${classes.root}[data-avatar-gradient='custom'] .${classes.placeholder}.${solidClassName} { background-image: none; background-color: ${hex}; box-shadow: inset 0 0 3px ${hexToRgba(
                             hex,
                             0.4,
                         )}; color: ${textColor}; }`}

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
@@ -13,6 +13,29 @@
         inset 0 0 0 1px rgba(120, 120, 120, 0.15);
 }
 
+/* Classic "no fill" swatch: light circle with a red diagonal slash. */
+.noColorSwatch {
+    position: relative;
+    display: block;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    overflow: hidden;
+    background-color: var(--mantine-color-body);
+    border: 1px solid var(--mantine-color-ldGray-4);
+}
+
+.noColorSwatch::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: -4px;
+    bottom: -4px;
+    width: 2px;
+    background-color: var(--mantine-color-red-6);
+    transform: rotate(45deg);
+}
+
 .avatarEditWrapper {
     position: relative;
     display: inline-flex;

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
@@ -12,3 +12,32 @@
         0 0 6px rgba(80, 80, 80, 0.25),
         inset 0 0 0 1px rgba(120, 120, 120, 0.15);
 }
+
+.avatarEditWrapper {
+    position: relative;
+    display: inline-flex;
+    border: none;
+    background: none;
+    padding: 0;
+    border-radius: 50%;
+    cursor: pointer;
+    line-height: 0;
+}
+
+.avatarEditOverlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    pointer-events: none;
+}
+
+.avatarEditWrapper:hover .avatarEditOverlay,
+.avatarEditWrapper:focus-visible .avatarEditOverlay {
+    opacity: 1;
+}

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,19 +1,26 @@
 import {
+    isHexColorString,
+    isSolidColorString,
+    isUserAvatarGradientId,
+    toSolidColor,
     USER_AVATAR_GRADIENT_IDS,
+    type HexColor,
+    type UserAvatarColorValue,
     type UserAvatarGradientId,
 } from '@lightdash/common';
 import {
     Button,
     ColorPicker,
-    Divider,
     FileButton,
     Group,
     Popover,
+    SegmentedControl,
     Stack,
     Text,
     Tooltip,
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
+import { IconPencil } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
@@ -23,11 +30,12 @@ import {
 import { useUserUpdateMutation } from '../../../hooks/user/useUserUpdateMutation';
 import useApp from '../../../providers/App/useApp';
 import { LightdashUserAvatar } from '../../Avatar';
+import MantineIcon from '../../common/MantineIcon';
 import classes from './AvatarSettings.module.css';
 
-const DEFAULT_SWATCH_COLOR = '#ced4da';
+const DEFAULT_COLOR: HexColor = '#ced4da';
 
-const GRADIENT_SWATCH_COLORS: Record<UserAvatarGradientId, string> = {
+const GRADIENT_SWATCH_COLORS: Record<UserAvatarGradientId, HexColor> = {
     lilac: '#9d7fff',
     blush: '#ff6fc4',
     amethyst: '#5e4cff',
@@ -35,10 +43,17 @@ const GRADIENT_SWATCH_COLORS: Record<UserAvatarGradientId, string> = {
     slate: '#2a2a2a',
 };
 
-const gradientIdForColor = (color: string): UserAvatarGradientId | null =>
-    USER_AVATAR_GRADIENT_IDS.find(
-        (id) => GRADIENT_SWATCH_COLORS[id] === color,
-    ) ?? null;
+type CustomMode = 'gradient' | 'solid';
+
+const extractHex = (value: UserAvatarColorValue | null): HexColor => {
+    if (!value) return DEFAULT_COLOR;
+    if (isUserAvatarGradientId(value)) return GRADIENT_SWATCH_COLORS[value];
+    if (isSolidColorString(value)) return value.slice(6) as HexColor;
+    return value;
+};
+
+const modeForValue = (value: UserAvatarColorValue | null): CustomMode =>
+    value && isSolidColorString(value) ? 'solid' : 'gradient';
 
 const AvatarSettings: FC = () => {
     const { user } = useApp();
@@ -47,8 +62,9 @@ const AvatarSettings: FC = () => {
     const deleteMutation = useAvatarDeleteMutation();
     const updateUserMutation = useUserUpdateMutation();
     const [opened, { toggle, close }] = useDisclosure(false);
-    const [previewGradient, setPreviewGradient] =
-        useState<UserAvatarGradientId | null>(null);
+    const [previewValue, setPreviewValue] =
+        useState<UserAvatarColorValue | null>(null);
+    const [mode, setMode] = useState<CustomMode>('gradient');
 
     if (!user.data) return null;
 
@@ -70,26 +86,175 @@ const AvatarSettings: FC = () => {
 
     const handleToggle = () => {
         if (!opened) {
-            setPreviewGradient(avatarGradient ?? null);
+            setPreviewValue(avatarGradient ?? null);
+            setMode(modeForValue(avatarGradient ?? null));
         }
         toggle();
     };
 
+    const handleModeChange = (value: string) => {
+        const nextMode = value as CustomMode;
+        setMode(nextMode);
+        if (previewValue && !isUserAvatarGradientId(previewValue)) {
+            const hex = extractHex(previewValue);
+            setPreviewValue(nextMode === 'solid' ? toSolidColor(hex) : hex);
+        }
+    };
+
+    const handleColorChange = (color: string) => {
+        if (!isHexColorString(color)) return;
+        setPreviewValue(mode === 'solid' ? toSolidColor(color) : color);
+    };
+
+    const handlePresetClick = (gradientId: UserAvatarGradientId | null) => {
+        setPreviewValue(gradientId);
+    };
+
     const handleApply = () => {
-        updateUserMutation.mutate({ avatarGradient: previewGradient });
+        updateUserMutation.mutate({ avatarGradient: previewValue });
         close();
     };
 
+    const avatarTrigger = !avatarUrl && (
+        <Popover
+            opened={opened}
+            onChange={(isOpen) => {
+                if (!isOpen) close();
+            }}
+            width={260}
+            position="bottom-start"
+            withArrow
+        >
+            <Popover.Target>
+                <Tooltip label="Choose color">
+                    <button
+                        type="button"
+                        aria-label="Choose avatar color"
+                        className={classes.avatarEditWrapper}
+                        onClick={handleToggle}
+                    >
+                        <LightdashUserAvatar
+                            size={64}
+                            userUuid={userUuid}
+                            avatarGradient={avatarGradient}
+                        >
+                            {initials}
+                        </LightdashUserAvatar>
+                        <span className={classes.avatarEditOverlay}>
+                            <MantineIcon icon={IconPencil} color="white" />
+                        </span>
+                    </button>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown>
+                <Stack gap="sm">
+                    <Group justify="space-between" align="center">
+                        <Text size="xs" c="dimmed" fw={500}>
+                            Avatar color
+                        </Text>
+                        <LightdashUserAvatar
+                            size="sm"
+                            userUuid={userUuid}
+                            avatarGradient={previewValue}
+                        >
+                            {initials}
+                        </LightdashUserAvatar>
+                    </Group>
+                    <SegmentedControl
+                        fullWidth
+                        size="xs"
+                        value={mode}
+                        onChange={handleModeChange}
+                        data={[
+                            { label: 'Gradient', value: 'gradient' },
+                            { label: 'Solid', value: 'solid' },
+                        ]}
+                    />
+                    <ColorPicker
+                        format="hex"
+                        size="xs"
+                        fullWidth
+                        value={extractHex(previewValue)}
+                        onChange={handleColorChange}
+                    />
+                    <Stack gap={6}>
+                        <Text size="xs" c="dimmed" fw={500}>
+                            Lightdash presets
+                        </Text>
+                        <Group gap="xs" wrap="nowrap">
+                            <Tooltip label="No color (default)">
+                                <button
+                                    type="button"
+                                    aria-label="Use default avatar"
+                                    className={
+                                        !previewValue
+                                            ? `${classes.swatchButton} ${classes.swatchSelected}`
+                                            : classes.swatchButton
+                                    }
+                                    onClick={() => handlePresetClick(null)}
+                                >
+                                    <LightdashUserAvatar size="sm">
+                                        {' '}
+                                    </LightdashUserAvatar>
+                                </button>
+                            </Tooltip>
+                            {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (
+                                <Tooltip key={gradientId} label={gradientId}>
+                                    <button
+                                        type="button"
+                                        aria-label={`Use ${gradientId} avatar color`}
+                                        className={
+                                            gradientId === previewValue
+                                                ? `${classes.swatchButton} ${classes.swatchSelected}`
+                                                : classes.swatchButton
+                                        }
+                                        onClick={() =>
+                                            handlePresetClick(gradientId)
+                                        }
+                                    >
+                                        <LightdashUserAvatar
+                                            size="sm"
+                                            userUuid={userUuid}
+                                            avatarGradient={gradientId}
+                                        >
+                                            {' '}
+                                        </LightdashUserAvatar>
+                                    </button>
+                                </Tooltip>
+                            ))}
+                        </Group>
+                    </Stack>
+                    <Group justify="flex-end" gap="xs">
+                        <Button variant="subtle" size="xs" onClick={close}>
+                            Cancel
+                        </Button>
+                        <Button
+                            size="xs"
+                            loading={updateUserMutation.isLoading}
+                            onClick={handleApply}
+                        >
+                            Apply
+                        </Button>
+                    </Group>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+
     return (
         <Group align="center" gap="md" wrap="nowrap">
-            <LightdashUserAvatar
-                size={64}
-                userUuid={userUuid}
-                avatarUrl={avatarUrl}
-                avatarGradient={avatarGradient}
-            >
-                {initials}
-            </LightdashUserAvatar>
+            {avatarUrl ? (
+                <LightdashUserAvatar
+                    size={64}
+                    userUuid={userUuid}
+                    avatarUrl={avatarUrl}
+                    avatarGradient={avatarGradient}
+                >
+                    {initials}
+                </LightdashUserAvatar>
+            ) : (
+                avatarTrigger
+            )}
             <FileButton
                 onChange={handleFile}
                 accept="image/png,image/jpeg,image/webp"
@@ -105,7 +270,6 @@ const AvatarSettings: FC = () => {
                     </Button>
                 )}
             </FileButton>
-            {!avatarUrl && <Divider orientation="vertical" my="auto" h={20} />}
             {avatarUrl && (
                 <Button
                     variant="subtle"
@@ -116,91 +280,6 @@ const AvatarSettings: FC = () => {
                 >
                     Remove photo
                 </Button>
-            )}
-            {!avatarUrl && (
-                <Popover
-                    opened={opened}
-                    onChange={(isOpen) => {
-                        if (!isOpen) close();
-                    }}
-                    width={220}
-                    position="bottom-start"
-                    withArrow
-                >
-                    <Popover.Target>
-                        <Tooltip label="Choose color">
-                            <button
-                                type="button"
-                                aria-label="Choose avatar color"
-                                className={classes.swatchButton}
-                                onClick={handleToggle}
-                            >
-                                <LightdashUserAvatar
-                                    size="sm"
-                                    userUuid={userUuid}
-                                    avatarGradient={avatarGradient}
-                                >
-                                    {initials}
-                                </LightdashUserAvatar>
-                            </button>
-                        </Tooltip>
-                    </Popover.Target>
-                    <Popover.Dropdown>
-                        <Stack gap="sm">
-                            <Group justify="space-between" align="center">
-                                <Text size="xs" c="dimmed" fw={500}>
-                                    Avatar color
-                                </Text>
-                                <LightdashUserAvatar
-                                    size="sm"
-                                    userUuid={userUuid}
-                                    avatarGradient={previewGradient}
-                                >
-                                    {initials}
-                                </LightdashUserAvatar>
-                            </Group>
-                            <ColorPicker
-                                withPicker={false}
-                                format="hex"
-                                swatchesPerRow={6}
-                                swatches={[
-                                    DEFAULT_SWATCH_COLOR,
-                                    ...USER_AVATAR_GRADIENT_IDS.map(
-                                        (id) => GRADIENT_SWATCH_COLORS[id],
-                                    ),
-                                ]}
-                                value={
-                                    previewGradient
-                                        ? GRADIENT_SWATCH_COLORS[
-                                              previewGradient
-                                          ]
-                                        : DEFAULT_SWATCH_COLOR
-                                }
-                                onChange={(color) =>
-                                    setPreviewGradient(
-                                        gradientIdForColor(color),
-                                    )
-                                }
-                            />
-                            <Group justify="flex-end" gap="xs">
-                                <Button
-                                    variant="subtle"
-                                    size="xs"
-                                    onClick={close}
-                                >
-                                    Cancel
-                                </Button>
-                                <Button
-                                    size="xs"
-                                    loading={updateUserMutation.isLoading}
-                                    onClick={handleApply}
-                                >
-                                    Apply
-                                </Button>
-                            </Group>
-                        </Stack>
-                    </Popover.Dropdown>
-                </Popover>
             )}
         </Group>
     );

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -41,6 +41,7 @@ const GRADIENT_SWATCH_COLORS: Record<UserAvatarGradientId, HexColor> = {
     amethyst: '#5e4cff',
     sunrise: '#b3a0ff',
     slate: '#2a2a2a',
+    pearl: '#e4e4ea',
 };
 
 type CustomMode = 'gradient' | 'solid';
@@ -186,9 +187,7 @@ const AvatarSettings: FC = () => {
                                     }
                                     onClick={() => handlePresetClick(null)}
                                 >
-                                    <LightdashUserAvatar size="sm">
-                                        {' '}
-                                    </LightdashUserAvatar>
+                                    <span className={classes.noColorSwatch} />
                                 </button>
                             </Tooltip>
                             {USER_AVATAR_GRADIENT_IDS.map((gradientId) => (

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -136,7 +136,9 @@ const AvatarSettings: FC = () => {
                         <LightdashUserAvatar
                             size={64}
                             userUuid={userUuid}
-                            avatarGradient={avatarGradient}
+                            avatarGradient={
+                                opened ? previewValue : avatarGradient
+                            }
                         >
                             {initials}
                         </LightdashUserAvatar>
@@ -148,18 +150,9 @@ const AvatarSettings: FC = () => {
             </Popover.Target>
             <Popover.Dropdown>
                 <Stack gap="sm">
-                    <Group justify="space-between" align="center">
-                        <Text size="xs" c="dimmed" fw={500}>
-                            Avatar color
-                        </Text>
-                        <LightdashUserAvatar
-                            size="sm"
-                            userUuid={userUuid}
-                            avatarGradient={previewValue}
-                        >
-                            {initials}
-                        </LightdashUserAvatar>
-                    </Group>
+                    <Text size="xs" c="dimmed" fw={500}>
+                        Avatar color
+                    </Text>
                     <SegmentedControl
                         fullWidth
                         size="xs"


### PR DESCRIPTION
## Summary
Custom avatar colors (stack 5, on #25056).

- Replaces the preset-only swatch popover with a full Mantine `ColorPicker`: pick any hex, choose **Gradient** (generated paint-splatter mesh: bright corner highlight, two saturated spots derived via HSL shifts, diagonal wash) or **Solid** (flat fill), with the 5 curated gradients kept as "Lightdash presets" swatches. Preview-then-Apply — nothing saves until Apply.
- Persists in the existing `avatar_gradient` varchar(32): presets as-is, custom mesh as raw hex (`#5e4cff`), solid as `solid:#5e4cff`. No migration — the column was always unconstrained; only `UserService.updateUser` validation widens (`isUserAvatarColorValue`).
- Initials color is computed via WCAG relative luminance (black on light, white on dark) and injected with a selector matching the shared rule's specificity — custom colors stay readable.
- Hex values are regex-validated (`#[0-9a-fA-F]{6}`) server-side on write **and** client-side before interpolation into the injected `<style>`, so nothing attacker-controlled reaches the stylesheet.
- Fixes `OrganizationMemberProfileModel.parseRow` still using the preset-only guard, which dropped custom colors from every org-members-fed surface.

## Regression analysis
Additive: users who never open the picker keep their preset/default. API consumers see `avatarGradient` widen from a closed enum to `preset | hex | solid:hex` — unknown values were already treated as null by all readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016htskgLvEp8haqHV9GdEfX