### PR TITLE
fix(ai-agents): persist Slack "approve & don't ask again" for SQL across pods and suspend/resume

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -16,6 +16,7 @@ export type DbAiThread = {
     created_from: 'slack' | 'web_app' | 'evals'; // slack, web_app, evals etc
     title: string | null;
     title_generated_at: Date | null;
+    sql_auto_approved_at: Date | null;
 };
 
 export type AiThreadTable = Knex.CompositeTableType<
@@ -32,6 +33,7 @@ export type AiThreadTable = Knex.CompositeTableType<
             | 'title_generated_at'
             | 'project_uuid'
             | 'share_source_thread_share_uuid'
+            | 'sql_auto_approved_at'
         >
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260703100000_add_sql_auto_approved_at_to_ai_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260703100000_add_sql_auto_approved_at_to_ai_thread.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+const AiThreadTableName = 'ai_thread';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        // Set when a user clicks "Approve & don't ask again" on a Slack SQL
+        // approval card; subsequent runSql calls in the thread skip approval.
+        table.timestamp('sql_auto_approved_at', { useTz: true }).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.dropColumn('sql_auto_approved_at');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5906,6 +5906,25 @@ export class AiAgentModel {
     }
 
     /**
+     * Marks a thread as SQL auto-approved ("Approve & don't ask again").
+     * First write wins so the original approval timestamp is preserved.
+     */
+    async setThreadSqlAutoApproved(threadUuid: string): Promise<void> {
+        await this.database(AiThreadTableName)
+            .where({ ai_thread_uuid: threadUuid })
+            .whereNull('sql_auto_approved_at')
+            .update({ sql_auto_approved_at: new Date() });
+    }
+
+    async isThreadSqlAutoApproved(threadUuid: string): Promise<boolean> {
+        const row = await this.database(AiThreadTableName)
+            .where({ ai_thread_uuid: threadUuid })
+            .select('sql_auto_approved_at')
+            .first();
+        return row?.sql_auto_approved_at != null;
+    }
+
+    /**
      * Polls `ai_sql_approval` for a decision keyed by `toolCallId`.
      * Resolves to the decision once one is recorded, or `'timeout'`
      * after `timeoutMs` of no activity.

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -247,7 +247,6 @@ import {
 } from '../ai/repoFs/mountingRepoFileSystem';
 import { RepoFs } from '../ai/repoFs/RepoFs';
 import { renderBlocks as renderSqlApprovalBlocks } from '../ai/tools/slackSqlAggregate';
-import { markSlackThreadAutoApproved } from '../ai/tools/sqlApprovals';
 import {
     AiAgentArgs,
     AiAgentDependencies,
@@ -7543,6 +7542,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     decision,
                     decidedByUserUuid,
                 ),
+            isThreadSqlAutoApproved: (threadUuid) =>
+                this.aiAgentModel.isThreadSqlAutoApproved(threadUuid),
             loadSkill: async (name) =>
                 this.aiAgentToolsService.loadAgentSkill(name),
 
@@ -9365,7 +9366,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 }
 
                 if (isApprovedAlways) {
-                    markSlackThreadAutoApproved(threadUuid);
+                    await this.aiAgentModel.setThreadSqlAutoApproved(
+                        threadUuid,
+                    );
                 }
 
                 // We don't reverse-map Slack user IDs → Lightdash user UUIDs

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -406,6 +406,7 @@ const getAgentTools = (
               siteUrl: args.siteUrl,
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
+              isThreadSqlAutoApproved: dependencies.isThreadSqlAutoApproved,
               storeToolResults: dependencies.storeToolResults,
               maxQueryLimit: args.runSqlMaxLimit,
               autoApproveSql: args.autoApproveSql,

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -182,6 +182,7 @@ const makeAgentTools = () => {
         runSql: getRunSql({
             getPrompt: noop,
             recordSqlApproval: noop,
+            isThreadSqlAutoApproved: noop,
             storeToolResults: noop,
             runSqlJob: noop,
             sendFile: noop,

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -62,6 +62,7 @@ const makeTool = ({
         siteUrl: 'https://lightdash.example',
         waitForSqlApproval,
         recordSqlApproval,
+        isThreadSqlAutoApproved: vi.fn().mockResolvedValue(false),
         storeToolResults: vi.fn().mockResolvedValue(undefined),
         autoApproveSql,
         autoApproveSqlUserUuid,

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -9,6 +9,7 @@ import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
 import type {
     GetPromptFn,
+    IsThreadSqlAutoApprovedFn,
     RecordSqlApprovalFn,
     RunSqlJobFn,
     SendFileFn,
@@ -20,7 +21,6 @@ import type {
 import { serializeData } from '../utils/serializeData';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import { renderBlocks, type SectionState } from './slackSqlAggregate';
-import { isSlackThreadAutoApproved } from './sqlApprovals';
 
 type Dependencies = {
     updateProgress: UpdateProgressFn;
@@ -31,6 +31,7 @@ type Dependencies = {
     siteUrl: string;
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
+    isThreadSqlAutoApproved: IsThreadSqlAutoApprovedFn;
     storeToolResults: StoreToolResultsFn;
     maxQueryLimit: number;
     autoApproveSql?: boolean;
@@ -89,6 +90,7 @@ export const getRunSql = ({
     siteUrl,
     waitForSqlApproval,
     recordSqlApproval,
+    isThreadSqlAutoApproved,
     storeToolResults,
     maxQueryLimit,
     autoApproveSql = false,
@@ -110,7 +112,7 @@ export const getRunSql = ({
         const prompt = await getPrompt();
         return (
             isSlackPrompt(prompt) &&
-            !isSlackThreadAutoApproved(prompt.threadUuid)
+            !(await isThreadSqlAutoApproved(prompt.threadUuid))
         );
     };
 
@@ -142,7 +144,7 @@ export const getRunSql = ({
             const prompt = await getPrompt();
             const isSlack = isSlackPrompt(prompt);
             const slackAutoApproved =
-                isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
+                isSlack && (await isThreadSqlAutoApproved(prompt.threadUuid));
             const shouldAutoApprove = autoApproveSql || slackAutoApproved;
             // When native approval gated this call, execute only runs after the
             // user approved (or auto-approve). No blocking wait, no pending card

--- a/packages/backend/src/ee/services/ai/tools/sqlApprovals.ts
+++ b/packages/backend/src/ee/services/ai/tools/sqlApprovals.ts
@@ -1,27 +1,9 @@
 import { type AiSqlApprovalDecision } from '../../../database/entities/ai';
 
-// ---------------------------------------------------------------------------
-// SQL approval — in-memory UX flag for Slack "approve & don't ask again"
-//
-// The decision itself (approved / rejected) is persisted in the
-// `ai_sql_approval` table via `AiAgentModel.waitForSqlApproval` /
-// `recordSqlApproval`. That part is the one that has to survive pod
-// restarts / cross-pod requests.
-//
-// What's left here is session-scoped UX state: when the user clicks
-// "Approve & don't ask again" from a Slack approval message, we remember
-// that thread for the lifetime of this pod so subsequent runSql calls in
-// the same thread skip the approval flow. It's a UX nicety, not a
-// correctness primitive, so the in-memory Set is fine.
-// ---------------------------------------------------------------------------
-
-const slackAutoApprovedThreads = new Set<string>();
+// SQL approval decisions (approved / rejected) persist per tool call in the
+// `ai_sql_approval` table; the thread-level "approve & don't ask again" flag
+// persists on `ai_thread.sql_auto_approved_at`. Both survive pod restarts and
+// cross-pod requests (Slack interactivity is handled by the API pod while the
+// agent runs on the scheduler worker).
 
 export type SqlApprovalDecision = AiSqlApprovalDecision | 'timeout';
-
-export const markSlackThreadAutoApproved = (threadUuid: string): void => {
-    slackAutoApprovedThreads.add(threadUuid);
-};
-
-export const isSlackThreadAutoApproved = (threadUuid: string): boolean =>
-    slackAutoApprovedThreads.has(threadUuid);

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -35,6 +35,7 @@ import {
     GetSavedChartFn,
     GetVerifiedFieldUsageFn,
     IsPromptInterruptedFn,
+    IsThreadSqlAutoApprovedFn,
     ListContentFn,
     ListExploresFn,
     ListKnowledgeDocumentsFn,
@@ -205,6 +206,7 @@ export type AiAgentDependencies = {
     getProjectInfo: GetProjectInfoFn;
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
+    isThreadSqlAutoApproved: IsThreadSqlAutoApprovedFn;
     loadSkill: LoadAgentSkillFn;
     perf: PerformanceMetrics;
 };

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -488,6 +488,10 @@ export type RecordSqlApprovalFn = (
     decidedByUserUuid: string | null,
 ) => Promise<boolean>;
 
+export type IsThreadSqlAutoApprovedFn = (
+    threadUuid: string,
+) => Promise<boolean>;
+
 export type LoadAgentSkillFn = (
     name: string,
 ) => Promise<AiAgentSkill | undefined>;


### PR DESCRIPTION
## Problem

Clicking **Approve & don't ask again** on a Slack SQL approval card doesn't stick: every subsequent `runSql` call in the same thread posts a fresh "Awaiting approval to run SQL" card, immediately after the "✅ SQL approved — won't ask again this thread" confirmation.

## Root cause

The thread-level "don't ask again" flag was only ever an **in-memory `Set`** (`sqlApprovals.ts`), written by the process that handles Slack interactivity (API pod) and read by the scheduler-worker job that runs the agent — two different processes in production. The `ai_sql_approval` table persists only the per-tool-call `approved`/`rejected` decision; the "always" part of `approved_always` was collapsed and never stored.

The modern-blocks native-approval flow (#24562) made this always broken, even single-pod: each approval suspends the run and resumes via a re-enqueued Graphile job, so `needsApproval` is evaluated in a fresh job where the Set is cold. The flag also silently died on every deploy/pod restart. #22993 fixed exactly this class of bug for the approve/reject decision itself but left the thread flag in memory.

## Fix

Persist the flag on the thread and drop the in-memory Set:

- **Migration**: nullable `sql_auto_approved_at` timestamptz on `ai_thread`.
- **`AiAgentModel`**: `setThreadSqlAutoApproved` (first-write-wins) + `isThreadSqlAutoApproved`.
- **Slack button handler**: `approved_always` now writes `ai_thread.sql_auto_approved_at` instead of the Set.
- **`runSql` tool**: `needsApproval` and the execute-path auto-approve check read the flag via a new injected `isThreadSqlAutoApproved` dependency (DB primary-key lookup).
- **`sqlApprovals.ts`**: reduced to the `SqlApprovalDecision` type.

## Behavior change / regression analysis

- **Slack agent users**: "don't ask again" now actually holds for the lifetime of the thread — across worker jobs, pods, and deploys. Previously it only held within a single process lifetime (i.e. effectively never in cloud). This makes the flag *more* durable: it no longer resets on pod restart. That matches what the button promises ("won't ask again this thread") and the flag is scoped to a single thread, so the blast radius of a mistaken click is unchanged.
- **Web-app agent users**: unaffected — the flag is only ever set from the Slack button handler, and all reads remain gated on `isSlackPrompt`.
- **Auto-approve agents (`autoApproveSql`)**: unaffected — checked before the thread flag, same as before.
- **Cost**: one indexed PK lookup per `runSql` call (in `needsApproval` and once in execute).

## Testing

- Backend typecheck + affected unit tests pass (mocks updated for the new dependency).
- Live end-to-end in Slack: approval card → "Approve & don't ask again" → `ai_thread.sql_auto_approved_at` set; a second `runSql` in the same run auto-approved with no card; a **follow-up prompt in the same thread** (fresh worker job — the previously broken case) ran SQL with no approval card.

Closes: ZAP-587

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKwGCTswbs3MfCVbpstXFU
