### PR TITLE
feat(query-sdk): follow the host color scheme inside data apps

### DIFF
--- a/packages/query-sdk/src/client.ts
+++ b/packages/query-sdk/src/client.ts
@@ -10,6 +10,7 @@ import { mountInspector } from './inspector';
 import { mountLineage } from './lineage';
 import { createPostMessageTransport } from './postMessageTransport';
 import { QueryBuilder } from './query';
+import { mountThemeSync } from './theme';
 import type {
     ExternalFetchOptions,
     ExternalFetchResult,
@@ -103,14 +104,20 @@ function configFromEnv(): LightdashClientConfig | null {
 export function createClient(): LightdashClient {
     // 1. postMessage transport (iframe hosted by Lightdash parent)
     if (typeof window !== 'undefined' && window.location.hash) {
-        const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+        const params = new URLSearchParams(
+            window.location.hash.replace(/^#/, ''),
+        );
         if (params.get('transport') === 'postMessage') {
             const projectUuid = params.get('projectUuid') ?? '';
             mountInspector(window.parent);
             mountLineage(window.parent);
+            mountThemeSync();
             return new LightdashClient(
                 { apiKey: '', baseUrl: '', projectUuid },
-                createPostMessageTransport({ targetWindow: window.parent, projectUuid }),
+                createPostMessageTransport({
+                    targetWindow: window.parent,
+                    projectUuid,
+                }),
             );
         }
     }

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -93,3 +93,7 @@ export type {
     DataAppVizContextMessage,
     VizContextRequestMessage,
 } from './vizContext';
+
+// Host color-scheme sync (light/dark mode follows the Lightdash parent)
+export { getHashColorScheme, mountThemeSync, useColorScheme } from './theme';
+export type { ColorScheme, SdkThemeMessage } from './theme';

--- a/packages/query-sdk/src/theme.test.ts
+++ b/packages/query-sdk/src/theme.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `mountThemeSync` is module-level idempotent, so each test gets a fresh module.
+async function loadTheme() {
+    vi.resetModules();
+    return import('./theme');
+}
+
+function postTheme(data: unknown) {
+    window.dispatchEvent(new MessageEvent('message', { data }));
+}
+
+beforeEach(() => {
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.colorScheme = '';
+    window.location.hash = '';
+});
+
+describe('getHashColorScheme', () => {
+    it('reads the theme param from the URL hash', async () => {
+        const { getHashColorScheme } = await loadTheme();
+        window.location.hash =
+            '#transport=postMessage&projectUuid=abc&theme=dark';
+        expect(getHashColorScheme()).toBe('dark');
+        window.location.hash = '#transport=postMessage&theme=light';
+        expect(getHashColorScheme()).toBe('light');
+    });
+
+    it('returns null when the param is missing or invalid', async () => {
+        const { getHashColorScheme } = await loadTheme();
+        window.location.hash = '#transport=postMessage&projectUuid=abc';
+        expect(getHashColorScheme()).toBeNull();
+        window.location.hash = '#theme=blue';
+        expect(getHashColorScheme()).toBeNull();
+    });
+});
+
+describe('mountThemeSync', () => {
+    it('applies the URL-hash scheme immediately', async () => {
+        const { mountThemeSync } = await loadTheme();
+        window.location.hash = '#transport=postMessage&theme=dark';
+        mountThemeSync();
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        expect(document.documentElement.style.colorScheme).toBe('dark');
+    });
+
+    it('leaves the document untouched when the host sends no signal', async () => {
+        const { mountThemeSync } = await loadTheme();
+        mountThemeSync();
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+        expect(document.documentElement.style.colorScheme).toBe('');
+    });
+
+    it('follows lightdash:sdk:theme messages', async () => {
+        const { mountThemeSync } = await loadTheme();
+        mountThemeSync();
+
+        postTheme({ type: 'lightdash:sdk:theme', colorScheme: 'dark' });
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        expect(document.documentElement.style.colorScheme).toBe('dark');
+
+        postTheme({ type: 'lightdash:sdk:theme', colorScheme: 'light' });
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+        expect(document.documentElement.style.colorScheme).toBe('light');
+    });
+
+    it('ignores unrelated and malformed messages', async () => {
+        const { mountThemeSync } = await loadTheme();
+        window.location.hash = '#transport=postMessage&theme=dark';
+        mountThemeSync();
+
+        postTheme({ type: 'lightdash:sdk:ready' });
+        postTheme({ type: 'lightdash:sdk:theme', colorScheme: 'blue' });
+        postTheme(null);
+        postTheme('lightdash:sdk:theme');
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+});

--- a/packages/query-sdk/src/theme.ts
+++ b/packages/query-sdk/src/theme.ts
@@ -1,0 +1,86 @@
+/**
+ * Host color-scheme sync for apps running inside the Lightdash iframe.
+ *
+ * The host owns light/dark mode; the app follows. Two delivery paths:
+ * the initial scheme rides the iframe URL hash (`theme=`) so the first
+ * paint is correct, and live toggles arrive as `lightdash:sdk:theme`
+ * postMessages. Applying a scheme toggles the `dark` class on `<html>`
+ * (Tailwind `darkMode: ['class']`) and sets the CSS `color-scheme` so
+ * native controls and scrollbars follow.
+ *
+ * Hosts older than this protocol send neither signal — the document is
+ * left untouched and the app keeps its authored scheme.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+export type ColorScheme = 'light' | 'dark';
+
+/** Pushed by the host on iframe load and on every theme toggle. */
+export type SdkThemeMessage = {
+    type: 'lightdash:sdk:theme';
+    colorScheme: ColorScheme;
+};
+
+const THEME_MESSAGE = 'lightdash:sdk:theme';
+
+let currentColorScheme: ColorScheme = 'light';
+const listeners = new Set<() => void>();
+
+function isColorScheme(value: unknown): value is ColorScheme {
+    return value === 'light' || value === 'dark';
+}
+
+/** Initial scheme from the URL hash (`theme=`), or null when the host didn't send one. */
+export function getHashColorScheme(): ColorScheme | null {
+    if (typeof window === 'undefined' || !window.location.hash) return null;
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    const theme = params.get('theme');
+    return isColorScheme(theme) ? theme : null;
+}
+
+function applyColorScheme(colorScheme: ColorScheme): void {
+    currentColorScheme = colorScheme;
+    document.documentElement.classList.toggle('dark', colorScheme === 'dark');
+    document.documentElement.style.colorScheme = colorScheme;
+    listeners.forEach((listener) => listener());
+}
+
+let mounted = false;
+
+/**
+ * Applies the URL-hash scheme immediately, then follows the host's
+ * `lightdash:sdk:theme` messages. Mounted by `createClient()` on the
+ * postMessage transport path; idempotent.
+ */
+export function mountThemeSync(): void {
+    if (mounted || typeof window === 'undefined') return;
+    mounted = true;
+
+    const initial = getHashColorScheme();
+    if (initial) applyColorScheme(initial);
+
+    window.addEventListener('message', (event: MessageEvent) => {
+        const data = event.data as Partial<SdkThemeMessage> | undefined;
+        if (data?.type !== THEME_MESSAGE) return;
+        if (!isColorScheme(data.colorScheme)) return;
+        applyColorScheme(data.colorScheme);
+    });
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}
+
+const getSnapshot = (): ColorScheme => currentColorScheme;
+const getServerSnapshot = (): ColorScheme => 'light';
+
+/**
+ * Current host color scheme — 'light' until the host signals otherwise.
+ * For JS that can't read the CSS variables (e.g. imperative chart config);
+ * token-based styling adapts through the `dark` class without this hook.
+ */
+export function useColorScheme(): ColorScheme {
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/sandboxes/data-apps/template/index.html
+++ b/sandboxes/data-apps/template/index.html
@@ -4,6 +4,22 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Lightdash Data App</title>
+        <!-- Apply the host's color scheme (URL-hash `theme=`) before the
+             bundle loads so the first paint doesn't flash the wrong theme.
+             The SDK keeps it in sync with host toggles after boot. -->
+        <script>
+            (function () {
+                var match = /[#&]theme=(light|dark)(?:&|$)/.exec(
+                    window.location.hash,
+                );
+                if (!match) return;
+                document.documentElement.classList.toggle(
+                    'dark',
+                    match[1] === 'dark',
+                );
+                document.documentElement.style.colorScheme = match[1];
+            })();
+        </script>
     </head>
     <body>
         <div id="root"></div>


### PR DESCRIPTION
## Summary

The iframe side of the data-app theme channel (host side in the down-stack PR):

- New `theme.ts` in `@lightdash/query-sdk`: `mountThemeSync()` applies the URL-hash scheme immediately, then follows `lightdash:sdk:theme` messages by toggling the `dark` class on `<html>` (Tailwind `darkMode: ['class']`) and setting CSS `color-scheme`. Mounted from `createClient()` on the postMessage-transport path, alongside the inspector/lineage mounts. Hosts that send no signal leave the document untouched, so apps keep their authored scheme against older hosts.
- `useColorScheme()` hook for imperative consumers that can't read CSS variables.
- Sandbox template `index.html` gets a tiny pre-bundle script that applies the hash scheme before the bundle loads, killing the flash of wrong theme on dark reloads.

The template's `:root`/`.dark` token sets already exist, so token-styled apps adapt with no generated code. Ships to generated apps on the next sandbox template rebuild.

## Testing

- New `theme.test.ts` (hash parsing, message handling, no-signal no-op); query-sdk suite 50/50; typecheck + lint clean.
- A dev sandbox template was published from this branch; live end-to-end verification (fresh app generation + host toggle) is in progress and will be reported before marking ready for review.

Relates: GLITCH-591