### PR TITLE
feat(data-apps): persistent lineage selection + upgrade hint on disabled Inspect-data toggle (GLITCH-590)

### DIFF
--- a/packages/frontend/src/features/apps/AppInspector.module.css
+++ b/packages/frontend/src/features/apps/AppInspector.module.css
@@ -150,16 +150,21 @@
     }
 }
 
+/* Persistent while the query stays selected (lineage click-select) — the
+   entry flash draws the eye, then settles on a lasting tint + accent bar
+   matching the in-app element outline (#7c3aed). */
 .queryRowFocused {
     animation: queryRowFlash 1.2s ease-out;
+    background-color: rgba(124, 58, 237, 0.1);
+    box-shadow: inset 2px 0 0 0 #7c3aed;
 }
 
 @keyframes queryRowFlash {
     0% {
-        background-color: rgba(124, 58, 237, 0.18);
+        background-color: rgba(124, 58, 237, 0.28);
     }
     100% {
-        background-color: transparent;
+        background-color: rgba(124, 58, 237, 0.1);
     }
 }
 

--- a/packages/frontend/src/features/apps/AppInspectorPanel.test.tsx
+++ b/packages/frontend/src/features/apps/AppInspectorPanel.test.tsx
@@ -141,15 +141,33 @@ describe('AppInspectorPanel lineage hooks', () => {
             expect(onToggleLineage).toHaveBeenCalledTimes(1);
         });
 
-        it('disables the toggle when lineage is unavailable', () => {
+        it('marks the toggle disabled and ignores clicks when lineage is unavailable', () => {
+            const onToggleLineage = vi.fn();
+            renderPanel({
+                onToggleLineage,
+                lineageAvailable: false,
+                defaultCollapsed: false,
+            });
+            const toggle = screen.getByLabelText(
+                'Toggle data lineage inspector',
+            );
+            expect(toggle).toHaveAttribute('data-disabled');
+            fireEvent.click(toggle);
+            expect(onToggleLineage).not.toHaveBeenCalled();
+        });
+
+        it('explains the upgrade path in the tooltip when lineage is unavailable', async () => {
             renderPanel({
                 onToggleLineage: vi.fn(),
                 lineageAvailable: false,
                 defaultCollapsed: false,
             });
-            expect(
+            fireEvent.mouseEnter(
                 screen.getByLabelText('Toggle data lineage inspector'),
-            ).toBeDisabled();
+            );
+            expect(
+                await screen.findByText(/upgrade the app/i),
+            ).toBeInTheDocument();
         });
     });
 });

--- a/packages/frontend/src/features/apps/AppInspectorPanel.tsx
+++ b/packages/frontend/src/features/apps/AppInspectorPanel.tsx
@@ -232,13 +232,20 @@ const AppInspectorPanel: FC<Props> = ({
                         {onToggleLineage && activeTab === 'queries' && (
                             <Tooltip
                                 label={
-                                    lineageEnabled
-                                        ? 'Inspect data: on'
-                                        : 'Inspect data'
+                                    !lineageAvailable
+                                        ? 'Inspect data is not available in this app version — upgrade the app (regenerate it) to enable it'
+                                        : lineageEnabled
+                                          ? 'Inspect data: on'
+                                          : 'Inspect data'
                                 }
                                 withArrow
                                 position="top"
+                                maw={260}
+                                multiline
                             >
+                                {/* data-disabled (not disabled): a truly
+                                    disabled button swallows the hover events
+                                    the explanatory tooltip needs. */}
                                 <ActionIcon
                                     variant={
                                         lineageEnabled ? 'filled' : 'subtle'
@@ -247,9 +254,13 @@ const AppInspectorPanel: FC<Props> = ({
                                     size="xs"
                                     onClick={(e) => {
                                         e.stopPropagation();
+                                        if (!lineageAvailable) return;
                                         onToggleLineage();
                                     }}
-                                    disabled={!lineageAvailable}
+                                    data-disabled={
+                                        !lineageAvailable || undefined
+                                    }
+                                    aria-disabled={!lineageAvailable}
                                     aria-label="Toggle data lineage inspector"
                                 >
                                     <MantineIcon

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -2849,6 +2849,10 @@ const AppGenerate: FC = () => {
                                                             );
                                                         return next;
                                                     });
+                                                    // Entering inspector mode
+                                                    // force-disables lineage —
+                                                    // drop its selection too.
+                                                    setFocusedQueryUuid(null);
                                                 }}
                                                 disabled={!inspectorAvailable}
                                             />

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -569,13 +569,18 @@ const AppGenerate: FC = () => {
     const handleLineageSelected = useCallback(
         (event: { queryUuid: string }) => {
             setNetworkPanelHidden(false);
-            setFocusedQueryUuid(event.queryUuid);
+            // Selection persists (row highlight + in-app element outline);
+            // re-clicking the selected element deselects it.
+            setFocusedQueryUuid((prev) =>
+                prev === event.queryUuid ? null : event.queryUuid,
+            );
         },
         [],
     );
 
     const handleLineageCancelled = useCallback(() => {
         setLineageEnabled(false);
+        setFocusedQueryUuid(null);
     }, []);
 
     const handleToggleLineage = useCallback(() => {
@@ -584,6 +589,7 @@ const AppGenerate: FC = () => {
             if (next) setInspectorEnabled(false);
             return next;
         });
+        setFocusedQueryUuid(null);
     }, []);
     const [localMessages, setLocalMessages] = useState<ChatMessage[]>([]);
     // Pre-build clarification round: captured submission args that we need
@@ -3076,7 +3082,9 @@ const AppGenerate: FC = () => {
                                             handleLineageSelected
                                         }
                                         lineageHighlightQueryUuid={
-                                            hoveredQueryUuid
+                                            // Hover overrides; falls back to
+                                            // the persistent click-selection.
+                                            hoveredQueryUuid ?? focusedQueryUuid
                                         }
                                         onLineageCancelled={
                                             handleLineageCancelled

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -101,21 +101,25 @@ export default function AppPreviewTest() {
         clearExternalRequests();
     }, [clearQueries, clearExternalRequests]);
 
-    const handleToggleLineage = useCallback(
-        () => setLineageEnabled((v) => !v),
-        [],
-    );
+    const handleToggleLineage = useCallback(() => {
+        setLineageEnabled((v) => !v);
+        setFocusedQueryUuid(null);
+    }, []);
     const handleLineageSelected = useCallback(
         (event: { queryUuid: string }) => {
             setNetworkPanelHidden(false);
-            setFocusedQueryUuid(event.queryUuid);
+            // Selection persists (row highlight + in-app element outline);
+            // re-clicking the selected element deselects it.
+            setFocusedQueryUuid((prev) =>
+                prev === event.queryUuid ? null : event.queryUuid,
+            );
         },
         [],
     );
-    const handleLineageCancelled = useCallback(
-        () => setLineageEnabled(false),
-        [],
-    );
+    const handleLineageCancelled = useCallback(() => {
+        setLineageEnabled(false);
+        setFocusedQueryUuid(null);
+    }, []);
 
     const previewOrigin = usePreviewOrigin();
 
@@ -275,7 +279,11 @@ export default function AppPreviewTest() {
                     lineageEnabled={lineageEnabled}
                     onLineageAvailabilityChange={setLineageAvailable}
                     onLineageSelected={handleLineageSelected}
-                    lineageHighlightQueryUuid={hoveredQueryUuid}
+                    lineageHighlightQueryUuid={
+                        // Hover overrides; falls back to the persistent
+                        // click-selection.
+                        hoveredQueryUuid ?? focusedQueryUuid
+                    }
                     onLineageCancelled={handleLineageCancelled}
                 />
                 {!networkPanelHidden && (


### PR DESCRIPTION
## Problem

Feedback on the data-lineage inspect flow (GLITCH-532): the connection between a data-app chart and the query inspector wasn't obvious enough.

1. Clicking a chart element in Inspect-data mode flashed the query row for 1.2s and expanded it — then all visual connection evaporated. The in-app element outline only ever appeared while *hovering* a query row.
2. The Inspect-data toggle can be disabled (app without lineage stamps — see GLITCH-575) with no explanation, leaving users staring at a dead button.

## Solution (parent-side only — works with already-generated apps that have the lineage runtime)

- **Persistent selection.** `lineageHighlightQueryUuid` now falls back from row-hover to the click-selection (`hoveredQueryUuid ?? focusedQueryUuid`), so the clicked element keeps the purple outline; hovering another row temporarily overrides and returns on mouse-leave. `.queryRowFocused` keeps its entry flash but settles on a lasting tint + accent bar matching the element outline. Re-clicking the selected element deselects (the parent toggles on repeated `lineage:selected` for the same query); leaving Inspect-data mode (toggle or Esc) clears the selection. Applied to both the builder (`AppGenerate`) and preview (`AppPreviewTest`) pages.
- **Upgrade hint.** The disabled Inspect-data toggle now explains: "Inspect data is not available in this app version — upgrade the app (regenerate it) to enable it". Uses `data-disabled` + a click guard instead of `disabled` because a truly disabled button swallows the hover events the tooltip needs.

## Testing

- Unit: toggle marked `data-disabled` + click ignored when unavailable; tooltip shows the upgrade path (AppInspectorPanel.test.tsx, 12/12).
- Live against local dev on a stamped generated app: click-select → element outline + row highlight persist minutes after the flash (computed style pinned: `rgba(124,58,237,.1)` bg + inset accent); the highlight renders through the selection fallback with no hover; re-click deselects both sides; hover still overrides.

Closes: GLITCH-590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
