### PR TITLE
docs(cli): local install/build is an optional pre-check for data apps [GLITCH-587]

### DIFF
--- a/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
@@ -5,3 +5,5 @@ Two skills in `.claude/skills/` describe how to edit this app:
 - `developing-data-apps-locally` — the local workflow: edit `src/`, `pnpm build`, `lightdash upload --apps`; the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
 
 Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
+
+The local `pnpm install && pnpm build` is an optional pre-check. If install fails, skip it and upload — never modify machine config, npmrc, or dependency files to force it; the server rebuild is authoritative.

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -4,7 +4,7 @@ Downloaded with `lightdash download --apps`.
 
 ## Edit → build → upload
 1. Edit files under `src/`.
-2. `pnpm install && pnpm build` to check it compiles locally.
+2. Optionally, `pnpm install && pnpm build` to check it compiles locally. If install fails in your environment, skip it — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
 3. `lightdash upload --apps` — Lightdash rebuilds and serves the app.
 
 ## What's read-only

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -15,8 +15,14 @@ You are editing a Lightdash **data app** that was downloaded with `lightdash dow
 ## The edit → build → upload loop
 
 1. Edit files under `src/` only.
-2. `pnpm install` then `pnpm build` to check it compiles. This is a **local pre-check**.
+2. Optionally, `pnpm install` then `pnpm build` to check it compiles. This is an **optional local pre-check** — see below.
 3. `lightdash upload --apps` — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
+
+## The local build is optional — never fight a failing install
+
+- If `pnpm install` fails (registry policy, an unavailable pinned SDK version, no network access), **skip the local build entirely and go straight to upload**. The server rebuild is authoritative and surfaces build errors on the app page.
+- Do **not** modify machine configuration, `.npmrc` files, registry settings, or the project's dependency files to force an install to work.
+- A missing `node_modules` is a normal state, not a problem to fix. Never run installs just because it is absent.
 
 ## Project context (read-only reference)
 


### PR DESCRIPTION
Reframes the local `pnpm install && pnpm build` as an **optional pre-check** in the shipped authoring guidance (`developing-data-apps-locally` skill, app README, AGENTS.md). Local agents were fighting failing installs (registry policies, unavailable pinned SDK versions, sandboxed environments) or mutating machine config to force them.

New guidance: if install fails, skip the local build entirely and upload — the server rebuild is authoritative and surfaces errors on the app page; never modify machine config, npmrc, or dependency files; a missing `node_modules` is a normal state.

The scaffolding files themselves stay (they work when the environment allows, and Phase 3a's preview builds on them).

Closes: GLITCH-587

🤖 Generated with [Claude Code](https://claude.com/claude-code)