### PR TITLE
feat(cli): lightdash apps preview — local preview of data apps against real data [GLITCH-593]

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -1046,7 +1046,7 @@ Cross-project and cross-instance upload are both a plain **slug upsert** against
 ### Constraints & notes
 
 - **Enterprise-only** (`APP_RUNTIME_ENABLED`); the caller needs `view` / `create` / `manage:DataApp`.
-- **Declared dependencies:** apps can declare custom npm packages in their `package.json`. The CLI validates the declared set (registry-only specs, no git/file/url, up to 60 direct deps, `pnpm-lock.yaml` must be committed) and warns which packages will be installed in the build sandbox before uploading. Install scripts never run. The instance-level flag `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED` (default `false` during rollout) gates this feature; when disabled, uploads with a non-empty custom dependency set are rejected at the API with a clear error, and builds/iterations of versions that already store custom deps refuse to run (template-only uploads are always accepted). The AI builder and in-app UI cannot change the dependency set — dependencies are declared by editing `package.json` and re-uploading. The dependency summary (name + version) is shown as a chip on the assistant bubble in the chat UI so the author can confirm what was installed.
+- **Declared dependencies:** apps can declare custom npm packages in their `package.json`. The CLI validates the declared set (registry-only specs, no git/file/url, up to 60 direct deps, `pnpm-lock.yaml` must be committed) and warns which packages will be installed in the build sandbox before uploading. Install scripts never run. Both the instance-level `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED` setting and the per-organization `EnableDataAppCustomDependencies` feature flag must be enabled, and uploading custom dependencies requires `manage:DataAppDependency` (admin-only by default). Uploads are screened against the OSV malicious-packages feed; operators can also require a minimum package release age. Builds/iterations of versions that already store custom deps remain protected by the instance kill switch. Template-only uploads are unaffected. The AI builder and in-app UI cannot change the dependency set — dependencies are declared by editing `package.json` and re-uploading. The dependency summary (name + version) is shown as a chip on the assistant bubble in the chat UI so the author can confirm what was installed.
 - **Semantic-layer coupling:** a moved app's queries run against the **target project's** fields *by name*; fields missing in the target surface as in-app query errors, not upload failures.
 - **External connection links travel in the manifest.** `lightdash-app.yml` carries `externalConnections: [{alias, connectionSlug}]` — download emits the app's live links, upload resolves each slug in the target project and **reconciles** the app's links to match (`replaceAppLinks`: adds, repoints, and removes; an empty list unlinks everything; an absent key leaves links untouched for pre-field bundles). A slug missing in the target is skipped with a warning in the upload response (the CLI prints it) — the same warn-don't-fail stance as semantic-layer coupling. Aliases are validated (charset/length/dupes) and each resolved connection requires `manage:ExternalConnection`, both rejected before any app row is created. Under `--include-all`, connections upload before apps, so config + links move in one pass.
 - **Data app vizs round-trip their schema via the manifest.** A viz's declared schema (`app_versions.viz_schema`) exists only in the database — it is emitted as structured output during generation, never written into the source tree. So `lightdash-app.yml` carries a `vizSchema` field for `data_app_viz` apps, and upload validates it (fail-loud) and persists it on the new version. Without it the uploaded viz would never appear in the viz picker (the picker requires a non-null schema on the latest ready version). Bundles downloaded before this field existed re-upload without a schema — re-download from the source project to fix.
@@ -1070,12 +1070,13 @@ All scaffolding and context files are read-only reference — see [Upload is sou
 #### The local loop
 
 ```sh
-edit src/  →  pnpm install && pnpm build  →  lightdash upload --apps <slug>  →  server rebuilds
+edit src/  →  pnpm install && pnpm build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
 ```
 
 1. Edit files under `src/`.
 2. Run `pnpm install && pnpm build` as a pre-flight compile check against the downloaded scaffolding.
-3. Upload with `lightdash upload --apps <slug>` — or `--include-apps` for every downloaded app folder (fire-and-forget, as in Phase 1). The server rebuilds in its trusted sandbox.
+3. Optionally run `lightdash apps preview` to test against real data using the current CLI login.
+4. Upload with `lightdash upload --apps <slug>` — or `--include-apps` for every downloaded app folder (fire-and-forget, as in Phase 1). The server rebuilds in its trusted sandbox.
 
 **The server's build is authoritative.** Your local build is a compile check only; the deployed app is always the server's output.
 
@@ -1091,10 +1092,31 @@ Only `src/` is sent on upload. Scaffolding files and `.lightdash/context/` are l
 
 If the org design linked to the app has more than **30 asset files**, the theme assets are skipped during download and a warning is printed; the theme instruction markdown is still written to `.lightdash/context/theme/`. An app whose theme was skipped may not build locally without those assets — the server-side rebuild is unaffected.
 
-#### Out of scope (Phase 3)
+#### Local preview against real data (Phase 3)
 
-- **Local preview against real data** — `pnpm build` is a compile check only, not a live data preview.
-- **Org-level custom-dependency toggle** — the `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED` flag is instance-wide only; per-org control is not implemented.
+`lightdash apps preview [path]` starts the downloaded app's Vite server and connects its SDK to the project in
+`lightdash-app.yml` (override with `--project`). It pre-flights both the CLI credential and project before starting, so
+an expired login or an app downloaded from another instance fails with an actionable error instead of an in-app query
+failure. Bare `pnpm dev` has no authenticated data access.
+
+Preview does not copy or pass the durable CLI credential to the app. A loopback-only proxy injects the canonical PAT or
+service-account authorization header (plus configured reverse-proxy authorization) after enforcing the shared data-app
+SDK route allowlist and the selected project. Vite knows only the proxy address and a random per-run nonce; browser code
+gets a non-authenticating sentinel. The Vite child is started with a minimal environment so `LIGHTDASH_API_KEY` and
+unrelated parent-process secrets are not inherited. The dev CSP limits network requests to the local origin, forcing SDK
+API calls through that proxy. The deployed postMessage bridge enforces the same route and project boundary.
+
+This removes the credential from the app environment and browser; it does **not** turn local authoring into the
+production sandbox. Vite and the downloaded tooling execute as the local OS user, so malicious local code could read
+that user's files (including the existing CLI config), and the app is intentionally allowed to read query results. Only
+preview trusted source and dependencies. Preview also uses the developer's own permissions and user attributes, which
+may differ from a deployed viewer's. The production app remains the authoritative CSP/sandbox check.
+
+Current local-preview parity is the direct SDK transport: metric and saved-chart queries, polling, underlying data,
+downloads, and current-user lookup. Host-mediated capabilities are not emulated. In particular, external connections
+(`externalFetch`), data-app-viz row/field context, Google Sheets export, and product inspector/URL-state integration need
+the in-product postMessage host. Full host emulation should be implemented as a separate local iframe harness rather than
+expanding the credential proxy ad hoc.
 
 ---
 

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -1070,11 +1070,11 @@ All scaffolding and context files are read-only reference — see [Upload is sou
 #### The local loop
 
 ```sh
-edit src/  →  pnpm install && pnpm build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
+edit src/  →  npm install && npm run build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
 ```
 
 1. Edit files under `src/`.
-2. Run `pnpm install && pnpm build` as a pre-flight compile check against the downloaded scaffolding.
+2. Run `npm install && npm run build` as a pre-flight compile check against the downloaded scaffolding.
 3. Optionally run `lightdash apps preview` to test against real data using the current CLI login.
 4. Upload with `lightdash upload --apps <slug>` — or `--include-apps` for every downloaded app folder (fire-and-forget, as in Phase 1). The server rebuilds in its trusted sandbox.
 
@@ -1097,7 +1097,7 @@ If the org design linked to the app has more than **30 asset files**, the theme 
 `lightdash apps preview [path]` starts the downloaded app's Vite server and connects its SDK to the project in
 `lightdash-app.yml` (override with `--project`). It pre-flights both the CLI credential and project before starting, so
 an expired login or an app downloaded from another instance fails with an actionable error instead of an in-app query
-failure. Bare `pnpm dev` has no authenticated data access.
+failure. Bare `npm run dev` has no authenticated data access.
 
 Preview does not copy or pass the durable CLI credential to the app. A loopback-only proxy injects the canonical PAT or
 service-account authorization header (plus configured reverse-proxy authorization) after enforcing the shared data-app

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -1101,8 +1101,10 @@ failure. Bare `pnpm dev` has no authenticated data access.
 
 Preview does not copy or pass the durable CLI credential to the app. A loopback-only proxy injects the canonical PAT or
 service-account authorization header (plus configured reverse-proxy authorization) after enforcing the shared data-app
-SDK route allowlist and the selected project. Vite knows only the proxy address and a random per-run nonce; browser code
-gets a non-authenticating sentinel. The Vite child is started with a minimal environment so `LIGHTDASH_API_KEY` and
+SDK route allowlist and the selected project. Vite and browser code receive only a random per-run nonce scoped to that
+allowlist and project, never the durable credential. Cross-origin browser access to Vite is disabled, and Vite only adds
+authentication to proxy traffic when the SDK presents that nonce. The Vite child is started with a minimal environment
+so `LIGHTDASH_API_KEY` and
 unrelated parent-process secrets are not inherited. The dev CSP limits network requests to the local origin, forcing SDK
 API calls through that proxy. The deployed postMessage bridge enforces the same route and project boundary.
 

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,0 +1,47 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ensureConfigFilePermissions, writeConfigToFile } from './config';
+
+// Masking file-type bits is the standard way to assert POSIX permissions.
+// eslint-disable-next-line no-bitwise
+const permissionBits = (mode: number): number => mode & 0o777;
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
+
+describePosix('CLI config permissions', () => {
+    let tempDir: string;
+    let configDir: string;
+    let configPath: string;
+
+    beforeEach(async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-config-'));
+        configDir = path.join(tempDir, 'lightdash');
+        configPath = path.join(configDir, 'config.yaml');
+    });
+
+    afterEach(async () => {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('creates the config directory and file with private permissions', async () => {
+        await writeConfigToFile(configPath, {
+            context: { apiKey: 'ldpat_secret' },
+        });
+
+        expect(permissionBits((await fs.stat(configDir)).mode)).toBe(0o700);
+        expect(permissionBits((await fs.stat(configPath)).mode)).toBe(0o600);
+    });
+
+    it('tightens permissions on an existing config path', async () => {
+        await fs.mkdir(configDir, { recursive: true, mode: 0o755 });
+        await fs.writeFile(configPath, 'context: {}', { mode: 0o644 });
+        await fs.chmod(configDir, 0o755);
+        await fs.chmod(configPath, 0o644);
+
+        await ensureConfigFilePermissions(configPath);
+
+        expect(permissionBits((await fs.stat(configDir)).mode)).toBe(0o700);
+        expect(permissionBits((await fs.stat(configPath)).mode)).toBe(0o600);
+    });
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -33,14 +33,57 @@ export type Config = {
     };
 };
 
+/** @internal Exported for filesystem-permission regression tests. */
+export const ensureConfigFilePermissions = async (
+    filePath: string,
+): Promise<void> => {
+    if (process.platform === 'win32') return;
+    await fs.chmod(path.dirname(filePath), 0o700);
+    try {
+        await fs.chmod(filePath, 0o600);
+    } catch (error: unknown) {
+        if (
+            !(
+                error instanceof Error &&
+                'code' in error &&
+                error.code === 'ENOENT'
+            )
+        ) {
+            throw error;
+        }
+    }
+};
+
+/** @internal Exported for filesystem-permission regression tests. */
+export const writeConfigToFile = async (
+    filePath: string,
+    config: Config,
+): Promise<void> => {
+    const directory = path.dirname(filePath);
+    await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+    // Tighten an existing config before overwriting it. `mode` on writeFile
+    // only applies when it creates a new file.
+    await ensureConfigFilePermissions(filePath);
+    await fs.writeFile(filePath, yaml.dump(config), {
+        encoding: 'utf8',
+        mode: 0o600,
+    });
+
+    // `mode` only applies when mkdir/writeFile creates a path. Tighten
+    // existing CLI config paths as well; Windows does not implement POSIX
+    // permission bits, so leave ACL management to the OS there.
+    await ensureConfigFilePermissions(filePath);
+};
+
 const setConfig = async (config: Config) => {
-    await fs.mkdir(path.dirname(configFilePath), { recursive: true });
-    await fs.writeFile(configFilePath, yaml.dump(config), 'utf8');
+    await writeConfigToFile(configFilePath, config);
 };
 
 const getRawConfig = async (): Promise<Config> => {
     try {
-        const raw = yaml.load(await fs.readFile(configFilePath, 'utf8'));
+        await ensureConfigFilePermissions(configFilePath);
+        const contents = await fs.readFile(configFilePath, 'utf8');
+        const raw = yaml.load(contents);
         return raw as Config;
     } catch (e: unknown) {
         if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {

--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -10,6 +10,7 @@ import {
     buildImportBody,
     readBundleFromDir,
     readDependenciesFromDir,
+    readManifestFromDir,
     resolveAppFolderName,
     writeBundleToDir,
     writeContextToDir,
@@ -129,6 +130,13 @@ const bundle = {
         },
     ],
 };
+
+it('readManifestFromDir returns just the manifest', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-app-'));
+    await writeBundleToDir(dir, bundle);
+    const manifest = await readManifestFromDir(dir);
+    expect(manifest).toEqual(bundle.manifest);
+});
 
 it('writes then reads back an identical bundle', async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-app-'));

--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -182,8 +182,13 @@ it('upload reads back only src/ files, ignoring scaffolding and context', async 
         'models: []',
     );
     await fs.writeFile(path.join(dir, '.claude/skills/x/SKILL.md'), '# skill');
+    await fs.writeFile(
+        path.join(dir, '.env.local'),
+        'VITE_LIGHTDASH_API_KEY=secret',
+    );
     const read = await readBundleFromDir(dir);
     expect(read.files.every((f) => f.path.startsWith('src/'))).toBe(true);
+    expect(read.files.map((f) => f.path)).not.toContain('.env.local');
     expect(read.files.map((f) => f.path).sort()).toEqual(
         bundle.files.map((f) => f.path).sort(),
     );

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -299,19 +299,24 @@ export const attachDependenciesToCode = (
 ): DataAppCode =>
     Object.keys(customDeps).length > 0 ? { ...code, dependencies: deps } : code;
 
-export const readBundleFromDir = async (dir: string): Promise<DataAppCode> => {
+export const readManifestFromDir = async (
+    dir: string,
+): Promise<DataAppManifest> => {
     const manifestRaw = await fs.readFile(
         path.join(dir, MANIFEST_FILENAME),
         'utf-8',
     );
-    let manifest: DataAppManifest;
     try {
-        manifest = YAML.parse(manifestRaw) as DataAppManifest;
+        return YAML.parse(manifestRaw) as DataAppManifest;
     } catch (err) {
         throw new Error(
             `Could not parse ${MANIFEST_FILENAME}: ${getErrorMessage(err)}`,
         );
     }
+};
+
+export const readBundleFromDir = async (dir: string): Promise<DataAppCode> => {
+    const manifest = await readManifestFromDir(dir);
 
     const srcDir = path.join(dir, 'src');
     const srcExists = await fs

--- a/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
@@ -2,12 +2,12 @@
 
 Two skills in `.claude/skills/` describe how to edit this app:
 - `lightdash-data-app` — the Lightdash SDK surface (querying data, filters, downloads).
-- `developing-data-apps-locally` — the local workflow: edit `src/`, `pnpm build`, `lightdash upload --apps <appUuid>` (uuid in `lightdash-app.yml`); the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
+- `developing-data-apps-locally` — the local workflow: edit `src/`, `npm run build`, `lightdash upload --apps <appUuid>` (uuid in `lightdash-app.yml`); the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
 
 Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
 
-The local `pnpm install && pnpm build` is an optional pre-check. If install fails, skip it and upload — never modify machine config, npmrc, or dependency files to force it; the server rebuild is authoritative.
+The local `npm install && npm run build` is an optional pre-check. If install fails, skip it and upload — never modify machine config, npmrc, or dependency files to force it; the server rebuild is authoritative.
 
-Build with the template's preinstalled dependency set (see `package.json`). Adding new npm packages only works when the instance has custom dependencies enabled — assume it does not; ask the user before considering a new library, and never vendor library source into `src/` as a workaround. Where enabled, adding a dependency requires a matching `pnpm-lock.yaml`, so `pnpm add <pkg>` (or `pnpm install --lockfile-only`) must succeed locally. If it fails, stop and report the error — hand-editing `package.json` without the lockfile makes the upload fail.
+Build with the template's preinstalled dependency set (see `package.json`). Adding new npm packages only works when the instance has custom dependencies enabled — assume it does not; ask the user before considering a new library, and never vendor library source into `src/` as a workaround. Where enabled, adding a dependency is the one workflow that still requires pnpm: upload requires a matching `pnpm-lock.yaml`, so `pnpm add <pkg>` (or `pnpm install --lockfile-only`) must succeed locally. If it fails, stop and report the error — hand-editing `package.json` without the lockfile makes the upload fail.
 
 `.npmrc` sets `ignore-scripts=true` — never remove it or run installs with scripts enabled; this app may be authored by someone else and their dependencies' lifecycle scripts must not run here.

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -5,7 +5,8 @@ Downloaded with the Lightdash CLI (`lightdash download`).
 ## Edit → build → upload
 1. Edit files under `src/`.
 2. Optionally, `pnpm install && pnpm build` to check it compiles locally. If install fails in your environment, skip it — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
-3. `lightdash upload --apps <appUuid>` (the `appUuid` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
+3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `pnpm install`).
+4. `lightdash upload --apps` — Lightdash rebuilds and serves the app.
 
 ## What's read-only
 Most root config is read-only: `vite.config.js`, `tailwind.config.js`, `tsconfig.json`, etc. The server rebuilds against a trusted template, so local edits to those files don't change the deployed app.

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -4,8 +4,8 @@ Downloaded with the Lightdash CLI (`lightdash download`).
 
 ## Edit → build → upload
 1. Edit files under `src/`.
-2. Optionally, `pnpm install && pnpm build` to check it compiles locally. If install fails in your environment, skip it — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
-3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `pnpm install`).
+2. Optionally, `npm install && npm run build` to check it compiles locally. If install fails in your environment, skip it — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
+3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `npm install`).
 4. `lightdash upload --apps` — Lightdash rebuilds and serves the app.
 
 Local preview uses your existing CLI login through a project- and route-restricted loopback proxy; the credential is not written into this folder or exposed to browser code. It runs local tooling as your OS user (with access to that user's files, including the existing CLI config) and shows data under your own permissions, so preview only source/dependencies you trust. Host-mediated features such as external connections and data-app-viz context still need testing after upload.
@@ -13,8 +13,8 @@ Local preview uses your existing CLI login through a project- and route-restrict
 ## What's read-only
 Most root config is read-only: `vite.config.js`, `tailwind.config.js`, `tsconfig.json`, etc. The server rebuilds against a trusted template, so local edits to those files don't change the deployed app.
 
-The app builds against the template's fixed dependency set (see `package.json`) — design within it. Only when custom dependencies are enabled on your Lightdash instance (most instances: not enabled), `package.json` becomes partially editable: run `pnpm add <pkg>` to declare extra npm dependencies (registry packages, plain semver versions only, up to 60 direct deps). `pnpm-lock.yaml` must be updated to match — `pnpm add` does this; if you edit `package.json` by hand, run `pnpm install --lockfile-only`. Upload rejects new dependencies without a matching lockfile. On upload the CLI warns which packages will be installed in the build sandbox; install scripts never run, and the server replaces `scripts` with the trusted template's (the sandbox build command is not uploader-controlled). The AI builder and in-app UI cannot change the dependency set — dependencies are declared by editing `package.json` and re-uploading.
+The app builds against the template's fixed dependency set (see `package.json`) — design within it. Only when custom dependencies are enabled on your Lightdash instance (most instances: not enabled), `package.json` becomes partially editable. This is the one workflow that still requires pnpm: run `pnpm add <pkg>` to declare extra npm dependencies (registry packages, plain semver versions only, up to 60 direct deps). `pnpm-lock.yaml` must be updated to match — `pnpm add` does this; if you edit `package.json` by hand, run `pnpm install --lockfile-only`. Upload rejects new dependencies without a matching lockfile. On upload the CLI warns which packages will be installed in the build sandbox; install scripts never run, and the server replaces `scripts` with the trusted template's (the sandbox build command is not uploader-controlled). The AI builder and in-app UI cannot change the dependency set — dependencies are declared by editing `package.json` and re-uploading.
 
-`.npmrc` sets `ignore-scripts=true` so dependencies' lifecycle scripts never run on your machine either — downloaded apps may be authored by someone else. Keep it; explicit `pnpm build`/`pnpm dev` still work.
+`.npmrc` sets `ignore-scripts=true` so dependencies' lifecycle scripts never run on your machine either — downloaded apps may be authored by someone else. Keep it; explicit commands such as `npm run build` still work.
 
 `.lightdash/context/` is a point-in-time snapshot of the source project; re-download to refresh it.

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -8,6 +8,8 @@ Downloaded with the Lightdash CLI (`lightdash download`).
 3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `pnpm install`).
 4. `lightdash upload --apps` — Lightdash rebuilds and serves the app.
 
+Local preview uses your existing CLI login through a project- and route-restricted loopback proxy; the credential is not written into this folder or exposed to browser code. It runs local tooling as your OS user (with access to that user's files, including the existing CLI config) and shows data under your own permissions, so preview only source/dependencies you trust. Host-mediated features such as external connections and data-app-viz context still need testing after upload.
+
 ## What's read-only
 Most root config is read-only: `vite.config.js`, `tailwind.config.js`, `tsconfig.json`, etc. The server rebuilds against a trusted template, so local edits to those files don't change the deployed app.
 

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -39,6 +39,13 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 - **Exception — adding a dependency** (only on instances with custom dependencies enabled — see "Library boundaries" above). Upload rejects new dependencies unless `pnpm-lock.yaml` was regenerated to match `package.json`, so dependency resolution MUST succeed locally. Use `pnpm add <pkg>`, or after editing `package.json` run `pnpm install --lockfile-only` (updates the lockfile without installing). If resolution fails, **stop and report the exact pnpm error to the user** — never hand-edit `package.json` and proceed without the lockfile; the upload will fail.
 - **Never run dependency lifecycle scripts.** The app's `.npmrc` sets `ignore-scripts=true` — leave it. A downloaded app can be authored by someone else, and their dependencies' install scripts must not execute on this machine. Explicit `pnpm build`/`pnpm dev` still work.
 
+## Preview locally against real data
+
+`lightdash apps preview` (run in this folder) starts a local dev server that renders the app against the Lightdash instance you are logged into, using your CLI credential. It writes `.env.local` (gitignored — contains your API key) and runs `pnpm dev`. Requires `pnpm install` to have succeeded; if it hasn't, skip preview and rely on the server rebuild.
+
+- Manual equivalent: write `VITE_LIGHTDASH_URL`, `VITE_LIGHTDASH_API_KEY`, `VITE_LIGHTDASH_PROJECT_UUID` into `.env.local` and run `pnpm dev`.
+- Preview shows **your** data under **your** permissions and user attributes — viewers of the deployed app may see different data. Do not treat preview as verification of viewer-specific behavior.
+
 ## Project context (read-only reference)
 
 `.lightdash/context/` holds a point-in-time snapshot of the source project:

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -28,25 +28,25 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 ## The edit → build → upload loop
 
 1. Edit files under `src/` only.
-2. Optionally, `pnpm install` then `pnpm build` to check it compiles. This is an **optional local pre-check** — see below.
+2. Optionally, `npm install` then `npm run build` to check it compiles. This is an **optional local pre-check** — see below.
 3. `lightdash upload --apps <appUuid>` (the `appUuid` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
 
 ## The local build is optional — never fight a failing install
 
-- If `pnpm install` fails (registry policy, an unavailable pinned SDK version, no network access), **skip the local build entirely and go straight to upload**. The server rebuild is authoritative and surfaces build errors on the app page.
+- If `npm install` fails (registry policy, an unavailable pinned SDK version, no network access), **skip the local build entirely and go straight to upload**. The server rebuild is authoritative and surfaces build errors on the app page.
 - Do **not** modify machine configuration, `.npmrc` files, registry settings, or the project's dependency files to force an install to work.
 - A missing `node_modules` is a normal state, not a problem to fix. Never run installs just because it is absent.
-- **Exception — adding a dependency** (only on instances with custom dependencies enabled — see "Library boundaries" above). Upload rejects new dependencies unless `pnpm-lock.yaml` was regenerated to match `package.json`, so dependency resolution MUST succeed locally. Use `pnpm add <pkg>` — prefixed with Socket Firewall when available (`sfw pnpm add <pkg>`; check with `command -v sfw`) to block known-malicious packages — or after editing `package.json` run `pnpm install --lockfile-only` (updates the lockfile without installing). If resolution fails, **stop and report the exact pnpm error to the user** — never hand-edit `package.json` and proceed without the lockfile; the upload will fail.
-- **Never run dependency lifecycle scripts.** The app's `.npmrc` sets `ignore-scripts=true` — leave it. A downloaded app can be authored by someone else, and their dependencies' install scripts must not execute on this machine. Explicit `pnpm build`/`pnpm dev` still work.
+- **Exception — adding a dependency** (only on instances with custom dependencies enabled — see "Library boundaries" above). This is the one workflow that still requires pnpm: upload rejects new dependencies unless `pnpm-lock.yaml` was regenerated to match `package.json`, so dependency resolution MUST succeed locally. Use `pnpm add <pkg>` — prefixed with Socket Firewall when available (`sfw pnpm add <pkg>`; check with `command -v sfw`) to block known-malicious packages — or after editing `package.json` run `pnpm install --lockfile-only` (updates the lockfile without installing). If resolution fails, **stop and report the exact pnpm error to the user** — never hand-edit `package.json` and proceed without the lockfile; the upload will fail.
+- **Never run dependency lifecycle scripts.** The app's `.npmrc` sets `ignore-scripts=true` — leave it. A downloaded app can be authored by someone else, and their dependencies' install scripts must not execute on this machine. Explicit commands such as `npm run build` still work.
 
 ## Preview locally against real data
 
-`lightdash apps preview` (run in this folder) starts a local dev server that renders the app against the Lightdash instance you are logged into, using your CLI credential. Requires `pnpm install` to have succeeded; if it hasn't, skip preview and rely on the server rebuild.
+`lightdash apps preview` (run in this folder) starts a local dev server that renders the app against the Lightdash instance you are logged into, using your CLI credential. Requires `npm install` to have succeeded; if it hasn't, skip preview and rely on the server rebuild.
 
 - Preview does not pass your API key to vite or browser code: the CLI holds it behind a loopback proxy that only forwards the SDK route allowlist (query execution, result polling, downloads, current user), pinned to this app's project. No credential is written to the app folder. Never put a real key in `.env.local` or any `VITE_`-prefixed var — anything `VITE_*` is inlined into the page and readable by any code running there.
-- There is no manual `pnpm dev` equivalent with data access — bare `pnpm dev` starts the page but API calls fail with 401. Always use `lightdash apps preview`.
+- There is no manual `npm run dev` equivalent with data access — bare `npm run dev` starts the page but API calls fail with 401. Always use `lightdash apps preview`.
 - An endpoint that works in preview but not when deployed means it is outside the data-app SDK surface — use the SDK, don't work around the proxy.
-- Declared custom dependencies work in preview too — the dev server bundles whatever `pnpm install` put in `node_modules`, the same set the server installs on upload.
+- Declared custom dependencies work in preview too — the dev server bundles whatever the dependency install put in `node_modules`, the same set the server installs on upload.
 - Preview shows **your** data under **your** permissions and user attributes — viewers of the deployed app may see different data. Do not treat preview as verification of viewer-specific behavior.
 - Local preview keeps the credential out of the app environment/browser but is **not a sandbox**: vite and the downloaded tooling execute as your OS user, can read that user's files (including the existing CLI config), and the app can read the query results it requests. Only preview source and dependencies you trust.
 - The dev server applies a CSP that forces API traffic through its same-origin proxy, but `script-src` stays permissive (vite needs it), so preview is **not** a full stand-in for the deployed Content-Security-Policy. A library that works in preview may still be blocked when deployed; the app page after upload is the final check.
@@ -65,4 +65,4 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 
 Most root config is reference only — editing it has **no effect** because the server rebuilds against its trusted template. This applies to `vite.config.js`, `tailwind.config.js`, `tsconfig.json`, and other build/tooling files.
 
-`package.json` is **partially editable** only when custom dependencies are enabled on the Lightdash instance — see "Library boundaries" above; treat it as read-only otherwise. When enabled, you may add npm dependencies with `pnpm add <pkg>` — registry packages with plain semver versions only (no git/file/url specs), up to 60 direct dependencies, and `pnpm-lock.yaml` must be updated alongside (see the exception above — this is the one step that must succeed locally). On upload the CLI warns which packages will be installed in the build sandbox; install scripts never run. Other root config (vite/tailwind/tsconfig) remains read-only.
+`package.json` is **partially editable** only when custom dependencies are enabled on the Lightdash instance — see "Library boundaries" above; treat it as read-only otherwise. When enabled, you may add npm dependencies with `pnpm add <pkg>` — registry packages with plain semver versions only (no git/file/url specs), up to 60 direct dependencies, and `pnpm-lock.yaml` must be updated alongside (see the exception above — this is the one step that still requires pnpm and must succeed locally). On upload the CLI warns which packages will be installed in the build sandbox; install scripts never run. Other root config (vite/tailwind/tsconfig) remains read-only.

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -9,7 +9,7 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 
 ## The only way to reach data is the SDK
 
-- All data access goes through `@lightdash/query-sdk` (a postMessage bridge to Lightdash). There is **no** `fetch`, no REST calls, no other network access at runtime — anything else is blocked.
+- All app data access goes through `@lightdash/query-sdk`. Deployed apps use Lightdash's postMessage bridge; `lightdash apps preview` uses a loopback proxy restricted to the same SDK routes and project. Do not add direct `fetch` or REST calls.
 - For the SDK surface (query builder, `useLightdash`, filters, downloads), read the `lightdash-data-app` skill in this folder.
 
 ## External HTTP APIs go through linked connections
@@ -41,13 +41,16 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 
 ## Preview locally against real data
 
-`lightdash apps preview` (run in this folder) starts a local dev server that renders the app against the Lightdash instance you are logged into, using your CLI credential. It writes `.env.local` (gitignored) and runs `pnpm dev`. Requires `pnpm install` to have succeeded; if it hasn't, skip preview and rely on the server rebuild.
+`lightdash apps preview` (run in this folder) starts a local dev server that renders the app against the Lightdash instance you are logged into, using your CLI credential. Requires `pnpm install` to have succeeded; if it hasn't, skip preview and rely on the server rebuild.
 
-- Your API key is kept **out of the browser**: `.env.local` stores it as `LIGHTDASH_PREVIEW_API_KEY` (read only by the vite dev server, which injects it into proxied `/api` requests). The browser sees only a non-secret sentinel. Do not add the real key to a `VITE_`-prefixed var — anything `VITE_*` is inlined into the page and readable by any code running there.
-- Manual equivalent: write `VITE_LIGHTDASH_URL`, `VITE_LIGHTDASH_PROJECT_UUID`, and `LIGHTDASH_PREVIEW_API_KEY` (not `VITE_`) into `.env.local`, then run `pnpm dev`.
+- Preview does not pass your API key to vite or browser code: the CLI holds it behind a loopback proxy that only forwards the SDK route allowlist (query execution, result polling, downloads, current user), pinned to this app's project. No credential is written to the app folder. Never put a real key in `.env.local` or any `VITE_`-prefixed var — anything `VITE_*` is inlined into the page and readable by any code running there.
+- There is no manual `pnpm dev` equivalent with data access — bare `pnpm dev` starts the page but API calls fail with 401. Always use `lightdash apps preview`.
+- An endpoint that works in preview but not when deployed means it is outside the data-app SDK surface — use the SDK, don't work around the proxy.
 - Declared custom dependencies work in preview too — the dev server bundles whatever `pnpm install` put in `node_modules`, the same set the server installs on upload.
 - Preview shows **your** data under **your** permissions and user attributes — viewers of the deployed app may see different data. Do not treat preview as verification of viewer-specific behavior.
-- The dev server applies a CSP that locks network egress to the Lightdash origin, but `script-src` stays permissive (vite needs it), so preview is **not** a full stand-in for the deployed Content-Security-Policy. A library that works in preview may still be blocked when deployed; the app page after upload is the final check.
+- Local preview keeps the credential out of the app environment/browser but is **not a sandbox**: vite and the downloaded tooling execute as your OS user, can read that user's files (including the existing CLI config), and the app can read the query results it requests. Only preview source and dependencies you trust.
+- The dev server applies a CSP that forces API traffic through its same-origin proxy, but `script-src` stays permissive (vite needs it), so preview is **not** a full stand-in for the deployed Content-Security-Policy. A library that works in preview may still be blocked when deployed; the app page after upload is the final check.
+- Host-mediated features are not emulated locally. External connections (`externalFetch`), data-app-viz row/field context, Google Sheets export, the product inspector, and product URL-state integration must be tested after upload.
 
 ## Project context (read-only reference)
 

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -36,7 +36,7 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 - If `pnpm install` fails (registry policy, an unavailable pinned SDK version, no network access), **skip the local build entirely and go straight to upload**. The server rebuild is authoritative and surfaces build errors on the app page.
 - Do **not** modify machine configuration, `.npmrc` files, registry settings, or the project's dependency files to force an install to work.
 - A missing `node_modules` is a normal state, not a problem to fix. Never run installs just because it is absent.
-- **Exception — adding a dependency** (only on instances with custom dependencies enabled — see "Library boundaries" above). Upload rejects new dependencies unless `pnpm-lock.yaml` was regenerated to match `package.json`, so dependency resolution MUST succeed locally. Use `pnpm add <pkg>`, or after editing `package.json` run `pnpm install --lockfile-only` (updates the lockfile without installing). If resolution fails, **stop and report the exact pnpm error to the user** — never hand-edit `package.json` and proceed without the lockfile; the upload will fail.
+- **Exception — adding a dependency** (only on instances with custom dependencies enabled — see "Library boundaries" above). Upload rejects new dependencies unless `pnpm-lock.yaml` was regenerated to match `package.json`, so dependency resolution MUST succeed locally. Use `pnpm add <pkg>` — prefixed with Socket Firewall when available (`sfw pnpm add <pkg>`; check with `command -v sfw`) to block known-malicious packages — or after editing `package.json` run `pnpm install --lockfile-only` (updates the lockfile without installing). If resolution fails, **stop and report the exact pnpm error to the user** — never hand-edit `package.json` and proceed without the lockfile; the upload will fail.
 - **Never run dependency lifecycle scripts.** The app's `.npmrc` sets `ignore-scripts=true` — leave it. A downloaded app can be authored by someone else, and their dependencies' install scripts must not execute on this machine. Explicit `pnpm build`/`pnpm dev` still work.
 
 ## Preview locally against real data
@@ -44,7 +44,9 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 `lightdash apps preview` (run in this folder) starts a local dev server that renders the app against the Lightdash instance you are logged into, using your CLI credential. It writes `.env.local` (gitignored — contains your API key) and runs `pnpm dev`. Requires `pnpm install` to have succeeded; if it hasn't, skip preview and rely on the server rebuild.
 
 - Manual equivalent: write `VITE_LIGHTDASH_URL`, `VITE_LIGHTDASH_API_KEY`, `VITE_LIGHTDASH_PROJECT_UUID` into `.env.local` and run `pnpm dev`.
+- Declared custom dependencies work in preview too — the dev server bundles whatever `pnpm install` put in `node_modules`, the same set the server installs on upload.
 - Preview shows **your** data under **your** permissions and user attributes — viewers of the deployed app may see different data. Do not treat preview as verification of viewer-specific behavior.
+- Preview does **not** apply the deployed Content-Security-Policy. A library that works in preview may still be blocked when deployed; the app page after upload is the final check.
 
 ## Project context (read-only reference)
 

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -41,12 +41,13 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 
 ## Preview locally against real data
 
-`lightdash apps preview` (run in this folder) starts a local dev server that renders the app against the Lightdash instance you are logged into, using your CLI credential. It writes `.env.local` (gitignored — contains your API key) and runs `pnpm dev`. Requires `pnpm install` to have succeeded; if it hasn't, skip preview and rely on the server rebuild.
+`lightdash apps preview` (run in this folder) starts a local dev server that renders the app against the Lightdash instance you are logged into, using your CLI credential. It writes `.env.local` (gitignored) and runs `pnpm dev`. Requires `pnpm install` to have succeeded; if it hasn't, skip preview and rely on the server rebuild.
 
-- Manual equivalent: write `VITE_LIGHTDASH_URL`, `VITE_LIGHTDASH_API_KEY`, `VITE_LIGHTDASH_PROJECT_UUID` into `.env.local` and run `pnpm dev`.
+- Your API key is kept **out of the browser**: `.env.local` stores it as `LIGHTDASH_PREVIEW_API_KEY` (read only by the vite dev server, which injects it into proxied `/api` requests). The browser sees only a non-secret sentinel. Do not add the real key to a `VITE_`-prefixed var — anything `VITE_*` is inlined into the page and readable by any code running there.
+- Manual equivalent: write `VITE_LIGHTDASH_URL`, `VITE_LIGHTDASH_PROJECT_UUID`, and `LIGHTDASH_PREVIEW_API_KEY` (not `VITE_`) into `.env.local`, then run `pnpm dev`.
 - Declared custom dependencies work in preview too — the dev server bundles whatever `pnpm install` put in `node_modules`, the same set the server installs on upload.
 - Preview shows **your** data under **your** permissions and user attributes — viewers of the deployed app may see different data. Do not treat preview as verification of viewer-specific behavior.
-- Preview does **not** apply the deployed Content-Security-Policy. A library that works in preview may still be blocked when deployed; the app page after upload is the final check.
+- The dev server applies a CSP that locks network egress to the Lightdash origin, but `script-src` stays permissive (vite needs it), so preview is **not** a full stand-in for the deployed Content-Security-Policy. A library that works in preview may still be blocked when deployed; the app page after upload is the final check.
 
 ## Project context (read-only reference)
 

--- a/packages/cli/src/handlers/apps/authoring/gitignore
+++ b/packages/cli/src/handlers/apps/authoring/gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env*

--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -1,0 +1,26 @@
+import { buildPreviewEnv } from './preview';
+
+describe('buildPreviewEnv', () => {
+    it('renders the three VITE vars exactly, with trailing newline', () => {
+        expect(
+            buildPreviewEnv({
+                serverUrl: 'http://localhost:3000',
+                apiKey: 'ldpat_abc',
+                projectUuid: 'proj-uuid-1',
+            }),
+        ).toBe(
+            'VITE_LIGHTDASH_URL=http://localhost:3000\n' +
+                'VITE_LIGHTDASH_API_KEY=ldpat_abc\n' +
+                'VITE_LIGHTDASH_PROJECT_UUID=proj-uuid-1\n',
+        );
+    });
+
+    it('strips a trailing slash from the server url', () => {
+        const env = buildPreviewEnv({
+            serverUrl: 'http://localhost:3000/',
+            apiKey: 'k',
+            projectUuid: 'p',
+        });
+        expect(env).toContain('VITE_LIGHTDASH_URL=http://localhost:3000\n');
+    });
+});

--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -1,4 +1,27 @@
-import { buildPreviewEnv } from './preview';
+import { type DataAppCode } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeBundleToDir } from './appCodeFiles';
+import {
+    assertNodeModulesPresent,
+    buildPreviewEnv,
+    resolvePreviewTarget,
+} from './preview';
+
+const previewBundle: DataAppCode = {
+    manifest: {
+        codeVersion: 1 as const,
+        appUuid: 'app-uuid-1',
+        projectUuid: 'proj-uuid-1',
+        version: 2,
+        name: 'Preview App',
+        description: '',
+        template: null,
+        downloadedAt: '2026-07-01T00:00:00.000Z',
+    },
+    files: [],
+};
 
 describe('buildPreviewEnv', () => {
     it('renders the three VITE vars exactly, with trailing newline', () => {
@@ -22,5 +45,50 @@ describe('buildPreviewEnv', () => {
             projectUuid: 'p',
         });
         expect(env).toContain('VITE_LIGHTDASH_URL=http://localhost:3000\n');
+    });
+});
+
+describe('resolvePreviewTarget', () => {
+    it('defaults appDir to cwd and project to the manifest projectUuid', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        await writeBundleToDir(dir, previewBundle);
+        const target = await resolvePreviewTarget({ cwd: dir });
+        expect(target.appDir).toBe(dir);
+        expect(target.projectUuid).toBe('proj-uuid-1');
+    });
+
+    it('resolves a relative path arg against cwd and honors --project override', async () => {
+        const parent = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        const appDir = path.join(parent, 'apps', 'my-app');
+        await writeBundleToDir(appDir, previewBundle);
+        const target = await resolvePreviewTarget({
+            pathArg: 'apps/my-app',
+            projectFlag: 'other-proj',
+            cwd: parent,
+        });
+        expect(target.appDir).toBe(appDir);
+        expect(target.projectUuid).toBe('other-proj');
+    });
+
+    it('errors clearly when the folder has no manifest', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        await expect(resolvePreviewTarget({ cwd: dir })).rejects.toThrow(
+            /No lightdash-app\.yml found in/,
+        );
+    });
+});
+
+describe('assertNodeModulesPresent', () => {
+    it('passes when node_modules exists', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        await fs.mkdir(path.join(dir, 'node_modules'));
+        await expect(assertNodeModulesPresent(dir)).resolves.toBeUndefined();
+    });
+
+    it('errors telling the user to pnpm install, without installing', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        await expect(assertNodeModulesPresent(dir)).rejects.toThrow(
+            /Run 'pnpm install' in .* \(preview does not auto-install\)/,
+        );
     });
 });

--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -6,6 +6,7 @@ import { writeBundleToDir } from './appCodeFiles';
 import {
     assertNodeModulesPresent,
     buildPreviewEnv,
+    projectNotFoundMessage,
     resolvePreviewTarget,
 } from './preview';
 
@@ -90,5 +91,18 @@ describe('assertNodeModulesPresent', () => {
         await expect(assertNodeModulesPresent(dir)).rejects.toThrow(
             /Run 'pnpm install' in .* \(preview does not auto-install\)/,
         );
+    });
+});
+
+describe('projectNotFoundMessage', () => {
+    it('names the project, the server, and both remedies', () => {
+        const msg = projectNotFoundMessage({
+            projectUuid: 'proj-uuid-1',
+            serverUrl: 'https://cloud.example.com',
+        });
+        expect(msg).toContain('proj-uuid-1');
+        expect(msg).toContain('https://cloud.example.com');
+        expect(msg).toMatch(/lightdash login/);
+        expect(msg).toMatch(/--project/);
     });
 });

--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -6,6 +6,7 @@ import { writeBundleToDir } from './appCodeFiles';
 import {
     assertNodeModulesPresent,
     buildPreviewEnv,
+    PREVIEW_API_KEY_SENTINEL,
     projectNotFoundMessage,
     resolvePreviewTarget,
 } from './preview';
@@ -25,7 +26,7 @@ const previewBundle: DataAppCode = {
 };
 
 describe('buildPreviewEnv', () => {
-    it('renders the three VITE vars exactly, with trailing newline', () => {
+    it('keeps the real key server-side and inlines only a sentinel', () => {
         expect(
             buildPreviewEnv({
                 serverUrl: 'http://localhost:3000',
@@ -34,9 +35,25 @@ describe('buildPreviewEnv', () => {
             }),
         ).toBe(
             'VITE_LIGHTDASH_URL=http://localhost:3000\n' +
-                'VITE_LIGHTDASH_API_KEY=ldpat_abc\n' +
-                'VITE_LIGHTDASH_PROJECT_UUID=proj-uuid-1\n',
+                `VITE_LIGHTDASH_API_KEY=${PREVIEW_API_KEY_SENTINEL}\n` +
+                'VITE_LIGHTDASH_PROJECT_UUID=proj-uuid-1\n' +
+                'LIGHTDASH_PREVIEW_API_KEY=ldpat_abc\n',
         );
+    });
+
+    it('never inlines the real key into a VITE_ (browser) var', () => {
+        const env = buildPreviewEnv({
+            serverUrl: 'http://localhost:3000',
+            apiKey: 'ldpat_secret',
+            projectUuid: 'p',
+        });
+        // The real key must only appear on the non-VITE, server-only line.
+        for (const line of env.split('\n')) {
+            if (line.startsWith('VITE_')) {
+                expect(line).not.toContain('ldpat_secret');
+            }
+        }
+        expect(env).toContain('LIGHTDASH_PREVIEW_API_KEY=ldpat_secret\n');
     });
 
     it('strips a trailing slash from the server url', () => {

--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -2,10 +2,12 @@ import { type DataAppCode } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { getAuthHeader } from '../utils';
 import { writeBundleToDir } from './appCodeFiles';
 import {
     assertNodeModulesPresent,
-    buildPreviewEnv,
+    assertScaffoldingSupportsPreviewProxy,
+    buildPreviewChildEnv,
     PREVIEW_API_KEY_SENTINEL,
     projectNotFoundMessage,
     resolvePreviewTarget,
@@ -25,44 +27,81 @@ const previewBundle: DataAppCode = {
     files: [],
 };
 
-describe('buildPreviewEnv', () => {
-    it('keeps the real key server-side and inlines only a sentinel', () => {
-        expect(
-            buildPreviewEnv({
-                serverUrl: 'http://localhost:3000',
-                apiKey: 'ldpat_abc',
-                projectUuid: 'proj-uuid-1',
-            }),
-        ).toBe(
-            'VITE_LIGHTDASH_URL=http://localhost:3000\n' +
-                `VITE_LIGHTDASH_API_KEY=${PREVIEW_API_KEY_SENTINEL}\n` +
-                'VITE_LIGHTDASH_PROJECT_UUID=proj-uuid-1\n' +
-                'LIGHTDASH_PREVIEW_API_KEY=ldpat_abc\n',
-        );
+describe('getAuthHeader', () => {
+    it('uses ApiKey authentication for personal access tokens', () => {
+        expect(getAuthHeader('ldpat_secret')).toBe('ApiKey ldpat_secret');
     });
 
-    it('never inlines the real key into a VITE_ (browser) var', () => {
-        const env = buildPreviewEnv({
+    it('uses Bearer authentication for service-account tokens', () => {
+        expect(getAuthHeader('ldsvc_secret')).toBe('Bearer ldsvc_secret');
+    });
+});
+
+describe('buildPreviewChildEnv', () => {
+    it('passes through only required host variables and no parent secrets', () => {
+        const env = buildPreviewChildEnv({
             serverUrl: 'http://localhost:3000',
-            apiKey: 'ldpat_secret',
-            projectUuid: 'p',
+            projectUuid: 'proj-uuid-1',
+            proxyPort: 45678,
+            proxyNonce: 'nonce-abc',
+            parentEnv: {
+                HOME: '/home/developer',
+                PATH: '/usr/bin',
+                LIGHTDASH_API_KEY: 'ldpat_parent_secret',
+                LIGHTDASH_PROXY_AUTHORIZATION: 'Basic parent-secret',
+                NPM_TOKEN: 'npm_parent_secret',
+                VITE_LIGHTDASH_API_KEY: 'ldpat_browser_secret',
+            },
         });
-        // The real key must only appear on the non-VITE, server-only line.
-        for (const line of env.split('\n')) {
-            if (line.startsWith('VITE_')) {
-                expect(line).not.toContain('ldpat_secret');
-            }
+        expect(env).toEqual({
+            HOME: '/home/developer',
+            PATH: '/usr/bin',
+            VITE_LIGHTDASH_URL: 'http://localhost:3000',
+            VITE_LIGHTDASH_API_KEY: PREVIEW_API_KEY_SENTINEL,
+            VITE_LIGHTDASH_PROJECT_UUID: 'proj-uuid-1',
+            LIGHTDASH_PREVIEW_PROXY_TARGET: 'http://127.0.0.1:45678',
+            LIGHTDASH_PREVIEW_PROXY_NONCE: 'nonce-abc',
+        });
+        expect(env).not.toHaveProperty('LIGHTDASH_API_KEY');
+        expect(env).not.toHaveProperty('LIGHTDASH_PROXY_AUTHORIZATION');
+        expect(env).not.toHaveProperty('NPM_TOKEN');
+        for (const value of Object.values(env)) {
+            expect(value).not.toMatch(/^ld(pat|svc)_/);
         }
-        expect(env).toContain('LIGHTDASH_PREVIEW_API_KEY=ldpat_secret\n');
     });
 
     it('strips a trailing slash from the server url', () => {
-        const env = buildPreviewEnv({
+        const env = buildPreviewChildEnv({
             serverUrl: 'http://localhost:3000/',
-            apiKey: 'k',
             projectUuid: 'p',
+            proxyPort: 1,
+            proxyNonce: 'n',
         });
-        expect(env).toContain('VITE_LIGHTDASH_URL=http://localhost:3000\n');
+        expect(env.VITE_LIGHTDASH_URL).toBe('http://localhost:3000');
+    });
+});
+
+describe('assertScaffoldingSupportsPreviewProxy', () => {
+    it('passes when vite.config.js reads the proxy target', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        await fs.writeFile(
+            path.join(dir, 'vite.config.js'),
+            'const t = env.LIGHTDASH_PREVIEW_PROXY_TARGET;',
+        );
+        await expect(
+            assertScaffoldingSupportsPreviewProxy(dir),
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects pre-proxy scaffolding with a re-download instruction', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        await fs.writeFile(
+            path.join(dir, 'vite.config.js'),
+            'const k = env.LIGHTDASH_PREVIEW_API_KEY;',
+        );
+        await expect(
+            assertScaffoldingSupportsPreviewProxy(dir),
+        ).rejects.toThrow(/Re-download the app/);
     });
 });
 

--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -8,7 +8,9 @@ import {
     assertNodeModulesPresent,
     assertScaffoldingSupportsPreviewProxy,
     buildPreviewChildEnv,
+    preflightPreviewRequest,
     projectNotFoundMessage,
+    removeLegacyPreviewCredential,
     resolvePreviewTarget,
 } from './preview';
 
@@ -159,5 +161,85 @@ describe('projectNotFoundMessage', () => {
         expect(msg).toContain('https://cloud.example.com');
         expect(msg).toMatch(/lightdash login/);
         expect(msg).toMatch(/--project/);
+    });
+});
+
+describe('preflightPreviewRequest', () => {
+    it('reports network failures separately from rejected credentials', async () => {
+        const fetchFn = vi
+            .fn()
+            .mockRejectedValue(new Error('connection refused')) as typeof fetch;
+
+        await expect(
+            preflightPreviewRequest({
+                apiPath: '/api/v1/user',
+                serverUrl: 'http://localhost:8080',
+                authorization: 'ApiKey test',
+                fetchFn,
+            }),
+        ).rejects.toThrow(
+            'Could not connect to http://localhost:8080 while starting preview: connection refused',
+        );
+    });
+
+    it('returns false for an HTTP rejection', async () => {
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+
+        await expect(
+            preflightPreviewRequest({
+                apiPath: '/api/v1/user',
+                serverUrl: 'http://localhost:8080',
+                authorization: 'ApiKey test',
+                fetchFn,
+            }),
+        ).resolves.toBe(false);
+    });
+});
+
+describe('removeLegacyPreviewCredential', () => {
+    it('removes only the obsolete credential and preserves other settings', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        const envPath = path.join(dir, '.env.local');
+        await fs.writeFile(
+            envPath,
+            [
+                'VITE_CUSTOM_SETTING=keep-me',
+                'LIGHTDASH_PREVIEW_API_KEY=ldpat_remove_me',
+                '# LIGHTDASH_PREVIEW_API_KEY=commented-out',
+                'ANOTHER_SETTING=also-keep-me',
+                '',
+            ].join('\n'),
+        );
+
+        await expect(removeLegacyPreviewCredential(dir)).resolves.toBe(true);
+        await expect(fs.readFile(envPath, 'utf-8')).resolves.toBe(
+            [
+                'VITE_CUSTOM_SETTING=keep-me',
+                '# LIGHTDASH_PREVIEW_API_KEY=commented-out',
+                'ANOTHER_SETTING=also-keep-me',
+                '',
+            ].join('\n'),
+        );
+    });
+
+    it('deletes an env file that contains only the obsolete credential', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        const envPath = path.join(dir, '.env.local');
+        await fs.writeFile(
+            envPath,
+            'export LIGHTDASH_PREVIEW_API_KEY=ldpat_remove_me\n',
+        );
+
+        await expect(removeLegacyPreviewCredential(dir)).resolves.toBe(true);
+        await expect(fs.stat(envPath)).rejects.toMatchObject({
+            code: 'ENOENT',
+        });
+    });
+
+    it('does nothing when there is no legacy credential', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        await expect(removeLegacyPreviewCredential(dir)).resolves.toBe(false);
     });
 });

--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -8,7 +8,6 @@ import {
     assertNodeModulesPresent,
     assertScaffoldingSupportsPreviewProxy,
     buildPreviewChildEnv,
-    PREVIEW_API_KEY_SENTINEL,
     projectNotFoundMessage,
     resolvePreviewTarget,
 } from './preview';
@@ -57,7 +56,7 @@ describe('buildPreviewChildEnv', () => {
             HOME: '/home/developer',
             PATH: '/usr/bin',
             VITE_LIGHTDASH_URL: 'http://localhost:3000',
-            VITE_LIGHTDASH_API_KEY: PREVIEW_API_KEY_SENTINEL,
+            VITE_LIGHTDASH_API_KEY: 'nonce-abc',
             VITE_LIGHTDASH_PROJECT_UUID: 'proj-uuid-1',
             LIGHTDASH_PREVIEW_PROXY_TARGET: 'http://127.0.0.1:45678',
             LIGHTDASH_PREVIEW_PROXY_NONCE: 'nonce-abc',

--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -143,10 +143,10 @@ describe('assertNodeModulesPresent', () => {
         await expect(assertNodeModulesPresent(dir)).resolves.toBeUndefined();
     });
 
-    it('errors telling the user to pnpm install, without installing', async () => {
+    it('errors telling the user to npm install, without installing', async () => {
         const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
         await expect(assertNodeModulesPresent(dir)).rejects.toThrow(
-            /Run 'pnpm install' in .* \(preview does not auto-install\)/,
+            /Run 'npm install' in .* \(preview does not auto-install\)/,
         );
     });
 });

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -1,3 +1,8 @@
+import { type DataAppManifest } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { readManifestFromDir } from './appCodeFiles';
+
 export const buildPreviewEnv = (args: {
     serverUrl: string;
     apiKey: string;
@@ -10,4 +15,45 @@ export const buildPreviewEnv = (args: {
         `VITE_LIGHTDASH_PROJECT_UUID=${args.projectUuid}`,
         '',
     ].join('\n');
+};
+
+export const resolvePreviewTarget = async (args: {
+    pathArg?: string;
+    projectFlag?: string;
+    cwd: string;
+}): Promise<{ appDir: string; projectUuid: string }> => {
+    const appDir = args.pathArg
+        ? path.resolve(args.cwd, args.pathArg)
+        : args.cwd;
+
+    let manifest: DataAppManifest;
+    try {
+        manifest = await readManifestFromDir(appDir);
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            throw new Error(
+                `No lightdash-app.yml found in ${appDir}. Run this from a downloaded app folder (apps/<slug>/), or pass it as an argument: lightdash apps preview <path>.`,
+            );
+        }
+        throw err;
+    }
+
+    return {
+        appDir,
+        projectUuid: args.projectFlag ?? manifest.projectUuid,
+    };
+};
+
+export const assertNodeModulesPresent = async (
+    appDir: string,
+): Promise<void> => {
+    const isDir = await fs
+        .stat(path.join(appDir, 'node_modules'))
+        .then((s) => s.isDirectory())
+        .catch(() => false);
+    if (!isDir) {
+        throw new Error(
+            `Dependencies are not installed. Run 'pnpm install' in ${appDir} first (preview does not auto-install).`,
+        );
+    }
 };

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -8,16 +8,28 @@ import * as styles from '../../styles';
 import { checkLightdashVersion } from '../dbt/apiClient';
 import { readManifestFromDir } from './appCodeFiles';
 
+// Non-secret placeholder inlined into the browser in place of the real key.
+// The vite proxy overrides the Authorization header with the real credential
+// (LIGHTDASH_PREVIEW_API_KEY) server-side, so this value never authenticates.
+export const PREVIEW_API_KEY_SENTINEL = 'preview-proxy-injected';
+
 export const buildPreviewEnv = (args: {
     serverUrl: string;
     apiKey: string;
     projectUuid: string;
 }): string => {
     const baseUrl = args.serverUrl.replace(/\/+$/, '');
+    // The real credential goes into LIGHTDASH_PREVIEW_API_KEY, which the vite
+    // dev server reads server-side and injects into proxied /api requests — it
+    // is never inlined into the browser bundle (only VITE_* vars are). The
+    // browser gets a non-secret sentinel so the SDK still builds a client and
+    // sends a well-formed (but useless) Authorization header the proxy
+    // overrides. Result: no usable API key ever reaches the page.
     return [
         `VITE_LIGHTDASH_URL=${baseUrl}`,
-        `VITE_LIGHTDASH_API_KEY=${args.apiKey}`,
+        `VITE_LIGHTDASH_API_KEY=${PREVIEW_API_KEY_SENTINEL}`,
         `VITE_LIGHTDASH_PROJECT_UUID=${args.projectUuid}`,
+        `LIGHTDASH_PREVIEW_API_KEY=${args.apiKey}`,
         '',
     ].join('\n');
 };

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { getConfig } from '../../config';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
-import { checkLightdashVersion, lightdashApi } from '../dbt/apiClient';
+import { checkLightdashVersion } from '../dbt/apiClient';
 import { readManifestFromDir } from './appCodeFiles';
 
 export const buildPreviewEnv = (args: {
@@ -63,6 +63,18 @@ export const assertNodeModulesPresent = async (
     }
 };
 
+/**
+ * The login context can point at a different instance than the one the app
+ * was downloaded from — the credential pre-flight passes there, but the
+ * app's project doesn't exist, which would surface as a confusing 404
+ * inside the running app.
+ */
+export const projectNotFoundMessage = (args: {
+    projectUuid: string;
+    serverUrl: string;
+}): string =>
+    `Project ${args.projectUuid} was not found on ${args.serverUrl} (or you don't have access). This app belongs to a different project or instance than the one you're logged into — run 'lightdash login <url>' for the server the app was downloaded from, or pass --project to preview against another project.`;
+
 type AppsPreviewOptions = {
     project?: string;
     url?: string;
@@ -94,23 +106,33 @@ export const appsPreviewHandler = async (
 
     // Pre-flight the credential before starting vite: an expired/revoked
     // token would otherwise surface as opaque query failures inside the app.
-    if (options.url || options.token) {
-        // lightdashApi reads the stored config, so flag-overridden
-        // credentials can't be pre-flighted through it; skip the check.
-        GlobalState.debug('Skipping credential pre-flight (--url/--token).');
-    } else {
+    // Flag-supplied credentials (--url/--token) bypass the stored config, so
+    // hit the API directly with exactly what will be written to .env.local.
+    if (!options.url && !options.token) {
         await checkLightdashVersion();
+    }
+    const preflight = async (apiPath: string): Promise<boolean> => {
         try {
-            await lightdashApi({
-                method: 'GET',
-                url: '/api/v1/user',
-                body: undefined,
+            const res = await fetch(new URL(apiPath, serverUrl), {
+                headers: { Authorization: `ApiKey ${apiKey}` },
             });
-        } catch (err) {
-            throw new AuthorizationError(
-                `Your Lightdash credential was rejected by ${serverUrl}. Run 'lightdash login ${serverUrl}' to refresh it.`,
-            );
+            return res.ok;
+        } catch {
+            return false;
         }
+    };
+    if (!(await preflight('/api/v1/user'))) {
+        throw new AuthorizationError(
+            `Your Lightdash credential was rejected by ${serverUrl}. Run 'lightdash login ${serverUrl}' to refresh it, or check the --url/--token values.`,
+        );
+    }
+    if (!(await preflight(`/api/v1/projects/${target.projectUuid}`))) {
+        throw new Error(
+            projectNotFoundMessage({
+                projectUuid: target.projectUuid,
+                serverUrl,
+            }),
+        );
     }
 
     const envPath = path.join(target.appDir, '.env.local');

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -1,6 +1,11 @@
-import { type DataAppManifest } from '@lightdash/common';
+import { AuthorizationError, type DataAppManifest } from '@lightdash/common';
+import execa from 'execa';
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { getConfig } from '../../config';
+import GlobalState from '../../globalState';
+import * as styles from '../../styles';
+import { checkLightdashVersion, lightdashApi } from '../dbt/apiClient';
 import { readManifestFromDir } from './appCodeFiles';
 
 export const buildPreviewEnv = (args: {
@@ -56,4 +61,80 @@ export const assertNodeModulesPresent = async (
             `Dependencies are not installed. Run 'pnpm install' in ${appDir} first (preview does not auto-install).`,
         );
     }
+};
+
+type AppsPreviewOptions = {
+    project?: string;
+    url?: string;
+    token?: string;
+    verbose: boolean;
+};
+
+export const appsPreviewHandler = async (
+    pathArg: string | undefined,
+    options: AppsPreviewOptions,
+): Promise<void> => {
+    GlobalState.setVerbose(options.verbose);
+
+    const config = await getConfig();
+    const serverUrl = options.url ?? config.context?.serverUrl;
+    const apiKey = options.token ?? config.context?.apiKey;
+    if (!serverUrl || !apiKey) {
+        throw new AuthorizationError(
+            `Not logged in or missing server URL. Run 'lightdash login <url>' first, or pass --url and --token.`,
+        );
+    }
+
+    const target = await resolvePreviewTarget({
+        pathArg,
+        projectFlag: options.project,
+        cwd: process.cwd(),
+    });
+    await assertNodeModulesPresent(target.appDir);
+
+    // Pre-flight the credential before starting vite: an expired/revoked
+    // token would otherwise surface as opaque query failures inside the app.
+    if (options.url || options.token) {
+        // lightdashApi reads the stored config, so flag-overridden
+        // credentials can't be pre-flighted through it; skip the check.
+        GlobalState.debug('Skipping credential pre-flight (--url/--token).');
+    } else {
+        await checkLightdashVersion();
+        try {
+            await lightdashApi({
+                method: 'GET',
+                url: '/api/v1/user',
+                body: undefined,
+            });
+        } catch (err) {
+            throw new AuthorizationError(
+                `Your Lightdash credential was rejected by ${serverUrl}. Run 'lightdash login ${serverUrl}' to refresh it.`,
+            );
+        }
+    }
+
+    const envPath = path.join(target.appDir, '.env.local');
+    await fs.writeFile(
+        envPath,
+        buildPreviewEnv({
+            serverUrl,
+            apiKey,
+            projectUuid: target.projectUuid,
+        }),
+        'utf-8',
+    );
+    GlobalState.log(
+        `Wrote ${envPath} (gitignored; contains your API key — do not commit or share it).`,
+    );
+    GlobalState.log(
+        styles.warning(
+            `Preview renders YOUR data with YOUR permissions and user attributes — viewers of the deployed app may see different data.`,
+        ),
+    );
+    GlobalState.log(`Starting dev server (Ctrl-C to stop)…`);
+
+    await execa('pnpm', ['dev'], {
+        cwd: target.appDir,
+        stdio: 'inherit',
+    });
 };

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -1,0 +1,13 @@
+export const buildPreviewEnv = (args: {
+    serverUrl: string;
+    apiKey: string;
+    projectUuid: string;
+}): string => {
+    const baseUrl = args.serverUrl.replace(/\/+$/, '');
+    return [
+        `VITE_LIGHTDASH_URL=${baseUrl}`,
+        `VITE_LIGHTDASH_API_KEY=${args.apiKey}`,
+        `VITE_LIGHTDASH_PROJECT_UUID=${args.projectUuid}`,
+        '',
+    ].join('\n');
+};

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -11,17 +11,12 @@ import { getAuthHeader } from '../utils';
 import { readManifestFromDir } from './appCodeFiles';
 import { startPreviewProxy } from './previewProxy';
 
-// Non-secret placeholder inlined into the browser in place of the real key.
-// The CLI's loopback proxy replaces the Authorization header with the real
-// credential before forwarding upstream, so this value never authenticates.
-export const PREVIEW_API_KEY_SENTINEL = 'preview-proxy-injected';
-
 /**
  * Environment passed to the `pnpm dev` child process. Only the small set of
  * host variables needed to launch a portable child process is inherited. In
  * particular, no Lightdash credential or unrelated parent-process secret is
- * copied into vite. The nonce is a run-scoped capability for the proxy's
- * allowlisted routes; it is not exposed to browser code.
+ * copied into vite. The nonce is exposed to browser code as a run-scoped,
+ * project- and route-limited capability; it is not a Lightdash credential.
  */
 export const buildPreviewChildEnv = (args: {
     serverUrl: string;
@@ -67,7 +62,7 @@ export const buildPreviewChildEnv = (args: {
     return {
         ...childEnv,
         VITE_LIGHTDASH_URL: args.serverUrl.replace(/\/+$/, ''),
-        VITE_LIGHTDASH_API_KEY: PREVIEW_API_KEY_SENTINEL,
+        VITE_LIGHTDASH_API_KEY: args.proxyNonce,
         VITE_LIGHTDASH_PROJECT_UUID: args.projectUuid,
         LIGHTDASH_PREVIEW_PROXY_TARGET: `http://127.0.0.1:${args.proxyPort}`,
         LIGHTDASH_PREVIEW_PROXY_NONCE: args.proxyNonce,

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -1,4 +1,5 @@
 import { AuthorizationError, type DataAppManifest } from '@lightdash/common';
+import { randomBytes } from 'crypto';
 import execa from 'execa';
 import { promises as fs } from 'fs';
 import * as path from 'path';
@@ -6,32 +7,89 @@ import { getConfig } from '../../config';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
 import { checkLightdashVersion } from '../dbt/apiClient';
+import { getAuthHeader } from '../utils';
 import { readManifestFromDir } from './appCodeFiles';
+import { startPreviewProxy } from './previewProxy';
 
 // Non-secret placeholder inlined into the browser in place of the real key.
-// The vite proxy overrides the Authorization header with the real credential
-// (LIGHTDASH_PREVIEW_API_KEY) server-side, so this value never authenticates.
+// The CLI's loopback proxy replaces the Authorization header with the real
+// credential before forwarding upstream, so this value never authenticates.
 export const PREVIEW_API_KEY_SENTINEL = 'preview-proxy-injected';
 
-export const buildPreviewEnv = (args: {
+/**
+ * Environment passed to the `pnpm dev` child process. Only the small set of
+ * host variables needed to launch a portable child process is inherited. In
+ * particular, no Lightdash credential or unrelated parent-process secret is
+ * copied into vite. The nonce is a run-scoped capability for the proxy's
+ * allowlisted routes; it is not exposed to browser code.
+ */
+export const buildPreviewChildEnv = (args: {
     serverUrl: string;
-    apiKey: string;
     projectUuid: string;
-}): string => {
-    const baseUrl = args.serverUrl.replace(/\/+$/, '');
-    // The real credential goes into LIGHTDASH_PREVIEW_API_KEY, which the vite
-    // dev server reads server-side and injects into proxied /api requests — it
-    // is never inlined into the browser bundle (only VITE_* vars are). The
-    // browser gets a non-secret sentinel so the SDK still builds a client and
-    // sends a well-formed (but useless) Authorization header the proxy
-    // overrides. Result: no usable API key ever reaches the page.
-    return [
-        `VITE_LIGHTDASH_URL=${baseUrl}`,
-        `VITE_LIGHTDASH_API_KEY=${PREVIEW_API_KEY_SENTINEL}`,
-        `VITE_LIGHTDASH_PROJECT_UUID=${args.projectUuid}`,
-        `LIGHTDASH_PREVIEW_API_KEY=${args.apiKey}`,
-        '',
-    ].join('\n');
+    proxyPort: number;
+    proxyNonce: string;
+    parentEnv?: NodeJS.ProcessEnv;
+}): Record<string, string> => {
+    const parentEnv = args.parentEnv ?? process.env;
+    const passthroughKeys = [
+        'APPDATA',
+        'CI',
+        'COLORTERM',
+        'COMSPEC',
+        'ComSpec',
+        'FORCE_COLOR',
+        'HOME',
+        'LANG',
+        'LC_ALL',
+        'LOCALAPPDATA',
+        'NODE_OPTIONS',
+        'NODE_PATH',
+        'NO_COLOR',
+        'PATH',
+        'PATHEXT',
+        'PNPM_HOME',
+        'SHELL',
+        'SYSTEMROOT',
+        'SystemRoot',
+        'TEMP',
+        'TERM',
+        'TMP',
+        'TMPDIR',
+        'USERPROFILE',
+        'WINDIR',
+    ] as const;
+    const childEnv: Record<string, string> = {};
+    for (const key of passthroughKeys) {
+        const value = parentEnv[key];
+        if (value !== undefined) childEnv[key] = value;
+    }
+
+    return {
+        ...childEnv,
+        VITE_LIGHTDASH_URL: args.serverUrl.replace(/\/+$/, ''),
+        VITE_LIGHTDASH_API_KEY: PREVIEW_API_KEY_SENTINEL,
+        VITE_LIGHTDASH_PROJECT_UUID: args.projectUuid,
+        LIGHTDASH_PREVIEW_PROXY_TARGET: `http://127.0.0.1:${args.proxyPort}`,
+        LIGHTDASH_PREVIEW_PROXY_NONCE: args.proxyNonce,
+    };
+};
+
+/**
+ * Older downloads have a vite.config.js that proxies /api straight to the
+ * instance and expects the credential in .env.local — incompatible with the
+ * proxy-based flow (requests would go out uncredentialed and 401).
+ */
+export const assertScaffoldingSupportsPreviewProxy = async (
+    appDir: string,
+): Promise<void> => {
+    const viteConfig = await fs
+        .readFile(path.join(appDir, 'vite.config.js'), 'utf-8')
+        .catch(() => '');
+    if (!viteConfig.includes('LIGHTDASH_PREVIEW_PROXY_TARGET')) {
+        throw new Error(
+            `This app's scaffolding predates the secure preview proxy. Re-download the app ('lightdash download --apps <appUuid>') to refresh vite.config.js, then run preview again.`,
+        );
+    }
 };
 
 export const resolvePreviewTarget = async (args: {
@@ -102,10 +160,23 @@ export const appsPreviewHandler = async (
 
     const config = await getConfig();
     const serverUrl = options.url ?? config.context?.serverUrl;
+    // getConfig() already folds LIGHTDASH_API_KEY into context.apiKey, so the
+    // env-var path is safe. The only exposure is an explicit --token on the
+    // command line (visible in shell history / `ps aux`) — warn rather than
+    // block, since --token is a supported CI path.
     const apiKey = options.token ?? config.context?.apiKey;
     if (!serverUrl || !apiKey) {
         throw new AuthorizationError(
-            `Not logged in or missing server URL. Run 'lightdash login <url>' first, or pass --url and --token.`,
+            `Not logged in or missing server URL. Run 'lightdash login <url>' first, or set LIGHTDASH_URL and LIGHTDASH_API_KEY.`,
+        );
+    }
+    const authorization = getAuthHeader(apiKey);
+    const proxyAuthorization = config.context?.proxyAuthorization;
+    if (options.token) {
+        GlobalState.log(
+            styles.warning(
+                `Passing --token on the command line exposes it in your shell history and process list. Prefer 'lightdash login' or the LIGHTDASH_API_KEY environment variable.`,
+            ),
         );
     }
 
@@ -116,17 +187,24 @@ export const appsPreviewHandler = async (
     });
     await assertNodeModulesPresent(target.appDir);
 
+    await assertScaffoldingSupportsPreviewProxy(target.appDir);
+
     // Pre-flight the credential before starting vite: an expired/revoked
     // token would otherwise surface as opaque query failures inside the app.
     // Flag-supplied credentials (--url/--token) bypass the stored config, so
-    // hit the API directly with exactly what will be written to .env.local.
+    // hit the API directly with exactly what the proxy will forward.
     if (!options.url && !options.token) {
         await checkLightdashVersion();
     }
     const preflight = async (apiPath: string): Promise<boolean> => {
         try {
             const res = await fetch(new URL(apiPath, serverUrl), {
-                headers: { Authorization: `ApiKey ${apiKey}` },
+                headers: {
+                    Authorization: authorization,
+                    ...(proxyAuthorization
+                        ? { 'Proxy-Authorization': proxyAuthorization }
+                        : {}),
+                },
             });
             return res.ok;
         } catch {
@@ -147,18 +225,29 @@ export const appsPreviewHandler = async (
         );
     }
 
-    const envPath = path.join(target.appDir, '.env.local');
-    await fs.writeFile(
-        envPath,
-        buildPreviewEnv({
-            serverUrl,
-            apiKey,
-            projectUuid: target.projectUuid,
-        }),
-        'utf-8',
-    );
+    // Previous versions of this command persisted the credential in
+    // .env.local. It's no longer read or written — nudge cleanup if found.
+    const legacyEnvPath = path.join(target.appDir, '.env.local');
+    const legacyEnv = await fs.readFile(legacyEnvPath, 'utf-8').catch(() => '');
+    if (legacyEnv.includes('LIGHTDASH_PREVIEW_API_KEY=')) {
+        GlobalState.log(
+            styles.warning(
+                `${legacyEnvPath} holds a credential from an older preview version. It is no longer used — delete the file.`,
+            ),
+        );
+    }
+
+    const proxyNonce = randomBytes(16).toString('hex');
+    const proxy = await startPreviewProxy({
+        upstreamUrl: serverUrl,
+        authorization,
+        proxyAuthorization,
+        projectUuid: target.projectUuid,
+        nonce: proxyNonce,
+    });
+
     GlobalState.log(
-        `Wrote ${envPath} (gitignored; contains your API key — do not commit or share it).`,
+        `Preview proxy on 127.0.0.1:${proxy.port} — your credential is not passed to the app; SDK traffic is restricted to project ${target.projectUuid}.`,
     );
     GlobalState.log(
         styles.warning(
@@ -167,8 +256,19 @@ export const appsPreviewHandler = async (
     );
     GlobalState.log(`Starting dev server (Ctrl-C to stop)…`);
 
-    await execa('pnpm', ['dev'], {
-        cwd: target.appDir,
-        stdio: 'inherit',
-    });
+    try {
+        await execa('pnpm', ['dev'], {
+            cwd: target.appDir,
+            stdio: 'inherit',
+            extendEnv: false,
+            env: buildPreviewChildEnv({
+                serverUrl,
+                projectUuid: target.projectUuid,
+                proxyPort: proxy.port,
+                proxyNonce,
+            }),
+        });
+    } finally {
+        await proxy.close();
+    }
 };

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -12,7 +12,7 @@ import { readManifestFromDir } from './appCodeFiles';
 import { startPreviewProxy } from './previewProxy';
 
 /**
- * Environment passed to the `pnpm dev` child process. Only the small set of
+ * Environment passed to the `npm run dev` child process. Only the small set of
  * host variables needed to launch a portable child process is inherited. In
  * particular, no Lightdash credential or unrelated parent-process secret is
  * copied into vite. The nonce is exposed to browser code as a run-scoped,
@@ -123,7 +123,7 @@ export const assertNodeModulesPresent = async (
         .catch(() => false);
     if (!isDir) {
         throw new Error(
-            `Dependencies are not installed. Run 'pnpm install' in ${appDir} first (preview does not auto-install).`,
+            `Dependencies are not installed. Run 'npm install' in ${appDir} first (preview does not auto-install).`,
         );
     }
 };
@@ -311,7 +311,7 @@ export const appsPreviewHandler = async (
     GlobalState.log(`Starting dev server (Ctrl-C to stop)…`);
 
     try {
-        await execa('pnpm', ['dev'], {
+        await execa('npm', ['run', 'dev'], {
             cwd: target.appDir,
             stdio: 'inherit',
             extendEnv: false,

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -145,6 +145,22 @@ export const projectNotFoundMessage = (args: {
 }): string =>
     `Project ${args.projectUuid} was not found on ${args.serverUrl} (or you don't have access). This app belongs to a different project or instance than the one you're logged into — run 'lightdash login <url>' for the server the app was downloaded from, or pass --project to preview against another project.`;
 
+// Ctrl-C is the documented way to stop the dev server, so an interrupted child
+// is a normal exit rather than a crash to report. The runner may either die
+// from the signal or translate it into the conventional 128+signal exit code.
+const isUserStoppedDevServer = (error: unknown): boolean => {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+    const { signal, exitCode } = error as execa.ExecaError;
+    return (
+        signal === 'SIGINT' ||
+        signal === 'SIGTERM' ||
+        exitCode === 130 ||
+        exitCode === 143
+    );
+};
+
 type AppsPreviewOptions = {
     project?: string;
     url?: string;
@@ -268,6 +284,11 @@ export const appsPreviewHandler = async (
                 proxyNonce,
             }),
         });
+    } catch (e) {
+        if (!isUserStoppedDevServer(e)) {
+            throw e;
+        }
+        GlobalState.log('Preview stopped.');
     } finally {
         await proxy.close();
     }

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -140,6 +140,59 @@ export const projectNotFoundMessage = (args: {
 }): string =>
     `Project ${args.projectUuid} was not found on ${args.serverUrl} (or you don't have access). This app belongs to a different project or instance than the one you're logged into — run 'lightdash login <url>' for the server the app was downloaded from, or pass --project to preview against another project.`;
 
+export const preflightPreviewRequest = async (args: {
+    apiPath: string;
+    serverUrl: string;
+    authorization: string;
+    proxyAuthorization?: string;
+    fetchFn?: typeof fetch;
+}): Promise<boolean> => {
+    const fetchFn = args.fetchFn ?? fetch;
+    try {
+        const res = await fetchFn(new URL(args.apiPath, args.serverUrl), {
+            headers: {
+                Authorization: args.authorization,
+                ...(args.proxyAuthorization
+                    ? { 'Proxy-Authorization': args.proxyAuthorization }
+                    : {}),
+            },
+        });
+        return res.ok;
+    } catch (error) {
+        const reason =
+            error instanceof Error ? error.message : 'Unknown network error';
+        throw new Error(
+            `Could not connect to ${args.serverUrl} while starting preview: ${reason}`,
+        );
+    }
+};
+
+const LEGACY_PREVIEW_CREDENTIAL =
+    /^[ \t]*(?:export[ \t]+)?LIGHTDASH_PREVIEW_API_KEY[ \t]*=.*(?:\r?\n|$)/gm;
+
+export const removeLegacyPreviewCredential = async (
+    appDir: string,
+): Promise<boolean> => {
+    const legacyEnvPath = path.join(appDir, '.env.local');
+    let legacyEnv: string;
+    try {
+        legacyEnv = await fs.readFile(legacyEnvPath, 'utf-8');
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+        throw error;
+    }
+
+    const sanitizedEnv = legacyEnv.replace(LEGACY_PREVIEW_CREDENTIAL, '');
+    if (sanitizedEnv === legacyEnv) return false;
+
+    if (sanitizedEnv.trim() === '') {
+        await fs.unlink(legacyEnvPath);
+    } else {
+        await fs.writeFile(legacyEnvPath, sanitizedEnv, 'utf-8');
+    }
+    return true;
+};
+
 // Ctrl-C is the documented way to stop the dev server, so an interrupted child
 // is a normal exit rather than a crash to report. The runner may either die
 // from the signal or translate it into the conventional 128+signal exit code.
@@ -207,21 +260,13 @@ export const appsPreviewHandler = async (
     if (!options.url && !options.token) {
         await checkLightdashVersion();
     }
-    const preflight = async (apiPath: string): Promise<boolean> => {
-        try {
-            const res = await fetch(new URL(apiPath, serverUrl), {
-                headers: {
-                    Authorization: authorization,
-                    ...(proxyAuthorization
-                        ? { 'Proxy-Authorization': proxyAuthorization }
-                        : {}),
-                },
-            });
-            return res.ok;
-        } catch {
-            return false;
-        }
-    };
+    const preflight = (apiPath: string) =>
+        preflightPreviewRequest({
+            apiPath,
+            serverUrl,
+            authorization,
+            proxyAuthorization,
+        });
     if (!(await preflight('/api/v1/user'))) {
         throw new AuthorizationError(
             `Your Lightdash credential was rejected by ${serverUrl}. Run 'lightdash login ${serverUrl}' to refresh it, or check the --url/--token values.`,
@@ -236,14 +281,12 @@ export const appsPreviewHandler = async (
         );
     }
 
-    // Previous versions of this command persisted the credential in
-    // .env.local. It's no longer read or written — nudge cleanup if found.
-    const legacyEnvPath = path.join(target.appDir, '.env.local');
-    const legacyEnv = await fs.readFile(legacyEnvPath, 'utf-8').catch(() => '');
-    if (legacyEnv.includes('LIGHTDASH_PREVIEW_API_KEY=')) {
+    // Previous versions persisted this credential in .env.local. Remove only
+    // that obsolete entry, preserving any unrelated user-managed settings.
+    if (await removeLegacyPreviewCredential(target.appDir)) {
         GlobalState.log(
             styles.warning(
-                `${legacyEnvPath} holds a credential from an older preview version. It is no longer used — delete the file.`,
+                `Removed an obsolete preview credential from ${path.join(target.appDir, '.env.local')}.`,
             ),
         );
     }

--- a/packages/cli/src/handlers/apps/previewProxy.test.ts
+++ b/packages/cli/src/handlers/apps/previewProxy.test.ts
@@ -1,0 +1,194 @@
+import * as http from 'http';
+import {
+    PREVIEW_PROXY_NONCE_HEADER,
+    startPreviewProxy,
+    type PreviewProxyHandle,
+} from './previewProxy';
+
+const PROJECT_UUID = 'proj-uuid-1';
+const NONCE = 'test-nonce';
+const API_KEY = 'ldpat_secret';
+const AUTHORIZATION = `ApiKey ${API_KEY}`;
+
+type SeenRequest = {
+    method: string;
+    url: string;
+    headers: http.IncomingHttpHeaders;
+    body: string;
+};
+
+/** Records every request and replies 200 with a JSON echo. */
+const startFakeUpstream = (): Promise<{
+    url: string;
+    seen: SeenRequest[];
+    close: () => Promise<void>;
+}> => {
+    const seen: SeenRequest[] = [];
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        req.on('end', () => {
+            seen.push({
+                method: req.method ?? '',
+                url: req.url ?? '',
+                headers: req.headers,
+                body: Buffer.concat(chunks).toString('utf-8'),
+            });
+            res.writeHead(200, {
+                'content-type': 'application/json',
+                'set-cookie': 'upstream=1',
+            });
+            res.end(JSON.stringify({ status: 'ok' }));
+        });
+    });
+    return new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address() as { port: number };
+            resolve({
+                url: `http://127.0.0.1:${port}`,
+                seen,
+                close: () =>
+                    new Promise<void>((r) => {
+                        server.close(() => r());
+                        server.closeAllConnections();
+                    }),
+            });
+        });
+    });
+};
+
+describe('startPreviewProxy', () => {
+    let upstream: Awaited<ReturnType<typeof startFakeUpstream>>;
+    let proxy: PreviewProxyHandle;
+
+    const proxyFetch = (
+        path: string,
+        init: RequestInit & { nonce?: string | null } = {},
+    ) => {
+        const { nonce = NONCE, ...rest } = init;
+        const headers = new Headers(rest.headers);
+        if (nonce !== null) headers.set(PREVIEW_PROXY_NONCE_HEADER, nonce);
+        return fetch(`http://127.0.0.1:${proxy.port}${path}`, {
+            ...rest,
+            headers,
+        });
+    };
+
+    beforeEach(async () => {
+        upstream = await startFakeUpstream();
+        proxy = await startPreviewProxy({
+            upstreamUrl: upstream.url,
+            authorization: AUTHORIZATION,
+            projectUuid: PROJECT_UUID,
+            nonce: NONCE,
+        });
+    });
+
+    afterEach(async () => {
+        await proxy.close();
+        await upstream.close();
+    });
+
+    it('forwards an allowlisted route with the credential attached', async () => {
+        const res = await proxyFetch(
+            `/api/v2/projects/${PROJECT_UUID}/query/metric-query`,
+            {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    authorization: 'ApiKey preview-proxy-injected',
+                },
+                body: JSON.stringify({ exploreName: 'orders' }),
+            },
+        );
+        expect(res.status).toBe(200);
+        expect(upstream.seen).toHaveLength(1);
+        const forwarded = upstream.seen[0];
+        expect(forwarded.method).toBe('POST');
+        expect(forwarded.body).toBe('{"exploreName":"orders"}');
+        // The browser-side sentinel is replaced by the real credential…
+        expect(forwarded.headers.authorization).toBe(AUTHORIZATION);
+        // …and the run-scoped nonce never travels upstream.
+        expect(forwarded.headers[PREVIEW_PROXY_NONCE_HEADER]).toBeUndefined();
+    });
+
+    it('preserves the query string on result polling', async () => {
+        const res = await proxyFetch(
+            `/api/v2/projects/${PROJECT_UUID}/query/some-query-uuid?page=2&pageSize=500`,
+        );
+        expect(res.status).toBe(200);
+        expect(upstream.seen[0].url).toBe(
+            `/api/v2/projects/${PROJECT_UUID}/query/some-query-uuid?page=2&pageSize=500`,
+        );
+    });
+
+    it('rejects non-SDK routes without contacting upstream', async () => {
+        const res = await proxyFetch('/api/v1/org/projects');
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { message: string };
+        expect(body.message).toMatch(/not a data-app SDK route/);
+        expect(upstream.seen).toHaveLength(0);
+    });
+
+    it('rejects allowlisted routes aimed at a different project', async () => {
+        const res = await proxyFetch(
+            '/api/v2/projects/other-project/query/metric-query',
+            { method: 'POST' },
+        );
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { message: string };
+        expect(body.message).toMatch(/pinned to proj-uuid-1/);
+        expect(upstream.seen).toHaveLength(0);
+    });
+
+    it('rejects allowlisted paths with the wrong method', async () => {
+        const res = await proxyFetch('/api/v1/user', { method: 'POST' });
+        expect(res.status).toBe(403);
+        expect(upstream.seen).toHaveLength(0);
+    });
+
+    it('rejects requests without the per-run nonce', async () => {
+        const missing = await proxyFetch('/api/v1/user', { nonce: null });
+        expect(missing.status).toBe(401);
+        const wrong = await proxyFetch('/api/v1/user', { nonce: 'guessed' });
+        expect(wrong.status).toBe(401);
+        expect(upstream.seen).toHaveLength(0);
+    });
+
+    it('does not pass upstream cookies back to the page', async () => {
+        const res = await proxyFetch('/api/v1/user');
+        expect(res.status).toBe(200);
+        expect(res.headers.get('set-cookie')).toBeNull();
+    });
+
+    it('forwards service-account and reverse-proxy authorization', async () => {
+        const serviceProxy = await startPreviewProxy({
+            upstreamUrl: upstream.url,
+            authorization: 'Bearer ldsvc_secret',
+            proxyAuthorization: 'Basic reverse-proxy-secret',
+            projectUuid: PROJECT_UUID,
+            nonce: 'service-nonce',
+        });
+
+        try {
+            const res = await fetch(
+                `http://127.0.0.1:${serviceProxy.port}/api/v1/user`,
+                {
+                    headers: {
+                        [PREVIEW_PROXY_NONCE_HEADER]: 'service-nonce',
+                    },
+                },
+            );
+            expect(res.status).toBe(200);
+            const forwarded = upstream.seen.at(-1);
+            expect(forwarded?.headers.authorization).toBe(
+                'Bearer ldsvc_secret',
+            );
+            expect(forwarded?.headers['proxy-authorization']).toBe(
+                'Basic reverse-proxy-secret',
+            );
+        } finally {
+            await serviceProxy.close();
+        }
+    });
+});

--- a/packages/cli/src/handlers/apps/previewProxy.test.ts
+++ b/packages/cli/src/handlers/apps/previewProxy.test.ts
@@ -63,11 +63,21 @@ describe('startPreviewProxy', () => {
 
     const proxyFetch = (
         path: string,
-        init: RequestInit & { nonce?: string | null } = {},
+        init: RequestInit & {
+            nonce?: string | null;
+            authorization?: string | null;
+        } = {},
     ) => {
-        const { nonce = NONCE, ...rest } = init;
+        const {
+            nonce = NONCE,
+            authorization = `ApiKey ${NONCE}`,
+            ...rest
+        } = init;
         const headers = new Headers(rest.headers);
         if (nonce !== null) headers.set(PREVIEW_PROXY_NONCE_HEADER, nonce);
+        if (authorization !== null) {
+            headers.set('authorization', authorization);
+        }
         return fetch(`http://127.0.0.1:${proxy.port}${path}`, {
             ...rest,
             headers,
@@ -96,7 +106,7 @@ describe('startPreviewProxy', () => {
                 method: 'POST',
                 headers: {
                     'content-type': 'application/json',
-                    authorization: 'ApiKey preview-proxy-injected',
+                    authorization: `ApiKey ${NONCE}`,
                 },
                 body: JSON.stringify({ exploreName: 'orders' }),
             },
@@ -106,7 +116,7 @@ describe('startPreviewProxy', () => {
         const forwarded = upstream.seen[0];
         expect(forwarded.method).toBe('POST');
         expect(forwarded.body).toBe('{"exploreName":"orders"}');
-        // The browser-side sentinel is replaced by the real credential…
+        // The browser-side scoped capability is replaced by the real credential…
         expect(forwarded.headers.authorization).toBe(AUTHORIZATION);
         // …and the run-scoped nonce never travels upstream.
         expect(forwarded.headers[PREVIEW_PROXY_NONCE_HEADER]).toBeUndefined();
@@ -155,6 +165,18 @@ describe('startPreviewProxy', () => {
         expect(upstream.seen).toHaveLength(0);
     });
 
+    it('rejects requests without the browser-side scoped capability', async () => {
+        const missing = await proxyFetch('/api/v1/user', {
+            authorization: null,
+        });
+        expect(missing.status).toBe(401);
+        const wrong = await proxyFetch('/api/v1/user', {
+            authorization: 'ApiKey guessed',
+        });
+        expect(wrong.status).toBe(401);
+        expect(upstream.seen).toHaveLength(0);
+    });
+
     it('does not pass upstream cookies back to the page', async () => {
         const res = await proxyFetch('/api/v1/user');
         expect(res.status).toBe(200);
@@ -176,6 +198,7 @@ describe('startPreviewProxy', () => {
                 {
                     headers: {
                         [PREVIEW_PROXY_NONCE_HEADER]: 'service-nonce',
+                        authorization: 'ApiKey service-nonce',
                     },
                 },
             );

--- a/packages/cli/src/handlers/apps/previewProxy.ts
+++ b/packages/cli/src/handlers/apps/previewProxy.ts
@@ -1,0 +1,190 @@
+import {
+    extractAppSdkRouteProjectUuid,
+    isAllowedAppSdkRoute,
+} from '@lightdash/common';
+import * as http from 'http';
+import * as https from 'https';
+
+// Per-run shared secret between the CLI proxy and the vite dev server's /api
+// proxy. Requests without it are rejected, so a drive-by page (or another
+// local process) that discovers the loopback port cannot use the proxy.
+export const PREVIEW_PROXY_NONCE_HEADER = 'x-lightdash-preview-nonce';
+
+// Hop-by-hop headers are connection-scoped and must not be forwarded.
+const HOP_BY_HOP_HEADERS = new Set([
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+]);
+
+// Client → upstream: host is derived from the upstream URL; the browser-side
+// authorization sentinel and the nonce must not travel upstream, and
+// localhost cookies are not the instance's business.
+const DROPPED_REQUEST_HEADERS = new Set([
+    'host',
+    'authorization',
+    'cookie',
+    PREVIEW_PROXY_NONCE_HEADER,
+]);
+
+// Upstream → client: the instance must not plant cookies on the dev origin.
+const DROPPED_RESPONSE_HEADERS = new Set(['set-cookie']);
+
+const filterHeaders = (
+    source: http.IncomingHttpHeaders,
+    dropped: Set<string>,
+): http.OutgoingHttpHeaders => {
+    const out: http.OutgoingHttpHeaders = {};
+    for (const [name, value] of Object.entries(source)) {
+        const lower = name.toLowerCase();
+        if (
+            value !== undefined &&
+            !HOP_BY_HOP_HEADERS.has(lower) &&
+            !dropped.has(lower)
+        ) {
+            out[lower] = value;
+        }
+    }
+    return out;
+};
+
+export type PreviewProxyHandle = {
+    port: number;
+    close: () => Promise<void>;
+};
+
+const sendJsonError = (
+    res: http.ServerResponse,
+    status: number,
+    message: string,
+): void => {
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ status: 'error', results: null, message }));
+};
+
+/**
+ * Loopback proxy that owns the preview credential. The vite dev server
+ * forwards /api traffic here; only routes a deployed app could reach through
+ * the SDK bridge — pinned to the previewed project — are forwarded upstream,
+ * with the credential attached server-side. Preview does not write it into the
+ * app folder or pass it to the vite process/browser.
+ */
+export const startPreviewProxy = (args: {
+    upstreamUrl: string;
+    authorization: string;
+    proxyAuthorization?: string;
+    projectUuid: string;
+    nonce: string;
+}): Promise<PreviewProxyHandle> => {
+    const upstream = new URL(args.upstreamUrl);
+    const requestFn =
+        upstream.protocol === 'https:' ? https.request : http.request;
+
+    const server = http.createServer((req, res) => {
+        const method = req.method ?? 'GET';
+        const nonceHeader = req.headers[PREVIEW_PROXY_NONCE_HEADER];
+        if (nonceHeader !== args.nonce) {
+            sendJsonError(res, 401, 'Preview proxy: missing or invalid nonce');
+            return;
+        }
+
+        let pathname: string;
+        try {
+            pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+        } catch {
+            sendJsonError(res, 400, 'Preview proxy: malformed request URL');
+            return;
+        }
+
+        // Same authority as the deployed app's postMessage bridge: anything
+        // the bridge would reject, preview rejects too.
+        if (!isAllowedAppSdkRoute(method, pathname)) {
+            sendJsonError(
+                res,
+                403,
+                `Preview proxy: ${method} ${pathname} is not a data-app SDK route. Preview only allows the routes a deployed app can reach.`,
+            );
+            return;
+        }
+
+        const routeProjectUuid = extractAppSdkRouteProjectUuid(pathname);
+        if (
+            routeProjectUuid !== null &&
+            routeProjectUuid !== args.projectUuid
+        ) {
+            sendJsonError(
+                res,
+                403,
+                `Preview proxy: request targets project ${routeProjectUuid}, but this preview is pinned to ${args.projectUuid}.`,
+            );
+            return;
+        }
+
+        const headers = filterHeaders(req.headers, DROPPED_REQUEST_HEADERS);
+        headers.authorization = args.authorization;
+        if (args.proxyAuthorization) {
+            headers['proxy-authorization'] = args.proxyAuthorization;
+        }
+
+        const upstreamReq = requestFn(
+            {
+                protocol: upstream.protocol,
+                hostname: upstream.hostname,
+                port: upstream.port || undefined,
+                path: req.url,
+                method,
+                headers,
+            },
+            (upstreamRes) => {
+                res.writeHead(
+                    upstreamRes.statusCode ?? 502,
+                    filterHeaders(
+                        upstreamRes.headers,
+                        DROPPED_RESPONSE_HEADERS,
+                    ),
+                );
+                upstreamRes.pipe(res);
+            },
+        );
+        upstreamReq.on('error', (err) => {
+            if (!res.headersSent) {
+                sendJsonError(
+                    res,
+                    502,
+                    `Preview proxy: upstream request failed (${err.message})`,
+                );
+            } else {
+                res.destroy();
+            }
+        });
+        req.pipe(upstreamReq);
+    });
+
+    return new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            if (address === null || typeof address === 'string') {
+                reject(
+                    new Error('Preview proxy failed to bind a loopback port'),
+                );
+                return;
+            }
+            resolve({
+                port: address.port,
+                close: () =>
+                    new Promise<void>((resolveClose) => {
+                        server.close(() => resolveClose());
+                        // Pending keep-alive sockets would otherwise delay
+                        // shutdown after vite exits.
+                        server.closeAllConnections();
+                    }),
+            });
+        });
+    });
+};

--- a/packages/cli/src/handlers/apps/previewProxy.ts
+++ b/packages/cli/src/handlers/apps/previewProxy.ts
@@ -2,6 +2,7 @@ import {
     extractAppSdkRouteProjectUuid,
     isAllowedAppSdkRoute,
 } from '@lightdash/common';
+import { timingSafeEqual } from 'crypto';
 import * as http from 'http';
 import * as https from 'https';
 
@@ -67,6 +68,20 @@ const sendJsonError = (
     res.end(JSON.stringify({ status: 'error', results: null, message }));
 };
 
+const secretsMatch = (
+    actual: string | string[] | undefined,
+    expected: string,
+): boolean => {
+    if (typeof actual !== 'string') return false;
+
+    const actualBuffer = Buffer.from(actual);
+    const expectedBuffer = Buffer.from(expected);
+    return (
+        actualBuffer.length === expectedBuffer.length &&
+        timingSafeEqual(actualBuffer, expectedBuffer)
+    );
+};
+
 /**
  * Loopback proxy that owns the preview credential. The vite dev server
  * forwards /api traffic here; only routes a deployed app could reach through
@@ -90,8 +105,8 @@ export const startPreviewProxy = (args: {
         const nonceHeader = req.headers[PREVIEW_PROXY_NONCE_HEADER];
         const browserAuthorization = req.headers.authorization;
         if (
-            nonceHeader !== args.nonce ||
-            browserAuthorization !== `ApiKey ${args.nonce}`
+            !secretsMatch(nonceHeader, args.nonce) ||
+            !secretsMatch(browserAuthorization, `ApiKey ${args.nonce}`)
         ) {
             sendJsonError(res, 401, 'Preview proxy: missing or invalid nonce');
             return;

--- a/packages/cli/src/handlers/apps/previewProxy.ts
+++ b/packages/cli/src/handlers/apps/previewProxy.ts
@@ -5,9 +5,9 @@ import {
 import * as http from 'http';
 import * as https from 'https';
 
-// Per-run shared secret between the CLI proxy and the vite dev server's /api
-// proxy. Requests without it are rejected, so a drive-by page (or another
-// local process) that discovers the loopback port cannot use the proxy.
+// Per-run shared secret between the browser, Vite, and the CLI proxy. Vite
+// forwards the browser's scoped Authorization value and adds this header;
+// both must match before the durable credential is attached upstream.
 export const PREVIEW_PROXY_NONCE_HEADER = 'x-lightdash-preview-nonce';
 
 // Hop-by-hop headers are connection-scoped and must not be forwarded.
@@ -23,7 +23,7 @@ const HOP_BY_HOP_HEADERS = new Set([
 ]);
 
 // Client → upstream: host is derived from the upstream URL; the browser-side
-// authorization sentinel and the nonce must not travel upstream, and
+// scoped preview capability and the nonce must not travel upstream, and
 // localhost cookies are not the instance's business.
 const DROPPED_REQUEST_HEADERS = new Set([
     'host',
@@ -88,7 +88,11 @@ export const startPreviewProxy = (args: {
     const server = http.createServer((req, res) => {
         const method = req.method ?? 'GET';
         const nonceHeader = req.headers[PREVIEW_PROXY_NONCE_HEADER];
-        if (nonceHeader !== args.nonce) {
+        const browserAuthorization = req.headers.authorization;
+        if (
+            nonceHeader !== args.nonce ||
+            browserAuthorization !== `ApiKey ${args.nonce}`
+        ) {
             sendJsonError(res, 401, 'Preview proxy: missing or invalid nonce');
             return;
         }

--- a/packages/cli/src/handlers/apps/scaffolding.test.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.test.ts
@@ -86,6 +86,16 @@ describe('buildStaticAuthoringFiles', () => {
         expect(text('.gitignore')).toContain('node_modules');
     });
 
+    it('uses npm for the standard local workflow', () => {
+        expect(text('README.md')).toContain('npm install && npm run build');
+        expect(text('AGENTS.md')).toContain('npm install && npm run build');
+        expect(
+            text('.claude/skills/developing-data-apps-locally/SKILL.md'),
+        ).toContain('`npm install` then `npm run build`');
+        expect(text('.npmrc')).toContain('ignore-scripts=true');
+        expect(text('.npmrc')).not.toContain('shamefully-hoist');
+    });
+
     it('never writes app source (no src/ files)', () => {
         expect(files.every((f) => !f.path.startsWith('src/'))).toBe(true);
     });

--- a/packages/cli/src/handlers/utils.ts
+++ b/packages/cli/src/handlers/utils.ts
@@ -27,7 +27,7 @@ type RequestHeader = {
  *
  * See {@link AuthTokenPrefix} for the available token prefixes
  */
-function getAuthHeader(token: string) {
+export function getAuthHeader(token: string) {
     const authType = token?.startsWith(AuthTokenPrefix.SERVICE_ACCOUNT)
         ? TokenType.Bearer
         : TokenType.ApiKey;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from './env';
 import { getDiagnosticsHint } from './error';
 import GlobalState from './globalState';
+import { appsPreviewHandler } from './handlers/apps/preview';
 import { compileHandler } from './handlers/compile';
 import { connectSnowflakeHandler } from './handlers/connectSnowflake';
 import { refreshHandler } from './handlers/dbt/refresh';
@@ -1071,6 +1072,26 @@ const uploadCommand = program
     );
 
 uploadCommand.action(withOrganizationMode(uploadHandler));
+
+const appsProgram = program
+    .command('apps')
+    .description('Work with data apps (enterprise)');
+appsProgram
+    .command('preview [path]')
+    .description(
+        'Preview a downloaded data app locally against a real Lightdash instance, authenticated as you. Writes .env.local and runs `pnpm dev`.',
+    )
+    .option(
+        '--project <project uuid>',
+        'preview against a specific project (default: the projectUuid in lightdash-app.yml)',
+    )
+    .option('--url <url>', 'Lightdash server URL (default: your login config)')
+    .option(
+        '--token <token>',
+        'API key / personal access token (default: your login config)',
+    )
+    .option('--verbose', undefined, false)
+    .action(appsPreviewHandler);
 
 program
     .command('deploy')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1079,7 +1079,7 @@ const appsProgram = program
 appsProgram
     .command('preview [path]')
     .description(
-        'Preview a downloaded data app locally against a real Lightdash instance, authenticated as you. Writes .env.local and runs `pnpm dev`.',
+        'Preview a downloaded data app locally against a real Lightdash instance, authenticated as you. Your credential stays in the CLI, behind a local proxy limited to data-app SDK routes.',
     )
     .option(
         '--project <project uuid>',

--- a/packages/common/src/ee/apps/sdkBridgeRoutes.ts
+++ b/packages/common/src/ee/apps/sdkBridgeRoutes.ts
@@ -1,0 +1,67 @@
+/**
+ * The API routes a data app is allowed to reach, shared by the two places
+ * that mediate app traffic so their authority can never drift apart:
+ *
+ * - the in-product postMessage bridge (`useAppSdkBridge`), where deployed
+ *   apps run credential-less in a sandboxed iframe
+ * - the CLI preview proxy (`lightdash apps preview`), where the same app
+ *   code runs on a local vite page against the developer's credential
+ *
+ * Everything not matched here is rejected by both.
+ */
+export type AppSdkAllowedRoute = {
+    method: 'GET' | 'POST';
+    pattern: RegExp;
+};
+
+export const APP_SDK_ALLOWED_ROUTES: AppSdkAllowedRoute[] = [
+    // Async metric query execution
+    {
+        method: 'POST',
+        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/metric-query$/,
+    },
+    // Run a saved chart live by UUID (linked charts)
+    {
+        method: 'POST',
+        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/chart$/,
+    },
+    // Run underlying-data queries for SDK result rows
+    {
+        method: 'POST',
+        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/underlying-data$/,
+    },
+    // Poll for query results
+    {
+        method: 'GET',
+        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/[^/]+$/,
+    },
+    // Schedule backend CSV/XLSX export jobs for SDK query results
+    {
+        method: 'POST',
+        pattern:
+            /^\/api\/v2\/projects\/[^/]+\/query\/[^/]+\/schedule-download$/,
+    },
+    // Poll export job status until the backend returns a file URL
+    {
+        method: 'GET',
+        pattern: /^\/api\/v1\/schedulers\/job\/[^/]+\/status$/,
+    },
+    // Get current user
+    { method: 'GET', pattern: /^\/api\/v1\/user$/ },
+];
+
+export const isAllowedAppSdkRoute = (method: string, path: string): boolean =>
+    APP_SDK_ALLOWED_ROUTES.some(
+        (route) =>
+            route.method === method.toUpperCase() && route.pattern.test(path),
+    );
+
+/**
+ * Project uuid embedded in an app-SDK API path, or null for the routes that
+ * aren't project-scoped (scheduler job status, current user). Callers that
+ * pin preview traffic to one project compare this against their target.
+ */
+export const extractAppSdkRouteProjectUuid = (path: string): string | null => {
+    const match = path.match(/^\/api\/v2\/projects\/([^/]+)\//);
+    return match ? match[1] : null;
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -12,6 +12,7 @@ export * from './AiRouter';
 export * from './apps/sdkFeatures';
 export * from './apps/types';
 export * from './apps/code';
+export * from './apps/sdkBridgeRoutes';
 export * from './ambientAi';
 export * from './commercialFeatureFlags';
 export * from './designs/types';

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -445,17 +445,30 @@ describe('useAppSdkBridge', () => {
         );
     });
 
-    it('blocks SDK queries targeting a different project', () => {
+    it('blocks SDK routes aimed at a different project', async () => {
         renderBridge(() => undefined);
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
 
         dispatchFetchMessage({
             type: 'lightdash:sdk:fetch',
             id: POST_ID,
             method: 'POST',
-            path: '/api/v2/projects/another-project/query/metric-query',
+            path: '/api/v2/projects/other-project/query/metric-query',
             body: { query: METRIC_QUERY },
         });
 
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    error: expect.stringContaining(
+                        'request targets project other-project',
+                    ),
+                }),
+                '*',
+            ),
+        );
         expect(fetch).not.toHaveBeenCalled();
     });
 

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,6 +1,8 @@
 import {
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
+    extractAppSdkRouteProjectUuid,
+    isAllowedAppSdkRoute,
     JWT_HEADER_NAME,
     LightdashAppUuidHeader,
     type DataAppVizContext,
@@ -130,61 +132,10 @@ export type ExternalRequestEvent = {
     error: string | null;
 };
 
-/**
- * Routes the SDK is allowed to call through the postMessage bridge.
- * Everything else is rejected. Patterns use :param for path segments.
- */
-const ALLOWED_ROUTES: Array<{ method: string; pattern: RegExp }> = [
-    // Async metric query execution
-    {
-        method: 'POST',
-        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/metric-query$/,
-    },
-    // Run a saved chart live by UUID (linked charts)
-    {
-        method: 'POST',
-        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/chart$/,
-    },
-    // Run underlying-data queries for SDK result rows
-    {
-        method: 'POST',
-        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/underlying-data$/,
-    },
-    // Poll for query results
-    {
-        method: 'GET',
-        pattern: /^\/api\/v2\/projects\/[^/]+\/query\/[^/]+$/,
-    },
-    // Schedule backend CSV/XLSX export jobs for SDK query results
-    {
-        method: 'POST',
-        pattern:
-            /^\/api\/v2\/projects\/[^/]+\/query\/[^/]+\/schedule-download$/,
-    },
-    // Poll export job status until the backend returns a file URL
-    {
-        method: 'GET',
-        pattern: /^\/api\/v1\/schedulers\/job\/[^/]+\/status$/,
-    },
-    // Get current user
-    { method: 'GET', pattern: /^\/api\/v1\/user$/ },
-];
-
-function isAllowedRoute(
-    method: string,
-    path: string,
-    projectUuid: string,
-): boolean {
-    const projectPath = path.match(/^\/api\/v2\/projects\/([^/]+)\//);
-    if (projectPath && projectPath[1] !== projectUuid) {
-        return false;
-    }
-
-    return ALLOWED_ROUTES.some(
-        (route) =>
-            route.method === method.toUpperCase() && route.pattern.test(path),
-    );
-}
+// Routes the SDK is allowed to call through the postMessage bridge live in
+// @lightdash/common (APP_SDK_ALLOWED_ROUTES) — shared with the CLI preview
+// proxy so preview and deployed authority can't drift. Everything else is
+// rejected.
 
 // Keep in sync with MAX_URL_STATE_CHARS in packages/query-sdk/src/urlState.ts.
 // Caps what an app can push into the host page's URL / browser history.
@@ -693,8 +644,19 @@ export function useAppSdkBridge({
                 );
             };
 
-            if (!isAllowedRoute(method, path, projectUuid)) {
+            if (!isAllowedAppSdkRoute(method, path)) {
                 respond({ error: `Blocked: ${method} ${path}` });
+                return;
+            }
+
+            const requestProjectUuid = extractAppSdkRouteProjectUuid(path);
+            if (
+                requestProjectUuid !== null &&
+                requestProjectUuid !== projectUuid
+            ) {
+                respond({
+                    error: `Blocked: request targets project ${requestProjectUuid}, but this app belongs to ${projectUuid}`,
+                });
                 return;
             }
 

--- a/sandboxes/data-apps/template/.npmrc
+++ b/sandboxes/data-apps/template/.npmrc
@@ -1,8 +1,4 @@
-# pnpm <=10 only. pnpm 11 reads these settings from pnpm-workspace.yaml.
-shamefully-hoist=true
-ignore-workspace-root-check=true
-# The pinned SDK version is often <3 days old; exempt it from release-age policies
-minimum-release-age-exclude[]=@lightdash/query-sdk
 # Downloaded apps may be authored by someone else — never run their
-# dependencies' lifecycle scripts locally (explicit `pnpm run` still works)
+# dependencies' lifecycle scripts locally (explicit `npm run` still works).
+# pnpm-specific settings live in pnpm-workspace.yaml.
 ignore-scripts=true

--- a/sandboxes/data-apps/template/vite.config.js
+++ b/sandboxes/data-apps/template/vite.config.js
@@ -142,7 +142,43 @@ function jsxSourceLocVitePlugin() {
 }
 
 export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, process.cwd(), 'VITE_');
+    // Load VITE_* (inlined into the browser bundle) AND the preview-only
+    // LIGHTDASH_PREVIEW_API_KEY (stays server-side — never inlined, since
+    // envPrefix defaults to 'VITE_'). `lightdash apps preview` writes the real
+    // credential as the latter and only a non-secret sentinel as
+    // VITE_LIGHTDASH_API_KEY, so no usable credential reaches the page.
+    const env = loadEnv(mode, process.cwd(), ['VITE_', 'LIGHTDASH_PREVIEW_']);
+    const previewApiKey = env.LIGHTDASH_PREVIEW_API_KEY;
+    const lightdashUrl =
+        env.VITE_LIGHTDASH_URL || 'https://app.lightdash.cloud';
+
+    let lightdashOrigin = '';
+    try {
+        lightdashOrigin = new URL(lightdashUrl).origin;
+    } catch {
+        lightdashOrigin = '';
+    }
+
+    // Dev-server CSP that emulates the deployed app policy for the vectors that
+    // matter for credential/data theft: network egress is locked to same-origin
+    // (the /api proxy) plus the Lightdash origin. script-src/style-src stay
+    // permissive because Vite's dev runtime needs inline + eval — so this is
+    // NOT a full stand-in for the deployed CSP (the app page after upload is
+    // the final check), but it does block exfiltration channels in preview.
+    const previewCsp = [
+        `default-src 'none'`,
+        `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:`,
+        `style-src 'self' 'unsafe-inline'`,
+        `connect-src 'self' ${lightdashOrigin}`.trim(),
+        `img-src 'self' data: blob:`,
+        `font-src 'self' data:`,
+        `worker-src 'self' blob:`,
+        `child-src 'self' blob:`,
+        `object-src 'none'`,
+        `base-uri 'self'`,
+        `form-action 'self'`,
+        `frame-ancestors 'self'`,
+    ].join('; ');
 
     return {
         plugins: [jsxSourceLocVitePlugin(), react()],
@@ -153,12 +189,25 @@ export default defineConfig(({ mode }) => {
             },
         },
         server: {
+            headers: { 'Content-Security-Policy': previewCsp },
             proxy: {
                 '/api': {
-                    target:
-                        env.VITE_LIGHTDASH_URL || 'https://app.lightdash.cloud',
+                    target: lightdashUrl,
                     changeOrigin: true,
                     secure: true,
+                    // Inject the real credential server-side: the browser only
+                    // ever sends a sentinel, and this overrides it before the
+                    // request leaves the dev server. Keeps the API key out of
+                    // the page entirely.
+                    configure: (proxy) => {
+                        if (!previewApiKey) return;
+                        proxy.on('proxyReq', (proxyReq) => {
+                            proxyReq.setHeader(
+                                'authorization',
+                                `ApiKey ${previewApiKey}`,
+                            );
+                        });
+                    },
                 },
             },
         },

--- a/sandboxes/data-apps/template/vite.config.js
+++ b/sandboxes/data-apps/template/vite.config.js
@@ -147,9 +147,8 @@ export default defineConfig(({ mode }) => {
     // envPrefix defaults to 'VITE_'). `lightdash apps preview` starts a
     // loopback proxy that holds the real credential and enforces the data-app
     // SDK route allowlist; this dev server only ever learns the proxy's
-    // address and a run-scoped nonce. The browser gets a non-secret sentinel
-    // as VITE_LIGHTDASH_API_KEY, so no usable credential is passed to this
-    // process or inlined into the page.
+    // address and a run-scoped nonce. The browser receives that nonce as a
+    // project- and route-limited capability, never the durable credential.
     const env = loadEnv(mode, process.cwd(), ['VITE_', 'LIGHTDASH_PREVIEW_']);
     const previewProxyTarget = env.LIGHTDASH_PREVIEW_PROXY_TARGET;
     const previewProxyNonce = env.LIGHTDASH_PREVIEW_PROXY_NONCE;
@@ -185,6 +184,10 @@ export default defineConfig(({ mode }) => {
             },
         },
         server: {
+            host: '127.0.0.1',
+            // Vite otherwise permits every localhost origin. Preview is a
+            // credentialed endpoint, so only the page's own origin may read it.
+            cors: false,
             headers: { 'Content-Security-Policy': previewCsp },
             proxy: {
                 '/api': {
@@ -199,11 +202,21 @@ export default defineConfig(({ mode }) => {
                     secure: true,
                     configure: (proxy) => {
                         if (!previewProxyNonce) return;
-                        proxy.on('proxyReq', (proxyReq) => {
-                            proxyReq.setHeader(
-                                'x-lightdash-preview-nonce',
-                                previewProxyNonce,
-                            );
+                        proxy.on('proxyReq', (proxyReq, req) => {
+                            // Do not turn Vite into an unauthenticated front
+                            // door to the nonce-protected CLI proxy. The SDK
+                            // presents the run-scoped nonce as its local API
+                            // key; only matching requests receive the inner
+                            // proxy header.
+                            if (
+                                req.headers.authorization ===
+                                `ApiKey ${previewProxyNonce}`
+                            ) {
+                                proxyReq.setHeader(
+                                    'x-lightdash-preview-nonce',
+                                    previewProxyNonce,
+                                );
+                            }
                         });
                     },
                 },

--- a/sandboxes/data-apps/template/vite.config.js
+++ b/sandboxes/data-apps/template/vite.config.js
@@ -143,33 +143,29 @@ function jsxSourceLocVitePlugin() {
 
 export default defineConfig(({ mode }) => {
     // Load VITE_* (inlined into the browser bundle) AND the preview-only
-    // LIGHTDASH_PREVIEW_API_KEY (stays server-side — never inlined, since
-    // envPrefix defaults to 'VITE_'). `lightdash apps preview` writes the real
-    // credential as the latter and only a non-secret sentinel as
-    // VITE_LIGHTDASH_API_KEY, so no usable credential reaches the page.
+    // LIGHTDASH_PREVIEW_PROXY_* vars (stay server-side — never inlined, since
+    // envPrefix defaults to 'VITE_'). `lightdash apps preview` starts a
+    // loopback proxy that holds the real credential and enforces the data-app
+    // SDK route allowlist; this dev server only ever learns the proxy's
+    // address and a run-scoped nonce. The browser gets a non-secret sentinel
+    // as VITE_LIGHTDASH_API_KEY, so no usable credential is passed to this
+    // process or inlined into the page.
     const env = loadEnv(mode, process.cwd(), ['VITE_', 'LIGHTDASH_PREVIEW_']);
-    const previewApiKey = env.LIGHTDASH_PREVIEW_API_KEY;
+    const previewProxyTarget = env.LIGHTDASH_PREVIEW_PROXY_TARGET;
+    const previewProxyNonce = env.LIGHTDASH_PREVIEW_PROXY_NONCE;
     const lightdashUrl =
         env.VITE_LIGHTDASH_URL || 'https://app.lightdash.cloud';
 
-    let lightdashOrigin = '';
-    try {
-        lightdashOrigin = new URL(lightdashUrl).origin;
-    } catch {
-        lightdashOrigin = '';
-    }
-
     // Dev-server CSP that emulates the deployed app policy for the vectors that
     // matter for credential/data theft: network egress is locked to same-origin
-    // (the /api proxy) plus the Lightdash origin. script-src/style-src stay
-    // permissive because Vite's dev runtime needs inline + eval — so this is
-    // NOT a full stand-in for the deployed CSP (the app page after upload is
-    // the final check), but it does block exfiltration channels in preview.
+    // so all API traffic must pass through the allowlisted /api proxy.
+    // script-src/style-src stay permissive because Vite's dev runtime needs
+    // inline + eval, so this is NOT a full stand-in for the deployed sandbox.
     const previewCsp = [
         `default-src 'none'`,
         `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:`,
         `style-src 'self' 'unsafe-inline'`,
-        `connect-src 'self' ${lightdashOrigin}`.trim(),
+        `connect-src 'self'`,
         `img-src 'self' data: blob:`,
         `font-src 'self' data:`,
         `worker-src 'self' blob:`,
@@ -192,19 +188,21 @@ export default defineConfig(({ mode }) => {
             headers: { 'Content-Security-Policy': previewCsp },
             proxy: {
                 '/api': {
-                    target: lightdashUrl,
+                    // Under `lightdash apps preview`, /api goes to the CLI's
+                    // loopback proxy, which checks the route against the
+                    // data-app SDK allowlist and attaches the credential
+                    // before forwarding to Lightdash. Without the CLI (bare
+                    // `pnpm dev`) requests go to the instance uncredentialed
+                    // and fail with 401 — preview requires the CLI command.
+                    target: previewProxyTarget || lightdashUrl,
                     changeOrigin: true,
                     secure: true,
-                    // Inject the real credential server-side: the browser only
-                    // ever sends a sentinel, and this overrides it before the
-                    // request leaves the dev server. Keeps the API key out of
-                    // the page entirely.
                     configure: (proxy) => {
-                        if (!previewApiKey) return;
+                        if (!previewProxyNonce) return;
                         proxy.on('proxyReq', (proxyReq) => {
                             proxyReq.setHeader(
-                                'authorization',
-                                `ApiKey ${previewApiKey}`,
+                                'x-lightdash-preview-nonce',
+                                previewProxyNonce,
                             );
                         });
                     },

--- a/sandboxes/data-apps/template/vite.config.js
+++ b/sandboxes/data-apps/template/vite.config.js
@@ -195,7 +195,7 @@ export default defineConfig(({ mode }) => {
                     // loopback proxy, which checks the route against the
                     // data-app SDK allowlist and attaches the credential
                     // before forwarding to Lightdash. Without the CLI (bare
-                    // `pnpm dev`) requests go to the instance uncredentialed
+                    // `npm run dev`) requests go to the instance uncredentialed
                     // and fail with 401 — preview requires the CLI command.
                     target: previewProxyTarget || lightdashUrl,
                     changeOrigin: true,


### PR DESCRIPTION
## Summary

Adds `lightdash apps preview [path]`: one command that runs a downloaded data app locally against real data from a Lightdash instance, authenticated with the developer's existing CLI login.

The same app source continues to use `@lightdash/query-sdk` in both environments:

- locally, the SDK's API transport sends same-origin `/api` requests through the preview proxy;
- after upload, the SDK uses the existing postMessage bridge in Lightdash's sandboxed iframe.

No backend endpoint or preview-token minting flow is required.

## How it works

1. Resolve the app folder from `lightdash-app.yml` and select its project (`--project` can override it).
2. Reuse the current CLI credential from `lightdash login`, environment variables, or `--token`.
3. Pre-flight both the credential (`GET /api/v1/user`) and target project (`GET /api/v1/projects/{uuid}`), including when `--url` or `--token` is supplied.
4. Start a loopback-only CLI proxy with a random per-run nonce.
5. Start the downloaded app's loopback-only Vite server with a minimal, allowlisted environment and cross-origin browser access disabled.
6. Forward SDK requests only when the browser presents the per-run nonce and both the route and project match the deployed data-app boundary, adding the durable authentication only at the CLI proxy before sending requests upstream.

The proxy uses the CLI's canonical authentication scheme (`ApiKey` for PATs and `Bearer` for service-account tokens) and forwards configured reverse-proxy authorization where needed.

## Security and trust boundary

- The durable credential is not written into the app folder, passed to the Vite child, or exposed to browser code. Browser code receives only the random per-run nonce, scoped to the preview's SDK routes and project.
- The Vite child does not inherit `LIGHTDASH_API_KEY`, `LIGHTDASH_PROXY_AUTHORIZATION`, or unrelated parent-process secrets.
- Vite binds to loopback, disables cross-origin browser access, and adds the inner proxy header only when the SDK presents the matching per-run nonce.
- The loopback proxy independently requires both the browser's scoped authorization and Vite's nonce header, applies the shared SDK route allowlist, and pins project-scoped requests to the selected project.
- The deployed postMessage bridge now enforces the same project boundary, so local and deployed authorization cannot drift.
- Preview's CSP restricts browser network access to the local origin, forcing SDK API traffic through the proxy. `script-src` remains permissive for Vite development, so the uploaded app remains the authoritative CSP check.
- Existing CLI config files are tightened to `0600`, with the Lightdash config directory set to `0700`, on POSIX systems.
- Legacy `.env.local` files containing `LIGHTDASH_PREVIEW_API_KEY` are no longer read; preview warns the developer to delete one if found.

This isolates the durable credential from the app environment and browser, but it is **not an OS sandbox**. Vite and installed dependencies execute as the developer's OS user and can read that user's files, including the existing CLI config. Preview only trusted source and dependencies.

Preview also runs with the developer's permissions and user attributes. A deployed viewer may see different data.

## Current parity

Local preview supports the SDK's direct-transport surface:

- metric and saved-chart queries;
- result polling;
- underlying-data queries;
- download scheduling and polling;
- current-user lookup.

Host-mediated features are intentionally not emulated here: `externalFetch`, data-app-viz row/field context, Google Sheets export, inspector integration, and product URL-state integration still require testing after upload. Full host parity should be implemented separately as a local iframe harness rather than by broadening the credential proxy.

## Validation

- CLI config/environment tests: 14 passed
- CLI loopback proxy tests: 9 passed
- Frontend SDK bridge tests: 32 passed
- CLI and frontend typechecks
- Focused CLI/frontend lint and formatting checks

Closes: GLITCH-593

Relates: GLITCH-558
