### PR TITLE
feat(ai): judge-side dedup for review items + notify only on new items

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -1154,12 +1154,13 @@ describe('AiAgentReviewClassifierModel', () => {
                 .insert(AiAgentReviewItemEventsTableName)
                 .responseOnce([]);
 
-            await model.createTurnSignal({
+            const result = await model.createTurnSignal({
                 runUuid: RUN_UUID,
                 turnSignal,
                 finding: promotedFinding,
             });
 
+            expect(result.reviewItemOutcome).toBe('created');
             const eventInserts = tracker.history.insert.filter((q) =>
                 q.sql.includes(AiAgentReviewItemEventsTableName),
             );
@@ -1185,12 +1186,13 @@ describe('AiAgentReviewClassifierModel', () => {
                 .insert(AiAgentReviewItemEventsTableName)
                 .responseOnce([]);
 
-            await model.createTurnSignal({
+            const result = await model.createTurnSignal({
                 runUuid: RUN_UUID,
                 turnSignal,
                 finding: promotedFinding,
             });
 
+            expect(result.reviewItemOutcome).toBe('recurred');
             const eventInserts = tracker.history.insert.filter((q) =>
                 q.sql.includes(AiAgentReviewItemEventsTableName),
             );
@@ -1247,7 +1249,7 @@ describe('AiAgentReviewClassifierModel', () => {
                 },
             });
 
-            expect(result).toBe(TURN_SIGNAL_UUID);
+            expect(result.turnSignalUuid).toBe(TURN_SIGNAL_UUID);
             // Supersede: the turn's prior signal is deleted before the new one
             // is inserted (one current signal per turn).
             expect(tracker.history.delete).toHaveLength(1);
@@ -1281,12 +1283,13 @@ describe('AiAgentReviewClassifierModel', () => {
                 },
             ]);
 
-            await model.createTurnSignal({
+            const result = await model.createTurnSignal({
                 runUuid: RUN_UUID,
                 turnSignal: { ...turnSignal, promotedToFinding: false },
                 finding: null,
             });
 
+            expect(result.reviewItemOutcome).toBeNull();
             expect(tracker.history.insert).toHaveLength(1);
             expect(tracker.history.insert[0].sql).toContain(
                 AiAgentTurnSignalTableName,
@@ -1352,7 +1355,7 @@ describe('AiAgentReviewClassifierModel', () => {
                 .insert(AiAgentReviewItemEventsTableName)
                 .responseOnce([]);
 
-            await model.createTurnSignal({
+            const result = await model.createTurnSignal({
                 runUuid: RUN_UUID,
                 turnSignal,
                 finding: {
@@ -1373,6 +1376,9 @@ describe('AiAgentReviewClassifierModel', () => {
                 },
             });
 
+            // Same-turn re-review (supersede path) is neither created nor
+            // recurred — no ping.
+            expect(result.reviewItemOutcome).toBeNull();
             // The item is re-touched (upsert), never deleted, since the
             // fingerprint is stable across the re-review.
             expect(
@@ -1475,6 +1481,100 @@ describe('AiAgentReviewClassifierModel', () => {
                     q.sql.includes(AiAgentReviewItemTableName),
                 ),
             ).toHaveLength(0);
+        });
+    });
+
+    describe('findReviewItemDedupCandidates', () => {
+        it('joins candidate items to their latest signal and excludes duplicates', async () => {
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([
+                {
+                    fingerprint: FINGERPRINT,
+                    status: 'open',
+                    dismissed_reason: null,
+                },
+                {
+                    fingerprint: 'ai_agent_review_item:second',
+                    status: 'dismissed',
+                    dismissed_reason: 'expected_behavior',
+                },
+            ]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                makeTurnSignalRow({
+                    fingerprint: FINGERPRINT,
+                    review_item_title: 'Revenue metric mismatch',
+                    primary_root_cause: 'semantic_layer',
+                    target_refs: [
+                        {
+                            type: 'metric',
+                            modelName: 'orders',
+                            metricName: 'revenue',
+                        },
+                    ],
+                }),
+            ]);
+
+            const result = await model.findReviewItemDedupCandidates({
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+                limit: 30,
+            });
+
+            // Item order preserved; latest signal fields joined by fingerprint;
+            // an item without a signal falls back to null fields.
+            expect(result).toEqual([
+                {
+                    fingerprint: FINGERPRINT,
+                    title: 'Revenue metric mismatch',
+                    status: 'open',
+                    dismissedReason: null,
+                    primaryRootCause: 'semantic_layer',
+                    targetRefs: [
+                        {
+                            type: 'metric',
+                            modelName: 'orders',
+                            metricName: 'revenue',
+                        },
+                    ],
+                },
+                {
+                    fingerprint: 'ai_agent_review_item:second',
+                    title: null,
+                    status: 'dismissed',
+                    dismissedReason: 'expected_behavior',
+                    primaryRootCause: null,
+                    targetRefs: null,
+                },
+            ]);
+
+            const [itemQuery] = tracker.history.select;
+            expect(itemQuery.bindings).toEqual(
+                expect.arrayContaining([
+                    'triage',
+                    'open',
+                    'in_progress',
+                    'resolved',
+                    'dismissed',
+                ]),
+            );
+            expect(itemQuery.bindings).not.toContain('duplicate');
+            expect(itemQuery.sql).toContain('order by');
+            expect(itemQuery.bindings).toContain(30);
+        });
+
+        it('skips the signal lookup when no candidate items exist', async () => {
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+
+            const result = await model.findReviewItemDedupCandidates({
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+                limit: 30,
+            });
+
+            expect(result).toEqual([]);
+            const signalQueries = tracker.history.select.filter((q) =>
+                q.sql.includes(AiAgentTurnSignalTableName),
+            );
+            expect(signalQueries).toHaveLength(0);
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -2025,6 +2025,88 @@ export class AiAgentReviewClassifierModel {
         return items[0] ?? null;
     }
 
+    async findReviewItemDedupCandidates(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        limit: number;
+    }): Promise<
+        Array<{
+            fingerprint: string;
+            title: string | null;
+            status: AiAgentReviewItemStatus;
+            dismissedReason: AiAgentReviewItemDismissedReason | null;
+            primaryRootCause: string | null;
+            targetRefs: AiAgentTargetRef[] | null;
+        }>
+    > {
+        const dedupCandidateStatuses: AiAgentReviewItemStatus[] = [
+            'triage',
+            'open',
+            'in_progress',
+            'resolved',
+            'dismissed',
+        ];
+
+        const itemRows = (await this.database<AiAgentReviewItemTable>(
+            AiAgentReviewItemTableName,
+        )
+            .where('organization_uuid', args.organizationUuid)
+            .where('project_uuid', args.projectUuid)
+            .whereIn('status', dedupCandidateStatuses)
+            .orderBy('updated_at', 'desc')
+            .limit(args.limit)
+            .select('fingerprint', 'status', 'dismissed_reason')) as Pick<
+            DbAiAgentReviewItem,
+            'fingerprint' | 'status' | 'dismissed_reason'
+        >[];
+
+        const fingerprints = itemRows.map((row) => row.fingerprint);
+
+        // Latest signal per fingerprint carries the title/root-cause/target the
+        // judge sees — same distinctOn pattern listReviewItems uses.
+        const latestSignalRows =
+            fingerprints.length === 0
+                ? []
+                : ((await this.database<AiAgentTurnSignalTable>(
+                      AiAgentTurnSignalTableName,
+                  )
+                      .distinctOn('fingerprint')
+                      .select(
+                          'fingerprint',
+                          'review_item_title',
+                          'primary_root_cause',
+                          'target_refs',
+                      )
+                      .where('organization_uuid', args.organizationUuid)
+                      .whereIn('fingerprint', fingerprints)
+                      .orderBy('fingerprint')
+                      .orderBy('created_at', 'desc')) as Pick<
+                      DbAiAgentTurnSignal,
+                      | 'fingerprint'
+                      | 'review_item_title'
+                      | 'primary_root_cause'
+                      | 'target_refs'
+                  >[]);
+
+        const latestByFingerprint = new Map(
+            latestSignalRows
+                .filter((row) => row.fingerprint !== null)
+                .map((row) => [row.fingerprint as string, row]),
+        );
+
+        return itemRows.map((row) => {
+            const latest = latestByFingerprint.get(row.fingerprint);
+            return {
+                fingerprint: row.fingerprint,
+                title: latest?.review_item_title ?? null,
+                status: row.status,
+                dismissedReason: row.dismissed_reason,
+                primaryRootCause: latest?.primary_root_cause ?? null,
+                targetRefs: latest?.target_refs ?? null,
+            };
+        });
+    }
+
     async getPromptText(args: GetPromptTextArgs): Promise<string | null> {
         const row = await this.database(`${AiPromptTableName} as prompt`)
             .join(
@@ -2362,7 +2444,10 @@ export class AiAgentReviewClassifierModel {
         return rows.map(AiAgentReviewClassifierModel.mapReviewSignalSummary);
     }
 
-    async createTurnSignal(args: CreateTurnSignalArgs): Promise<string> {
+    async createTurnSignal(args: CreateTurnSignalArgs): Promise<{
+        turnSignalUuid: string;
+        reviewItemOutcome: 'created' | 'recurred' | null;
+    }> {
         const { finding, turnSignal } = args;
         const promptUuid = turnSignal.subject.assistantPromptUuid;
         const newFingerprint =
@@ -2459,6 +2544,7 @@ export class AiAgentReviewClassifierModel {
 
             // Write the review item in the same transaction so a signal and the
             // item it promotes are always created together.
+            let reviewItemOutcome: 'created' | 'recurred' | null = null;
             if (newFingerprint && finding) {
                 const existingItem = await trx<AiAgentReviewItemTable>(
                     AiAgentReviewItemTableName,
@@ -2502,6 +2588,7 @@ export class AiAgentReviewClassifierModel {
                 const isSameTurnReReview =
                     supersededFingerprints.includes(newFingerprint);
                 if (!isSameTurnReReview) {
+                    reviewItemOutcome = existingItem ? 'recurred' : 'created';
                     await this.createReviewItemEvent({
                         fingerprint: newFingerprint,
                         organizationUuid: turnSignal.subject.organizationUuid,
@@ -2557,7 +2644,10 @@ export class AiAgentReviewClassifierModel {
                 }
             }
 
-            return inserted[0].ai_agent_review_turn_signal_uuid;
+            return {
+                turnSignalUuid: inserted[0].ai_agent_review_turn_signal_uuid,
+                reviewItemOutcome,
+            };
         });
     }
 }

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
@@ -104,6 +104,7 @@ const replayInput: AiAgentReviewJudgeReplayInput = {
         threadWritebackPullRequests: [],
         toolOutcomes: [],
         pendingApprovalTimeout: false,
+        existingReviewItems: [],
     },
 };
 
@@ -125,6 +126,7 @@ const judgeOutput = (
     evidenceExcerpts: [],
     recommendation: null,
     projectContextEntry: null,
+    matchedExistingItemKey: null,
     reviewItem: { title: 'Fix it', description: 'why' },
     ...overrides,
 });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -134,6 +134,7 @@ const makeJudgeOutput = (
     ],
     recommendation: null,
     projectContextEntry: null,
+    matchedExistingItemKey: null,
     reviewItem: {
         title: 'No review needed',
         description: 'Judge found no actionable issue.',
@@ -291,6 +292,7 @@ describe('AiAgentReviewClassifierService', () => {
         createTurnSignal: vi.fn(),
         getThreadWritebackPullRequests: vi.fn().mockResolvedValue(new Map()),
         getAgentMcpCapabilities: vi.fn().mockResolvedValue([]),
+        findReviewItemDedupCandidates: vi.fn().mockResolvedValue([]),
     } as unknown as import('vitest').Mocked<AiAgentReviewClassifierModel>;
     const aiAgentModel = {
         getAgent: vi.fn(),
@@ -342,7 +344,11 @@ describe('AiAgentReviewClassifierService', () => {
         });
         model.createRun.mockResolvedValue(makeRun());
         model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
-        model.createTurnSignal.mockResolvedValue(SIGNAL_UUID);
+        model.createTurnSignal.mockResolvedValue({
+            turnSignalUuid: SIGNAL_UUID,
+            reviewItemOutcome: 'created',
+        });
+        model.findReviewItemDedupCandidates.mockResolvedValue([]);
         model.getThreadWritebackPullRequests.mockResolvedValue(new Map());
         aiAgentReviewNotificationService.notifyNeedsReview.mockResolvedValue(
             undefined,
@@ -914,6 +920,170 @@ describe('AiAgentReviewClassifierService', () => {
                     primaryRootCause: 'product_capability',
                 }),
             }),
+        );
+    });
+
+    it('passes existing review items to the judge as dedup candidates', async () => {
+        model.findReviewItemDedupCandidates.mockResolvedValue([
+            {
+                fingerprint: 'ai_agent_review_item:existing-1',
+                title: 'Country not available',
+                status: 'open',
+                dismissedReason: null,
+                primaryRootCause: 'semantic_layer',
+                targetRefs: [
+                    {
+                        type: 'dimension',
+                        modelName: 'airports',
+                        dimensionName: 'country',
+                    },
+                ],
+            },
+        ]);
+        model.listTurnReviewCandidates.mockResolvedValue([makeCandidate()]);
+
+        await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+        });
+
+        const packet = judgeTurn.mock.calls[0][1];
+        expect(packet.existingReviewItems).toEqual([
+            {
+                key: 'item_1',
+                title: 'Country not available',
+                status: 'open',
+                dismissedReason: null,
+                primaryRootCause: 'semantic_layer',
+                objectSummary: 'country',
+            },
+        ]);
+    });
+
+    it('falls back to defaults for untitled or unclassified dedup candidates', async () => {
+        model.findReviewItemDedupCandidates.mockResolvedValue([
+            {
+                fingerprint: 'ai_agent_review_item:existing-1',
+                title: null,
+                status: 'triage',
+                dismissedReason: null,
+                primaryRootCause: null,
+                targetRefs: null,
+            },
+        ]);
+        model.listTurnReviewCandidates.mockResolvedValue([makeCandidate()]);
+
+        await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+        });
+
+        const packet = judgeTurn.mock.calls[0][1];
+        expect(packet.existingReviewItems[0]).toEqual({
+            key: 'item_1',
+            title: 'Untitled review item',
+            status: 'triage',
+            dismissedReason: null,
+            primaryRootCause: 'ambiguous',
+            objectSummary: null,
+        });
+    });
+
+    it('degrades to no dedup candidates when the query fails', async () => {
+        model.findReviewItemDedupCandidates.mockRejectedValue(
+            new Error('db down'),
+        );
+        model.listTurnReviewCandidates.mockResolvedValue([makeCandidate()]);
+
+        const result = await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+        });
+
+        expect(result.processedTurns).toBe(1);
+        expect(judgeTurn.mock.calls[0][1].existingReviewItems).toEqual([]);
+    });
+
+    it('reuses an existing item fingerprint when the judge matches a candidate', async () => {
+        model.findReviewItemDedupCandidates.mockResolvedValue([
+            {
+                fingerprint: 'ai_agent_review_item:existing-1',
+                title: 'Country not available',
+                status: 'open',
+                dismissedReason: null,
+                primaryRootCause: 'semantic_layer',
+                targetRefs: null,
+            },
+        ]);
+        model.createTurnSignal.mockResolvedValue({
+            turnSignalUuid: SIGNAL_UUID,
+            reviewItemOutcome: 'recurred',
+        });
+        judgeTurn.mockResolvedValueOnce({
+            ...makeSemanticJudgeOutput(),
+            matchedExistingItemKey: 'item_1',
+        });
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({
+                nextUserPrompt:
+                    'No, country is not available here, so use airport name.',
+            }),
+        ]);
+
+        const result = await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+            persistFindings: true,
+            promoteFindingsToReviewItems: true,
+        });
+
+        expect(model.createTurnSignal).toHaveBeenCalledWith(
+            expect.objectContaining({
+                finding: expect.objectContaining({
+                    reviewItem: expect.objectContaining({
+                        fingerprint: 'ai_agent_review_item:existing-1',
+                    }),
+                }),
+            }),
+        );
+        // A recurrence accrues onto the existing card without re-notifying.
+        expect(result.reviewItemCount).toBe(1);
+        expect(
+            aiAgentReviewNotificationService.notifyNeedsReview,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('computes a fresh fingerprint when the matched key is not a candidate', async () => {
+        model.findReviewItemDedupCandidates.mockResolvedValue([]);
+        judgeTurn.mockResolvedValueOnce({
+            ...makeSemanticJudgeOutput(),
+            matchedExistingItemKey: 'item_99',
+        });
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({
+                nextUserPrompt:
+                    'No, country is not available here, so use airport name.',
+            }),
+        ]);
+
+        await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+            persistFindings: true,
+            promoteFindingsToReviewItems: true,
+        });
+
+        const [{ finding }] = model.createTurnSignal.mock.calls[0];
+        expect(finding?.reviewItem.fingerprint).toContain(
+            'ai_agent_review_item:',
+        );
+        expect(finding?.reviewItem.fingerprint).not.toBe(
+            'ai_agent_review_item:existing-1',
         );
     });
 });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import {
     aiAgentReviewClassifierJudgeOutputSchema,
+    assertUnreachable,
     CatalogType,
     FeatureFlags,
     filterExploreByTags,
@@ -22,6 +23,7 @@ import {
     type AiAgentReviewClassifierToolOutcome,
     type AiAgentReviewClassifierTurnCandidate,
     type AiAgentReviewClassifierTurnSignal,
+    type AiAgentReviewItemDedupCandidate,
     type AiAgentRootCause,
     type AiAgentTargetRef,
     type AiAgentTurnSignal,
@@ -47,7 +49,7 @@ import { getAiCallTelemetry } from './ai/utils/aiCallTelemetry';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
-const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v14';
+const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v15';
 const WRITEBACK_TOOL_NAMES = new Set([
     'editDbtProject',
     'propose_writeback',
@@ -158,6 +160,9 @@ export type AiAgentReviewJudgeEvidencePacket = {
     toolOutcomes: AiAgentReviewClassifierToolOutcome[];
     // A human SQL-approval gate expired during the turn (user stepped away).
     pendingApprovalTimeout: boolean;
+    // Existing review items in this project the judge can dedup against. Each
+    // key ("item_1") maps server-side to a fingerprint never shown to the LLM.
+    existingReviewItems: AiAgentReviewItemDedupCandidate[];
 };
 
 // What a tag-restricted agent can see, mirroring filterExploreByTags.
@@ -647,35 +652,42 @@ export class AiAgentReviewClassifierService extends BaseService {
             /* eslint-disable no-await-in-loop */
             // eslint-disable-next-line no-restricted-syntax
             for (const { classifiedTurn } of reviewedTurns) {
+                let reviewItemOutcome: 'created' | 'recurred' | null = null;
                 if (shouldPersistSignals) {
-                    await this.aiAgentReviewClassifierModel.createTurnSignal({
-                        runUuid: run.uuid,
-                        turnSignal: classifiedTurn.signal,
-                        finding: shouldPersistFindings
-                            ? classifiedTurn.finding
-                            : null,
-                    });
+                    const persisted =
+                        await this.aiAgentReviewClassifierModel.createTurnSignal(
+                            {
+                                runUuid: run.uuid,
+                                turnSignal: classifiedTurn.signal,
+                                finding: shouldPersistFindings
+                                    ? classifiedTurn.finding
+                                    : null,
+                            },
+                        );
+                    reviewItemOutcome = persisted.reviewItemOutcome;
                 }
                 signalCount += 1;
 
                 if (shouldPersistFindings && classifiedTurn.finding) {
                     findingCount += 1;
                     if (shouldPromoteFindingsToReviewItems) {
-                        reviewItemFingerprints.add(
-                            classifiedTurn.finding.reviewItem.fingerprint,
-                        );
-                        const projectFingerprints =
-                            reviewItemFingerprintsByProject.get(
-                                classifiedTurn.signal.subject.projectUuid,
-                            ) ?? new Set<string>();
-                        projectFingerprints.add(
-                            classifiedTurn.finding.reviewItem.fingerprint,
-                        );
-                        reviewItemFingerprintsByProject.set(
-                            classifiedTurn.signal.subject.projectUuid,
-                            projectFingerprints,
-                        );
+                        const { fingerprint } =
+                            classifiedTurn.finding.reviewItem;
+                        reviewItemFingerprints.add(fingerprint);
                         reviewItemCount = reviewItemFingerprints.size;
+                        // Only newly created items ping Slack; a recurrence
+                        // accrues onto its existing card without re-notifying.
+                        if (reviewItemOutcome === 'created') {
+                            const projectFingerprints =
+                                reviewItemFingerprintsByProject.get(
+                                    classifiedTurn.signal.subject.projectUuid,
+                                ) ?? new Set<string>();
+                            projectFingerprints.add(fingerprint);
+                            reviewItemFingerprintsByProject.set(
+                                classifiedTurn.signal.subject.projectUuid,
+                                projectFingerprints,
+                            );
+                        }
                     }
                 }
 
@@ -865,6 +877,25 @@ export class AiAgentReviewClassifierService extends BaseService {
                     !judgeOutput.promotedToFinding,
             });
         }
+        // Resolve the judge's dedup match: a valid key reuses that item's
+        // fingerprint; a null/hallucinated key falls back to computing one.
+        const { matchedExistingItemKey } = judgeOutput;
+        const matchedFingerprint =
+            matchedExistingItemKey !== null
+                ? (reviewEvidence.dedupKeyToFingerprint.get(
+                      matchedExistingItemKey,
+                  ) ?? null)
+                : null;
+        if (matchedExistingItemKey !== null && matchedFingerprint === null) {
+            this.debugLog('InvalidMatchedItemKey', {
+                promptUuid: candidate.subject.assistantPromptUuid,
+                threadUuid: candidate.subject.threadUuid,
+                matchedExistingItemKey,
+            });
+        }
+        const fingerprintSource: 'matched' | 'computed' =
+            matchedFingerprint !== null ? 'matched' : 'computed';
+
         const signal: AiAgentReviewClassifierTurnSignal = {
             subject: candidate.subject,
             interactionSource: candidate.interactionSource,
@@ -899,6 +930,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             promotedToFinding: judgeOutput.promotedToFinding,
             confidence: judgeOutput.confidence,
             judgePromptHash: JUDGE_PROMPT_HASH,
+            matchedExistingItemKey: judgeOutput.matchedExistingItemKey,
             implicitSignalSources: judgeOutput.implicitSignalSources,
             hasImplicitSignal: judgeOutput.implicitSignalSources.length > 0,
             hasPromotableImplicitSignal:
@@ -926,6 +958,9 @@ export class AiAgentReviewClassifierService extends BaseService {
             targetRefs: judgeOutput.targetRefs,
             recommendationAction: judgeOutput.recommendation?.actionType,
             reviewItemTitle: judgeOutput.reviewItem.title,
+            matchedExistingItemKey,
+            matchedKeyValidated: matchedFingerprint !== null,
+            fingerprintSource,
         });
 
         if (!judgeOutput.promotedToFinding) {
@@ -951,26 +986,29 @@ export class AiAgentReviewClassifierService extends BaseService {
               }
             : null;
 
-        const fingerprint = getAiAgentReviewItemFingerprint({
-            organizationUuid: candidate.subject.organizationUuid,
-            projectUuid: candidate.subject.projectUuid,
-            agentUuid: candidate.subject.agentUuid,
-            threadUuid: candidate.subject.threadUuid,
-            primaryRootCause: judgeOutput.primaryRootCause,
-            subcategories: judgeOutput.subcategories,
-            fixTargets: judgeOutput.fixTargets,
-            targetRefs,
-            agentConfigurationSettings: judgeOutput.agentConfigurationSettings,
-            capabilityKey:
-                targetRefs.find(
-                    (
-                        targetRef,
-                    ): targetRef is Extract<
-                        AiAgentTargetRef,
-                        { type: 'product_capability' }
-                    > => targetRef.type === 'product_capability',
-                )?.capabilityKey ?? null,
-        });
+        const fingerprint =
+            matchedFingerprint ??
+            getAiAgentReviewItemFingerprint({
+                organizationUuid: candidate.subject.organizationUuid,
+                projectUuid: candidate.subject.projectUuid,
+                agentUuid: candidate.subject.agentUuid,
+                threadUuid: candidate.subject.threadUuid,
+                primaryRootCause: judgeOutput.primaryRootCause,
+                subcategories: judgeOutput.subcategories,
+                fixTargets: judgeOutput.fixTargets,
+                targetRefs,
+                agentConfigurationSettings:
+                    judgeOutput.agentConfigurationSettings,
+                capabilityKey:
+                    targetRefs.find(
+                        (
+                            targetRef,
+                        ): targetRef is Extract<
+                            AiAgentTargetRef,
+                            { type: 'product_capability' }
+                        > => targetRef.type === 'product_capability',
+                    )?.capabilityKey ?? null,
+            });
 
         const projectContextEntry =
             args.projectContextEnabled &&
@@ -1074,6 +1112,9 @@ export class AiAgentReviewClassifierService extends BaseService {
     ): Promise<{
         evidencePacket: AiAgentReviewJudgeEvidencePacket;
         agentConfig: AiAgentReviewAgentConfigEvidence;
+        // key ("item_1") → existing item fingerprint, kept server-side so a
+        // matchedExistingItemKey resolves to a real fingerprint (never the LLM).
+        dedupKeyToFingerprint: Map<string, string>;
     }> {
         const semanticContext = await this.buildSemanticContext(
             candidate,
@@ -1086,16 +1127,131 @@ export class AiAgentReviewClassifierService extends BaseService {
                 )
             ).get(candidate.subject.threadUuid) ?? [];
 
+        const { existingReviewItems, dedupKeyToFingerprint } =
+            await this.loadDedupCandidates(candidate);
+
         return {
             agentConfig,
+            dedupKeyToFingerprint,
             evidencePacket:
                 AiAgentReviewClassifierService.buildJudgeEvidencePacket({
                     candidate,
                     agentConfig,
                     semanticContext,
                     threadWritebackPullRequests,
+                    existingReviewItems,
                 }),
         };
+    }
+
+    /**
+     * Loads this project's existing review items as dedup candidates. Assigns
+     * opaque keys ("item_1", …) the judge can reference, and keeps a server-side
+     * key → fingerprint map so a match resolves to a real fingerprint. A failed
+     * load degrades to no candidates — it must never fail the review.
+     */
+    private async loadDedupCandidates(
+        candidate: AiAgentReviewClassifierTurnCandidate,
+    ): Promise<{
+        existingReviewItems: AiAgentReviewItemDedupCandidate[];
+        dedupKeyToFingerprint: Map<string, string>;
+    }> {
+        try {
+            const rows =
+                await this.aiAgentReviewClassifierModel.findReviewItemDedupCandidates(
+                    {
+                        organizationUuid: candidate.subject.organizationUuid,
+                        projectUuid: candidate.subject.projectUuid,
+                        limit: 30,
+                    },
+                );
+            const existingReviewItems: AiAgentReviewItemDedupCandidate[] = [];
+            const dedupKeyToFingerprint = new Map<string, string>();
+            rows.forEach((row, index) => {
+                const key = `item_${index + 1}`;
+                dedupKeyToFingerprint.set(key, row.fingerprint);
+                existingReviewItems.push({
+                    key,
+                    title: row.title ?? 'Untitled review item',
+                    status: row.status,
+                    dismissedReason: row.dismissedReason,
+                    primaryRootCause:
+                        (row.primaryRootCause as AiAgentRootCause | null) ??
+                        'ambiguous',
+                    objectSummary:
+                        AiAgentReviewClassifierService.buildDedupObjectSummary(
+                            row.targetRefs,
+                        ),
+                });
+            });
+            return { existingReviewItems, dedupKeyToFingerprint };
+        } catch (error) {
+            this.debugLog('DedupCandidatesFailed', {
+                promptUuid: candidate.subject.assistantPromptUuid,
+                projectUuid: candidate.subject.projectUuid,
+                errorMessage:
+                    error instanceof Error ? error.message : String(error),
+            });
+            return {
+                existingReviewItems: [],
+                dedupKeyToFingerprint: new Map<string, string>(),
+            };
+        }
+    }
+
+    /**
+     * Comma-joined human-readable leaf names of an item's target refs, so the
+     * judge can tell what each candidate is about without seeing fingerprints.
+     */
+    private static buildDedupObjectSummary(
+        targetRefs: AiAgentTargetRef[] | null,
+    ): string | null {
+        if (!targetRefs || targetRefs.length === 0) {
+            return null;
+        }
+        const names = targetRefs
+            .map((targetRef) =>
+                AiAgentReviewClassifierService.targetRefLeafName(targetRef),
+            )
+            .filter((name): name is string => !!name);
+        return names.length > 0 ? names.join(', ') : null;
+    }
+
+    private static targetRefLeafName(
+        targetRef: AiAgentTargetRef,
+    ): string | null {
+        switch (targetRef.type) {
+            case 'model':
+                return targetRef.modelName;
+            case 'explore':
+                return targetRef.exploreName;
+            case 'join':
+                return targetRef.joinName;
+            case 'dimension':
+                return targetRef.dimensionName;
+            case 'metric':
+                return targetRef.metricName;
+            case 'additional_dimension':
+                return targetRef.dimensionName;
+            case 'required_filter':
+                return targetRef.fieldName;
+            case 'ai_hint':
+                return targetRef.targetName;
+            case 'agent_config':
+                return targetRef.setting;
+            case 'product_capability':
+                return targetRef.capabilityKey;
+            case 'runtime':
+                return targetRef.key;
+            case 'agent':
+            case 'content':
+                return null;
+            default:
+                return assertUnreachable(
+                    targetRef,
+                    'Unknown target ref type in dedup object summary',
+                );
+        }
     }
 
     private async captureAgentConfigSnapshot(
@@ -1518,7 +1674,12 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
 - kind: definition | context. Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for everything else (routing/join rules, guidance, durable object-scoped facts).
 - content: a single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').
 - terms: the prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.
-- objects: the semantic objects this fact concerns, from targetRefs — explore names and/or field ids in the \`table_field\` form shown as fieldId in field results (e.g. "payments_total_amount"); [] when purely prompt-driven.`,
+- objects: the semantic objects this fact concerns, from targetRefs — explore names and/or field ids in the \`table_field\` form shown as fieldId in field results (e.g. "payments_total_amount"); [] when purely prompt-driven.
+
+Existing review items — dedup rules. The evidence packet field existingReviewItems lists this project's existing review items (key, title, status, dismissedReason, primaryRootCause, objectSummary). Apply these rules when promoting:
+- If the finding's underlying user need matches an existing item — even when you would assign a DIFFERENT root cause or blame a DIFFERENT object — set matchedExistingItemKey to that item's key. The test is "would a human say this is the same problem?", not "same technical label". A timeout, a missing field, and a routing gap that all block the same user question are ONE problem.
+- Items with dismissedReason=expected_behavior are known non-issues already reviewed by a human. If the turn's failure is that same behavior, set promotedToFinding=false and matchedExistingItemKey=null — do not re-file it.
+- Otherwise set matchedExistingItemKey=null.`,
                 },
                 {
                     role: 'user',
@@ -1714,11 +1875,13 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
         agentConfig,
         semanticContext,
         threadWritebackPullRequests,
+        existingReviewItems,
     }: {
         candidate: AiAgentReviewClassifierTurnCandidate;
         agentConfig: AiAgentReviewJudgeEvidencePacket['agentConfig'];
         semanticContext: AiAgentReviewJudgeEvidencePacket['semanticContext'];
         threadWritebackPullRequests: AiAgentReviewJudgeEvidencePacket['threadWritebackPullRequests'];
+        existingReviewItems: AiAgentReviewItemDedupCandidate[];
     }): AiAgentReviewJudgeEvidencePacket {
         return {
             subject: candidate.subject,
@@ -1759,6 +1922,7 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
             threadWritebackPullRequests,
             toolOutcomes: candidate.toolOutcomes,
             pendingApprovalTimeout: candidate.pendingApprovalTimeout,
+            existingReviewItems,
         };
     }
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -15,6 +15,7 @@ const baseJudgeOutput = {
     confidence: 'high' as const,
     promotedToFinding: true,
     promotionReason: 'Found a semantic-layer correction.',
+    matchedExistingItemKey: null,
     primaryRootCause: 'semantic_layer' as const,
     secondaryRootCauses: [],
     subcategories: [],
@@ -431,6 +432,33 @@ describe('aiAgentReviewClassifierJudgeOutputSchema', () => {
                 },
             }).success,
         ).toBe(true);
+    });
+
+    it('accepts a matchedExistingItemKey pointing at a candidate', () => {
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse({
+                ...baseJudgeOutput,
+                matchedExistingItemKey: 'item_3',
+            }).success,
+        ).toBe(true);
+    });
+
+    it('accepts a null matchedExistingItemKey', () => {
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse({
+                ...baseJudgeOutput,
+                matchedExistingItemKey: null,
+            }).success,
+        ).toBe(true);
+    });
+
+    it('rejects an output missing matchedExistingItemKey', () => {
+        const withoutKey: Record<string, unknown> = { ...baseJudgeOutput };
+        delete withoutKey.matchedExistingItemKey;
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse(withoutKey)
+                .success,
+        ).toBe(false);
     });
 });
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -321,6 +321,18 @@ export type AiAgentReviewItemDismissedReason =
     | 'low_confidence'
     | 'other';
 
+// Existing item shown to the judge so it can attach a recurring finding to an
+// open card instead of splitting it into a new one. `key` is a server-minted
+// opaque handle ("item_1"); fingerprints are never exposed to the LLM.
+export type AiAgentReviewItemDedupCandidate = {
+    key: string;
+    title: string;
+    status: AiAgentReviewItemStatus;
+    dismissedReason: AiAgentReviewItemDismissedReason | null;
+    primaryRootCause: AiAgentRootCause;
+    objectSummary: string | null;
+};
+
 // A recurring finding reopens a closed item so its "fixed → regressed" history
 // stays on one card — except items dismissed as expected behavior, which stay
 // dismissed rather than clawing back open on every recurrence.
@@ -524,6 +536,7 @@ export const aiAgentReviewClassifierJudgeOutputSchema = z
         confidence: z.enum(['low', 'medium', 'high']),
         promotedToFinding: z.boolean(),
         promotionReason: z.string().nullable(),
+        matchedExistingItemKey: z.string().nullable(),
         primaryRootCause: z.enum([
             'semantic_layer',
             'project_context',


### PR DESCRIPTION
## Problem

The review classifier judges each turn in isolation and never sees the agent's existing review items. The only dedup is a post-hoc exact-fingerprint upsert, and the judge blames a different root cause / object for the same underlying need on every run — so fingerprints never collide. One unanswerable question ("new vs returning customers") produced 6 review items across 3 root causes in one evening, each firing its own Slack notification. No deterministic fingerprint can merge across root causes; the judge (already on the strong tier) has the context to match, it just was never shown the candidates.

## Change

**Judge-side dedup.** The evidence packet now includes `existingReviewItems`: up to 30 most-recently-updated items for the project (statuses triage/open/in_progress/resolved/dismissed; `duplicate` excluded), each with an opaque key (`item_1`, …), title, status, dismissedReason, root cause, and an object summary derived from its target refs. The judge gets one new output field — `matchedExistingItemKey: string | null` (flat nullable string; the structured-output grammar has no headroom for enums/nested objects) — and prompt rules that say: match on the **underlying user need**, even across different root causes or blamed objects.

Server-side, the key is validated against a key→fingerprint map that never leaves the backend:
- valid key → reuse that item's fingerprint (all downstream logic — upsert, reopen-on-recurrence, created/recurred events — unchanged)
- null or hallucinated key → compute the deterministic fingerprint exactly as before (logged as `InvalidMatchedItemKey`)

The deterministic fingerprint remains the identity backbone; the LLM can only *narrow* to a server-presented list, never mint identity. A failed candidates load degrades to no candidates and never fails the review.

**Notify only on new items.** `createTurnSignal` now reports whether the promotion `created` a new item, `recurred` on an existing one, or was a same-turn re-review. Only `created` fingerprints reach `notifyNeedsReview` — recurrences accrue onto the existing board card silently. Run counters are unchanged.

Items dismissed as `expected_behavior` are presented to the judge as known non-issues with an instruction not to re-file them (they also keep their existing stay-dismissed carve-out server-side).

`JUDGE_PROMPT_HASH` bumped v14 → v15.

## Who's affected

- **Board/notifications only** — no API surface, ability, or migration changes. Affects all orgs with the review classifier enabled: fewer duplicate cards, Slack pings only for genuinely new items.
- **Recurrence visibility**: admins no longer get pinged when a known open item recurs; the recurrence is still recorded (finding appended, `recurred` event, reopen if it was resolved). This is the intended trade — the previous behavior pinged once per promoting run, which in practice meant several pings per day for one problem.
- Judge behavior is otherwise unchanged when there are no existing items (empty candidates list, field returns null).

## Known limitations

- Turns within one run are judged concurrently, so two *brand-new* duplicate findings in the same batch run can still split (they only merge if the judge names the same existing item, which can't exist yet mid-run). Cross-run dedup — the observed failure mode — is covered.
- The judge can decline to match (key=null) and split anyway; telemetry (`matchedExistingItemKey`, `fingerprintSource`, `matchedKeyValidated` on the judged-turn logs) tracks match rate and hallucinated-key rate per prompt hash for follow-up tuning.

## Testing

- Unit: schema accepts/requires the new field; candidate loading (defaults, failure degrade); fingerprint reuse on valid key + fallback on invalid key; `findReviewItemDedupCandidates` join/exclusion; notification fires for `created` and not for `recurred`.
- `pnpm -F backend typecheck` clean, 3362 backend tests pass, lint clean.
- Pre-merge follow-ups planned: live grammar canary with the v15 schema (structured-output grammar limits only surface live), replay comparison v14 vs v15, and an end-to-end re-run of the duplicate-storm scenario on a dev project.

Design doc: judge-side dedup for AI review items, 2026-07-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCPP8KZPqxa5d1NvoxrRxe