### PR TITLE
feat(verification): warn non-verifiers that saving removes verified status

### DIFF
--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -34,11 +34,13 @@ import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import ChartCreateModal from '../../common/modal/ChartCreateModal';
 
+export type VerificationSavePrompt = 'confirm-keep' | 'warn-removal';
+
 const SaveChartButton: FC<{
     disabled?: boolean;
     onSaveModalOpenChange?: (isOpen: boolean) => void;
-    showVerificationSaveOptions?: boolean;
-}> = ({ disabled, onSaveModalOpenChange, showVerificationSaveOptions }) => {
+    verificationSavePrompt?: VerificationSavePrompt;
+}> = ({ disabled, onSaveModalOpenChange, verificationSavePrompt }) => {
     const isAmbientAiEnabled = useAmbientAiEnabled();
     const embed = useEmbed();
     const isEmbedded = embed.embedToken !== undefined;
@@ -155,7 +157,7 @@ const SaveChartButton: FC<{
 
     const handleSaveChart = () => {
         if (savedChart) {
-            if (showVerificationSaveOptions) {
+            if (verificationSavePrompt) {
                 setIsSaveVerificationModalOpen(true);
                 return;
             }
@@ -279,30 +281,71 @@ const SaveChartButton: FC<{
                 onClose={() => setIsSaveVerificationModalOpen(false)}
                 title="Save verified chart"
             >
-                <Text mb="md">Keep this chart verified after saving?</Text>
-                <Group justify="flex-end">
-                    <Button
-                        variant="default"
-                        loading={update.isLoading || updateMetadata.isLoading}
-                        onClick={() => {
-                            setIsSaveVerificationModalOpen(false);
-                            handleSavedQueryUpdate(false);
-                        }}
-                    >
-                        Save
-                    </Button>
-                    <Button
-                        color="green.7"
-                        leftSection={<IconCircleCheckFilled size={16} />}
-                        loading={update.isLoading || updateMetadata.isLoading}
-                        onClick={() => {
-                            setIsSaveVerificationModalOpen(false);
-                            handleSavedQueryUpdate(true);
-                        }}
-                    >
-                        Save & verify
-                    </Button>
-                </Group>
+                {verificationSavePrompt === 'warn-removal' ? (
+                    <>
+                        <Text mb="md">
+                            This chart is verified. Saving your changes will
+                            remove its verified status until someone verifies it
+                            again.
+                        </Text>
+                        <Group justify="flex-end">
+                            <Button
+                                variant="default"
+                                onClick={() =>
+                                    setIsSaveVerificationModalOpen(false)
+                                }
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                loading={
+                                    update.isLoading || updateMetadata.isLoading
+                                }
+                                onClick={() => {
+                                    setIsSaveVerificationModalOpen(false);
+                                    handleSavedQueryUpdate(false);
+                                }}
+                            >
+                                Save anyway
+                            </Button>
+                        </Group>
+                    </>
+                ) : (
+                    <>
+                        <Text mb="md">
+                            Keep this chart verified after saving?
+                        </Text>
+                        <Group justify="flex-end">
+                            <Button
+                                variant="default"
+                                loading={
+                                    update.isLoading || updateMetadata.isLoading
+                                }
+                                onClick={() => {
+                                    setIsSaveVerificationModalOpen(false);
+                                    handleSavedQueryUpdate(false);
+                                }}
+                            >
+                                Save
+                            </Button>
+                            <Button
+                                color="green.7"
+                                leftSection={
+                                    <IconCircleCheckFilled size={16} />
+                                }
+                                loading={
+                                    update.isLoading || updateMetadata.isLoading
+                                }
+                                onClick={() => {
+                                    setIsSaveVerificationModalOpen(false);
+                                    handleSavedQueryUpdate(true);
+                                }}
+                            >
+                                Save & verify
+                            </Button>
+                        </Group>
+                    </>
+                )}
             </MantineModal>
         </>
     );

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -115,7 +115,9 @@ import ShareShortLinkButton from '../../common/ShareShortLinkButton';
 import TransferItemsModal from '../../common/TransferItemsModal/TransferItemsModal';
 import ExploreFromHereButton from '../../ExploreFromHereButton';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
-import SaveChartButton from '../SaveChartButton';
+import SaveChartButton, {
+    type VerificationSavePrompt,
+} from '../SaveChartButton';
 import { TitleBreadCrumbs } from './TitleBreadcrumbs';
 
 const SavedChartsHeader: FC = () => {
@@ -361,6 +363,17 @@ const SavedChartsHeader: FC = () => {
         savedChart?.verification !== null &&
         savedChart?.verification !== undefined;
 
+    const isOwnVerification =
+        savedChart?.verification?.verifiedBy.userUuid === user.data?.userUuid;
+
+    let verificationSavePrompt: VerificationSavePrompt | undefined;
+    if (isChartVerified) {
+        verificationSavePrompt =
+            canManageContentVerification || isOwnVerification
+                ? 'confirm-keep'
+                : 'warn-removal';
+    }
+
     const userCanPinChart = user.data?.ability.can(
         'manage',
         subject('PinnedItems', {
@@ -587,9 +600,8 @@ const SavedChartsHeader: FC = () => {
                                             onSaveModalOpenChange={
                                                 setIsSaveModalOpen
                                             }
-                                            showVerificationSaveOptions={
-                                                isChartVerified &&
-                                                canManageContentVerification
+                                            verificationSavePrompt={
+                                                verificationSavePrompt
                                             }
                                         />
                                         <Button

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -773,8 +773,13 @@ const Dashboard: FC = () => {
             }),
         ) === true;
 
-    const shouldShowVerificationSaveOptions =
-        !!dashboard?.verification && canManageContentVerification;
+    const isOwnVerification =
+        dashboard?.verification?.verifiedBy.userUuid === user.data?.userUuid;
+
+    const canPreserveVerification =
+        canManageContentVerification || isOwnVerification;
+
+    const shouldShowVerificationSaveOptions = !!dashboard?.verification;
 
     const handleSaveDashboard = (preserveVerification?: boolean) => {
         const dimensionFilters = [
@@ -924,30 +929,63 @@ const Dashboard: FC = () => {
                 onClose={saveVerificationModalHandlers.close}
                 title="Save verified dashboard"
             >
-                <Text mb="md">Keep this dashboard verified after saving?</Text>
-                <Group justify="flex-end">
-                    <Button
-                        variant="default"
-                        loading={isSaving}
-                        onClick={() => {
-                            saveVerificationModalHandlers.close();
-                            handleSaveDashboard(false);
-                        }}
-                    >
-                        Save
-                    </Button>
-                    <Button
-                        color="green.7"
-                        leftSection={<IconCircleCheckFilled size={16} />}
-                        loading={isSaving}
-                        onClick={() => {
-                            saveVerificationModalHandlers.close();
-                            handleSaveDashboard(true);
-                        }}
-                    >
-                        Save & verify
-                    </Button>
-                </Group>
+                {canPreserveVerification ? (
+                    <>
+                        <Text mb="md">
+                            Keep this dashboard verified after saving?
+                        </Text>
+                        <Group justify="flex-end">
+                            <Button
+                                variant="default"
+                                loading={isSaving}
+                                onClick={() => {
+                                    saveVerificationModalHandlers.close();
+                                    handleSaveDashboard(false);
+                                }}
+                            >
+                                Save
+                            </Button>
+                            <Button
+                                color="green.7"
+                                leftSection={
+                                    <IconCircleCheckFilled size={16} />
+                                }
+                                loading={isSaving}
+                                onClick={() => {
+                                    saveVerificationModalHandlers.close();
+                                    handleSaveDashboard(true);
+                                }}
+                            >
+                                Save & verify
+                            </Button>
+                        </Group>
+                    </>
+                ) : (
+                    <>
+                        <Text mb="md">
+                            This dashboard is verified. Saving your changes will
+                            remove its verified status until someone verifies it
+                            again.
+                        </Text>
+                        <Group justify="flex-end">
+                            <Button
+                                variant="default"
+                                onClick={saveVerificationModalHandlers.close}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                loading={isSaving}
+                                onClick={() => {
+                                    saveVerificationModalHandlers.close();
+                                    handleSaveDashboard(false);
+                                }}
+                            >
+                                Save anyway
+                            </Button>
+                        </Group>
+                    </>
+                )}
             </MantineModal>
 
             <Page


### PR DESCRIPTION
Closes [PROD-8473](https://linear.app/lightdash/issue/PROD-8473/save-time-keep-it-verified-prompt-handle-edits-by-non-verifiers)

## Summary

#24592 (PROD-8214) shipped the save-time *"keep it verified?"* prompt for users who can manage verification. This PR closes the remaining gap from PROD-8473 — **edits by non-verifiers**:

- **Users who can preserve verification** (anyone with `manage:ContentVerification`, or the original verifier even without that permission) get the existing keep/drop prompt. Previously the verifier-without-permission case got no prompt at all — the badge was silently kept with no way to drop it at save time.
- **Everyone else** (e.g. editors) now gets an explicit warning — *"This chart/dashboard is verified. Saving your changes will remove its verified status until someone verifies it again."* — with Cancel / Save anyway. Previously the badge was silently dropped.

This resolves the ticket's open detail as: non-verifier edits **drop the badge for re-verification**, but explicitly rather than silently. Users with verify permission are re-prompted (unchanged).

## Implementation

Frontend only — the backend semantics from #24592 already support all paths (`preserveVerification: false` is always allowed; `true` requires manage permission or being the verifier).

- `SaveChartButton`: `showVerificationSaveOptions: boolean` → `verificationSavePrompt?: 'confirm-keep' | 'warn-removal'`, with a warning variant of the save modal.
- `SavedChartsHeader`: computes the variant from ability + `verification.verifiedBy`.
- `Dashboard.tsx`: same two-variant modal for dashboard saves.

## Who is affected

- **Editors (and anyone without verify rights) editing verified content:** now see a confirmation modal before saving; the outcome (badge removed) is unchanged.
- **Verifiers who lack `manage:ContentVerification`:** now get the keep/drop prompt (backend already honored both choices).
- **Admins/managers:** unchanged.
- Unverified content: no modal, unchanged save flow.

## Testing

- `pnpm -F frontend typecheck:fast` — clean
- `pnpm -F frontend lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1pqqmPUWMVUJPrnZYpdNV