### PR TITLE
refactor(avatars): upload avatar via lightdashApi instead of raw fetch

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1053,6 +1053,7 @@ type ApiResults =
     | ApiCreateComment['results']
     | ApiGetComments['results']
     | ApiDeleteComment
+    | ApiUserAvatarResponse['results']
     | ApiSuccessEmpty
     | ApiCreateProjectResults
     | ApiDeployExploresResults

--- a/packages/frontend/src/hooks/user/useAvatarMutations.ts
+++ b/packages/frontend/src/hooks/user/useAvatarMutations.ts
@@ -7,22 +7,12 @@ const uploadAvatar = async (
     file: File,
 ): Promise<ApiUserAvatarResponse['results']> => {
     const blob = await downscaleAvatarImage(file);
-    const response = await fetch('/api/v1/user/me/avatar', {
+    return lightdashApi<ApiUserAvatarResponse['results']>({
+        url: '/user/me/avatar',
         method: 'PUT',
-        credentials: 'include',
         headers: { 'Content-Type': blob.type },
         body: blob,
     });
-    let json: unknown;
-    try {
-        json = await response.json();
-    } catch (e) {
-        throw new Error('Unexpected response uploading avatar');
-    }
-    if (!response.ok) {
-        throw json;
-    }
-    return (json as ApiUserAvatarResponse).results;
 };
 
 export const useAvatarUploadMutation = () => {


### PR DESCRIPTION
## Summary
Addresses the Graphite review thread on `useAvatarMutations.ts` (stack 7, on #25084).

`uploadAvatar` used a raw `fetch` while `deleteAvatar` right below goes through `lightdashApi`. The helper already accepts a `BodyInit` body (Blob included) and per-call header overrides, so the raw fetch gained nothing while bypassing centralized auth handling, error normalization (`handleError`), embed JWT headers, network history, and Sentry distributed tracing. Now both mutations share the same path.

Also registers `ApiUserAvatarResponse['results']` in the `ApiResults` union, which the `lightdashApi` generic constrains on.

## Regression analysis
Behavior-preserving: same endpoint, method, content type and body; error shape improves from ad-hoc thrown JSON to the normalized `ApiError` every other mutation produces (the mutation's typed error was already `ApiError`, so this fixes a latent mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016htskgLvEp8haqHV9GdEfX