### PR TITLE
fix(dashboard): scope chart tile description tooltip to title text

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -44,8 +44,9 @@
     text-decoration: none;
 
     display: block;
-    flex: 1;
+    flex: 0 1 auto;
     min-width: 0;
+    max-width: 100%;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Problem

The description hover tooltip on dashboard chart tiles activated over the whole header width — including near the edit controls in the top-right — rather than only over the title text.

## Cause

`.tileTitle` used `flex: 1` (`flex: 1 1 0%`), stretching the title element to fill the entire header row even when the text was short. Since the Mantine `Tooltip` wraps that element, hovering anywhere along its full width triggered the description.

## Fix

Size the title element to its content (`flex: 0 1 auto` + `max-width: 100%`). Short titles now occupy only their text width, so the hover target matches the visible title. Long titles still shrink and ellipsize via the existing `min-width: 0`, and the hover-to-expand behaviour is unaffected.

Single-file CSS change in `TileBase.module.css`.