### PR TITLE
feat(avatars): shuffleable mesh gradient vibes with grain finish

### DIFF
--- a/packages/common/src/types/userAvatars.test.ts
+++ b/packages/common/src/types/userAvatars.test.ts
@@ -1,4 +1,5 @@
 import {
+    AVATAR_MESH_VIBES,
     generateAvatarMeshBackgroundImage,
     generateAvatarMeshBorderColor,
     getAvatarMeshClassName,
@@ -7,8 +8,11 @@ import {
     getUserAvatarUrl,
     hexToRgba,
     isHexColorString,
+    isMeshColorString,
     isUserAvatarColorValue,
     isUserAvatarGradientId,
+    parseMeshColor,
+    toMeshColor,
     USER_AVATAR_GRADIENT_IDS,
 } from './userAvatars';
 
@@ -86,7 +90,36 @@ describe('isUserAvatarColorValue', () => {
     it('accepts preset ids and hex colors, rejects everything else', () => {
         expect(isUserAvatarColorValue('lilac')).toBe(true);
         expect(isUserAvatarColorValue('#5e4cff')).toBe(true);
+        expect(isUserAvatarColorValue('mesh:2:#5e4cff')).toBe(true);
         expect(isUserAvatarColorValue('not-a-color')).toBe(false);
+    });
+});
+
+describe('isMeshColorString', () => {
+    it('accepts mesh values for all vibes in both hex cases', () => {
+        expect(isMeshColorString('mesh:0:#5e4cff')).toBe(true);
+        expect(isMeshColorString('mesh:3:#5E4CFF')).toBe(true);
+    });
+
+    it('rejects invalid vibes and malformed values', () => {
+        expect(isMeshColorString('mesh:4:#5e4cff')).toBe(false);
+        expect(isMeshColorString('mesh:0:#fff')).toBe(false);
+        expect(isMeshColorString('mesh:0:5e4cff')).toBe(false);
+        expect(isMeshColorString('#5e4cff')).toBe(false);
+        expect(isMeshColorString('solid:#5e4cff')).toBe(false);
+    });
+});
+
+describe('toMeshColor / parseMeshColor', () => {
+    it('round-trips every vibe', () => {
+        AVATAR_MESH_VIBES.forEach((vibe) => {
+            const encoded = toMeshColor('#5e4cff', vibe);
+            expect(isMeshColorString(encoded)).toBe(true);
+            expect(parseMeshColor(encoded)).toEqual({
+                vibe,
+                hex: '#5e4cff',
+            });
+        });
     });
 });
 
@@ -103,6 +136,24 @@ describe('generateAvatarMeshBackgroundImage', () => {
         expect(result).toContain('radial-gradient');
         expect(result).toContain('linear-gradient');
     });
+
+    it('defaults to vibe 0 so bare hex values render unchanged', () => {
+        expect(generateAvatarMeshBackgroundImage('#5e4cff')).toBe(
+            generateAvatarMeshBackgroundImage('#5e4cff', 0),
+        );
+    });
+
+    it('produces a distinct layered recipe per vibe', () => {
+        const results = AVATAR_MESH_VIBES.map((vibe) =>
+            generateAvatarMeshBackgroundImage('#5e4cff', vibe),
+        );
+        expect(new Set(results).size).toBe(AVATAR_MESH_VIBES.length);
+        results.forEach((result) => {
+            expect(result).toContain('#5e4cff');
+            expect(result).toContain('radial-gradient');
+            expect(result).toContain('linear-gradient');
+        });
+    });
 });
 
 describe('generateAvatarMeshBorderColor', () => {
@@ -114,8 +165,11 @@ describe('generateAvatarMeshBorderColor', () => {
 });
 
 describe('getAvatarMeshClassName', () => {
-    it('derives a stable, lowercase class name from the hex color', () => {
-        expect(getAvatarMeshClassName('#5E4CFF')).toBe('avatar-mesh-5e4cff');
+    it('derives a stable, lowercase class name from the hex color and vibe', () => {
+        expect(getAvatarMeshClassName('#5E4CFF')).toBe('avatar-mesh-0-5e4cff');
+        expect(getAvatarMeshClassName('#5E4CFF', 2)).toBe(
+            'avatar-mesh-2-5e4cff',
+        );
     });
 });
 

--- a/packages/common/src/types/userAvatars.ts
+++ b/packages/common/src/types/userAvatars.ts
@@ -1,3 +1,5 @@
+import assertUnreachable from '../utils/assertUnreachable';
+
 export const USER_AVATAR_GRADIENT_IDS = [
     'lilac',
     'blush',
@@ -51,14 +53,43 @@ export const toSolidColor = (hex: HexColor): SolidColor => `solid:${hex}`;
 export const getHexFromSolidColor = (value: SolidColor): HexColor =>
     value.slice('solid:'.length);
 
-/* A curated preset id, a user-picked custom mesh hex color, or a flat solid hex color. */
-export type UserAvatarColorValue = UserAvatarGradientId | HexColor | SolidColor;
+export const AVATAR_MESH_VIBES = [0, 1, 2, 3] as const;
+
+export type AvatarMeshVibe = (typeof AVATAR_MESH_VIBES)[number];
+
+const MESH_COLOR_REGEX = /^mesh:[0-3]:#[0-9a-fA-F]{6}$/;
+
+export type MeshColor = string;
+
+export const isMeshColorString = (value: string): value is MeshColor =>
+    MESH_COLOR_REGEX.test(value);
+
+export const toMeshColor = (hex: HexColor, vibe: AvatarMeshVibe): MeshColor =>
+    `mesh:${vibe}:${hex}`;
+
+export const parseMeshColor = (
+    value: MeshColor,
+): { vibe: AvatarMeshVibe; hex: HexColor } => ({
+    vibe: Number(
+        value.slice('mesh:'.length, 'mesh:'.length + 1),
+    ) as AvatarMeshVibe,
+    hex: value.slice('mesh:0:'.length),
+});
+
+/* A curated preset id, a custom mesh hex color (bare hex = vibe 0, or
+   mesh:<vibe>:#hex), or a flat solid hex color. */
+export type UserAvatarColorValue =
+    | UserAvatarGradientId
+    | HexColor
+    | MeshColor
+    | SolidColor;
 
 export const isUserAvatarColorValue = (
     value: string,
 ): value is UserAvatarColorValue =>
     isUserAvatarGradientId(value) ||
     isHexColorString(value) ||
+    isMeshColorString(value) ||
     isSolidColorString(value);
 
 type Hsl = { h: number; s: number; l: number };
@@ -129,10 +160,12 @@ export const hexToRgba = (hex: HexColor, alpha: number): string => {
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 
-/* Generates the same "paint splatter" mesh recipe used by the curated
-   gradients (bright corner, subtle opposite corner, two saturated spots,
-   diagonal wash) but parameterized from an arbitrary base hex color. */
-export const generateAvatarMeshBackgroundImage = (hex: HexColor): string => {
+/* Tiling SVG fractal-noise tile blended soft-light over the mesh for a film-grain finish. */
+const GRAIN_LAYER = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`;
+
+/* The original "paint splatter" recipe (bright corner, subtle opposite
+   corner, two saturated spots, diagonal wash). */
+const splatterMesh = (hex: HexColor): string => {
     const spotA = shiftHsl(hex, { hueShift: 24, satShift: 15, lightShift: 0 });
     const spotB = shiftHsl(hex, {
         hueShift: -24,
@@ -149,11 +182,106 @@ export const generateAvatarMeshBackgroundImage = (hex: HexColor): string => {
     ].join(', ');
 };
 
+/* Soft off-center dome of lightened base over an analogous halo, vertical wash. */
+const bloomMesh = (hex: HexColor): string => {
+    const dome = shiftHsl(hex, { satShift: 8, lightShift: 18 });
+    const halo = shiftHsl(hex, { hueShift: 20, satShift: 12, lightShift: -4 });
+    const washLight = shiftHsl(hex, { satShift: -15, lightShift: 30 });
+    return [
+        'radial-gradient(circle at 30% 12%, rgba(255, 255, 255, 0.55) 0%, transparent 45%)',
+        `radial-gradient(circle at 50% 36%, ${dome} 0%, transparent 65%)`,
+        `radial-gradient(circle at 62% 78%, ${halo} 0%, transparent 60%)`,
+        `linear-gradient(180deg, ${washLight} 0%, ${hex} 100%)`,
+    ].join(', ');
+};
+
+/* Three saturated spots pinned near triangle corners with wide overlapping
+   falloffs, no white highlight — the classic mesh-gradient look. */
+const cornersMesh = (hex: HexColor): string => {
+    const spotA = shiftHsl(hex, { hueShift: 30, satShift: 18, lightShift: 6 });
+    const spotB = shiftHsl(hex, {
+        hueShift: -30,
+        satShift: 14,
+        lightShift: -4,
+    });
+    const spotC = shiftHsl(hex, { satShift: 20, lightShift: 14 });
+    const washDark = shiftHsl(hex, { satShift: 6, lightShift: -18 });
+    return [
+        `radial-gradient(circle at 18% 20%, ${spotA} 0%, transparent 55%)`,
+        `radial-gradient(circle at 82% 24%, ${spotB} 0%, transparent 52%)`,
+        `radial-gradient(circle at 50% 88%, ${spotC} 0%, transparent 55%)`,
+        `linear-gradient(315deg, ${washDark} 0%, ${hex} 100%)`,
+    ].join(', ');
+};
+
+/* Two large opposing radials of the base and a hue-drifted twin bleeding
+   into each other diagonally, plus a small white glint. */
+const duotoneDriftMesh = (hex: HexColor): string => {
+    const driftA = shiftHsl(hex, { satShift: 12, lightShift: 10 });
+    const driftB = shiftHsl(hex, {
+        hueShift: 42,
+        satShift: 10,
+        lightShift: -2,
+    });
+    const washDeep = shiftHsl(hex, { hueShift: 20, lightShift: -14 });
+    return [
+        'radial-gradient(circle at 78% 15%, rgba(255, 255, 255, 0.8) 0%, transparent 22%)',
+        `radial-gradient(circle at 22% 25%, ${driftA} 0%, transparent 70%)`,
+        `radial-gradient(circle at 80% 78%, ${driftB} 0%, transparent 72%)`,
+        `linear-gradient(120deg, ${hex} 0%, ${washDeep} 100%)`,
+    ].join(', ');
+};
+
+export const generateAvatarMeshBackgroundImage = (
+    hex: HexColor,
+    vibe: AvatarMeshVibe = 0,
+): string => {
+    switch (vibe) {
+        case 0:
+            return splatterMesh(hex);
+        case 1:
+            return bloomMesh(hex);
+        case 2:
+            return cornersMesh(hex);
+        case 3:
+            return duotoneDriftMesh(hex);
+        default:
+            return assertUnreachable(vibe, `Unknown avatar mesh vibe ${vibe}`);
+    }
+};
+
+export type AvatarMeshBackground = {
+    backgroundImage: string;
+    backgroundBlendMode: string;
+    backgroundSize: string;
+};
+
+/* Grain tile stacked on top of the mesh; blend/size lists are per-layer. */
+export const generateAvatarMeshBackground = (
+    hex: HexColor,
+    vibe: AvatarMeshVibe = 0,
+): AvatarMeshBackground => {
+    const mesh = generateAvatarMeshBackgroundImage(hex, vibe);
+    const meshLayerCount = mesh.split('-gradient(').length - 1;
+    const meshLayers = Array.from({ length: meshLayerCount });
+    return {
+        backgroundImage: `${GRAIN_LAYER}, ${mesh}`,
+        backgroundBlendMode: `soft-light, ${meshLayers
+            .map(() => 'normal')
+            .join(', ')}`,
+        backgroundSize: `96px 96px, ${meshLayers
+            .map(() => '180% 180%')
+            .join(', ')}`,
+    };
+};
+
 export const generateAvatarMeshBorderColor = (hex: HexColor): string =>
     hexToRgba(hex, 0.4);
 
-export const getAvatarMeshClassName = (hex: HexColor): string =>
-    `avatar-mesh-${hex.slice(1).toLowerCase()}`;
+export const getAvatarMeshClassName = (
+    hex: HexColor,
+    vibe: AvatarMeshVibe = 0,
+): string => `avatar-mesh-${vibe}-${hex.slice(1).toLowerCase()}`;
 
 /* Relative luminance (WCAG) decides whether initials read better in black or white. */
 export const getContrastTextColor = (hex: HexColor): 'black' | 'white' => {

--- a/packages/frontend/src/components/Avatar.test.tsx
+++ b/packages/frontend/src/components/Avatar.test.tsx
@@ -43,6 +43,35 @@ describe('LightdashUserAvatar', () => {
         );
     });
 
+    it('renders the mesh branch for a vibe-encoded mesh value', () => {
+        renderWithProviders(
+            <LightdashUserAvatar
+                userUuid={UUID_A}
+                avatarGradient="mesh:2:#5e4cff"
+                name="Ada Lovelace"
+            />,
+        );
+        expect(
+            document.querySelector('[data-avatar-gradient="custom"]'),
+        ).toBeInTheDocument();
+        expect(
+            document.querySelector('.avatar-mesh-2-5e4cff'),
+        ).toBeInTheDocument();
+    });
+
+    it('falls back to the plain avatar for a malformed mesh value', () => {
+        renderWithProviders(
+            <LightdashUserAvatar
+                userUuid={UUID_A}
+                avatarGradient="mesh:9:#5e4cff"
+                name="Ada Lovelace"
+            />,
+        );
+        expect(
+            document.querySelector('[data-avatar-gradient]'),
+        ).not.toBeInTheDocument();
+    });
+
     it('keeps legacy color-initials behavior without a userUuid', () => {
         renderWithProviders(<LightdashUserAvatar name="Ada Lovelace" />);
         expect(

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -1,5 +1,5 @@
 import {
-    generateAvatarMeshBackgroundImage,
+    generateAvatarMeshBackground,
     generateAvatarMeshBorderColor,
     getAvatarMeshClassName,
     getAvatarSolidClassName,
@@ -7,8 +7,12 @@ import {
     getHexFromSolidColor,
     hexToRgba,
     isHexColorString,
+    isMeshColorString,
     isSolidColorString,
     isUserAvatarGradientId,
+    parseMeshColor,
+    type AvatarMeshVibe,
+    type HexColor,
     type UserAvatarColorValue,
 } from '@lightdash/common';
 import { Avatar, type AvatarProps } from '@mantine-8/core';
@@ -73,16 +77,26 @@ export const LightdashUserAvatar = forwardRef<HTMLDivElement, Props>(
                 />
             );
         }
-        if (userUuid && avatarGradient && isHexColorString(avatarGradient)) {
-            const meshClassName = getAvatarMeshClassName(avatarGradient);
-            const textColor = getContrastTextColor(avatarGradient);
+        const mesh: { hex: HexColor; vibe: AvatarMeshVibe } | null =
+            userUuid && avatarGradient && isHexColorString(avatarGradient)
+                ? { hex: avatarGradient, vibe: 0 }
+                : userUuid &&
+                    avatarGradient &&
+                    isMeshColorString(avatarGradient)
+                  ? parseMeshColor(avatarGradient)
+                  : null;
+        if (mesh) {
+            const meshClassName = getAvatarMeshClassName(mesh.hex, mesh.vibe);
+            const textColor = getContrastTextColor(mesh.hex);
+            const background = generateAvatarMeshBackground(
+                mesh.hex,
+                mesh.vibe,
+            );
             return (
                 <Fragment>
                     <style>
-                        {`.${classes.root}[data-avatar-gradient='custom'] .${classes.placeholder}.${meshClassName} { background-image: ${generateAvatarMeshBackgroundImage(
-                            avatarGradient,
-                        )}; box-shadow: inset 0 0 3px ${generateAvatarMeshBorderColor(
-                            avatarGradient,
+                        {`.${classes.root}[data-avatar-gradient='custom'] .${classes.placeholder}.${meshClassName} { background-image: ${background.backgroundImage}; background-blend-mode: ${background.backgroundBlendMode}; background-size: ${background.backgroundSize}; box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35), inset 0 0 3px ${generateAvatarMeshBorderColor(
+                            mesh.hex,
                         )}; color: ${textColor}; }`}
                     </style>
                     <Avatar

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.module.css
@@ -45,6 +45,7 @@
     border-radius: 50%;
     cursor: pointer;
     line-height: 0;
+    font: inherit;
 }
 
 .avatarEditOverlay {

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -1,9 +1,14 @@
 import {
+    AVATAR_MESH_VIBES,
     isHexColorString,
+    isMeshColorString,
     isSolidColorString,
     isUserAvatarGradientId,
+    parseMeshColor,
+    toMeshColor,
     toSolidColor,
     USER_AVATAR_GRADIENT_IDS,
+    type AvatarMeshVibe,
     type HexColor,
     type UserAvatarColorValue,
     type UserAvatarGradientId,
@@ -20,7 +25,7 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
-import { IconPencil } from '@tabler/icons-react';
+import { IconArrowsShuffle, IconPencil } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
@@ -50,8 +55,18 @@ const extractHex = (value: UserAvatarColorValue | null): HexColor => {
     if (!value) return DEFAULT_COLOR;
     if (isUserAvatarGradientId(value)) return GRADIENT_SWATCH_COLORS[value];
     if (isSolidColorString(value)) return value.slice(6) as HexColor;
+    if (isMeshColorString(value)) return parseMeshColor(value).hex;
     return value;
 };
+
+const extractVibe = (value: UserAvatarColorValue | null): AvatarMeshVibe =>
+    value && isMeshColorString(value) ? parseMeshColor(value).vibe : 0;
+
+/* Vibe 0 stays encoded as a bare hex for back-compat with existing values. */
+const encodeMesh = (
+    hex: HexColor,
+    vibe: AvatarMeshVibe,
+): UserAvatarColorValue => (vibe === 0 ? hex : toMeshColor(hex, vibe));
 
 const modeForValue = (value: UserAvatarColorValue | null): CustomMode =>
     value && isSolidColorString(value) ? 'solid' : 'gradient';
@@ -104,7 +119,20 @@ const AvatarSettings: FC = () => {
 
     const handleColorChange = (color: string) => {
         if (!isHexColorString(color)) return;
-        setPreviewValue(mode === 'solid' ? toSolidColor(color) : color);
+        setPreviewValue(
+            mode === 'solid'
+                ? toSolidColor(color)
+                : encodeMesh(color, extractVibe(previewValue)),
+        );
+    };
+
+    const handleShuffleVibe = () => {
+        const hex = extractHex(previewValue);
+        const currentVibe = extractVibe(previewValue);
+        const otherVibes = AVATAR_MESH_VIBES.filter((v) => v !== currentVibe);
+        const nextVibe =
+            otherVibes[Math.floor(Math.random() * otherVibes.length)];
+        setPreviewValue(encodeMesh(hex, nextVibe));
     };
 
     const handlePresetClick = (gradientId: UserAvatarGradientId | null) => {
@@ -171,6 +199,18 @@ const AvatarSettings: FC = () => {
                         value={extractHex(previewValue)}
                         onChange={handleColorChange}
                     />
+                    {mode === 'gradient' && (
+                        <Button
+                            variant="default"
+                            size="xs"
+                            leftSection={
+                                <MantineIcon icon={IconArrowsShuffle} />
+                            }
+                            onClick={handleShuffleVibe}
+                        >
+                            Shuffle gradient style
+                        </Button>
+                    )}
                     <Stack gap={6}>
                         <Text size="xs" c="dimmed" fw={500}>
                             Lightdash presets


### PR DESCRIPTION
## Summary

Custom gradient avatars all used a single fixed mesh recipe — users could change the color but every avatar had the same look. This adds **4 distinct mesh-gradient recipes ("vibes")** and a **shuffle button** in avatar settings so users can randomize the style of their chosen color:

| Vibe | Character |
|------|-----------|
| 0 — Splatter | The existing recipe (bright corner highlight, two hue-shifted spots, diagonal wash) |
| 1 — Bloom | Soft off-center radial dome + analogous halo, vertical wash |
| 2 — Corners | Three saturated spots with wide overlapping falloffs, no white highlight |
| 3 — Duotone drift | Two large opposing hue radials bleeding diagonally |

Also in this PR:

- **Film-grain finish** on all custom mesh avatars — a tiling SVG `feTurbulence` layer blended `soft-light` over the gradient stack
- **Subtle white inner ring** (`inset 0 0 0 1px rgba(255,255,255,0.35)`) on custom mesh avatars
- **Fix**: initials in the settings avatar preview fell back to UA `sans-serif` instead of Inter — the `<button>` wrapper didn't inherit font (`font: inherit`)

## How it works

The vibe is encoded in the existing persisted avatar value string as `mesh:<0-3>:#rrggbb`, validated by the shared `isUserAvatarColorValue` guard (which the backend `UserService` already uses). **A bare `#hex` still renders the original recipe (vibe 0)**, so existing custom avatars are unaffected — no migration, no API shape change, no backend code changes.

The shuffle button always jumps to a *different* vibe than the current one; changing the color keeps the selected vibe. Curated presets and solid colors are untouched.

## Who is affected

- Existing users with bare-hex custom avatars: gradient recipe unchanged; they gain the grain finish + inner ring (visual polish only).
- Users on older frontend versions render unknown `mesh:` values via the existing fallback (plain initials avatar) until they refresh — same failure mode as any new value format.
- Curated preset and solid-color avatars: unchanged.

## Testing

- Unit: round-trip encode/parse, validator accept/reject, distinct recipe per vibe, bare-hex back-compat (`packages/common/src/types/userAvatars.test.ts`); mesh render branch + malformed-value fallback (`Avatar.test.tsx`)
- Verified live: shuffled through all 4 vibes in settings, applied, confirmed persistence (`mesh:1:#ff6fc4` in DB) and identical rendering in navbar and settings

Closes: ZAP-586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqZkkQ5XJeYhg8ia8i6y9P
