### PR TITLE
fix(avatars): surface errors and fix mode toggle in avatar settings

### DIFF
--- a/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/AvatarSettings.tsx
@@ -81,6 +81,7 @@ const AvatarSettings: FC = () => {
     const [previewValue, setPreviewValue] =
         useState<UserAvatarColorValue | null>(null);
     const [mode, setMode] = useState<CustomMode>('gradient');
+    const [vibe, setVibe] = useState<AvatarMeshVibe>(0);
 
     if (!user.data) return null;
 
@@ -90,6 +91,7 @@ const AvatarSettings: FC = () => {
 
     const handleFile = (file: File | null) => {
         if (!file) return;
+        close();
         uploadMutation.mutate(file, {
             onError: (error) => {
                 showToastError({
@@ -102,8 +104,10 @@ const AvatarSettings: FC = () => {
 
     const handleToggle = () => {
         if (!opened) {
-            setPreviewValue(avatarGradient ?? null);
-            setMode(modeForValue(avatarGradient ?? null));
+            const current = avatarGradient ?? null;
+            setPreviewValue(current);
+            setMode(modeForValue(current));
+            setVibe(extractVibe(current));
         }
         toggle();
     };
@@ -111,37 +115,46 @@ const AvatarSettings: FC = () => {
     const handleModeChange = (value: string) => {
         const nextMode = value as CustomMode;
         setMode(nextMode);
-        if (previewValue && !isUserAvatarGradientId(previewValue)) {
-            const hex = extractHex(previewValue);
-            setPreviewValue(nextMode === 'solid' ? toSolidColor(hex) : hex);
-        }
+        const hex = extractHex(previewValue);
+        setPreviewValue(
+            nextMode === 'solid' ? toSolidColor(hex) : encodeMesh(hex, vibe),
+        );
     };
 
     const handleColorChange = (color: string) => {
         if (!isHexColorString(color)) return;
         setPreviewValue(
-            mode === 'solid'
-                ? toSolidColor(color)
-                : encodeMesh(color, extractVibe(previewValue)),
+            mode === 'solid' ? toSolidColor(color) : encodeMesh(color, vibe),
         );
     };
 
     const handleShuffleVibe = () => {
         const hex = extractHex(previewValue);
-        const currentVibe = extractVibe(previewValue);
-        const otherVibes = AVATAR_MESH_VIBES.filter((v) => v !== currentVibe);
+        const otherVibes = AVATAR_MESH_VIBES.filter((v) => v !== vibe);
         const nextVibe =
             otherVibes[Math.floor(Math.random() * otherVibes.length)];
+        setVibe(nextVibe);
         setPreviewValue(encodeMesh(hex, nextVibe));
     };
 
     const handlePresetClick = (gradientId: UserAvatarGradientId | null) => {
+        setMode('gradient');
         setPreviewValue(gradientId);
     };
 
     const handleApply = () => {
-        updateUserMutation.mutate({ avatarGradient: previewValue });
-        close();
+        updateUserMutation.mutate(
+            { avatarGradient: previewValue },
+            {
+                onSuccess: () => close(),
+                onError: (error) => {
+                    showToastError({
+                        title: 'Failed to update avatar color',
+                        subtitle: error?.error?.message ?? undefined,
+                    });
+                },
+            },
+        );
     };
 
     const avatarTrigger = !avatarUrl && (
@@ -303,15 +316,33 @@ const AvatarSettings: FC = () => {
                 )}
             </FileButton>
             {avatarUrl && (
-                <Button
-                    variant="subtle"
-                    color="red"
-                    size="xs"
-                    loading={deleteMutation.isLoading}
-                    onClick={() => deleteMutation.mutate()}
+                <Tooltip
+                    label={
+                        avatarGradient
+                            ? 'Your avatar will go back to your chosen color'
+                            : 'Your avatar will go back to the default style'
+                    }
                 >
-                    Remove photo
-                </Button>
+                    <Button
+                        variant="subtle"
+                        color="red"
+                        size="xs"
+                        loading={deleteMutation.isLoading}
+                        onClick={() =>
+                            deleteMutation.mutate(undefined, {
+                                onError: (error) => {
+                                    showToastError({
+                                        title: 'Failed to remove avatar photo',
+                                        subtitle:
+                                            error?.error?.message ?? undefined,
+                                    });
+                                },
+                            })
+                        }
+                    >
+                        Remove photo
+                    </Button>
+                </Tooltip>
             )}
         </Group>
     );


### PR DESCRIPTION
## Summary

Follow-up UX fixes to avatar settings (#25112 / the avatar upload stack). All four issues share a root cause: failure and latency paths that never fire in local dev, so the flow looked fine locally but misbehaved in prod.

- **Apply no longer fails silently.** The color popover previously closed in the same tick as firing the PATCH — no error toast, and the Apply button's loading state could never render. It now stays open until the update and the user refetch complete, shows a toast on failure, and only closes on success. This also removes the stale-preview race where reopening the popover right after applying showed the old color.
- **Remove photo no longer fails silently.** The DELETE had no error handling anywhere; a failed removal just left the button un-spinning. It now shows an error toast, and the button has a tooltip explaining the avatar reverts to the chosen color (or default style).
- **Gradient/Solid toggle always converts.** Switching modes with a Lightdash preset (or the default) selected previously changed nothing — the mode said Solid while the preview and Apply still used the preset. Mode switches now always convert the current color, preset clicks set gradient mode, and the shuffled mesh vibe is kept in state so switching solid → gradient no longer resets it.
- **Upload closes an open color popover.** Previously a successful upload unmounted the popover mid-edit, silently discarding the preview; now it's closed explicitly when the upload starts.

## Who's affected

Frontend-only, single component (`AvatarSettings.tsx`); no API, persisted-format, or rendering changes. Existing saved avatar values are untouched — the only behavior change users can notice is error toasts where there was silence, and the mode toggle applying what it displays.

## Testing

Verified end-to-end in the dev app (Chrome DevTools): preset → Solid conversion sends `solid:#hex` in the PATCH; offline Apply and offline Remove photo both show error toasts and keep state; upload closes the popover and Remove photo reverts to the saved color.

Closes: ZAP-588

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tiwb1pEUswPLcLpaJZGQJN