### PR TITLE
feat(dashboards): assignable dashboard owners (users or groups)

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -41,6 +41,10 @@ import {
     DashboardTileCommentsTableName,
 } from '../database/entities/comments';
 import {
+    ContentOwnershipTable,
+    ContentOwnershipTableName,
+} from '../database/entities/contentOwnership';
+import {
     ContentVerificationTable,
     ContentVerificationTableName,
 } from '../database/entities/contentVerification';
@@ -643,6 +647,7 @@ declare module 'knex/types/tables' {
         [ManagedAgentActionsTableName]: ManagedAgentActionsTable;
         [ManagedAgentRunsTableName]: ManagedAgentRunsTable;
         [UserFavoritesTableName]: UserFavoritesTable;
+        [ContentOwnershipTableName]: ContentOwnershipTable;
         [ContentVerificationTableName]: ContentVerificationTable;
         [AppsTableName]: AppsTable;
         [AppVersionsTableName]: AppVersionsTable;

--- a/packages/backend/src/database/entities/contentOwnership.ts
+++ b/packages/backend/src/database/entities/contentOwnership.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex';
+
+export const ContentOwnershipTableName = 'content_ownership';
+
+export type DbContentOwnership = {
+    content_ownership_uuid: string;
+    content_type: string;
+    content_uuid: string;
+    project_uuid: string;
+    owner_user_uuid: string | null;
+    owner_group_uuid: string | null;
+    assigned_by_user_uuid: string | null;
+    assigned_at: Date;
+};
+
+export type CreateDbContentOwnership = Pick<
+    DbContentOwnership,
+    | 'content_type'
+    | 'content_uuid'
+    | 'project_uuid'
+    | 'owner_user_uuid'
+    | 'owner_group_uuid'
+    | 'assigned_by_user_uuid'
+>;
+
+export type UpdateDbContentOwnership = Pick<
+    DbContentOwnership,
+    'owner_user_uuid' | 'owner_group_uuid' | 'assigned_by_user_uuid'
+> & { assigned_at: Knex.Raw | Date };
+
+export type ContentOwnershipTable = Knex.CompositeTableType<
+    DbContentOwnership,
+    CreateDbContentOwnership,
+    UpdateDbContentOwnership
+>;

--- a/packages/backend/src/database/migrations/20260703110000_add_content_ownership_table.ts
+++ b/packages/backend/src/database/migrations/20260703110000_add_content_ownership_table.ts
@@ -1,0 +1,60 @@
+import { Knex } from 'knex';
+
+const TABLE_NAME = 'content_ownership';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(TABLE_NAME, (table) => {
+        table
+            .uuid('content_ownership_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table.string('content_type').notNullable();
+        table.uuid('content_uuid').notNullable();
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table
+            .uuid('owner_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE');
+        table
+            .uuid('owner_group_uuid')
+            .nullable()
+            .references('group_uuid')
+            .inTable('groups')
+            .onDelete('CASCADE');
+        table
+            .uuid('assigned_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+        table
+            .timestamp('assigned_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.unique(['content_type', 'content_uuid']);
+        table.index(['project_uuid']);
+        table.index(['owner_user_uuid']);
+        table.index(['owner_group_uuid']);
+    });
+
+    await knex.raw(`
+        ALTER TABLE ${TABLE_NAME}
+        ADD CONSTRAINT content_ownership_exactly_one_owner
+        CHECK (
+            (owner_user_uuid IS NOT NULL AND owner_group_uuid IS NULL) OR
+            (owner_user_uuid IS NULL AND owner_group_uuid IS NOT NULL)
+        )
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(TABLE_NAME);
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2698,6 +2698,78 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ContentOwner: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        email: { dataType: 'string', required: true },
+                        lastName: { dataType: 'string', required: true },
+                        firstName: { dataType: 'string', required: true },
+                        userUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['user'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        groupUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['group'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ContentOwnershipInfo: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                assignedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                assignedAt: { dataType: 'datetime', required: true },
+                owner: { ref: 'ContentOwner', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardTileTypes: {
         dataType: 'refEnum',
         enums: [
@@ -3554,6 +3626,14 @@ const models: TsoaRoute.Models = {
                 },
                 updatedAt: { dataType: 'datetime', required: true },
                 description: { dataType: 'string' },
+                ownership: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ContentOwnershipInfo' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 verification: {
                     dataType: 'union',
                     subSchemas: [
@@ -14847,11 +14927,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -14909,11 +14989,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -14950,11 +15030,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14969,11 +15049,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14988,11 +15068,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15007,11 +15087,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15156,56 +15236,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -15283,6 +15313,56 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
+                                                                                                joinedTables:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 label: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15320,11 +15400,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15349,21 +15429,6 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 pagination:
                                                                                     {
                                                                                         dataType:
@@ -15406,6 +15471,21 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -15415,14 +15495,14 @@ const models: TsoaRoute.Models = {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'success',
+                                                                                                    'error',
                                                                                                 ],
                                                                                             },
                                                                                             {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'error',
+                                                                                                    'success',
                                                                                                 ],
                                                                                             },
                                                                                             {
@@ -15557,11 +15637,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15576,11 +15656,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15595,11 +15675,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15642,11 +15722,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15685,6 +15765,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -15920,25 +16019,6 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -16091,15 +16171,15 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
                                                         dataType: 'string',
                                                     },
+                                                    required: true,
+                                                },
+                                                href: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 status: {
@@ -16129,11 +16209,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16148,11 +16228,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16167,11 +16247,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16186,11 +16266,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16219,6 +16299,13 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
                                                                                             'read',
                                                                                         ],
                                                                                     },
@@ -16227,13 +16314,6 @@ const models: TsoaRoute.Models = {
                                                                                             'enum',
                                                                                         enums: [
                                                                                             'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -16431,11 +16511,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16496,11 +16576,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16515,11 +16595,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16532,6 +16612,10 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'union',
                                                     subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
@@ -16539,10 +16623,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16561,11 +16641,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16723,11 +16803,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16742,11 +16822,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16761,11 +16841,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16780,11 +16860,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16799,11 +16879,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -25495,6 +25575,11 @@ const models: TsoaRoute.Models = {
         type: { dataType: 'string', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MeshColor: {
+        dataType: 'refAlias',
+        type: { dataType: 'string', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SolidColor: {
         dataType: 'refAlias',
         type: { dataType: 'string', validators: {} },
@@ -25507,6 +25592,7 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { ref: 'UserAvatarGradientId' },
                 { ref: 'HexColor' },
+                { ref: 'MeshColor' },
                 { ref: 'SolidColor' },
             ],
             validators: {},
@@ -27630,6 +27716,14 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { ref: 'ContentVerificationInfo' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    ownership: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'ContentOwnershipInfo' },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -33221,6 +33315,38 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardOwnerAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        email: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['user'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['group'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardAsCode: {
         dataType: 'refAlias',
         type: {
@@ -33232,6 +33358,13 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        owner: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'DashboardOwnerAsCode' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
                         verification: {
                             dataType: 'union',
                             subSchemas: [
@@ -33829,6 +33962,14 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    owner: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'DashboardOwnerAsCode' },
+                            { dataType: 'enum', enums: [null] },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -41078,6 +41219,55 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ContentOwnerAssignment: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        userUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['user'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        groupUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['group'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateDashboardOwnership: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                owner: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ContentOwnerAssignment' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdateDashboard: {
         dataType: 'refAlias',
         type: {
@@ -41098,6 +41288,7 @@ const models: TsoaRoute.Models = {
                     ],
                 },
                 { ref: 'PreserveContentVerification' },
+                { ref: 'UpdateDashboardOwnership' },
             ],
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2757,6 +2757,85 @@
                 "required": ["verifiedAt", "verifiedBy"],
                 "type": "object"
             },
+            "ContentOwner": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "email": {
+                                "type": "string"
+                            },
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["user"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "email",
+                            "lastName",
+                            "firstName",
+                            "userUuid",
+                            "type"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "groupUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["group"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "groupUuid", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ContentOwnershipInfo": {
+                "properties": {
+                    "assignedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "assignedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "owner": {
+                        "$ref": "#/components/schemas/ContentOwner"
+                    }
+                },
+                "required": ["assignedBy", "assignedAt", "owner"],
+                "type": "object"
+            },
             "DashboardTileTypes": {
                 "enum": [
                     "saved_chart",
@@ -3635,6 +3714,14 @@
                     "description": {
                         "type": "string"
                     },
+                    "ownership": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ContentOwnershipInfo"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "verification": {
                         "allOf": [
                             {
@@ -3678,6 +3765,7 @@
                     "filters",
                     "tiles",
                     "updatedAt",
+                    "ownership",
                     "verification",
                     "name",
                     "uuid",
@@ -16462,8 +16550,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16521,8 +16609,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16556,8 +16644,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16612,18 +16700,6 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "joinedTables": {
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -16659,6 +16735,18 @@
                                                                             },
                                                                             "type": "array"
                                                                         },
+                                                                        "joinedTables": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
@@ -16686,8 +16774,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16701,9 +16789,6 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "pagination": {
                                                                             "properties": {
                                                                                 "totalPageCount": {
@@ -16731,11 +16816,14 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "status": {
                                                                             "type": "string",
                                                                             "enum": [
-                                                                                "success",
-                                                                                "error"
+                                                                                "error",
+                                                                                "success"
                                                                             ]
                                                                         },
                                                                         "results": {
@@ -16800,8 +16888,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16835,8 +16923,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "not_found"
                                                         ]
                                                     }
@@ -16863,6 +16951,10 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "requiredFilters": {
@@ -16984,10 +17076,6 @@
                                                                         },
                                                                         "type": "array"
                                                                     },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
-                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -16997,9 +17085,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "rationale",
                                                                     "explore",
                                                                     "fields",
-                                                                    "rationale",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -17098,14 +17186,14 @@
                                                         ],
                                                         "type": "object"
                                                     },
-                                                    "href": {
-                                                        "type": "string"
-                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
+                                                    },
+                                                    "href": {
+                                                        "type": "string"
                                                     },
                                                     "status": {
                                                         "type": "string",
@@ -17124,8 +17212,8 @@
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "href",
                                                     "warnings",
+                                                    "href",
                                                     "status",
                                                     "slug",
                                                     "uuid",
@@ -17141,9 +17229,9 @@
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
+                                                                        "search",
                                                                         "read",
                                                                         "edit",
-                                                                        "search",
                                                                         "compile",
                                                                         "stage"
                                                                     ]
@@ -17259,8 +17347,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -17272,9 +17360,9 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "error",
                                                             "success",
                                                             "rejected",
-                                                            "error",
                                                             "timeout"
                                                         ]
                                                     }
@@ -17346,8 +17434,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -25655,6 +25743,9 @@
             "HexColor": {
                 "type": "string"
             },
+            "MeshColor": {
+                "type": "string"
+            },
             "SolidColor": {
                 "type": "string"
             },
@@ -25665,6 +25756,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/HexColor"
+                    },
+                    {
+                        "$ref": "#/components/schemas/MeshColor"
                     },
                     {
                         "$ref": "#/components/schemas/SolidColor"
@@ -27885,6 +27979,14 @@
                         ],
                         "nullable": true
                     },
+                    "ownership": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ContentOwnershipInfo"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "tiles": {
                         "items": {
                             "$ref": "#/components/schemas/DashboardTile"
@@ -27963,6 +28065,7 @@
                     "spaceUuid",
                     "dashboardVersionId",
                     "verification",
+                    "ownership",
                     "tiles",
                     "filters",
                     "spaceName",
@@ -33645,6 +33748,38 @@
                 "$ref": "#/components/schemas/Pick_DashboardFilterRule.Exclude_keyofDashboardFilterRule.id__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
+            "DashboardOwnerAsCode": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "email": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["user"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["email", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["group"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
             "DashboardAsCode": {
                 "allOf": [
                     {
@@ -33652,6 +33787,15 @@
                     },
                     {
                         "properties": {
+                            "owner": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/DashboardOwnerAsCode"
+                                    }
+                                ],
+                                "nullable": true,
+                                "description": "Declarative dashboard owner: a user (by email) or a group (by name).\n`null` clears the owner on upload, `undefined` leaves the current owner\nuntouched. Download sets this from the assigned owner."
+                            },
                             "verification": {
                                 "allOf": [
                                     {
@@ -34239,6 +34383,15 @@
                     "verified": {
                         "type": "boolean",
                         "description": "Declarative verification state.\n`true` verifies the dashboard on upload, `false` unverifies it, `undefined` leaves the\ncurrent state untouched. Download sets this to `true` when the dashboard is verified."
+                    },
+                    "owner": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DashboardOwnerAsCode"
+                            }
+                        ],
+                        "nullable": true,
+                        "description": "Declarative dashboard owner: a user (by email) or a group (by name).\n`null` clears the owner on upload, `undefined` leaves the current owner\nuntouched. Download sets this from the assigned owner."
                     }
                 },
                 "required": ["name", "slug", "version", "tabs", "spaceSlug"],
@@ -41270,6 +41423,51 @@
                 },
                 "type": "object"
             },
+            "ContentOwnerAssignment": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "userUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["user"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["userUuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "groupUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["group"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["groupUuid", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "UpdateDashboardOwnership": {
+                "properties": {
+                    "owner": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ContentOwnerAssignment"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
             "UpdateDashboard": {
                 "allOf": [
                     {
@@ -41294,6 +41492,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/PreserveContentVerification"
+                    },
+                    {
+                        "$ref": "#/components/schemas/UpdateDashboardOwnership"
                     }
                 ]
             },
@@ -43100,7 +43301,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3298.0",
+        "version": "0.3303.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ContentOwnershipModel.ts
+++ b/packages/backend/src/models/ContentOwnershipModel.ts
@@ -1,0 +1,236 @@
+import {
+    type ContentOwnerAssignment,
+    type ContentOwnershipInfo,
+    type ContentType,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { ContentOwnershipTableName } from '../database/entities/contentOwnership';
+import { EmailTableName } from '../database/entities/emails';
+import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { UserTableName } from '../database/entities/users';
+
+type ContentOwnershipModelArguments = {
+    database: Knex;
+};
+
+export class ContentOwnershipModel {
+    private readonly database: Knex;
+
+    constructor({ database }: ContentOwnershipModelArguments) {
+        this.database = database;
+    }
+
+    async getByContent(
+        contentType: ContentType,
+        contentUuid: string,
+    ): Promise<ContentOwnershipInfo | null> {
+        const row = await this.database(ContentOwnershipTableName)
+            .leftJoin(
+                { owner_user: UserTableName },
+                `${ContentOwnershipTableName}.owner_user_uuid`,
+                'owner_user.user_uuid',
+            )
+            .leftJoin({ owner_email: EmailTableName }, function joinEmail() {
+                this.on(
+                    'owner_user.user_id',
+                    '=',
+                    'owner_email.user_id',
+                ).andOnVal('owner_email.is_primary', true);
+            })
+            .leftJoin(
+                { owner_group: GroupTableName },
+                `${ContentOwnershipTableName}.owner_group_uuid`,
+                'owner_group.group_uuid',
+            )
+            .leftJoin(
+                { assigner: UserTableName },
+                `${ContentOwnershipTableName}.assigned_by_user_uuid`,
+                'assigner.user_uuid',
+            )
+            .where(`${ContentOwnershipTableName}.content_type`, contentType)
+            .where(`${ContentOwnershipTableName}.content_uuid`, contentUuid)
+            .select(
+                `${ContentOwnershipTableName}.assigned_at`,
+                this.database.ref('owner_user.user_uuid').as('owner_user_uuid'),
+                this.database
+                    .ref('owner_user.first_name')
+                    .as('owner_first_name'),
+                this.database.ref('owner_user.last_name').as('owner_last_name'),
+                this.database.ref('owner_email.email').as('owner_email'),
+                this.database
+                    .ref('owner_group.group_uuid')
+                    .as('owner_group_uuid'),
+                this.database.ref('owner_group.name').as('owner_group_name'),
+                this.database.ref('assigner.user_uuid').as('assigner_uuid'),
+                this.database
+                    .ref('assigner.first_name')
+                    .as('assigner_first_name'),
+                this.database
+                    .ref('assigner.last_name')
+                    .as('assigner_last_name'),
+            )
+            .first();
+
+        if (!row) return null;
+
+        const owner = row.owner_user_uuid
+            ? ({
+                  type: 'user',
+                  userUuid: row.owner_user_uuid,
+                  firstName: row.owner_first_name,
+                  lastName: row.owner_last_name,
+                  email: row.owner_email ?? '',
+              } as const)
+            : ({
+                  type: 'group',
+                  groupUuid: row.owner_group_uuid,
+                  name: row.owner_group_name,
+              } as const);
+
+        return {
+            owner,
+            assignedAt: row.assigned_at,
+            assignedBy: row.assigner_uuid
+                ? {
+                      userUuid: row.assigner_uuid,
+                      firstName: row.assigner_first_name,
+                      lastName: row.assigner_last_name,
+                  }
+                : null,
+        };
+    }
+
+    async upsert({
+        contentType,
+        contentUuid,
+        projectUuid,
+        owner,
+        assignedByUserUuid,
+    }: {
+        contentType: ContentType;
+        contentUuid: string;
+        projectUuid: string;
+        owner: ContentOwnerAssignment;
+        assignedByUserUuid: string;
+    }): Promise<void> {
+        const ownerColumns = {
+            owner_user_uuid: owner.type === 'user' ? owner.userUuid : null,
+            owner_group_uuid: owner.type === 'group' ? owner.groupUuid : null,
+        };
+
+        await this.database(ContentOwnershipTableName)
+            .insert({
+                content_type: contentType,
+                content_uuid: contentUuid,
+                project_uuid: projectUuid,
+                assigned_by_user_uuid: assignedByUserUuid,
+                ...ownerColumns,
+            })
+            .onConflict(['content_type', 'content_uuid'])
+            .merge({
+                ...ownerColumns,
+                assigned_by_user_uuid: assignedByUserUuid,
+                assigned_at: this.database.fn.now(),
+            });
+    }
+
+    async findUserOwnerByEmail(
+        email: string,
+        organizationUuid: string,
+    ): Promise<string | undefined> {
+        const row = await this.database(EmailTableName)
+            .innerJoin(
+                UserTableName,
+                `${EmailTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                `${UserTableName}.user_id`,
+                `${OrganizationMembershipsTableName}.user_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationMembershipsTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .whereRaw(`LOWER(${EmailTableName}.email) = LOWER(?)`, [email])
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .select(`${UserTableName}.user_uuid`)
+            .first();
+        return row?.user_uuid;
+    }
+
+    async findGroupOwnerByName(
+        name: string,
+        organizationUuid: string,
+    ): Promise<string | undefined> {
+        const row = await this.database(GroupTableName)
+            .innerJoin(
+                OrganizationTableName,
+                `${GroupTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .where(`${GroupTableName}.name`, name)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .select(`${GroupTableName}.group_uuid`)
+            .first();
+        return row?.group_uuid;
+    }
+
+    async isOwnerInOrganization(
+        owner: ContentOwnerAssignment,
+        organizationUuid: string,
+    ): Promise<boolean> {
+        if (owner.type === 'user') {
+            const row = await this.database(OrganizationMembershipsTableName)
+                .innerJoin(
+                    UserTableName,
+                    `${OrganizationMembershipsTableName}.user_id`,
+                    `${UserTableName}.user_id`,
+                )
+                .innerJoin(
+                    OrganizationTableName,
+                    `${OrganizationMembershipsTableName}.organization_id`,
+                    `${OrganizationTableName}.organization_id`,
+                )
+                .where(`${UserTableName}.user_uuid`, owner.userUuid)
+                .where(
+                    `${OrganizationTableName}.organization_uuid`,
+                    organizationUuid,
+                )
+                .first();
+            return row !== undefined;
+        }
+        const row = await this.database(GroupTableName)
+            .innerJoin(
+                OrganizationTableName,
+                `${GroupTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .where(`${GroupTableName}.group_uuid`, owner.groupUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .first();
+        return row !== undefined;
+    }
+
+    async remove(contentType: ContentType, contentUuid: string): Promise<void> {
+        await this.database(ContentOwnershipTableName)
+            .where({
+                content_type: contentType,
+                content_uuid: contentUuid,
+            })
+            .delete();
+    }
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -272,6 +272,7 @@ export const expectedDashboard: DashboardDAO = {
     name: dashboardEntry.name,
     slug: `name`,
     verification: null,
+    ownership: null,
 
     description: dashboardEntry.description,
     updatedAt: dashboardVersionEntry.created_at,

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -84,6 +84,7 @@ import {
     acquireProjectSlugLock,
     generateUniqueSlug,
 } from '../../utils/SlugUtils';
+import { ContentOwnershipModel } from '../ContentOwnershipModel';
 import { ContentVerificationModel } from '../ContentVerificationModel';
 import { SpaceModel } from '../SpaceModel';
 import Transaction = Knex.Transaction;
@@ -135,6 +136,7 @@ export type GetChartTileQuery = Pick<
 type DashboardModelArguments = {
     database: Knex;
     contentVerificationModel?: ContentVerificationModel;
+    contentOwnershipModel?: ContentOwnershipModel;
 };
 
 export class DashboardModel {
@@ -142,9 +144,12 @@ export class DashboardModel {
 
     private contentVerificationModel: ContentVerificationModel | undefined;
 
+    private contentOwnershipModel: ContentOwnershipModel | undefined;
+
     constructor(args: DashboardModelArguments) {
         this.database = args.database;
         this.contentVerificationModel = args.contentVerificationModel;
+        this.contentOwnershipModel = args.contentOwnershipModel;
     }
 
     private static async createVersion(
@@ -1124,13 +1129,21 @@ export class DashboardModel {
             dashboard.dashboard_uuid,
         );
 
-        const [[view], tiles, tabs, verificationResult] = await Promise.all([
-            viewQuery,
-            tilesQuery,
-            tabsQuery,
-            verificationQuery,
-        ]);
+        const ownershipQuery = this.contentOwnershipModel?.getByContent(
+            ContentType.DASHBOARD,
+            dashboard.dashboard_uuid,
+        );
+
+        const [[view], tiles, tabs, verificationResult, ownershipResult] =
+            await Promise.all([
+                viewQuery,
+                tilesQuery,
+                tabsQuery,
+                verificationQuery,
+                ownershipQuery,
+            ]);
         const verification = verificationResult ?? null;
+        const ownership = ownershipResult ?? null;
 
         // A version may have no dashboard_views row (e.g. legacy or partially
         // written data). Guard the backfill — the return below already defaults
@@ -1148,6 +1161,7 @@ export class DashboardModel {
             uuid: dashboard.dashboard_uuid,
             name: dashboard.name,
             verification,
+            ownership,
             description: dashboard.description,
             updatedAt: dashboard.created_at,
             pinnedListUuid: dashboard.pinned_list_uuid,
@@ -2276,6 +2290,12 @@ export class DashboardModel {
                 dashboard.dashboard_uuid,
             )) ?? null;
 
+        const ownership =
+            (await this.contentOwnershipModel?.getByContent(
+                ContentType.DASHBOARD,
+                dashboard.dashboard_uuid,
+            )) ?? null;
+
         return {
             organizationUuid: dashboard.organization_uuid,
             projectUuid: dashboard.project_uuid,
@@ -2284,6 +2304,7 @@ export class DashboardModel {
             uuid: dashboard.dashboard_uuid,
             name: dashboard.name,
             verification,
+            ownership,
             description: dashboard.description,
             updatedAt: dashboard.created_at,
             pinnedListUuid: dashboard.pinned_list_uuid,

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -9,6 +9,7 @@ import { CatalogModel } from './CatalogModel/CatalogModel';
 import { ChangesetModel } from './ChangesetModel';
 import { CommentModel } from './CommentModel/CommentModel';
 import { ContentModel } from './ContentModel/ContentModel';
+import { ContentOwnershipModel } from './ContentOwnershipModel';
 import { ContentVerificationModel } from './ContentVerificationModel';
 import { DashboardModel } from './DashboardModel/DashboardModel';
 import { PersonalAccessTokenModel } from './DashboardModel/PersonalAccessTokenModel';
@@ -134,6 +135,7 @@ export type ModelManifest = {
     catalogModel: CatalogModel;
     savedSqlModel: SavedSqlModel;
     contentModel: ContentModel;
+    contentOwnershipModel: ContentOwnershipModel;
     contentVerificationModel: ContentVerificationModel;
     tagsModel: TagsModel;
     featureFlagModel: FeatureFlagModel;
@@ -284,6 +286,7 @@ export class ModelRepository
                     database: this.database,
                     contentVerificationModel:
                         this.getContentVerificationModel(),
+                    contentOwnershipModel: this.getContentOwnershipModel(),
                 }),
         );
     }
@@ -755,6 +758,13 @@ export class ModelRepository
         return this.getModel(
             'contentModel',
             () => new ContentModel({ database: this.database }),
+        );
+    }
+
+    public getContentOwnershipModel(): ContentOwnershipModel {
+        return this.getModel(
+            'contentOwnershipModel',
+            () => new ContentOwnershipModel({ database: this.database }),
         );
     }
 

--- a/packages/backend/src/services/CoderService/CoderService.contentVerification.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.contentVerification.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { ContentOwnershipModel } from '../../models/ContentOwnershipModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -82,6 +83,11 @@ const buildService = () =>
         spacePermissionService: {} as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
+        contentOwnershipModel: {
+            getByContent: vi.fn(async () => null),
+            upsert: vi.fn(async () => undefined),
+            remove: vi.fn(async () => undefined),
+        } as unknown as ContentOwnershipModel,
     });
 
 const callSync = (

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -644,6 +644,7 @@ describe('CoderService', () => {
             const service = new CoderService({
                 analytics: {} as AnyType,
                 contentVerificationModel: {} as AnyType,
+                contentOwnershipModel: {} as AnyType,
                 dashboardModel: {} as AnyType,
                 lightdashConfig: {} as AnyType,
                 projectModel: {} as AnyType,

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -8,6 +8,7 @@ import {
     ChartAsCodeInternalization,
     ChartSummary,
     ContentAsCodeType,
+    ContentOwnerAssignment,
     ContentType,
     CreateSavedChart,
     currentVersion,
@@ -16,6 +17,7 @@ import {
     DashboardChartTileAsCode,
     DashboardDAO,
     DashboardMarkdownTileAsCode,
+    DashboardOwnerAsCode,
     DashboardSqlChartTileAsCode,
     DashboardTile,
     DashboardTileAsCode,
@@ -55,6 +57,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
+import { ContentOwnershipModel } from '../../models/ContentOwnershipModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -79,6 +82,7 @@ type CoderServiceArguments = {
     promoteService: PromoteService;
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
+    contentOwnershipModel: ContentOwnershipModel;
 };
 
 type UpsertContentAsCodeOptions = {
@@ -158,6 +162,8 @@ export class CoderService extends BaseService {
 
     contentVerificationModel: ContentVerificationModel;
 
+    contentOwnershipModel: ContentOwnershipModel;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -170,6 +176,7 @@ export class CoderService extends BaseService {
         promoteService,
         spacePermissionService,
         contentVerificationModel,
+        contentOwnershipModel,
     }: CoderServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -183,6 +190,7 @@ export class CoderService extends BaseService {
         this.promoteService = promoteService;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
+        this.contentOwnershipModel = contentOwnershipModel;
     }
 
     private static transformSpaces(
@@ -555,9 +563,20 @@ export class CoderService extends BaseService {
             downloadedAt: new Date(),
             verified: verificationMap.has(dashboard.uuid) ? true : undefined,
             verification: verificationMap.get(dashboard.uuid) ?? null,
+            owner: CoderService.getOwnerAsCode(dashboard),
         };
 
         return dashboardAsCode;
+    }
+
+    private static getOwnerAsCode(
+        dashboard: DashboardDAO,
+    ): DashboardOwnerAsCode | undefined {
+        if (!dashboard.ownership) return undefined;
+        const { owner } = dashboard.ownership;
+        return owner.type === 'user'
+            ? { type: 'user', email: owner.email }
+            : { type: 'group', name: owner.name };
     }
 
     async convertTileWithSlugsToUuids(
@@ -1205,6 +1224,64 @@ export class CoderService extends BaseService {
             total: sqlChartsTotal,
             offset: newOffset,
         };
+    }
+
+    private async syncOwnership({
+        user,
+        projectUuid,
+        organizationUuid,
+        contentType,
+        contentUuid,
+        owner,
+    }: {
+        user: SessionUser;
+        projectUuid: string;
+        organizationUuid: string;
+        contentType: ContentType;
+        contentUuid: string;
+        owner: DashboardOwnerAsCode | null | undefined;
+    }): Promise<void> {
+        if (owner === undefined) return;
+
+        if (owner === null) {
+            await this.contentOwnershipModel.remove(contentType, contentUuid);
+            return;
+        }
+
+        const assignment: ContentOwnerAssignment | undefined =
+            owner.type === 'user'
+                ? await this.contentOwnershipModel
+                      .findUserOwnerByEmail(owner.email, organizationUuid)
+                      .then((userUuid) =>
+                          userUuid
+                              ? ({ type: 'user', userUuid } as const)
+                              : undefined,
+                      )
+                : await this.contentOwnershipModel
+                      .findGroupOwnerByName(owner.name, organizationUuid)
+                      .then((groupUuid) =>
+                          groupUuid
+                              ? ({ type: 'group', groupUuid } as const)
+                              : undefined,
+                      );
+
+        if (!assignment) {
+            // Warn and skip so uploads referencing unknown owners don't fail CI pipelines.
+            this.logger.warn(
+                `Owner ${
+                    owner.type === 'user' ? owner.email : owner.name
+                } not found in organization; skipping ownership sync for ${contentType} ${contentUuid}.`,
+            );
+            return;
+        }
+
+        await this.contentOwnershipModel.upsert({
+            contentType,
+            contentUuid,
+            projectUuid,
+            owner: assignment,
+            assignedByUserUuid: user.userUuid,
+        });
     }
 
     private async syncVerification({
@@ -1979,6 +2056,15 @@ export class CoderService extends BaseService {
                 verified: dashboardAsCode.verified,
             });
 
+            await this.syncOwnership({
+                user,
+                projectUuid,
+                organizationUuid: project.organizationUuid,
+                contentType: ContentType.DASHBOARD,
+                contentUuid: newDashboard.uuid,
+                owner: dashboardAsCode.owner,
+            });
+
             return {
                 dashboards: [
                     {
@@ -2095,6 +2181,15 @@ export class CoderService extends BaseService {
             contentType: ContentType.DASHBOARD,
             contentUuid: dashboard.uuid,
             verified: dashboardAsCode.verified,
+        });
+
+        await this.syncOwnership({
+            user,
+            projectUuid,
+            organizationUuid: project.organizationUuid,
+            contentType: ContentType.DASHBOARD,
+            contentUuid: dashboard.uuid,
+            owner: dashboardAsCode.owner,
         });
 
         console.info(

--- a/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { ContentOwnershipModel } from '../../models/ContentOwnershipModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -86,6 +87,7 @@ const buildService = (
             getSpacesAccessContext,
         } as unknown as SpacePermissionService,
         contentVerificationModel: {} as unknown as ContentVerificationModel,
+        contentOwnershipModel: {} as unknown as ContentOwnershipModel,
     });
 
 const stubSpace = (service: CoderService, uuid: string = SPACE_UUID) =>

--- a/packages/backend/src/services/CommentService/CommentService.test.ts
+++ b/packages/backend/src/services/CommentService/CommentService.test.ts
@@ -37,6 +37,7 @@ const dashboard = {
     dashboardVersionId: 1,
     versionUuid: 'version-uuid',
     verification: null,
+    ownership: null,
     colorPaletteUuid: null,
 } as DashboardDAO;
 

--- a/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
@@ -10,6 +10,7 @@ import { SlackClient } from '../../clients/Slack/SlackClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentOwnershipModel } from '../../models/ContentOwnershipModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
@@ -87,6 +88,13 @@ const contentVerificationModel = {
     getByContent: vi.fn(async () => verificationInfo),
 };
 
+const contentOwnershipModel = {
+    getByContent: vi.fn(async () => null),
+    upsert: vi.fn(async () => undefined),
+    remove: vi.fn(async () => undefined),
+    isOwnerInOrganization: vi.fn(async () => true),
+};
+
 vi.spyOn(analyticsMock, 'track');
 
 describe('DashboardService - Content Verification', () => {
@@ -115,6 +123,8 @@ describe('DashboardService - Content Verification', () => {
         spacePermissionService: {} as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
+        contentOwnershipModel:
+            contentOwnershipModel as unknown as ContentOwnershipModel,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -100,6 +100,7 @@ export const dashboard: Dashboard = {
     name: 'name',
     slug: 'name',
     verification: null,
+    ownership: null,
 
     dashboardVersionId: 1,
     versionUuid: 'dashboard-version-uuid',

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -23,6 +23,7 @@ import { SlackClient } from '../../clients/Slack/SlackClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentOwnershipModel } from '../../models/ContentOwnershipModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
@@ -136,6 +137,13 @@ const contentVerificationModel = {
     unverify: vi.fn(async () => undefined),
 };
 
+const contentOwnershipModel = {
+    getByContent: vi.fn(async () => null),
+    upsert: vi.fn(async () => undefined),
+    remove: vi.fn(async () => undefined),
+    isOwnerInOrganization: vi.fn(async () => true),
+};
+
 const spaceContexts = {
     [space.space_uuid]: {
         organizationUuid: space.organization_uuid,
@@ -203,6 +211,8 @@ describe('DashboardService', () => {
             spacePermissionService as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
+        contentOwnershipModel:
+            contentOwnershipModel as unknown as ContentOwnershipModel,
     });
     afterEach(() => {
         vi.clearAllMocks();

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -75,6 +75,7 @@ import { getSchedulerTargetType } from '../../database/entities/scheduler';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { getChartFieldUsageChanges } from '../../models/CatalogModel/utils';
+import { ContentOwnershipModel } from '../../models/ContentOwnershipModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
@@ -117,6 +118,7 @@ type DashboardServiceArguments = {
     organizationModel: OrganizationModel;
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
+    contentOwnershipModel: ContentOwnershipModel;
 };
 
 export class DashboardService
@@ -160,6 +162,8 @@ export class DashboardService
     spacePermissionService: SpacePermissionService;
 
     contentVerificationModel: ContentVerificationModel;
+
+    contentOwnershipModel: ContentOwnershipModel;
 
     async scheduleExportContent(
         user: SessionUser,
@@ -263,6 +267,7 @@ export class DashboardService
         organizationModel,
         spacePermissionService,
         contentVerificationModel,
+        contentOwnershipModel,
     }: DashboardServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -284,6 +289,7 @@ export class DashboardService
         this.slackClient = slackClient;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
+        this.contentOwnershipModel = contentOwnershipModel;
     }
 
     async verifyDashboard(
@@ -1406,7 +1412,7 @@ export class DashboardService
                 projectUuid: options?.projectUuid,
             },
         );
-        const { preserveVerification, ...dashboardFields } = dashboard;
+        const { preserveVerification, owner, ...dashboardFields } = dashboard;
 
         const currentSpace =
             await this.spacePermissionService.getSpaceAccessContext(
@@ -1623,6 +1629,33 @@ export class DashboardService
                 ContentType.DASHBOARD,
                 existingDashboardDao.uuid,
             );
+        }
+
+        if (owner !== undefined) {
+            if (owner === null) {
+                await this.contentOwnershipModel.remove(
+                    ContentType.DASHBOARD,
+                    existingDashboardDao.uuid,
+                );
+            } else {
+                const isValidOwner =
+                    await this.contentOwnershipModel.isOwnerInOrganization(
+                        owner,
+                        existingDashboardDao.organizationUuid,
+                    );
+                if (!isValidOwner) {
+                    throw new ParameterError(
+                        'Owner must be a user or group in this organization',
+                    );
+                }
+                await this.contentOwnershipModel.upsert({
+                    contentType: ContentType.DASHBOARD,
+                    contentUuid: existingDashboardDao.uuid,
+                    projectUuid: existingDashboardDao.projectUuid,
+                    owner,
+                    assignedByUserUuid: user.userUuid,
+                });
+            }
         }
 
         const updatedNewDashboard = await this.dashboardModel.getByIdOrSlug(

--- a/packages/backend/src/services/PromoteService/PromoteService.mock.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.mock.ts
@@ -237,6 +237,7 @@ export const promotedDashboard: PromotedDashboard = {
         uuid: 'promoted-dashboard-uuid',
         name: 'dashboard',
         verification: null,
+        ownership: null,
         description: '',
         updatedAt: new Date(),
         pinnedListUuid: null,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -409,6 +409,8 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
+                    contentOwnershipModel:
+                        this.models.getContentOwnershipModel(),
                 }),
         );
     }
@@ -1142,6 +1144,8 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
+                    contentOwnershipModel:
+                        this.models.getContentOwnershipModel(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -110,6 +110,7 @@ export * from './types/coder';
 export * from './types/comments';
 export * from './types/conditionalFormatting';
 export * from './types/content';
+export * from './types/contentOwnership';
 export * from './types/contentVerification';
 export * from './types/dashboard';
 export * from './types/dataTimezonePreview';

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -418,6 +418,36 @@
             "required": ["w", "h", "y", "x", "type", "properties"],
             "type": "object"
         },
+        "DashboardOwnerAsCode": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "email": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": ["user"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["email", "type"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": ["group"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["name", "type"],
+                    "type": "object"
+                }
+            ]
+        },
         "DashboardParameters": {
             "$ref": "#/$defs/Record_string.DashboardParameterValue_"
         },
@@ -950,6 +980,21 @@
         "name": {
             "minLength": 1,
             "type": "string"
+        },
+        "owner": {
+            "anyOf": [
+                {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/DashboardOwnerAsCode"
+                        }
+                    ],
+                    "description": "Declarative dashboard owner: a user (by email) or a group (by name).\n`null` clears the owner on upload, `undefined` leaves the current owner\nuntouched. Download sets this from the assigned owner."
+                },
+                {
+                    "type": "null"
+                }
+            ]
         },
         "parameters": {
             "$ref": "#/$defs/DashboardParameters"

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -270,7 +270,17 @@ export type DashboardAsCode = Omit<
     verified?: boolean;
     /** Detailed verification info (who/when). Read-only; ignored on upload. */
     verification?: ContentVerificationInfo | null;
+    /**
+     * Declarative dashboard owner: a user (by email) or a group (by name).
+     * `null` clears the owner on upload, `undefined` leaves the current owner
+     * untouched. Download sets this from the assigned owner.
+     */
+    owner?: DashboardOwnerAsCode | null;
 };
+
+export type DashboardOwnerAsCode =
+    | { type: 'user'; email: string }
+    | { type: 'group'; name: string };
 
 export type SpaceAsCode = {
     contentType: ContentAsCodeType.SPACE;

--- a/packages/common/src/types/contentOwnership.ts
+++ b/packages/common/src/types/contentOwnership.ts
@@ -1,0 +1,36 @@
+export type ContentOwner =
+    | {
+          type: 'user';
+          userUuid: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+      }
+    | {
+          type: 'group';
+          groupUuid: string;
+          name: string;
+      };
+
+export type ContentOwnershipInfo = {
+    owner: ContentOwner;
+    assignedAt: Date;
+    assignedBy: {
+        userUuid: string;
+        firstName: string;
+        lastName: string;
+    } | null;
+};
+
+export type ContentOwnerAssignment =
+    | { type: 'user'; userUuid: string }
+    | { type: 'group'; groupUuid: string };
+
+export type UpdateContentOwnership = {
+    owner: ContentOwnerAssignment | null;
+};
+
+export type ApiContentOwnershipResponse = {
+    status: 'ok';
+    results: ContentOwnershipInfo | null;
+};

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,3 +1,7 @@
+import {
+    type ContentOwnerAssignment,
+    type ContentOwnershipInfo,
+} from './contentOwnership';
 import { type ContentVerificationInfo } from './contentVerification';
 import { type FilterableDimension, type Metric } from './field';
 import { type DashboardFilters } from './filter';
@@ -246,6 +250,7 @@ export type Dashboard = {
     uuid: string;
     name: string;
     verification: ContentVerificationInfo | null;
+    ownership: ContentOwnershipInfo | null;
     description?: string;
     updatedAt: Date;
     tiles: Array<DashboardTile>;
@@ -331,12 +336,18 @@ type PreserveContentVerification = {
     preserveVerification?: boolean;
 };
 
+type UpdateDashboardOwnership = {
+    // undefined = leave unchanged, null = clear owner, value = assign
+    owner?: ContentOwnerAssignment | null;
+};
+
 export type UpdateDashboard = (
     | DashboardUnversionedFields
     | DashboardVersionedFields
     | (DashboardUnversionedFields & DashboardVersionedFields)
 ) &
-    PreserveContentVerification;
+    PreserveContentVerification &
+    UpdateDashboardOwnership;
 
 export type UpdateMultipleDashboards = Pick<
     Dashboard,

--- a/packages/frontend/src/components/common/modal/DashboardUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardUpdateModal.tsx
@@ -1,6 +1,7 @@
-import { type Dashboard } from '@lightdash/common';
+import { type ContentOwnerAssignment, type Dashboard } from '@lightdash/common';
 import {
     Button,
+    Select,
     Stack,
     Textarea,
     TextInput,
@@ -15,6 +16,8 @@ import {
     useUpdateDashboard,
 } from '../../../hooks/dashboard/useDashboard';
 import useHealth from '../../../hooks/health/useHealth';
+import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import Callout from '../Callout';
 import MantineModal from '../MantineModal';
@@ -29,6 +32,23 @@ interface DashboardUpdateModalProps {
 
 type FormState = Pick<Dashboard, 'name' | 'description'> & {
     colorPaletteUuid: string | null;
+    // Encoded as `user:<uuid>` or `group:<uuid>`; null = no owner
+    ownerValue: string | null;
+};
+
+const encodeOwner = (ownership: Dashboard['ownership']): string | null => {
+    if (!ownership) return null;
+    return ownership.owner.type === 'user'
+        ? `user:${ownership.owner.userUuid}`
+        : `group:${ownership.owner.groupUuid}`;
+};
+
+const decodeOwner = (value: string | null): ContentOwnerAssignment | null => {
+    if (!value) return null;
+    const [type, uuid] = value.split(':');
+    return type === 'user'
+        ? { type: 'user', userUuid: uuid }
+        : { type: 'group', groupUuid: uuid };
 };
 
 const DashboardUpdateModal: FC<DashboardUpdateModalProps> = ({
@@ -47,12 +67,15 @@ const DashboardUpdateModal: FC<DashboardUpdateModalProps> = ({
         uuid,
         projectUuid,
     );
+    const { data: organizationUsers } = useOrganizationUsers();
+    const { data: organizationGroups } = useOrganizationGroups({});
 
     const form = useForm<FormState>({
         initialValues: {
             name: '',
             description: '',
             colorPaletteUuid: null,
+            ownerValue: null,
         },
     });
 
@@ -65,6 +88,7 @@ const DashboardUpdateModal: FC<DashboardUpdateModalProps> = ({
             name: dashboard.name,
             description: dashboard.description ?? '',
             colorPaletteUuid: dashboard.colorPaletteUuid ?? null,
+            ownerValue: encodeOwner(dashboard.ownership),
         });
     }, [dashboard, setValues]);
 
@@ -76,11 +100,33 @@ const DashboardUpdateModal: FC<DashboardUpdateModalProps> = ({
         !!health?.appearance.overrideColorPalette &&
         health.appearance.overrideColorPalette.length > 0;
 
+    const ownerOptions = [
+        {
+            group: 'Users',
+            items: (organizationUsers ?? []).map((member) => ({
+                value: `user:${member.userUuid}`,
+                label:
+                    `${member.firstName} ${member.lastName}`.trim() ||
+                    member.email,
+            })),
+        },
+        {
+            group: 'Groups',
+            items: (organizationGroups ?? []).map((group) => ({
+                value: `group:${group.uuid}`,
+                label: group.name,
+            })),
+        },
+    ];
+
     const handleConfirm = form.onSubmit(async (data) => {
+        const ownerChanged =
+            data.ownerValue !== encodeOwner(dashboard.ownership);
         await mutateAsync({
             name: data.name,
             description: data.description,
             colorPaletteUuid: data.colorPaletteUuid,
+            ...(ownerChanged ? { owner: decodeOwner(data.ownerValue) } : {}),
         });
         onConfirm?.();
     });
@@ -122,6 +168,20 @@ const DashboardUpdateModal: FC<DashboardUpdateModalProps> = ({
                         autosize
                         maxRows={3}
                         {...form.getInputProps('description')}
+                    />
+
+                    <Select
+                        label="Owner"
+                        description="Who is responsible for maintaining this dashboard"
+                        placeholder="No owner assigned"
+                        searchable
+                        clearable
+                        disabled={isUpdating}
+                        data={ownerOptions}
+                        value={form.values.ownerValue}
+                        onChange={(next) =>
+                            form.setFieldValue('ownerValue', next)
+                        }
                     />
 
                     {overrideActive && (


### PR DESCRIPTION
Part of [PROD-2585](https://linear.app/lightdash/issue/PROD-2585/i-want-to-be-able-to-assign-and-manage-dashboard-owners) / #19529

## Summary

Lets you assign an **owner** — a user or a group — to a dashboard, so it's clear who is responsible for its maintenance and accuracy.

- **New `content_ownership` table**, deliberately mirroring `content_verification`: keyed by `(content_type, content_uuid)` so the same table extends to charts later without a schema change. Exactly one of `owner_user_uuid` / `owner_group_uuid` is set (CHECK constraint). Tracks who assigned it and when.
- **Read:** `Dashboard.ownership` (`ContentOwnershipInfo | null`) is attached in `DashboardModel.getByIdOrSlug`, same pattern as `verification`.
- **Write:** `UpdateDashboard.owner` accepts `{type:'user',userUuid} | {type:'group',groupUuid} | null` (undefined = unchanged, null = clear). The owner is validated to belong to the dashboard's organization; permission is the existing dashboard-update check.
- **Dashboards-as-code:** `owner` round-trips — download serializes to a portable identity (user by **email**, group by **name**), upload resolves it back declaratively (mirrors the `verified` field's sync). Unknown owners warn and skip rather than failing CI uploads.
- **UI:** searchable Owner select (Users / Groups sections) in the Update Dashboard modal.

## Out of scope (follow-ups)

- Owner transfer in the user-deletion / leaver flow (like scheduler reassignment)
- Surfacing "content owned by X" listings and owner display on the dashboard header
- Chart ownership (schema already supports it)

## Who is affected

- No behavior changes for existing content: `ownership` is `null` everywhere until assigned. The API field is additive; `UpdateDashboard.owner` is optional.
- Anyone who can update a dashboard can set its owner (no new permission scope — ownership is metadata, not access control).
- Deleting an owning user or group cascades the ownership row away (dashboard simply becomes unowned).

## Testing

- `pnpm -F backend test:dev:nowatch` — 229 files / 3365 tests pass
- `pnpm -F common|backend|frontend typecheck:fast` — clean; `pnpm generate-api` regenerated
- **Live-verified** on local dev: assigned a user owner, reassigned to a group, cleared it, and confirmed `lightdash download` YAML serializes `owner: {type: group, name: ...}` — all via the real API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1pqqmPUWMVUJPrnZYpdNV