### PR TITLE
fix(ai): use theme-aware text color for viz field chips

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationMetricsAndDimensions.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationMetricsAndDimensions.module.css
@@ -1,6 +1,7 @@
 .itemButton {
     cursor: default;
     border: none;
+    color: var(--mantine-color-dark-7);
 }
 
 .itemButton:hover {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationMetricsAndDimensions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationMetricsAndDimensions.tsx
@@ -143,7 +143,7 @@ const MetricDimensionItem: FC<{
                     style={{ backgroundColor: itemColors.bg }}
                     styles={{
                         inner: {
-                            color: 'black',
+                            color: 'var(--mantine-color-ldDark-9)',
                         },
                         label: {
                             maxWidth: '100%',


### PR DESCRIPTION
## Summary

The AI visualization metric/dimension chips rendered their label text with a hardcoded `black` (inline `styles.inner.color`) and no `.itemButton` color, so the field name was near-invisible against the chip background in dark mode. This swaps both to Mantine theme variables so the label stays legible across color schemes.

- `.itemButton` now sets `color: var(--mantine-color-dark-7)`
- inline label color `'black'` → `var(--mantine-color-ldDark-9)`

## Testing

Verified the field chips render with legible text in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJaUXm1tybgoxFqUgZTQC