### PR TITLE
feat(tables): scope conditional formatting to data cells or totals

### DIFF
--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -557,6 +557,11 @@
             "enum": ["raw", "percentage"],
             "type": "string"
         },
+        "ConditionalFormattingAppliesTo": {
+            "description": "Scopes a conditional formatting rule to data cells, total cells (row/column\ntotals and subtotals), or both. Defaults to ALL for backwards compatibility\nwith charts saved before this option existed.",
+            "enum": ["all", "data", "totals"],
+            "type": "string"
+        },
         "ConditionalFormattingColorApplyTo": {
             "enum": ["cell", "text", "row"],
             "type": "string"
@@ -587,6 +592,10 @@
         },
         "ConditionalFormattingConfigWithColorRange": {
             "properties": {
+                "appliesTo": {
+                    "$ref": "#/$defs/ConditionalFormattingAppliesTo",
+                    "description": "Scope the rule to data cells only, total cells only, or both (default)"
+                },
                 "applyTo": {
                     "$ref": "#/$defs/ConditionalFormattingColorApplyTo",
                     "description": "Apply formatting to cell background or text"
@@ -624,6 +633,10 @@
         },
         "ConditionalFormattingConfigWithSingleColor": {
             "properties": {
+                "appliesTo": {
+                    "$ref": "#/$defs/ConditionalFormattingAppliesTo",
+                    "description": "Scope the rule to data cells only, total cells only, or both (default)"
+                },
                 "applyTo": {
                     "$ref": "#/$defs/ConditionalFormattingColorApplyTo",
                     "description": "Apply formatting to cell background or text"

--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -61,6 +61,8 @@ export type ConditionalFormattingConfigWithSingleColor = {
     rules: ConditionalFormattingWithFilterOperator[];
     /** Apply formatting to cell background or text */
     applyTo?: ConditionalFormattingColorApplyTo;
+    /** Scope the rule to data cells only, total cells only, or both (default) */
+    appliesTo?: ConditionalFormattingAppliesTo;
     /** Text styling (bold/italic/underline) applied to matching cell text */
     textStyle?: ConditionalFormattingTextStyle;
 };
@@ -79,6 +81,8 @@ export type ConditionalFormattingConfigWithColorRange = {
     rule: ConditionalFormattingMinMax<number | 'auto'>;
     /** Apply formatting to cell background or text */
     applyTo?: ConditionalFormattingColorApplyTo;
+    /** Scope the rule to data cells only, total cells only, or both (default) */
+    appliesTo?: ConditionalFormattingAppliesTo;
     /** Text styling (bold/italic/underline) applied to matching cell text */
     textStyle?: ConditionalFormattingTextStyle;
 };
@@ -134,6 +138,17 @@ export enum ConditionalFormattingColorApplyTo {
     CELL = 'cell',
     TEXT = 'text',
     ROW = 'row',
+}
+
+/**
+ * Scopes a conditional formatting rule to data cells, total cells (row/column
+ * totals and subtotals), or both. Defaults to ALL for backwards compatibility
+ * with charts saved before this option existed.
+ */
+export enum ConditionalFormattingAppliesTo {
+    ALL = 'all',
+    DATA = 'data',
+    TOTALS = 'totals',
 }
 
 export type ConditionalRuleLabel = {

--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -1,7 +1,11 @@
-import { ConditionalFormattingColorApplyTo } from '../types/conditionalFormatting';
+import {
+    ConditionalFormattingAppliesTo,
+    ConditionalFormattingColorApplyTo,
+} from '../types/conditionalFormatting';
 import { DimensionType, FieldType } from '../types/field';
 import { FilterOperator } from '../types/filter';
 import {
+    conditionalFormattingConfigAppliesToCell,
     createConditionalFormattingConfigWithSingleColor,
     createConditionalFormattingRuleWithValues,
     getConditionalFormattingConfig,
@@ -220,6 +224,121 @@ describe('getConditionalFormattingConfig', () => {
                 conditionalFormattings,
             }),
         ).toBe(textConfig);
+    });
+});
+
+describe('conditionalFormattingConfigAppliesToCell', () => {
+    const config = createConditionalFormattingConfigWithSingleColor('#ff0000');
+
+    it('applies everywhere when appliesTo is unset (backwards compatible)', () => {
+        expect(conditionalFormattingConfigAppliesToCell(config, false)).toBe(
+            true,
+        );
+        expect(conditionalFormattingConfigAppliesToCell(config, true)).toBe(
+            true,
+        );
+    });
+
+    it('applies everywhere when appliesTo is ALL', () => {
+        const allConfig = {
+            ...config,
+            appliesTo: ConditionalFormattingAppliesTo.ALL,
+        };
+        expect(conditionalFormattingConfigAppliesToCell(allConfig, false)).toBe(
+            true,
+        );
+        expect(conditionalFormattingConfigAppliesToCell(allConfig, true)).toBe(
+            true,
+        );
+    });
+
+    it('applies to data cells only when appliesTo is DATA', () => {
+        const dataConfig = {
+            ...config,
+            appliesTo: ConditionalFormattingAppliesTo.DATA,
+        };
+        expect(
+            conditionalFormattingConfigAppliesToCell(dataConfig, false),
+        ).toBe(true);
+        expect(conditionalFormattingConfigAppliesToCell(dataConfig, true)).toBe(
+            false,
+        );
+    });
+
+    it('applies to total cells only when appliesTo is TOTALS', () => {
+        const totalsConfig = {
+            ...config,
+            appliesTo: ConditionalFormattingAppliesTo.TOTALS,
+        };
+        expect(
+            conditionalFormattingConfigAppliesToCell(totalsConfig, false),
+        ).toBe(false);
+        expect(
+            conditionalFormattingConfigAppliesToCell(totalsConfig, true),
+        ).toBe(true);
+    });
+});
+
+describe('getConditionalFormattingConfig with totals scope', () => {
+    const buildConfig = (appliesTo: ConditionalFormattingAppliesTo) => {
+        const config =
+            createConditionalFormattingConfigWithSingleColor('#ff0000');
+        config.appliesTo = appliesTo;
+        config.rules[0].operator = FilterOperator.GREATER_THAN_OR_EQUAL;
+        config.rules[0].values = [0];
+        return config;
+    };
+
+    it('skips DATA-scoped rules on total cells but keeps them on data cells', () => {
+        const conditionalFormattings = [
+            buildConfig(ConditionalFormattingAppliesTo.DATA),
+        ];
+
+        expect(
+            getConditionalFormattingConfig({
+                field: mockNumericField,
+                value: 5,
+                minMaxMap: {},
+                conditionalFormattings,
+                isTotal: false,
+            }),
+        ).toBe(conditionalFormattings[0]);
+
+        expect(
+            getConditionalFormattingConfig({
+                field: mockNumericField,
+                value: 5,
+                minMaxMap: {},
+                conditionalFormattings,
+                isTotal: true,
+            }),
+        ).toBeUndefined();
+    });
+
+    it('applies TOTALS-scoped rules only on total cells', () => {
+        const conditionalFormattings = [
+            buildConfig(ConditionalFormattingAppliesTo.TOTALS),
+        ];
+
+        expect(
+            getConditionalFormattingConfig({
+                field: mockNumericField,
+                value: 5,
+                minMaxMap: {},
+                conditionalFormattings,
+                isTotal: false,
+            }),
+        ).toBeUndefined();
+
+        expect(
+            getConditionalFormattingConfig({
+                field: mockNumericField,
+                value: 5,
+                minMaxMap: {},
+                conditionalFormattings,
+                isTotal: true,
+            }),
+        ).toBe(conditionalFormattings[0]);
     });
 });
 

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -7,6 +7,7 @@ import type {
     ItemsMap,
 } from '..';
 import {
+    ConditionalFormattingAppliesTo,
     ConditionalFormattingColorApplyTo,
     isConditionalFormattingConfigWithColorRange,
     isConditionalFormattingConfigWithSingleColor,
@@ -519,6 +520,31 @@ export const hasMatchingConditionalRules = (
     return assertUnreachable(config, 'Unknown conditional formatting config');
 };
 
+/**
+ * Whether a config should apply to a cell given whether that cell is a total
+ * (row/column total or subtotal). `appliesTo` defaults to ALL so charts saved
+ * before this option existed behave exactly as before.
+ */
+export const conditionalFormattingConfigAppliesToCell = (
+    config: ConditionalFormattingConfig,
+    isTotal: boolean,
+): boolean => {
+    const appliesTo = config.appliesTo ?? ConditionalFormattingAppliesTo.ALL;
+    switch (appliesTo) {
+        case ConditionalFormattingAppliesTo.ALL:
+            return true;
+        case ConditionalFormattingAppliesTo.DATA:
+            return !isTotal;
+        case ConditionalFormattingAppliesTo.TOTALS:
+            return isTotal;
+        default:
+            return assertUnreachable(
+                appliesTo,
+                'Unknown conditional formatting appliesTo',
+            );
+    }
+};
+
 export const getConditionalFormattingConfig = ({
     field,
     value,
@@ -526,6 +552,7 @@ export const getConditionalFormattingConfig = ({
     conditionalFormattings,
     rowFields,
     applyTo,
+    isTotal = false,
 }: {
     field: ItemsMap[string] | undefined;
     value: unknown | undefined;
@@ -533,6 +560,8 @@ export const getConditionalFormattingConfig = ({
     conditionalFormattings: ConditionalFormattingConfig[] | undefined;
     rowFields?: ConditionalFormattingRowFields;
     applyTo?: ConditionalFormattingColorApplyTo;
+    /** True when the cell is a row/column total or subtotal */
+    isTotal?: boolean;
 }) => {
     // For backwards compatibility with old table calculations without type
     const isCalculationTypeUndefined =
@@ -552,6 +581,10 @@ export const getConditionalFormattingConfig = ({
             (config.applyTo ?? ConditionalFormattingColorApplyTo.CELL) !==
                 applyTo
         ) {
+            return false;
+        }
+
+        if (!conditionalFormattingConfigAppliesToCell(config, isTotal)) {
             return false;
         }
 
@@ -761,15 +794,21 @@ export const getRowConditionalFormattingConfig = ({
     conditionalFormattings,
     rowFields,
     minMaxMap = {},
+    isTotal = false,
 }: {
     conditionalFormattings: ConditionalFormattingConfig[] | undefined;
     rowFields: ConditionalFormattingRowFields;
     minMaxMap: ConditionalFormattingMinMaxMap | undefined;
+    /** True when the row is a total or subtotal row */
+    isTotal?: boolean;
 }): ConditionalFormattingConfig | undefined => {
     if (!conditionalFormattings) return undefined;
 
     return conditionalFormattings.find((config) => {
         if (config.applyTo !== ConditionalFormattingColorApplyTo.ROW) {
+            return false;
+        }
+        if (!conditionalFormattingConfigAppliesToCell(config, isTotal)) {
             return false;
         }
         const targetFieldId = config.target?.fieldId;
@@ -795,6 +834,8 @@ export const getRowConditionalFormattingColor = (args: {
     conditionalFormattings: ConditionalFormattingConfig[] | undefined;
     rowFields: ConditionalFormattingRowFields;
     minMaxMap: ConditionalFormattingMinMaxMap | undefined;
+    /** True when the row is a total or subtotal row */
+    isTotal?: boolean;
 }): string | null => {
     const match = getRowConditionalFormattingConfig(args);
 

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    ConditionalFormattingAppliesTo,
     ConditionalFormattingColorApplyTo,
     ConditionalFormattingComparisonType,
     ConditionalFormattingConfigType,
@@ -363,6 +364,17 @@ export const ConditionalFormattingItem: FC<Props> = ({
         [handleChange, config],
     );
 
+    const handleChangeAppliesTo = useCallback(
+        (newAppliesTo: ConditionalFormattingAppliesTo) => {
+            handleChange(
+                produce(config, (draft) => {
+                    draft.appliesTo = newAppliesTo;
+                }),
+            );
+        },
+        [handleChange, config],
+    );
+
     const handleToggleTextStyle = useCallback(
         (key: keyof ConditionalFormattingTextStyle) => {
             handleChange(
@@ -526,6 +538,36 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                 onChange={(value) =>
                                     handleChangeApplyTo(
                                         value as ConditionalFormattingColorApplyTo,
+                                    )
+                                }
+                            />
+                        </Group>
+
+                        <Group gap="xs">
+                            <Config.Label>Totals</Config.Label>
+
+                            <SegmentedControl
+                                data={[
+                                    {
+                                        value: ConditionalFormattingAppliesTo.ALL,
+                                        label: 'Include',
+                                    },
+                                    {
+                                        value: ConditionalFormattingAppliesTo.DATA,
+                                        label: 'Exclude',
+                                    },
+                                    {
+                                        value: ConditionalFormattingAppliesTo.TOTALS,
+                                        label: 'Only',
+                                    },
+                                ]}
+                                value={
+                                    config.appliesTo ??
+                                    ConditionalFormattingAppliesTo.ALL
+                                }
+                                onChange={(value) =>
+                                    handleChangeAppliesTo(
+                                        value as ConditionalFormattingAppliesTo,
                                     )
                                 }
                             />

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1707,11 +1707,16 @@ const PivotTable: FC<PivotTableProps> = ({
                                 )
                           : buildRowFieldsFromVisibleCells(row, undefined);
 
+                    // Subtotal (grouped) rows are treated as totals for
+                    // conditional-formatting scope.
+                    const isSubtotalRow = row.getIsGrouped();
+
                     const rowBackgroundColor = getRowConditionalFormattingColor(
                         {
                             conditionalFormattings,
                             rowFields: rowLevelFields,
                             minMaxMap,
+                            isTotal: isSubtotalRow,
                         },
                     );
 
@@ -1720,6 +1725,7 @@ const PivotTable: FC<PivotTableProps> = ({
                             conditionalFormattings,
                             rowFields: rowLevelFields,
                             minMaxMap,
+                            isTotal: isSubtotalRow,
                         });
 
                     return (
@@ -1938,6 +1944,10 @@ const PivotTable: FC<PivotTableProps> = ({
                                             currentHeaderInfo,
                                         );
 
+                                // A cell is a total when it sits in the row-
+                                // total ("Total") column or in a subtotal row.
+                                const isTotalCell = isRowTotal || isSubtotalRow;
+
                                 const cellConditionalFormattingConfig =
                                     isMetricSubtotal
                                         ? undefined
@@ -1949,6 +1959,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                               rowFields: rowFieldsForCell,
                                               applyTo:
                                                   ConditionalFormattingColorApplyTo.CELL,
+                                              isTotal: isTotalCell,
                                           });
                                 const textConditionalFormattingConfig =
                                     isMetricSubtotal
@@ -1961,6 +1972,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                               rowFields: rowFieldsForCell,
                                               applyTo:
                                                   ConditionalFormattingColorApplyTo.TEXT,
+                                              isTotal: isTotalCell,
                                           });
 
                                 const cellConditionalFormattingResult =

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -93,6 +93,8 @@ const TableRow: FC<TableRowProps> = ({
     rowSpanMergesByColumnId,
 }) => {
     const { colorScheme } = useMantineColorScheme();
+    // Subtotal (group) rows are treated as totals for conditional-formatting scope.
+    const isTotalRow = row.getIsGrouped();
     const rowFields = useMemo(
         () =>
             row
@@ -134,8 +136,9 @@ const TableRow: FC<TableRowProps> = ({
                 conditionalFormattings,
                 rowFields,
                 minMaxMap,
+                isTotal: isTotalRow,
             }),
-        [conditionalFormattings, rowFields, minMaxMap],
+        [conditionalFormattings, rowFields, minMaxMap, isTotalRow],
     );
 
     const rowConditionalFormattingConfig = useMemo(
@@ -144,8 +147,9 @@ const TableRow: FC<TableRowProps> = ({
                 conditionalFormattings,
                 rowFields,
                 minMaxMap,
+                isTotal: isTotalRow,
             }),
-        [conditionalFormattings, rowFields, minMaxMap],
+        [conditionalFormattings, rowFields, minMaxMap, isTotalRow],
     );
 
     return (
@@ -172,6 +176,7 @@ const TableRow: FC<TableRowProps> = ({
                         conditionalFormattings,
                         rowFields,
                         applyTo: ConditionalFormattingColorApplyTo.CELL,
+                        isTotal: isTotalRow,
                     });
                 const textConditionalFormattingConfig =
                     getConditionalFormattingConfig({
@@ -181,6 +186,7 @@ const TableRow: FC<TableRowProps> = ({
                         conditionalFormattings,
                         rowFields,
                         applyTo: ConditionalFormattingColorApplyTo.TEXT,
+                        isTotal: isTotalRow,
                     });
 
                 const cellConditionalFormattingResult =


### PR DESCRIPTION
## What & why

Conditional formatting rules currently apply to totals (row/column totals and subtotals) as well as data cells, which skews color scales — totals are usually far larger than the cells they aggregate and drown out the heatmap. There was no way to scope a rule to data only, or to give totals their own rule.

This adds an **`appliesTo`** option to each conditional formatting rule:

- **Include** (`all`) — data + totals (default; existing behaviour, so saved charts are unchanged)
- **Exclude** (`data`) — data cells only; totals are left unformatted
- **Only** (`totals`) — totals only; a rule that formats totals independently

## Approach

- **Types** (`packages/common`): new `ConditionalFormattingAppliesTo` enum + optional `appliesTo` on both single-color and color-range config types. Optional/defaulting to `all` keeps old saved charts identical.
- **Utils**: `conditionalFormattingConfigAppliesToCell(config, isTotal)` gates rule selection; threaded an `isTotal` flag through `getConditionalFormattingConfig` / `getRowConditionalFormattingConfig` / `getRowConditionalFormattingColor`.
- **Renderers**: flat table (`TableBody.tsx`) treats grouped/subtotal rows as totals; pivot table (`PivotTable/index.tsx`) treats the row-total ("Total") column and subtotal rows as totals.
- **UI**: a "Totals" segmented control (Include / Exclude / Only) on each rule.
- Regenerated OpenAPI + chart-as-code schemas.

**Auto min/max:** color-range auto scaling is computed in `useTableConfig` from query result rows only — totals aren't part of that set — so an `Exclude`-scoped color scale already derives its min/max from data cells only. No change was needed there.

## Scope note

Coverage is for totals that currently receive conditional formatting: **pivot row totals and subtotals (flat + pivot)**. The pivot column-totals footer and flat-table column-calculation footer never had conditional formatting, so they're left untouched to keep `Include` rendering byte-for-byte identical — formatting those footer totals could be a follow-up (relates to PROD-3937 / PROD-610).

## Testing

- Unit tests for the gating helper and scoped config selection (`conditionalFormatting.test.ts`).
- `common`/`frontend` typecheck, oxlint, and chart-as-code schema check pass.
- Not yet verified live in the browser (no dev server in this environment) — worth a manual check on a pivot with row totals + subtotals across the three scope options and both pivot layouts.
