### PR TITLE
fix(conditional-formatting): saturate out-of-range values in color scales

### DIFF
--- a/packages/common/src/utils/colors.test.ts
+++ b/packages/common/src/utils/colors.test.ts
@@ -116,9 +116,9 @@ describe('cleanColorArray', () => {
 
 describe('getColorFromRange', () => {
     it('should interpolate a color for a value within the range', () => {
-        expect(
-            getColorFromRange(50, colorRange, { min: 0, max: 100 }),
-        ).toBe('#808080');
+        expect(getColorFromRange(50, colorRange, { min: 0, max: 100 })).toBe(
+            '#808080',
+        );
     });
 
     it('should return the start color for the min value', () => {
@@ -159,10 +159,14 @@ describe('getColorFromRange', () => {
 
     it('should return undefined for invalid color range', () => {
         expect(
-            getColorFromRange(50, { start: 'red', end: '#000000' }, {
-                min: 0,
-                max: 100,
-            }),
+            getColorFromRange(
+                50,
+                { start: 'red', end: '#000000' },
+                {
+                    min: 0,
+                    max: 100,
+                },
+            ),
         ).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/colors.test.ts
+++ b/packages/common/src/utils/colors.test.ts
@@ -1,4 +1,11 @@
-import { cleanColorArray, getInvalidHexColors, isHexCodeColor } from './colors';
+import {
+    cleanColorArray,
+    getColorFromRange,
+    getInvalidHexColors,
+    isHexCodeColor,
+} from './colors';
+
+const colorRange = { start: '#fff', end: '#000000' };
 
 describe('isHexCodeColor', () => {
     it('should return true for valid 3-digit hex colors', () => {
@@ -104,5 +111,58 @@ describe('cleanColorArray', () => {
         const expectedCleanedColors = ['#123', 'red', '#456789', 'blue'];
 
         expect(cleanColorArray(mixedColors)).toEqual(expectedCleanedColors);
+    });
+});
+
+describe('getColorFromRange', () => {
+    it('should interpolate a color for a value within the range', () => {
+        expect(
+            getColorFromRange(50, colorRange, { min: 0, max: 100 }),
+        ).toBe('#808080');
+    });
+
+    it('should return the start color for the min value', () => {
+        expect(getColorFromRange(0, colorRange, { min: 0, max: 100 })).toBe(
+            '#fff',
+        );
+    });
+
+    it('should return the end color for the max value', () => {
+        expect(getColorFromRange(100, colorRange, { min: 0, max: 100 })).toBe(
+            '#000',
+        );
+    });
+
+    it('should saturate to the end color for values above the max', () => {
+        expect(getColorFromRange(400, colorRange, { min: 0, max: 100 })).toBe(
+            '#000',
+        );
+    });
+
+    it('should saturate to the start color for values below the min', () => {
+        expect(getColorFromRange(0, colorRange, { min: 10, max: 100 })).toBe(
+            '#fff',
+        );
+    });
+
+    it('should return undefined when min is greater than max', () => {
+        expect(
+            getColorFromRange(50, colorRange, { min: 100, max: 0 }),
+        ).toBeUndefined();
+    });
+
+    it('should return the end color when min equals max', () => {
+        expect(getColorFromRange(50, colorRange, { min: 50, max: 50 })).toBe(
+            '#000',
+        );
+    });
+
+    it('should return undefined for invalid color range', () => {
+        expect(
+            getColorFromRange(50, { start: 'red', end: '#000000' }, {
+                min: 0,
+                max: 100,
+            }),
+        ).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/colors.ts
+++ b/packages/common/src/utils/colors.ts
@@ -68,7 +68,7 @@ export const getColorFromRange = (
     if (!interpolateColor) return undefined;
 
     const { min, max } = minMaxRange;
-    if (min > max || value < min || value > max) {
+    if (min > max) {
         return undefined;
     }
 
@@ -76,7 +76,10 @@ export const getColorFromRange = (
         return interpolateColor(1).toString({ format: 'hex' });
     }
 
-    const percentage = (value - min) / (max - min);
+    // Clamp values outside the range so out-of-range values saturate to the
+    // start/end colors rather than rendering with no color.
+    const clamped = Math.min(Math.max(value, min), max);
+    const percentage = (clamped - min) / (max - min);
 
     return interpolateColor(percentage).toString({ format: 'hex' });
 };

--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -1,4 +1,7 @@
-import { ConditionalFormattingColorApplyTo } from '../types/conditionalFormatting';
+import {
+    ConditionalFormattingColorApplyTo,
+    type ConditionalFormattingConfig,
+} from '../types/conditionalFormatting';
 import { DimensionType, FieldType } from '../types/field';
 import { FilterOperator } from '../types/filter';
 import {
@@ -194,7 +197,7 @@ describe('hasMatchingConditionalRules', () => {
             ).toBe(true);
         });
 
-        it('should match values above the max so they can clamp to the end color', () => {
+        it('should not match values above the max', () => {
             expect(
                 hasMatchingConditionalRules(
                     mockNumericField,
@@ -202,10 +205,10 @@ describe('hasMatchingConditionalRules', () => {
                     {},
                     colorRangeConfig,
                 ),
-            ).toBe(true);
+            ).toBe(false);
         });
 
-        it('should match values below the min so they can clamp to the start color', () => {
+        it('should not match values below the min', () => {
             expect(
                 hasMatchingConditionalRules(
                     mockNumericField,
@@ -213,7 +216,7 @@ describe('hasMatchingConditionalRules', () => {
                     {},
                     colorRangeConfig,
                 ),
-            ).toBe(true);
+            ).toBe(false);
         });
 
         it('should not match when min is greater than max', () => {
@@ -286,6 +289,98 @@ describe('getConditionalFormattingConfig', () => {
                 conditionalFormattings,
             }),
         ).toBe(textConfig);
+    });
+
+    describe('color range rules with out-of-range values', () => {
+        const lowRange = {
+            target: null,
+            color: { start: '#ffffff', end: '#0000ff' },
+            rule: { min: 0, max: 100 },
+        };
+        const highRange = {
+            target: null,
+            color: { start: '#ffffff', end: '#ff0000' },
+            rule: { min: 100, max: 200 },
+        };
+        const singleColorAbove500 = {
+            target: null,
+            color: '#00ff00',
+            rules: [
+                {
+                    id: '1',
+                    operator: FilterOperator.GREATER_THAN,
+                    values: [500],
+                },
+            ],
+        };
+
+        const pick = (
+            value: number,
+            conditionalFormattings: ConditionalFormattingConfig[],
+        ) =>
+            getConditionalFormattingConfig({
+                field: mockNumericField,
+                value,
+                minMaxMap: {},
+                conditionalFormattings,
+            });
+
+        it('returns a single color range rule for an out-of-range value so it can clamp', () => {
+            expect(pick(999, [lowRange])).toBe(lowRange);
+            expect(pick(-10, [lowRange])).toBe(lowRange);
+        });
+
+        it('prefers the rule whose range contains the value over a later range rule', () => {
+            expect(pick(50, [lowRange, highRange])).toBe(lowRange);
+            expect(pick(150, [lowRange, highRange])).toBe(highRange);
+        });
+
+        it('falls back to the last color range rule when the value is outside all ranges', () => {
+            expect(pick(999, [lowRange, highRange])).toBe(highRange);
+        });
+
+        it('prefers a matching single color rule over an out-of-range color range rule', () => {
+            expect(pick(600, [singleColorAbove500, lowRange])).toBe(
+                singleColorAbove500,
+            );
+        });
+
+        it('falls back to a color range rule when no rule matches strictly', () => {
+            expect(pick(300, [lowRange, singleColorAbove500])).toBe(lowRange);
+        });
+
+        it('does not fall back to a color range rule with min greater than max', () => {
+            expect(
+                pick(300, [{ ...lowRange, rule: { min: 100, max: 0 } }]),
+            ).toBeUndefined();
+        });
+
+        it('does not fall back to a color range rule targeting another field', () => {
+            expect(
+                pick(999, [
+                    {
+                        ...lowRange,
+                        target: { fieldId: 'other_table_other_field' },
+                    },
+                ]),
+            ).toBeUndefined();
+        });
+
+        it('respects applyTo when falling back', () => {
+            const textRange = {
+                ...lowRange,
+                applyTo: ConditionalFormattingColorApplyTo.TEXT,
+            };
+            expect(
+                getConditionalFormattingConfig({
+                    field: mockNumericField,
+                    value: 999,
+                    minMaxMap: {},
+                    conditionalFormattings: [textRange],
+                    applyTo: ConditionalFormattingColorApplyTo.CELL,
+                }),
+            ).toBeUndefined();
+        });
     });
 });
 

--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -175,6 +175,72 @@ describe('hasMatchingConditionalRules', () => {
             expect(result).toBe(true);
         });
     });
+
+    describe('color range config', () => {
+        const colorRangeConfig = {
+            target: null,
+            color: { start: '#ffffff', end: '#000000' },
+            rule: { min: 100, max: 1000 },
+        };
+
+        it('should match values within the range', () => {
+            expect(
+                hasMatchingConditionalRules(
+                    mockNumericField,
+                    500,
+                    {},
+                    colorRangeConfig,
+                ),
+            ).toBe(true);
+        });
+
+        it('should match values above the max so they can clamp to the end color', () => {
+            expect(
+                hasMatchingConditionalRules(
+                    mockNumericField,
+                    2397,
+                    {},
+                    colorRangeConfig,
+                ),
+            ).toBe(true);
+        });
+
+        it('should match values below the min so they can clamp to the start color', () => {
+            expect(
+                hasMatchingConditionalRules(
+                    mockNumericField,
+                    38,
+                    {},
+                    colorRangeConfig,
+                ),
+            ).toBe(true);
+        });
+
+        it('should not match when min is greater than max', () => {
+            expect(
+                hasMatchingConditionalRules(
+                    mockNumericField,
+                    500,
+                    {},
+                    {
+                        ...colorRangeConfig,
+                        rule: { min: 1000, max: 100 },
+                    },
+                ),
+            ).toBe(false);
+        });
+
+        it('should not match non-numeric values', () => {
+            expect(
+                hasMatchingConditionalRules(
+                    mockNumericField,
+                    'not a number',
+                    {},
+                    colorRangeConfig,
+                ),
+            ).toBe(false);
+        });
+    });
 });
 
 describe('getConditionalFormattingConfig', () => {

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -127,6 +127,7 @@ export const hasMatchingConditionalRules = (
     minMaxMap: ConditionalFormattingMinMaxMap,
     config: ConditionalFormattingConfig | undefined,
     rowFields?: ConditionalFormattingRowFields,
+    options?: { matchOutOfRangeValues?: boolean },
 ) => {
     if (!config) return false;
 
@@ -514,9 +515,13 @@ export const hasMatchingConditionalRules = (
             max = config.rule.max;
         }
 
-        // Out-of-range values still match — they are clamped to the range
-        // colors by getColorFromRange
-        return min <= max;
+        if (min > max) return false;
+
+        // With matchOutOfRangeValues, out-of-range values match so they can be
+        // clamped to the range colors by getColorFromRange
+        if (options?.matchOutOfRangeValues) return true;
+
+        return convertedValue >= min && convertedValue <= max;
     }
 
     return assertUnreachable(config, 'Unknown conditional formatting config');
@@ -549,23 +554,41 @@ export const getConditionalFormattingConfig = ({
     )
         return undefined;
 
-    return findLast(conditionalFormattings, (config) => {
-        if (
-            applyTo !== undefined &&
-            (config.applyTo ?? ConditionalFormattingColorApplyTo.CELL) !==
-                applyTo
-        ) {
-            return false;
-        }
+    const matchesApplyTo = (config: ConditionalFormattingConfig) =>
+        applyTo === undefined ||
+        (config.applyTo ?? ConditionalFormattingColorApplyTo.CELL) === applyTo;
 
-        return hasMatchingConditionalRules(
-            field,
-            value,
-            minMaxMap,
-            config,
-            rowFields,
-        );
-    });
+    const strictMatch = findLast(
+        conditionalFormattings,
+        (config) =>
+            matchesApplyTo(config) &&
+            hasMatchingConditionalRules(
+                field,
+                value,
+                minMaxMap,
+                config,
+                rowFields,
+            ),
+    );
+    if (strictMatch) return strictMatch;
+
+    // Fall back to the last color range rule so out-of-range values saturate
+    // to the range colors instead of rendering with no color. Rules whose
+    // range contains the value always take precedence via the strict pass.
+    return findLast(
+        conditionalFormattings,
+        (config) =>
+            isConditionalFormattingConfigWithColorRange(config) &&
+            matchesApplyTo(config) &&
+            hasMatchingConditionalRules(
+                field,
+                value,
+                minMaxMap,
+                config,
+                rowFields,
+                { matchOutOfRangeValues: true },
+            ),
+    );
 };
 
 export const getConditionalFormattingDescription = (

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -490,7 +490,8 @@ export const hasMatchingConditionalRules = (
     }
 
     if (isConditionalFormattingConfigWithColorRange(config)) {
-        if (typeof convertedValue !== 'number') return false;
+        if (typeof convertedValue !== 'number' || Number.isNaN(convertedValue))
+            return false;
 
         let min: number;
         let max: number;
@@ -513,7 +514,9 @@ export const hasMatchingConditionalRules = (
             max = config.rule.max;
         }
 
-        return convertedValue >= min && convertedValue <= max;
+        // Out-of-range values still match — they are clamped to the range
+        // colors by getColorFromRange
+        return min <= max;
     }
 
     return assertUnreachable(config, 'Unknown conditional formatting config');


### PR DESCRIPTION
When a color-scale conditional formatting rule has a custom min/max, values outside the range rendered with no color (blank), which reads as "no data" and hides outliers.

`getColorFromRange` now clamps values to the range so out-of-range values saturate to the start/end colors — standard spreadsheet color-scale behavior. This is a shared function, so table, pivot table, and Excel/CSV exports all get the corrected behavior.

- Value above max → end color; value below min → start color.
- Auto min/max unchanged (values are in range by construction); `min > max` still returns no color.

**Multiple rules**: rule selection in `getConditionalFormattingConfig` is now two-pass so stacked rules keep their existing precedence:

1. Strict pass (unchanged behavior): last rule whose condition/range actually contains the value wins.
2. Fallback pass: only when no rule matches strictly, the last color-range rule targeting the field is used and the value is clamped to its colors.

So a value inside one of several stacked ranges is colored by that range exactly as before; single-color rules keep winning whenever they match; only values that no rule covers saturate on the last color-range rule instead of rendering blank.

Added unit tests for `getColorFromRange` in `colors.test.ts` and multi-rule precedence/fallback tests in `conditionalFormatting.test.ts`.

Closes #25102