### PR TITLE
fix(cli): spell out manifest retarget consequences on app create [GLITCH-586]

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -5,6 +5,7 @@ import {
     classifyAppUpload,
     computeUpsertedTotal,
     ensureDownloadedAppContext,
+    manifestRetargetHint,
     MAX_INCLUDE_APPS,
     selectAppsToDownload,
     shouldWarnAllSkipped,
@@ -163,6 +164,20 @@ describe('classifyAppUpload', () => {
         expect(classifyAppUpload('proj-a', 'proj-b', false)).toBe(
             'needs-confirmation',
         );
+    });
+});
+
+describe('manifestRetargetHint', () => {
+    it('names both uuids, the consequence, and the manual fix', () => {
+        const hint = manifestRetargetHint({
+            folder: 'my-app',
+            appUuid: 'new-app-uuid',
+            projectUuid: 'target-proj-uuid',
+        });
+        expect(hint).toContain('my-app/lightdash-app.yml');
+        expect(hint).toContain('appUuid: new-app-uuid');
+        expect(hint).toContain('projectUuid: target-proj-uuid');
+        expect(hint).toMatch(/ask to create again/i);
     });
 });
 

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -51,6 +51,17 @@ export const ensureDownloadedAppContext = (
 export type AppDownloadFailure = { appUuid: string; message: string };
 
 /**
+ * Shown when a newly created app's folder manifest was NOT retargeted —
+ * spells out the consequence and the manual fix.
+ */
+export const manifestRetargetHint = (args: {
+    folder: string;
+    appUuid: string;
+    projectUuid: string;
+}): string =>
+    `${args.folder}/lightdash-app.yml still targets the original app, so future uploads here will ask to create again. To update the new app instead, set appUuid: ${args.appUuid} and projectUuid: ${args.projectUuid} in lightdash-app.yml.`;
+
+/**
  * Sums changes entries that represent actual upserts — excluding both
  * 'skipped' and 'failed' keys so that failures don't suppress the
  * "all content was skipped" warning.

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -52,6 +52,7 @@ import {
     capListedApps,
     classifyAppUpload,
     ensureDownloadedAppContext,
+    manifestRetargetHint,
     MAX_INCLUDE_APPS,
     selectAppsToDownload,
     shouldWarnAllSkipped,
@@ -1979,7 +1980,7 @@ export const uploadHandler = async (
                             ]);
                             if (!confirmed) {
                                 GlobalState.log(
-                                    `Skipped "${subDir.name}" (cross-project create declined). Pass --create-new to make this explicit.`,
+                                    `Skipped "${subDir.name}" (cross-project create declined). Pass --create-new to make this explicit. If this app was already moved to the target project, set appUuid and projectUuid in lightdash-app.yml to the moved app instead.`,
                                 );
                                 appsSkipped += 1;
                                 // eslint-disable-next-line no-continue
@@ -1988,7 +1989,7 @@ export const uploadHandler = async (
                         } else {
                             GlobalState.log(
                                 styles.error(
-                                    `Cannot upload "${subDir.name}": its manifest targets project ${code.manifest.projectUuid} but you are uploading to project ${projectId}. Pass --create-new to create a new app in the target project.`,
+                                    `Cannot upload "${subDir.name}": its manifest targets project ${code.manifest.projectUuid} but you are uploading to project ${projectId}. Pass --create-new to create a new app in the target project. If this app was already moved there, set appUuid and projectUuid in lightdash-app.yml to the moved app instead.`,
                                 ),
                             );
                             appsFailed += 1;
@@ -2036,7 +2037,7 @@ export const uploadHandler = async (
                                 {
                                     type: 'confirm',
                                     name: 'retarget',
-                                    message: `Update ${subDir.name}/lightdash-app.yml to target the new app, so future uploads update it?`,
+                                    message: `Update ${subDir.name}/lightdash-app.yml to target the new app? This sets appUuid ${appUuid}, projectUuid ${projectId}, version ${version} — future uploads will update this app.`,
                                     default: true,
                                 },
                             ]);
@@ -2049,14 +2050,28 @@ export const uploadHandler = async (
                                 });
                                 GlobalState.log(
                                     styles.success(
-                                        `Updated ${subDir.name}/lightdash-app.yml to target ${appUuid}.`,
+                                        `Updated ${subDir.name}/lightdash-app.yml → appUuid ${appUuid}, projectUuid ${projectId}, version ${version}.`,
+                                    ),
+                                );
+                            } else {
+                                GlobalState.log(
+                                    styles.warning(
+                                        manifestRetargetHint({
+                                            folder: subDir.name,
+                                            appUuid,
+                                            projectUuid: projectId,
+                                        }),
                                     ),
                                 );
                             }
                         } else {
                             GlobalState.log(
                                 styles.warning(
-                                    `${subDir.name}/lightdash-app.yml still targets the original app. Set appUuid: ${appUuid} (and projectUuid: ${projectId}) there to update the new app on future uploads.`,
+                                    manifestRetargetHint({
+                                        folder: subDir.name,
+                                        appUuid,
+                                        projectUuid: projectId,
+                                    }),
                                 ),
                             );
                         }


### PR DESCRIPTION
Messaging-only fix for the app-create retarget flow, from a reproduced stuck-loop: a user moved an app to a new project, the manifest retarget didn't land, and every subsequent upload re-asked "will CREATE a new app" — answering no just bailed.

- Retarget prompt and success line now enumerate exactly what changes: `appUuid`, `projectUuid`, and `version` (behavior already updated all three; the wording hid it).
- Declining the retarget (and the non-TTY create path) now prints a shared hint: the folder still targets the original app, future uploads will ask to create again, and the exact fields to set in `lightdash-app.yml` to fix it.
- Declining the cross-project create guard (TTY and non-TTY) now also says how to point the manifest at an already-moved app.

Closes: GLITCH-586

🤖 Generated with [Claude Code](https://claude.com/claude-code)