### PR TITLE
feat(permissions): allow developers to verify content

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -399,6 +399,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
             userUuid: member.userUuid,
         });
+        can('manage', 'ContentVerification', {
+            organizationUuid: member.organizationUuid,
+        });
     },
     admin(member, { can }) {
         applyOrganizationMemberStaticAbilities.developer(member, { can });
@@ -412,10 +415,6 @@ export const applyOrganizationMemberStaticAbilities: Record<
         });
 
         can('manage', 'OrganizationDesign', {
-            organizationUuid: member.organizationUuid,
-        });
-
-        can('manage', 'ContentVerification', {
             organizationUuid: member.organizationUuid,
         });
 

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -327,6 +327,9 @@ export const projectMemberAbilities: Record<
         can('manage', 'AiAgentDocument', {
             projectUuid: member.projectUuid,
         });
+        can('manage', 'ContentVerification', {
+            projectUuid: member.projectUuid,
+        });
     },
     admin(member, { can }) {
         projectMemberAbilities.developer(member, { can });
@@ -336,10 +339,6 @@ export const projectMemberAbilities: Record<
         });
 
         can('manage', 'ExternalConnection', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'ContentVerification', {
             projectUuid: member.projectUuid,
         });
 

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -149,6 +149,7 @@ const BASE_ROLE_SCOPES = {
         'manage:OrganizationAiAgent',
         'manage:AiAgentDocument',
         'manage:AiAgentThread@self', // User's own threads
+        'manage:ContentVerification',
     ],
 
     [ProjectMemberRole.ADMIN]: [
@@ -166,7 +167,6 @@ const BASE_ROLE_SCOPES = {
         'view:AiAgentThread', // All threads in project
         'manage:AiAgentThread', // All threads in project
         'manage:ScheduledDeliveries',
-        'manage:ContentVerification',
 
         // Organization-management scopes. These are no-ops at project
         // assignment (CASL conditions match `organizationUuid`-keyed


### PR DESCRIPTION
Closes [PROD-8472](https://linear.app/lightdash/issue/PROD-8472/allow-developers-to-verify-content-align-manual-verification-with-ai)

## Summary

Lets **developers** — not just admins — verify and unverify charts and dashboards, aligning manual verification permissions with AI-content verification (which developers can already do).

The `manage:ContentVerification` grant moves from the `admin` block into `developer` in both ability layers (admin inherits developer, so admins keep it), and the role→scope mapping entry moves from the ADMIN list to DEVELOPER accordingly.

## Who is affected

- **Developer system role (project + org level):** gains verify/unverify on charts and dashboards. This is the intended change.
- **Admin system role:** unchanged (inherits developer).
- **Existing custom roles:** unchanged. The scope vocabulary is untouched, so no `scoped_roles` migration is needed. Custom roles cloned from developer *before* this change will not gain the scope (they persist explicit scope strings) — operators can add it via the role builder.
- **Service accounts:** unchanged (`manage:ContentVerification` was already granted in `serviceAccountAbility.ts`).
- **Org-level additivity note:** since the org developer role now carries this grant and CASL layers are additive, a narrower project-level custom role cannot revoke verification from a user whose *org* role is developer. This matches how every other org developer grant behaves, and finer control remains available by assigning custom roles instead of the developer system role.

All enforcement sites (frontend buttons, backend service checks) are ability-based (`manage` on `ContentVerification` subject), so no other code changes were needed.

## Testing

- `pnpm -F common test` — 2636 passed, including the role→scope parity test
- `pnpm -F common typecheck:fast` + lint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1pqqmPUWMVUJPrnZYpdNV