### PR TITLE
docs(data-apps): generator authors both color schemes, host owns .dark

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -34,7 +34,7 @@ Build a print-optimized report:
 const DATA_APP_VIZ_INSTRUCTIONS = `[Data app viz]
 You are building ONE reusable chart component. You do NOT fetch data or run queries: Lightdash runs the query, then gives you the result rows plus a mapping from your field names to the columns in those rows. The same component is reused across many different queries, so never hardcode column names — just render whatever data you are handed.
 
-Three requirements, all mandatory:
+Four requirements, all mandatory:
 
 1. Build ONE chart visualization component whose job is to make the mapped data easy to read at a glance. Build the chart type the user asked for; only if they didn't specify one, pick what best fits the fields (bars to compare categories, a line for a trend over time, etc.). Either way, get the fundamentals right: clear axes and labels, readable spacing, and a tooltip on hover. This is a single reusable visualization, not an app: no dashboard, navigation, multiple panels, filters, or page chrome. Recharts, echarts, D3, or plain SVG all work.
    Fill the viewport: give your root element \`height: 100vh\` (or \`position: fixed; inset: 0\`), NOT \`height: 100%\` — that collapses to a 0-height invisible box unless every ancestor also sets a height. This gives auto-sizing charts like recharts \`<ResponsiveContainer>\` a real height to measure. Confirm the chart actually renders and isn't a blank box.
@@ -62,7 +62,15 @@ Three requirements, all mandatory:
    - \`label\`: human label shown in the mapping UI.
    - \`type\`: \`dimension\` (category/grouping), \`metric\` (number), or \`series\` (a dimension used to split/colour).
    - \`required\`: false only if the chart still renders without it.
-   Declare exactly what you read — no more, no less. e.g. "category" (dimension, required) + "value" (metric, required).`;
+   Declare exactly what you read — no more, no less. e.g. "category" (dimension, required) + "value" (metric, required).
+
+4. Follow the host's light/dark mode — never invent your own palette. Lightdash toggles the \`dark\` class on \`<html>\` and the template's CSS variables flip with it, so the viz must be colored entirely through semantic tokens:
+   - Surfaces, text, borders, gridlines, axis labels: \`hsl(var(--background))\`, \`hsl(var(--foreground))\`, \`hsl(var(--muted-foreground))\`, \`hsl(var(--border))\` (or the equivalent Tailwind classes). Your root viewport element gets \`background: hsl(var(--background))\`.
+   - Chart series colors: \`CHART_COLORS\` from \`@/lib/theme\`, cycled by index.
+   - Tooltips: \`ChartTooltipSurface\` from \`@/lib/floating\`.
+   - Never hardcode hex/rgb for any of the above, and never define your own base palette object — a hardcoded scheme is a bug that shows up as a glaring mismatched box inside a dashboard in the other mode.
+   - For chart props where a CSS variable string won't work, read \`useColorScheme()\` from \`@lightdash/query-sdk\` (\`'light' | 'dark'\`, re-renders on host toggle) and branch on it.
+   Verify both schemes before declaring done: toggle the \`dark\` class on \`<html>\` and check the chart stays legible on both backgrounds.`;
 
 export const getTemplateInstructions = (
     template: DataAppTemplate,

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -1089,7 +1089,7 @@ Lightdash-specific constraints that apply on top of `frontend-design`'s directio
 
 - **Chart series colors must come from `CHART_COLORS` in `@/lib/theme`** — the canonical Lightdash palette, so generated apps' charts visually match native Lightdash dashboards. Cycle by index for multi-series (`CHART_COLORS[i % CHART_COLORS.length]`). `frontend-design`'s chosen accent/background/typography colors are independent of this.
 - **Use semantic shadcn tokens for UI chrome** — `bg-background`, `bg-card`, `text-foreground`, `text-muted-foreground`, `text-destructive`, `border`, etc. Don't hardcode hex values for surfaces, text, or borders. (`frontend-design` may direct you to redefine the underlying CSS variables for a chosen theme — that's fine; the rule is no inline hex, not "use only the default token values".)
-- **Commit to one theme; don't design for dark while rendering light.** The template's `:root` defaults to white (light tokens). If your design needs a dark background, you must do *one* of: (a) apply `className="dark"` to your top-level `<div>` so Tailwind activates the dark token values, or (b) override the CSS variables on `:root` directly to match your chosen theme. **Never** author colors that assume a dark background without ensuring the page actually loads dark — the symptom is invisible secondary text (faint red/gray on white). Before declaring done, check: does the page background actually look the way you described it? If not, you have a theme-wiring bug.
+- **The app follows the host's light/dark mode — author both schemes, never hard-wire one.** Lightdash applies and removes the `dark` class on `<html>` automatically (a URL-hash bootstrap for first paint, then live `lightdash:sdk:theme` messages handled by the SDK). Your job is to keep both token sets coherent: light values live on `:root`, dark values in the `.dark` block — both are pre-populated in `src/index.css`. If your design direction restyles a token, redefine it in *both* scopes. **Never** add or remove the `dark` class yourself, and **never** move dark values onto `:root` to force a dark look — either pins the app to one scheme and breaks host switching. The classic symptom of a scheme-blind palette is invisible secondary text (faint gray on white, or dark-on-dark). Before declaring done, check the page with and without the `dark` class on `<html>` — both must be legible and intentional-looking. In the rare case JS needs the current scheme (e.g. an imperative chart option that can't read CSS variables), use `useColorScheme()` from `@lightdash/query-sdk` instead of sniffing the DOM.
 - **Leave a gutter at the bottom of the page.** Don't let the last card, chart, or footer sit flush against the iframe's bottom edge — it reads as clipped. Add bottom padding (`pb-8` or similar) on your page's top-level themed wrapper so the gutter inherits the theme's background. Don't push the gutter onto `#root` or `body` instead — those sit outside your theme, so any space below the wrapper falls back to the template default and shows as a mismatched strip.
 
 ### Organization themes
@@ -1116,6 +1116,7 @@ Hard rules when a theme is active:
 
 - **Theme CSS overrides `frontend-design`'s color/typography direction.** The aesthetic distinctness `frontend-design` pushes for still applies to layout, density, and motion — but colors, font families, and any other tokens the theme CSS defines win over your own picks. If the theme sets `--accent: #6B5B95`, your headings use that purple; don't reach for a "more distinctive" alternative.
 - **If the theme CSS defines a chart palette (CSS custom properties like `--chart-1`, `--chart-2`, …, or any `*-chart-*` variables), use it instead of `CHART_COLORS` from `@/lib/theme`.** Read the values via `getComputedStyle(document.documentElement).getPropertyValue('--chart-1')` once on mount and cycle them by index for multi-series. Falling back to `CHART_COLORS` when the theme doesn't define a chart palette is correct.
+- **Brand CSS may pin a single scheme — that's expected.** If the theme's stylesheets define surface/text colors on `:root` without `.dark` variants, the app will look the same in both host modes; brand fidelity wins over host light/dark switching. Don't invent dark variants of brand colors unless the theme instructions ask for them.
 - **Instruction text in the appended system prompt is binding.** Any rules described under "Organization theme instructions" later in this prompt override conflicting defaults in this file. Treat them as customer-supplied product requirements, not suggestions.
 - **Do not modify files under `/app/src/design/`.** `Write(//app/src/**)` would technically allow it, but those files are the source of truth for the brand and may be reused across many apps. Treat the directory as read-only.
 
@@ -1281,14 +1282,7 @@ Action menus and dialogs use shadcn's components as-is — no className needed f
 </DropdownMenuContent>
 ```
 
-**One scope rule still matters:** if you toggle dark mode via the `.dark` class, set it on `<html>`, never on a wrapper `<div>`. Radix portals into `document.body`, so `<div className="dark">` inside `<App />` doesn't contain portaled menus/dialogs/popovers — floating surfaces leak out to light scope. Either:
-
-```js
-// main.jsx — set once at boot, applies to <html> and every portal
-document.documentElement.classList.add('dark');
-```
-
-…or skip `.dark` entirely and put dark values directly in `:root`. Do not write `<div className="dark">` anywhere.
+**One scope rule still matters:** the `.dark` class lives on `<html>` and is owned by the host — Radix portals into `document.body`, so only an `<html>`-level class reaches portaled menus/dialogs/popovers. Never write `<div className="dark">` and never toggle the class from app code; style every surface (including floating ones) with semantic tokens so they follow the host scheme automatically.
 
 ### Data interactions — action menu
 


### PR DESCRIPTION
## Summary

Generator-rule counterpart to the theme plumbing down-stack.

skill.md changes:

- Replaces "commit to one theme" with: the app follows the host's light/dark mode; author both schemes with semantic tokens (light values in `:root`, dark in `.dark`), redefine restyled tokens in both scopes, and never add/remove the `dark` class or move dark values onto `:root`.
- The portal scope rule now states the host owns the `<html>`-level `.dark` class; app code never toggles it.
- Org-theme rules gain an explicit carve-out: brand CSS that pins a single scheme is expected to look the same in both host modes; don't invent dark variants of brand colors unless instructed.

Backend `templates.ts`: the data-app-viz prompt block gains a mandatory theming requirement. First-pass viz generations were inventing hardcoded hex palettes (verified against a real v1/v2 diff of a generated viz — v1 shipped a literal `BASE` palette object and hex chart colors, ignoring the host scheme entirely; v2, after a user complaint, switched to semantic tokens + `CHART_COLORS` + `useColorScheme()`). The new requirement prescribes exactly that v2 pattern up front.

## Testing

- Theme plumbing verified live: a viz generated against a dev sandbox template built from this stack follows the host toggle.
- First-pass generation quality (viz respects the scheme without being asked): instruction landed, pending one fresh generation to confirm.

Closes: GLITCH-591