### PR TITLE
feat(apps): push host color scheme into data app iframes

### DIFF
--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -618,3 +618,16 @@ export type DataAppVizContext = {
     fieldMapping: Record<string, string>;
     rows: Record<string, unknown>[];
 };
+
+// postMessage type the host uses to push its resolved color scheme into the
+// iframe so generated apps follow the host's light/dark mode. Sent on iframe
+// load and on every toggle; the initial scheme also rides the iframe URL hash
+// (`theme=`) so the app's first paint matches without waiting for a message.
+export const APP_SDK_THEME_MESSAGE = 'lightdash:sdk:theme';
+
+export type AppSdkColorScheme = 'light' | 'dark';
+
+export type AppSdkThemeMessage = {
+    type: typeof APP_SDK_THEME_MESSAGE;
+    colorScheme: AppSdkColorScheme;
+};

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -12,6 +12,7 @@ import AppIframePreview from '../../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../features/apps/previewOrigin';
+import { useInitialColorScheme } from '../../features/apps/useInitialColorScheme';
 import { DashboardTileComments } from '../../features/comments';
 import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFiltersForTile';
 import { useProject } from '../../hooks/useProject';
@@ -81,6 +82,7 @@ const DataAppTile: FC<Props> = (props) => {
     );
 
     const previewOrigin = usePreviewOrigin();
+    const initialColorScheme = useInitialColorScheme();
     const { data: project } = useProject(projectUuid);
     const isPreviewProject = project?.type === ProjectType.PREVIEW;
     // Skip the network calls when the backend already told us the app is
@@ -148,7 +150,7 @@ const DataAppTile: FC<Props> = (props) => {
 
     const previewUrl =
         token && latestReadyVersion
-            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/?f=${filtersKey}&r=${refreshCounter}#transport=postMessage&projectUuid=${projectUuid}`
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/?f=${filtersKey}&r=${refreshCounter}#transport=postMessage&projectUuid=${projectUuid}&theme=${initialColorScheme}`
             : undefined;
 
     const isForbidden =

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -7,6 +7,7 @@ import AppIframePreview from '../../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../features/apps/previewOrigin';
+import { useInitialColorScheme } from '../../features/apps/useInitialColorScheme';
 import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -29,6 +30,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { visualizationConfig, resultsData } = useVisualizationContext();
     const previewOrigin = usePreviewOrigin();
+    const initialColorScheme = useInitialColorScheme();
     const hasSignaledScreenshotReady = useRef(false);
 
     // Signal screenshot readiness on mount so dashboard capture isn't blocked
@@ -89,7 +91,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         );
     }
 
-    const previewUrl = `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${readyVersion}/t/${token}/?r=0#transport=postMessage&projectUuid=${projectUuid}`;
+    const previewUrl = `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${readyVersion}/t/${token}/?r=0#transport=postMessage&projectUuid=${projectUuid}&theme=${initialColorScheme}`;
 
     return (
         <AppIframePreview

--- a/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
@@ -5,6 +5,7 @@ import SuboptimalState from '../../../../../components/common/SuboptimalState/Su
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
 import { useEmbedAppPreviewToken } from '../../../../../features/apps/hooks/useEmbedAppPreviewToken';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
+import { useInitialColorScheme } from '../../../../../features/apps/useInitialColorScheme';
 
 type Props = {
     appUuid: string;
@@ -19,10 +20,12 @@ type Props = {
  */
 const EmbedApp: FC<Props> = ({ appUuid, projectUuid }) => {
     const previewOrigin = usePreviewOrigin();
+    // Reflects the embed's forced `?theme=` scheme (applied by the providers).
+    const initialColorScheme = useInitialColorScheme();
     const tokenQuery = useEmbedAppPreviewToken(projectUuid, appUuid);
 
     const previewUrl = tokenQuery.data
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/#transport=postMessage&projectUuid=${projectUuid}&theme=${initialColorScheme}`
         : undefined;
 
     const statusCode = tokenQuery.error?.error?.statusCode;

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
@@ -10,6 +10,7 @@ import TileBase from '../../../../../components/DashboardTiles/TileBase';
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
 import { useEmbedAppPreviewToken } from '../../../../../features/apps/hooks/useEmbedAppPreviewToken';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
+import { useInitialColorScheme } from '../../../../../features/apps/useInitialColorScheme';
 import useDashboardFiltersForTile from '../../../../../hooks/dashboard/useDashboardFiltersForTile';
 import { convertDateDashboardFilters } from '../../../../../utils/dateFilter';
 
@@ -42,6 +43,8 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
     );
 
     const previewOrigin = usePreviewOrigin();
+    // Reflects the embed's forced `?theme=` scheme (applied by the providers).
+    const initialColorScheme = useInitialColorScheme();
     // Skip the round-trip when the backend already flagged the app as gone.
     const shouldFetch = !!projectUuid && !!appUuid && !appDeletedAt;
     const tokenQuery = useEmbedAppPreviewToken(
@@ -58,7 +61,7 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
     );
 
     const previewUrl = tokenQuery.data
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/?f=${filtersKey}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/?f=${filtersKey}#transport=postMessage&projectUuid=${projectUuid}&theme=${initialColorScheme}`
         : undefined;
 
     const statusCode = tokenQuery.error?.error?.statusCode;

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -1,4 +1,5 @@
 import {
+    type AppSdkColorScheme,
     type DataAppVizContext,
     type DashboardFilters,
 } from '@lightdash/common';
@@ -91,6 +92,10 @@ type Props = {
     // Render context for data app vizs: the field mapping + host rows, pushed
     // into the iframe over the SDK bridge. Undefined for ordinary data apps.
     dataAppVizContext?: DataAppVizContext;
+    /** Overrides the color scheme pushed to the iframe — set to `light` by
+     *  MinimalApp so scheduled screenshots are deterministic. When undefined
+     *  the bridge follows the host's resolved Mantine scheme. */
+    forcedColorScheme?: AppSdkColorScheme;
 };
 
 /**
@@ -139,6 +144,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onIframeLoad,
             capabilities,
             dataAppVizContext,
+            forcedColorScheme,
         },
         ref,
     ) => {
@@ -178,6 +184,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onLineageSelected,
             onExternalRequestEvent,
             dataAppVizContext,
+            forcedColorScheme,
         });
         const { captureScreenshot } = useIframeScreenshot(iframeRef);
 

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,11 +1,15 @@
 import {
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+    APP_SDK_THEME_MESSAGE,
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     JWT_HEADER_NAME,
     LightdashAppUuidHeader,
+    type AppSdkColorScheme,
+    type AppSdkThemeMessage,
     type DataAppVizContext,
     type DashboardFilters,
 } from '@lightdash/common';
+import { useMantineColorScheme } from '@mantine/core';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { lightdashApi } from '../../../api';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
@@ -237,6 +241,12 @@ export type UseAppSdkBridgeParams = {
     // When set, the host pushes this render context into the iframe over the
     // existing bridge — on load and on every change. Only set for data app vizs.
     dataAppVizContext?: DataAppVizContext;
+    /**
+     * Overrides the host color scheme pushed into the iframe. Set to `light`
+     * by MinimalApp so scheduled screenshots are deterministic; everywhere
+     * else the bridge follows the resolved Mantine scheme.
+     */
+    forcedColorScheme?: AppSdkColorScheme;
 };
 
 export function useAppSdkBridge({
@@ -255,6 +265,7 @@ export function useAppSdkBridge({
     onLineageSelected,
     onExternalRequestEvent,
     dataAppVizContext,
+    forcedColorScheme,
 }: UseAppSdkBridgeParams) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -265,6 +276,20 @@ export function useAppSdkBridge({
     //     unchanged — the rewrite happens entirely on the parent side.
     const { embedToken, projectUuid: embedProjectUuid } = useEmbed();
     const { health, user } = useApp();
+
+    // Resolved host scheme ('light' | 'dark'; embed forcing already applied
+    // by the providers). Pushed into the iframe so generated apps follow it.
+    const { colorScheme } = useMantineColorScheme();
+    const effectiveColorScheme: AppSdkColorScheme =
+        forcedColorScheme ?? colorScheme;
+
+    const pushTheme = useCallback(() => {
+        const message: AppSdkThemeMessage = {
+            type: APP_SDK_THEME_MESSAGE,
+            colorScheme: effectiveColorScheme,
+        };
+        iframeRef.current?.contentWindow?.postMessage(message, '*');
+    }, [iframeRef, effectiveColorScheme]);
 
     // Maps queryUuid → POST request id. The SDK transport assigns a fresh
     // request id to the POST (`/metric-query`) and again to each GET poll
@@ -869,7 +894,10 @@ export function useAppSdkBridge({
             { type: 'lightdash:sdk:ready' },
             '*',
         );
-    }, [iframeRef]);
+        // The URL-hash `theme=` param only carries the scheme at iframe-src
+        // build time; re-push on load so reloads after a toggle stay in sync.
+        pushTheme();
+    }, [iframeRef, pushTheme]);
 
     // Re-push the render context whenever the host's field mapping or rows
     // change, so an already-loaded iframe re-renders live. The initial delivery
@@ -878,6 +906,12 @@ export function useAppSdkBridge({
     useEffect(() => {
         pushDataAppVizContext();
     }, [pushDataAppVizContext]);
+
+    // Push the scheme whenever it changes so an already-loaded iframe flips
+    // live. Initial delivery rides the URL hash + the load-time push above.
+    useEffect(() => {
+        pushTheme();
+    }, [pushTheme]);
 
     const enableInspector = useCallback(() => {
         iframeRef.current?.contentWindow?.postMessage(

--- a/packages/frontend/src/features/apps/useInitialColorScheme.ts
+++ b/packages/frontend/src/features/apps/useInitialColorScheme.ts
@@ -1,0 +1,14 @@
+import { type AppSdkColorScheme } from '@lightdash/common';
+import { useMantineColorScheme } from '@mantine/core';
+import { useState } from 'react';
+
+/**
+ * Host color scheme captured once at mount, for the iframe URL-hash `theme=`
+ * param. Frozen so the iframe src stays stable across toggles — live scheme
+ * changes ride the SDK bridge's theme push, not the URL.
+ */
+export const useInitialColorScheme = (): AppSdkColorScheme => {
+    const { colorScheme } = useMantineColorScheme();
+    const [initialColorScheme] = useState<AppSdkColorScheme>(colorScheme);
+    return initialColorScheme;
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -116,6 +116,7 @@ import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQuerie
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { getTemplate } from '../features/apps/templates';
+import { useInitialColorScheme } from '../features/apps/useInitialColorScheme';
 import {
     mergeChatMessages,
     type ChatChart,
@@ -239,8 +240,9 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
         } = useAppPreviewToken(projectUuid, appUuid, version);
 
         const previewOrigin = usePreviewOrigin();
+        const initialColorScheme = useInitialColorScheme();
         const previewUrl = token
-            ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}&theme=${initialColorScheme}`
             : undefined;
 
         if (isLoading) {

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -17,6 +17,7 @@ import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
+import { useInitialColorScheme } from '../features/apps/useInitialColorScheme';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import classes from './AppPreviewTest.module.css';
 
@@ -122,6 +123,7 @@ export default function AppPreviewTest() {
     }, []);
 
     const previewOrigin = usePreviewOrigin();
+    const initialColorScheme = useInitialColorScheme();
 
     if (dataAppsFlag.isLoading) {
         return null;
@@ -175,7 +177,7 @@ export default function AppPreviewTest() {
     }
 
     const previewUrl = token
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}&theme=${initialColorScheme}`
         : undefined;
 
     if (isLoading) {

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -178,8 +178,10 @@ export default function MinimalApp() {
         );
     }
 
+    // Scheduled screenshots must be deterministic — always capture light,
+    // regardless of whatever scheme the headless browser would resolve.
     const previewUrl = token
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}&theme=light`
         : undefined;
     if (!previewUrl) return null;
 
@@ -194,6 +196,7 @@ export default function MinimalApp() {
                 onIframeLoad={handleIframeLoad}
                 onQueryEvent={handleQueryEvent}
                 onScreenshotAvailabilityChange={handleScreenshotAvailable}
+                forcedColorScheme="light"
             />
             {isReady && (
                 <ScreenshotReadyIndicator


### PR DESCRIPTION
## Summary

Data apps render in a sandboxed, opaque-origin iframe with no signal of the host's light/dark mode. This PR adds the host side of a theme channel:

- New `APP_SDK_THEME_MESSAGE` (`lightdash:sdk:theme`) message type + `AppSdkColorScheme` in common.
- `useAppSdkBridge` pushes the resolved Mantine color scheme into the iframe on load and on every toggle (embeds inherit the forced `?theme=` scheme via the providers).
- Every preview-iframe src now carries the initial scheme in the URL hash (`theme=`), frozen at mount via a new `useInitialColorScheme` hook so toggles don't churn the src. This lets the app paint the right scheme before the first message arrives.
- `MinimalApp` forces light so scheduled screenshots stay deterministic.

No behavior change for existing apps: bundles without the new SDK ignore both signals.

## Testing

- `pnpm -F common test` (2636 pass), `typecheck:fast` + lint clean on common/frontend.
- Live end-to-end verification (fresh app generation against a dev sandbox template + host toggle) is in progress and will be reported before marking ready for review.

Relates: GLITCH-591