### PR TITLE
feat(ai): harden field discovery against false 'data missing' answers

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/tests/testCases.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/testCases.ts
@@ -239,6 +239,25 @@ export const testCases: TestCase[] = [
             `The status filter must be combined with the date selection under AND, so completed status applies to both March and May (not OR'd across the whole group, which would make status optional)`,
         ].join('\n'),
     },
+    {
+        // IMPORTANT: guards against "false absence" claims — the worst failure
+        // mode of field discovery. When a discovery tool (grep/FTS) returns
+        // noisy or empty results, the agent may confidently tell the user the
+        // data isn't modeled when it is. The prompt plants a false premise
+        // ("I don't think we track...") about a field that DOES exist
+        // (payments.payment_method); the agent must find it, not agree.
+        name: 'should not claim a modeled field is missing (false absence)',
+        prompt: "I don't think we track how customers pay us, but just in case: can you break our revenue down by the way the payment was made?",
+        expectedAnswer: [
+            `The response does NOT claim the data is missing, unavailable, or not tracked`,
+            `It does NOT agree with the false premise in the question`,
+            `It provides (or starts building) revenue broken down by payment method (e.g. credit_card, coupon, bank_transfer, gift_card)`,
+        ].join('\n'),
+        expectedToolOutcome: [
+            `It should have used field discovery (grepFields, findFields or findExplores) and found the payment method dimension on the payments explore`,
+            `It must NOT conclude from a noisy or empty discovery result that the field does not exist`,
+        ].join('\n'),
+    },
 ];
 
 type Context = {

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
@@ -108,3 +108,49 @@ describe('getMetadata description truncation', () => {
         expect(descriptionLine).not.toContain("'value_39'");
     });
 });
+
+describe('getMetadata explore field listing', () => {
+    // The explore summary must list the base table's field ids directly: when
+    // field discovery (grep/FTS) misbehaves, this is the agent's ground-truth
+    // escape hatch before claiming a field doesn't exist. Pointing back at
+    // grepFields ("use grepFields to list them") was circular.
+    it('lists base-table field ids in the explore summary', async () => {
+        const explore = makeExplore({});
+        const result = await execute(explore, [
+            { type: 'explore', exploreIds: ['sales'] },
+        ]);
+
+        expect(result.metadata).toEqual({ status: 'success' });
+        expect(result.result).toContain('orders_status');
+        expect(result.result).not.toContain('use grepFields to list them');
+    });
+
+    it('does not list hidden fields', async () => {
+        const explore = makeExplore({});
+        explore.tables.orders.dimensions.secret = {
+            ...explore.tables.orders.dimensions.status,
+            name: 'secret',
+            label: 'Secret',
+            hidden: true,
+        };
+        const result = await execute(explore, [
+            { type: 'explore', exploreIds: ['sales'] },
+        ]);
+        expect(result.result).not.toContain('orders_secret');
+    });
+
+    it('truncates very wide base tables with a "+N more" marker', async () => {
+        const explore = makeExplore({});
+        for (let i = 0; i < 150; i += 1) {
+            explore.tables.orders.dimensions[`attr_${i}`] = {
+                ...explore.tables.orders.dimensions.status,
+                name: `attr_${i}`,
+                label: `Attr ${i}`,
+            };
+        }
+        const result = await execute(explore, [
+            { type: 'explore', exploreIds: ['sales'] },
+        ]);
+        expect(result.result).toMatch(/\+\d+ more \(grepFields lists them\)/);
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.ts
@@ -26,14 +26,33 @@ const collapse = (text: string, max = 240): string =>
 // agent. Safe here: this tool only renders the few fields explicitly requested.
 const FIELD_DESCRIPTION_MAX = 2000;
 
+// Field-id lists in the explore summary are capped so an unusually wide table
+// can't flood the context; the overflow marker tells the agent how to see the
+// rest. High enough that typical base tables list in full.
+const FIELD_LIST_MAX = 120;
+
+// One comma-separated line of the base table's visible field ids. This listing
+// is the agent's ground truth for "does field X exist here" — search tools
+// (grep/FTS) are lossy, so the summary must not defer back to them for the
+// full list, or a search miss becomes unfalsifiable.
+const renderFieldList = (
+    kind: 'dimensions' | 'metrics',
+    fields: { table: string; name: string; hidden?: boolean }[],
+): string => {
+    const ids = fields
+        .filter((f) => !f.hidden)
+        .map((f) => `${f.table}_${f.name}`);
+    if (ids.length === 0) return `  base ${kind}: none`;
+    const shown = ids.slice(0, FIELD_LIST_MAX);
+    const overflow =
+        ids.length > shown.length
+            ? `, +${ids.length - shown.length} more (grepFields lists them)`
+            : '';
+    return `  base ${kind} (${ids.length}): ${shown.join(', ')}${overflow}`;
+};
+
 const renderExplore = (explore: Explore): string => {
     const baseTable = explore.tables[explore.baseTable];
-    const dimensionCount = Object.values(baseTable?.dimensions ?? {}).filter(
-        (d) => !d.hidden,
-    ).length;
-    const metricCount = Object.values(baseTable?.metrics ?? {}).filter(
-        (m) => !m.hidden,
-    ).length;
     const lines = [`Explore: ${explore.name} (${explore.label})`];
     if (baseTable?.description) {
         lines.push(`  description: ${collapse(baseTable.description)}`);
@@ -43,12 +62,20 @@ const renderExplore = (explore: Explore): string => {
     lines.push(`  base table: ${explore.baseTable}`);
     const joined = explore.joinedTables.map((j) => j.table);
     if (joined.length > 0) {
-        lines.push(`  joined tables (usable in queries): ${joined.join(', ')}`);
+        lines.push(
+            `  joined tables (usable in queries, grep with exploreName="${explore.name}" to list their fields): ${joined.join(
+                ', ',
+            )}`,
+        );
     }
     const required = summarizeRequiredFilters(explore);
     if (required) lines.push(`  ${required}`);
     lines.push(
-        `  fields: ${dimensionCount} dimensions, ${metricCount} metrics (use grepFields to list them)`,
+        renderFieldList(
+            'dimensions',
+            Object.values(baseTable?.dimensions ?? {}),
+        ),
+        renderFieldList('metrics', Object.values(baseTable?.metrics ?? {})),
     );
     return lines.join('\n');
 };

--- a/packages/backend/src/ee/services/ai/tools/grepFields.hardening.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFields.hardening.test.ts
@@ -1,0 +1,230 @@
+import {
+    DimensionType,
+    FieldType,
+    SupportedDbtAdapter,
+    type Explore,
+} from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import type { FindExploresFn } from '../types/aiAgentDependencies';
+import { getGrepFields } from './grepFields';
+
+type FieldSpec = {
+    name: string;
+    label?: string;
+    description?: string;
+};
+
+const makeExplore = (over: {
+    name: string;
+    label?: string;
+    aiHint?: string | string[];
+    fields: FieldSpec[];
+}): Explore => ({
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: over.name,
+    label: over.label ?? over.name,
+    tags: [],
+    aiHint: over.aiHint,
+    spotlight: { visibility: 'show', categories: [] },
+    baseTable: over.name,
+    joinedTables: [],
+    tables: {
+        [over.name]: {
+            name: over.name,
+            label: over.label ?? over.name,
+            database: 'test_db',
+            schema: 'public',
+            sqlTable: over.name,
+            sqlWhere: undefined,
+            uncompiledSqlWhere: undefined,
+            description: undefined,
+            dimensions: Object.fromEntries(
+                over.fields.map((f) => [
+                    f.name,
+                    {
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.STRING,
+                        name: f.name,
+                        label: f.label ?? f.name,
+                        table: over.name,
+                        tableLabel: over.label ?? over.name,
+                        sql: `\${TABLE}.${f.name}`,
+                        hidden: false,
+                        source: undefined,
+                        compiledSql: `${over.name}.${f.name}`,
+                        tablesReferences: [over.name],
+                        description: f.description,
+                    },
+                ]),
+            ),
+            metrics: {},
+            lineageGraph: {},
+        },
+    },
+});
+
+type ExecuteResult = {
+    result: string;
+    metadata: {
+        status: string;
+        patternStats?: Array<{
+            pattern: string;
+            matchCount: number;
+            scopeSize: number;
+            matchedAllFields: boolean;
+        }>;
+    };
+};
+
+const ftsField = (name: string, tableName: string) => ({
+    tableName,
+    name,
+    label: name,
+    fieldType: 'dimension',
+    description: undefined,
+    verifiedChartUsage: 0,
+    chartUsage: 0,
+    searchRank: 1,
+});
+
+const execute = async (
+    tool: ReturnType<typeof getGrepFields>,
+    args: { patterns: string[]; exploreName: string | null },
+): Promise<ExecuteResult> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await tool.execute!(args, {} as any);
+    return result as ExecuteResult;
+};
+
+describe('grepFields FTS cross-check on successful greps', () => {
+    const explore = makeExplore({
+        name: 'orders',
+        fields: [
+            { name: 'status', label: 'Status' },
+            { name: 'amount', label: 'Amount' },
+        ],
+    });
+
+    it('appends FTS fields that literal grep missed, even when grep matched', async () => {
+        // FTS (stemming) can find what a literal grep can't — e.g. searching
+        // "statuses" only FTS surfaces the singular field. The cross-check must
+        // run on SUCCESSFUL greps too, not just as a dry-grep fallback.
+        const findExplores = vi.fn(async () => ({
+            topMatchingFields: [ftsField('payment_state', 'payments')],
+        })) as unknown as FindExploresFn;
+        const tool = getGrepFields({
+            availableExplores: [explore],
+            findExplores,
+            verifiedFieldUsage: new Map(),
+        });
+        const { result } = await execute(tool, {
+            patterns: ['status'],
+            exploreName: null,
+        });
+        // grep hit is present…
+        expect(result).toContain('orders_status');
+        // …and the FTS-only field is appended as a cross-check
+        expect(result).toContain('payments_payment_state');
+        expect(findExplores).toHaveBeenCalled();
+    });
+
+    it('does not duplicate fields grep already matched', async () => {
+        const findExplores = vi.fn(async () => ({
+            topMatchingFields: [ftsField('status', 'orders')],
+        })) as unknown as FindExploresFn;
+        const tool = getGrepFields({
+            availableExplores: [explore],
+            findExplores,
+            verifiedFieldUsage: new Map(),
+        });
+        const { result } = await execute(tool, {
+            patterns: ['status'],
+            exploreName: null,
+        });
+        const occurrences = result.split('orders_status').length - 1;
+        expect(occurrences).toBe(1);
+    });
+
+    it('degrades silently when the FTS cross-check fails', async () => {
+        const findExplores = vi.fn(async () => {
+            throw new Error('fts down');
+        }) as unknown as FindExploresFn;
+        const tool = getGrepFields({
+            availableExplores: [explore],
+            findExplores,
+            verifiedFieldUsage: new Map(),
+        });
+        const { result, metadata } = await execute(tool, {
+            patterns: ['status'],
+            exploreName: null,
+        });
+        expect(metadata.status).toBe('success');
+        expect(result).toContain('orders_status');
+    });
+});
+
+describe('grepFields pattern stats metadata', () => {
+    it('reports per-pattern match counts and scope size for monitoring', async () => {
+        const explore = makeExplore({
+            name: 'orders',
+            fields: [
+                { name: 'status', label: 'Status' },
+                { name: 'amount', label: 'Amount' },
+            ],
+        });
+        const findExplores = vi.fn(async () => ({
+            topMatchingFields: [],
+        })) as unknown as FindExploresFn;
+        const tool = getGrepFields({
+            availableExplores: [explore],
+            findExplores,
+            verifiedFieldUsage: new Map(),
+        });
+        const { metadata } = await execute(tool, {
+            patterns: ['status', 'nomatchxyz'],
+            exploreName: null,
+        });
+        expect(metadata.patternStats).toEqual([
+            {
+                pattern: 'status',
+                matchCount: 1,
+                scopeSize: 2,
+                matchedAllFields: false,
+            },
+            {
+                pattern: 'nomatchxyz',
+                matchCount: 0,
+                scopeSize: 2,
+                matchedAllFields: false,
+            },
+        ]);
+    });
+
+    it('flags matchedAllFields — the fingerprint of a broken/too-broad grep', async () => {
+        const explore = makeExplore({
+            name: 'orders',
+            fields: Array.from({ length: 30 }, (_, i) => ({
+                name: `order_attr_${i}`,
+                label: `Order Attr ${i}`,
+            })),
+        });
+        const findExplores = vi.fn(async () => ({
+            topMatchingFields: [],
+        })) as unknown as FindExploresFn;
+        const tool = getGrepFields({
+            availableExplores: [explore],
+            findExplores,
+            verifiedFieldUsage: new Map(),
+        });
+        const { metadata } = await execute(tool, {
+            patterns: ['order'],
+            exploreName: 'orders',
+        });
+        expect(metadata.patternStats).toHaveLength(1);
+        expect(metadata.patternStats![0]).toMatchObject({
+            matchCount: 30,
+            scopeSize: 30,
+            matchedAllFields: true,
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/grepFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFields.ts
@@ -1,5 +1,6 @@
 import { grepFieldsToolDefinition, type Explore } from '@lightdash/common';
 import { tool } from 'ai';
+import Logger from '../../../../logging/logger';
 import type { FindExploresFn } from '../types/aiAgentDependencies';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
@@ -226,59 +227,104 @@ export const getGrepFields = ({
                 const scopedExplores = exploreName ? [] : getExploreIndex();
                 // Each pattern is matched against the whole (pre-filtered) index
                 // in one pass — "parallel" greps without an extra round-trip.
-                const blocks = patterns.map((pattern) => {
+                const perPattern = patterns.map((pattern) => {
                     const matches = compileMatcher(pattern);
                     const hits = scoped.filter((e) => matches(e.haystack));
                     const exploreHits = scopedExplores.filter((e) =>
                         matches(e.haystack),
                     );
-                    return renderPattern(
+                    return {
                         pattern,
                         hits,
-                        exploreHits,
-                        matches,
-                        scoped.length,
-                        requiredFiltersByExplore,
-                    );
-                });
-                const anyHit = blocks.some((b) => b.isSignal);
-                if (anyHit) {
-                    return {
-                        result: blocks.map((b) => b.text).join('\n\n'),
-                        metadata: { status: 'success' as const },
+                        block: renderPattern(
+                            pattern,
+                            hits,
+                            exploreHits,
+                            matches,
+                            scoped.length,
+                            requiredFiltersByExplore,
+                        ),
                     };
+                });
+                const blocks = perPattern.map((p) => p.block);
+                // Persisted with the tool result: makes grep quality observable
+                // in production. matchedAllFields is the fingerprint of a
+                // too-broad or broken grep.
+                const patternStats = perPattern.map((p) => ({
+                    pattern: p.pattern,
+                    matchCount: p.hits.length,
+                    scopeSize: scoped.length,
+                    matchedAllFields:
+                        scoped.length > 0 && p.hits.length === scoped.length,
+                }));
+                if (patternStats.some((s) => s.matchedAllFields)) {
+                    Logger.warn('grepFields pattern matched all fields', {
+                        patterns,
+                        exploreName,
+                        scopeSize: scoped.length,
+                    });
                 }
 
-                // Literal grep is dry — fall back to FTS (stemming + recall) so
-                // the agent gets matches now instead of re-grepping synonyms.
-                // A fallback failure degrades to the plain "no matches" message
-                // rather than erroring the whole (otherwise successful) grep.
+                // FTS (stemming + recall) runs on EVERY grep, not just dry
+                // ones: a grep that "succeeds" with plausible-but-wrong hits
+                // would otherwise suppress the search mode that finds what the
+                // literal grep missed. Failures degrade to grep-only results.
                 let ftsFields: NonNullable<
                     Awaited<
                         ReturnType<typeof findExplores>
                     >['topMatchingFields']
                 > = [];
                 try {
-                    const fallback = await findExplores({
+                    const fts = await findExplores({
                         fieldSearchSize: 25,
                         searchQuery: toFtsQuery(patterns),
                     });
-                    ftsFields = (fallback.topMatchingFields ?? []).filter(
+                    ftsFields = (fts.topMatchingFields ?? []).filter(
                         (f) => !exploreName || f.tableName === exploreName,
                     );
                 } catch {
                     ftsFields = [];
                 }
+
+                const blocksText = blocks.map((b) => b.text).join('\n\n');
+                const anyHit = blocks.some((b) => b.isSignal);
+                if (anyHit) {
+                    // Cross-check: append only FTS fields the grep did not
+                    // already surface, so stemmed matches aren't lost without
+                    // duplicating what the agent can already see.
+                    const greppedFieldIds = new Set(
+                        perPattern.flatMap((p) =>
+                            p.hits.map((h) => h.path.split('/')[1]),
+                        ),
+                    );
+                    const novel = ftsFields.filter(
+                        (f) => !greppedFieldIds.has(`${f.tableName}_${f.name}`),
+                    );
+                    const crossCheck =
+                        novel.length > 0
+                            ? `\n\nCatalog fuzzy search also matches (not in the grep results above):\n${novel
+                                  .slice(0, 8)
+                                  .map(
+                                      (f) =>
+                                          `  ${f.tableName}_${f.name}  [${f.fieldType}] ${f.label}`,
+                                  )
+                                  .join('\n')}`
+                            : '';
+                    return {
+                        result: `${blocksText}${crossCheck}`,
+                        metadata: { status: 'success' as const, patternStats },
+                    };
+                }
+
                 const scope = exploreName ? ` in explore "${exploreName}"` : '';
                 // Keep the per-pattern diagnosis (e.g. "matched all N fields")
                 // in front of the fallback so the agent knows WHY grep is dry.
-                const blocksText = blocks.map((b) => b.text).join('\n\n');
                 return {
                     result:
                         ftsFields.length > 0
                             ? `${blocksText}\n\n${renderFtsFallback(ftsFields)}`
                             : `${blocksText}\n\nNo fields matched any of the patterns${scope}, and the catalog search found nothing close. Try broader or alternative keywords.`,
-                    metadata: { status: 'success' as const },
+                    metadata: { status: 'success' as const, patternStats },
                 };
             } catch (error) {
                 return {

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGrepFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGrepFieldsArgs.ts
@@ -29,9 +29,23 @@ export const grepFieldsInputSchema = z.object({
 
 export type ToolGrepFieldsArgs = z.infer<typeof grepFieldsInputSchema>;
 
+// Per-pattern match stats, persisted with the tool result so grep quality is
+// observable in production. `matchedAllFields` is the fingerprint of a
+// too-broad or broken grep (the pattern discriminated nothing in its scope).
+export const grepFieldsPatternStatsSchema = z.array(
+    z.object({
+        pattern: z.string(),
+        matchCount: z.number(),
+        scopeSize: z.number(),
+        matchedAllFields: z.boolean(),
+    }),
+);
+
 export const toolGrepFieldsOutputSchema = z.object({
     result: z.string(),
-    metadata: baseOutputMetadataSchema,
+    metadata: baseOutputMetadataSchema.extend({
+        patternStats: grepFieldsPatternStatsSchema.optional(),
+    }),
 });
 
 export type ToolGrepFieldsOutput = z.infer<typeof toolGrepFieldsOutputSchema>;


### PR DESCRIPTION
Stacked on #25094 (base branch is `fix/grep-fields-haystack-pollution`; rebase onto main once that merges).

#25094 fixes the grepFields precision bug at its root. This PR adds four defense layers so that a single lossy discovery step can never again convince the agent that a modeled field doesn't exist:

## 1. Break the getMetadata → grepFields circularity
The explore summary used to end with `fields: N dimensions, M metrics (use grepFields to list them)` — when grep is the tool misbehaving, the agent's only verification path looped back into it, making a search miss unfalsifiable. The summary now lists the base table's visible field ids directly (`base dimensions (N): …` / `base metrics (N): …`), capped at 120 per kind with a `+N more` overflow marker; joined tables keep a pointer to scoped grep.

## 2. FTS cross-check on every grep, not just dry ones
The FTS catalog fallback previously fired only when literal grep returned zero matches — a grep that "succeeded" with plausible-but-wrong hits suppressed the search mode that would have found the right field. FTS now runs on every call; fields it finds that the grep didn't are appended as a compact `Catalog fuzzy search also matches` section (up to 8, deduped against grep hits). FTS failures degrade silently to grep-only results.

## 3. "False absence" agent eval
New integration eval case: a false-premise prompt ("I don't think we track how customers pay us, but…") about a field that **does** exist in the eval project (`payments.payment_method`). The judge fails the run if the agent agrees the data is missing instead of finding the field. This failure mode — confidently wrong, no error anywhere — is otherwise invisible to CI.

## 4. Monitoring fingerprint for grep quality
grepFields now returns `patternStats` (`pattern`, `matchCount`, `scopeSize`, `matchedAllFields`) in its tool-result metadata — persisted to `ai_agent_tool_result.metadata`, so grep quality is queryable in production — and logs a `grepFields pattern matched all fields` warning for log-based alerting. `matchedAllFields` (match count == scope size) is exactly the fingerprint the original incident showed. Schema change is an optional field on `toolGrepFieldsOutputSchema`; the frontend does not read grep metadata.

## Tests
TDD for 1, 2 and 4: new cases in `getMetadata.test.ts` and new `grepFields.hardening.test.ts`, written first and watched fail. Layer 3 is an eval-suite addition and runs in the eval harness (needs LLM keys + seeded project), not in unit CI. Full AI suite (659 tests), backend + common typecheck, and lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEz2UXs9Q2N782to2hZbpB