### PR TITLE
feat(dashboards): surface owner and transfer ownership when deleting users

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -11,8 +11,10 @@ import {
     ApiOrganizationMemberProfile,
     ApiOrganizationMemberProfiles,
     ApiOrganizationProjects,
+    ApiReassignUserContentOwnershipResponse,
     ApiReassignUserSchedulersResponse,
     ApiSuccessEmpty,
+    ApiUserContentOwnershipSummaryResponse,
     ApiUserSchedulersSummaryResponse,
     assertRegisteredAccount,
     CreateColorPalette,
@@ -22,6 +24,7 @@ import {
     KnexPaginateArgs,
     LightdashRequestMethodHeader,
     OrganizationMemberProfileUpdate,
+    ReassignUserContentOwnershipRequest,
     ReassignUserSchedulersRequest,
     UpdateAllowedEmailDomains,
     UpdateColorPalette,
@@ -418,6 +421,65 @@ export class OrganizationController extends BaseController {
             results: await this.services
                 .getSchedulerService()
                 .reassignUserSchedulers(
+                    toSessionUser(req.account),
+                    userUuid,
+                    body.newOwnerUserUuid,
+                ),
+        };
+    }
+
+    /**
+     * Gets a summary of content (dashboards) owned by a user across all projects
+     * @summary Get user content ownership
+     * @param req express request
+     * @param userUuid the uuid of the user
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/user/{userUuid}/content-ownership-summary')
+    @OperationId('GetUserContentOwnershipSummary')
+    async getUserContentOwnershipSummary(
+        @Request() req: express.Request,
+        @Path() userUuid: string,
+    ): Promise<ApiUserContentOwnershipSummaryResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getContentOwnershipService()
+                .getUserContentOwnershipSummary(
+                    toSessionUser(req.account),
+                    userUuid,
+                ),
+        };
+    }
+
+    /**
+     * Reassigns all content ownership from one user to another
+     * @summary Reassign content ownership
+     * @param req express request
+     * @param userUuid the uuid of the user whose owned content will be reassigned
+     * @param body the new owner details
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Patch('/user/{userUuid}/reassign-content-ownership')
+    @OperationId('ReassignUserContentOwnership')
+    async reassignUserContentOwnership(
+        @Request() req: express.Request,
+        @Path() userUuid: string,
+        @Body() body: ReassignUserContentOwnershipRequest,
+    ): Promise<ApiReassignUserContentOwnershipResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getContentOwnershipService()
+                .reassignUserContentOwnership(
                     toSessionUser(req.account),
                     userUuid,
                     body.newOwnerUserUuid,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14927,11 +14927,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -14989,11 +14989,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -15236,6 +15236,29 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -15326,29 +15349,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         dataType:
                                                                                                                             'string',
                                                                                                                     },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15765,6 +15765,130 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 rationale: {
                                                                     dataType:
                                                                         'union',
@@ -15866,12 +15990,6 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -15880,6 +15998,12 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -15893,130 +16017,6 @@ const models: TsoaRoute.Models = {
                                                                                 required: true,
                                                                             },
                                                                         },
-                                                                    required: true,
-                                                                },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -16047,17 +16047,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -16171,15 +16171,15 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
+                                                href: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
                                                         dataType: 'string',
                                                     },
-                                                    required: true,
-                                                },
-                                                href: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 status: {
@@ -16280,77 +16280,6 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16428,6 +16357,77 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16459,6 +16459,12 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -16466,12 +16472,6 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
-                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16618,11 +16618,11 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16662,6 +16662,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16740,25 +16759,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -35788,6 +35788,70 @@ const models: TsoaRoute.Models = {
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ReassignUserSchedulersRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                newOwnerUserUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserContentOwnershipSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                byProject: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            count: { dataType: 'double', required: true },
+                            projectName: { dataType: 'string', required: true },
+                            projectUuid: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                totalCount: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUserContentOwnershipSummaryResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'UserContentOwnershipSummary', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiReassignUserContentOwnershipResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        reassignedCount: { dataType: 'double', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ReassignUserContentOwnershipRequest: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -71768,6 +71832,134 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'reassignUserSchedulers',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationController_getUserContentOwnershipSummary: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        userUuid: {
+            in: 'path',
+            name: 'userUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/org/user/:userUuid/content-ownership-summary',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getUserContentOwnershipSummary,
+        ),
+
+        async function OrganizationController_getUserContentOwnershipSummary(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationController_getUserContentOwnershipSummary,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationController>(
+                        OrganizationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getUserContentOwnershipSummary',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationController_reassignUserContentOwnership: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        userUuid: {
+            in: 'path',
+            name: 'userUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ReassignUserContentOwnershipRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/org/user/:userUuid/reassign-content-ownership',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.reassignUserContentOwnership,
+        ),
+
+        async function OrganizationController_reassignUserContentOwnership(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationController_reassignUserContentOwnership,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationController>(
+                        OrganizationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'reassignUserContentOwnership',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16550,8 +16550,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16609,8 +16609,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16700,6 +16700,11 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -16740,11 +16745,6 @@
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -16951,6 +16951,66 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "fieldType",
+                                                                                "description",
+                                                                                "label",
+                                                                                "fieldId",
+                                                                                "table",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "rationale": {
                                                                         "type": "string",
                                                                         "nullable": true
@@ -16992,14 +17052,14 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -17009,72 +17069,12 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
                                                                         "type": "object"
-                                                                    },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "fieldValueType",
-                                                                                "caseSensitiveFilters",
-                                                                                "isFromJoinedTable",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "description",
-                                                                                "label",
-                                                                                "fieldId",
-                                                                                "name",
-                                                                                "table"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -17085,9 +17085,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "fields",
                                                                     "rationale",
                                                                     "explore",
-                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -17100,10 +17100,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -17111,8 +17111,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -17186,14 +17186,14 @@
                                                         ],
                                                         "type": "object"
                                                     },
+                                                    "href": {
+                                                        "type": "string"
+                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
-                                                    },
-                                                    "href": {
-                                                        "type": "string"
                                                     },
                                                     "status": {
                                                         "type": "string",
@@ -17212,8 +17212,8 @@
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
+                                                    "warnings",
                                                     "status",
                                                     "slug",
                                                     "uuid",
@@ -17223,32 +17223,6 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17276,6 +17250,32 @@
                                                         ],
                                                         "nullable": true
                                                     },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "search",
+                                                                        "read",
+                                                                        "edit",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17295,9 +17295,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
+                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -17361,8 +17361,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -17374,6 +17374,10 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17410,10 +17414,6 @@
                                                                 },
                                                                 "type": "array"
                                                             },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
@@ -17425,8 +17425,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "fields",
                                                             "searchQuery",
+                                                            "fields",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -36140,6 +36140,79 @@
                 "$ref": "#/components/schemas/ApiSuccess__reassignedCount-number__"
             },
             "ReassignUserSchedulersRequest": {
+                "properties": {
+                    "newOwnerUserUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["newOwnerUserUuid"],
+                "type": "object"
+            },
+            "UserContentOwnershipSummary": {
+                "properties": {
+                    "byProject": {
+                        "items": {
+                            "properties": {
+                                "count": {
+                                    "type": "number",
+                                    "format": "double"
+                                },
+                                "projectName": {
+                                    "type": "string"
+                                },
+                                "projectUuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["count", "projectName", "projectUuid"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "totalCount": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["byProject", "totalCount"],
+                "type": "object"
+            },
+            "ApiUserContentOwnershipSummaryResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/UserContentOwnershipSummary"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiReassignUserContentOwnershipResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "reassignedCount": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": ["reassignedCount"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ReassignUserContentOwnershipRequest": {
                 "properties": {
                     "newOwnerUserUuid": {
                         "type": "string"
@@ -61405,6 +61478,102 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ReassignUserSchedulersRequest",
+                                "description": "the new owner details"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/user/{userUuid}/content-ownership-summary": {
+            "get": {
+                "operationId": "GetUserContentOwnershipSummary",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUserContentOwnershipSummaryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets a summary of content (dashboards) owned by a user across all projects",
+                "summary": "Get user content ownership",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/org/user/{userUuid}/reassign-content-ownership": {
+            "patch": {
+                "operationId": "ReassignUserContentOwnership",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiReassignUserContentOwnershipResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Reassigns all content ownership from one user to another",
+                "summary": "Reassign content ownership",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user whose owned content will be reassigned",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the new owner details",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ReassignUserContentOwnershipRequest",
                                 "description": "the new owner details"
                             }
                         }

--- a/packages/backend/src/models/ContentOwnershipModel.ts
+++ b/packages/backend/src/models/ContentOwnershipModel.ts
@@ -2,6 +2,7 @@ import {
     type ContentOwnerAssignment,
     type ContentOwnershipInfo,
     type ContentType,
+    type UserContentOwnershipSummary,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { ContentOwnershipTableName } from '../database/entities/contentOwnership';
@@ -9,6 +10,7 @@ import { EmailTableName } from '../database/entities/emails';
 import { GroupTableName } from '../database/entities/groups';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
 import { UserTableName } from '../database/entities/users';
 
 type ContentOwnershipModelArguments = {
@@ -223,6 +225,60 @@ export class ContentOwnershipModel {
             )
             .first();
         return row !== undefined;
+    }
+
+    async getOwnershipSummaryByOwner(
+        ownerUserUuid: string,
+    ): Promise<UserContentOwnershipSummary> {
+        const rows = await this.database(ContentOwnershipTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ContentOwnershipTableName}.project_uuid`,
+                `${ProjectTableName}.project_uuid`,
+            )
+            .where(
+                `${ContentOwnershipTableName}.owner_user_uuid`,
+                ownerUserUuid,
+            )
+            .groupBy(
+                `${ProjectTableName}.project_uuid`,
+                `${ProjectTableName}.name`,
+            )
+            .select(
+                `${ProjectTableName}.project_uuid`,
+                this.database
+                    .ref(`${ProjectTableName}.name`)
+                    .as('project_name'),
+            )
+            .count(`${ContentOwnershipTableName}.content_ownership_uuid`, {
+                as: 'count',
+            });
+
+        const byProject = rows.map((row) => ({
+            projectUuid: row.project_uuid,
+            projectName: row.project_name,
+            count: Number(row.count),
+        }));
+
+        return {
+            totalCount: byProject.reduce((acc, p) => acc + p.count, 0),
+            byProject,
+        };
+    }
+
+    async reassignUserOwnership(
+        fromUserUuid: string,
+        toUserUuid: string,
+        assignedByUserUuid: string,
+    ): Promise<number> {
+        return this.database(ContentOwnershipTableName)
+            .where('owner_user_uuid', fromUserUuid)
+            .update({
+                owner_user_uuid: toUserUuid,
+                owner_group_uuid: null,
+                assigned_by_user_uuid: assignedByUserUuid,
+                assigned_at: this.database.fn.now(),
+            });
     }
 
     async remove(contentType: ContentType, contentUuid: string): Promise<void> {

--- a/packages/backend/src/services/ContentOwnershipService.ts
+++ b/packages/backend/src/services/ContentOwnershipService.ts
@@ -1,0 +1,139 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    InvalidUser,
+    isUserWithOrg,
+    NotFoundError,
+    type SessionUser,
+    type UserContentOwnershipSummary,
+} from '@lightdash/common';
+import { ContentOwnershipModel } from '../models/ContentOwnershipModel';
+import { UserModel } from '../models/UserModel';
+import { BaseService } from './BaseService';
+
+type ContentOwnershipServiceArguments = {
+    contentOwnershipModel: ContentOwnershipModel;
+    userModel: UserModel;
+};
+
+export class ContentOwnershipService extends BaseService {
+    private readonly contentOwnershipModel: ContentOwnershipModel;
+
+    private readonly userModel: UserModel;
+
+    constructor({
+        contentOwnershipModel,
+        userModel,
+    }: ContentOwnershipServiceArguments) {
+        super({ serviceName: 'ContentOwnershipService' });
+        this.contentOwnershipModel = contentOwnershipModel;
+        this.userModel = userModel;
+    }
+
+    private async validateOrgMember(
+        userUuid: string,
+        organizationUuid: string,
+    ): Promise<void> {
+        try {
+            await this.userModel.findSessionUserAndOrgByUuid(
+                userUuid,
+                organizationUuid,
+            );
+        } catch (error) {
+            if (error instanceof InvalidUser) {
+                throw new NotFoundError(
+                    'User not found or not a member of the organization',
+                );
+            }
+            throw error;
+        }
+    }
+
+    private assertCanManageOwnedContent(
+        user: SessionUser,
+        organizationUuid: string,
+        summary: UserContentOwnershipSummary,
+    ): void {
+        const auditedAbility = this.createAuditedAbility(user);
+        const projectsWithoutPermission = summary.byProject
+            .filter((project) =>
+                auditedAbility.cannot(
+                    'manage',
+                    subject('Dashboard', {
+                        organizationUuid,
+                        projectUuid: project.projectUuid,
+                        metadata: { projectName: project.projectName },
+                    }),
+                ),
+            )
+            .map((project) => project.projectName);
+
+        if (projectsWithoutPermission.length > 0) {
+            throw new ForbiddenError(
+                `You do not have permission to manage content in: ${projectsWithoutPermission.join(
+                    ', ',
+                )}`,
+            );
+        }
+    }
+
+    async getUserContentOwnershipSummary(
+        user: SessionUser,
+        targetUserUuid: string,
+    ): Promise<UserContentOwnershipSummary> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const { organizationUuid } = user;
+
+        await this.validateOrgMember(targetUserUuid, organizationUuid);
+
+        const summary =
+            await this.contentOwnershipModel.getOwnershipSummaryByOwner(
+                targetUserUuid,
+            );
+
+        this.assertCanManageOwnedContent(user, organizationUuid, summary);
+
+        return summary;
+    }
+
+    async reassignUserContentOwnership(
+        user: SessionUser,
+        fromUserUuid: string,
+        newOwnerUserUuid: string,
+    ): Promise<{ reassignedCount: number }> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const { organizationUuid } = user;
+
+        await this.validateOrgMember(fromUserUuid, organizationUuid);
+        await this.validateOrgMember(newOwnerUserUuid, organizationUuid);
+
+        const summary =
+            await this.contentOwnershipModel.getOwnershipSummaryByOwner(
+                fromUserUuid,
+            );
+
+        if (summary.totalCount === 0) {
+            return { reassignedCount: 0 };
+        }
+
+        this.assertCanManageOwnedContent(user, organizationUuid, summary);
+
+        const reassignedCount =
+            await this.contentOwnershipModel.reassignUserOwnership(
+                fromUserUuid,
+                newOwnerUserUuid,
+                user.userUuid,
+            );
+
+        this.logger.info(
+            `Reassigned ${reassignedCount} content ownership rows from ${fromUserUuid} to ${newOwnerUserUuid}`,
+            { organizationUuid, actorUuid: user.userUuid },
+        );
+
+        return { reassignedCount };
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -26,6 +26,7 @@ import { ChangesetService } from './ChangesetService';
 import { CiService } from './CiService/CiService';
 import { CoderService } from './CoderService/CoderService';
 import { CommentService } from './CommentService/CommentService';
+import { ContentOwnershipService } from './ContentOwnershipService';
 import { ContentService } from './ContentService/ContentService';
 import { ContentVerificationService } from './ContentVerificationService';
 import { CsvService } from './CsvService/CsvService';
@@ -133,6 +134,7 @@ interface ServiceManifest {
     promoteService: PromoteService;
     savedSqlService: SavedSqlService;
     contentService: ContentService;
+    contentOwnershipService: ContentOwnershipService;
     contentVerificationService: ContentVerificationService;
     coderService: CoderService;
     featureFlagService: FeatureFlagService;
@@ -1278,6 +1280,18 @@ export class ServiceRepository
                     appGenerateService: this.providers.appGenerateService
                         ? this.getAppGenerateService<AppGenerateService>()
                         : undefined,
+                }),
+        );
+    }
+
+    public getContentOwnershipService(): ContentOwnershipService {
+        return this.getService(
+            'contentOwnershipService',
+            () =>
+                new ContentOwnershipService({
+                    contentOwnershipModel:
+                        this.models.getContentOwnershipModel(),
+                    userModel: this.models.getUserModel(),
                 }),
         );
     }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -117,6 +117,10 @@ import {
     type ApiContentResponse,
 } from './content';
 import {
+    type ApiReassignUserContentOwnershipResponse,
+    type ApiUserContentOwnershipSummaryResponse,
+} from './contentOwnership';
+import {
     type ApiContentVerificationDeleteResponse,
     type ApiContentVerificationResponse,
     type ApiVerifiedContentListResponse,
@@ -1101,6 +1105,8 @@ type ApiResults =
     | ApiGetAsyncQueryResults
     | ApiSchedulersResponse['results']
     | ApiUserSchedulersSummaryResponse['results']
+    | ApiUserContentOwnershipSummaryResponse['results']
+    | ApiReassignUserContentOwnershipResponse['results']
     | ApiReassignUserSchedulersResponse['results']
     | ApiUserActivityDownloadCsv['results']
     | ApiRenameFieldsResponse['results']

--- a/packages/common/src/types/contentOwnership.ts
+++ b/packages/common/src/types/contentOwnership.ts
@@ -34,3 +34,26 @@ export type ApiContentOwnershipResponse = {
     status: 'ok';
     results: ContentOwnershipInfo | null;
 };
+
+export type UserContentOwnershipSummary = {
+    totalCount: number;
+    byProject: Array<{
+        projectUuid: string;
+        projectName: string;
+        count: number;
+    }>;
+};
+
+export type ReassignUserContentOwnershipRequest = {
+    newOwnerUserUuid: string;
+};
+
+export type ApiUserContentOwnershipSummaryResponse = {
+    status: 'ok';
+    results: UserContentOwnershipSummary;
+};
+
+export type ApiReassignUserContentOwnershipResponse = {
+    status: 'ok';
+    results: { reassignedCount: number };
+};

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
@@ -30,7 +30,9 @@ import useHealth from '../../../hooks/health/useHealth';
 import type { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import {
     useDeleteOrganizationUserMutation,
+    useReassignUserContentOwnershipMutation,
     useReassignUserSchedulersMutation,
+    useUserContentOwnershipSummary,
     useUserSchedulersSummary,
 } from '../../../hooks/useOrganizationUsers';
 import {
@@ -77,6 +79,11 @@ enum SchedulerAction {
     REASSIGN = 'reassign',
 }
 
+enum OwnershipAction {
+    UNASSIGN = 'unassign',
+    REASSIGN = 'reassign',
+}
+
 const UsersActionMenu: FC<UsersActionMenuProps> = ({
     user,
     disabled,
@@ -87,6 +94,8 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
     const [schedulerAction, setSchedulerAction] =
         React.useState<SchedulerAction>(SchedulerAction.REASSIGN);
+    const [ownershipAction, setOwnershipAction] =
+        React.useState<OwnershipAction>(OwnershipAction.REASSIGN);
     const [selectedNewOwner, setSelectedNewOwner] = React.useState<
         string | null
     >(null);
@@ -111,25 +120,53 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
         useReassignUserSchedulersMutation();
     const { data: schedulersSummary, isLoading: isLoadingSchedulers } =
         useUserSchedulersSummary(user.userUuid, isDeleteDialogOpen);
+    const {
+        mutateAsync: reassignContentOwnership,
+        isLoading: isReassigningOwnership,
+    } = useReassignUserContentOwnershipMutation();
+    const { data: ownershipSummary } = useUserContentOwnershipSummary(
+        user.userUuid,
+        isDeleteDialogOpen,
+    );
     const { track } = useTracking();
     const health = useHealth();
 
     const hasSchedulers = schedulersSummary && schedulersSummary.totalCount > 0;
-    const isProcessing = isDeleting || isReassigning;
+    const hasOwnedContent = ownershipSummary && ownershipSummary.totalCount > 0;
+    const isProcessing = isDeleting || isReassigning || isReassigningOwnership;
 
     // Reset state when modal opens/closes
     useEffect(() => {
         if (isDeleteDialogOpen) {
             setSchedulerAction(SchedulerAction.REASSIGN);
+            setOwnershipAction(OwnershipAction.REASSIGN);
             setSelectedNewOwner(null);
             setIsProjectBreakdownOpen(false);
         }
     }, [isDeleteDialogOpen]);
 
     const handleDelete = useCallback(async () => {
-        if (hasSchedulers && schedulerAction === SchedulerAction.REASSIGN) {
-            if (!selectedNewOwner) return;
+        const needsNewOwner =
+            (hasSchedulers && schedulerAction === SchedulerAction.REASSIGN) ||
+            (hasOwnedContent && ownershipAction === OwnershipAction.REASSIGN);
+        if (needsNewOwner && !selectedNewOwner) return;
+
+        if (
+            hasSchedulers &&
+            schedulerAction === SchedulerAction.REASSIGN &&
+            selectedNewOwner
+        ) {
             await reassignSchedulers({
+                userUuid: user.userUuid,
+                newOwnerUserUuid: selectedNewOwner,
+            });
+        }
+        if (
+            hasOwnedContent &&
+            ownershipAction === OwnershipAction.REASSIGN &&
+            selectedNewOwner
+        ) {
+            await reassignContentOwnership({
                 userUuid: user.userUuid,
                 newOwnerUserUuid: selectedNewOwner,
             });
@@ -139,8 +176,11 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
     }, [
         hasSchedulers,
         schedulerAction,
+        hasOwnedContent,
+        ownershipAction,
         selectedNewOwner,
         reassignSchedulers,
+        reassignContentOwnership,
         deleteUser,
         user.userUuid,
     ]);
@@ -161,10 +201,16 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
 
     const showResendInvite = canInvite && user.isPending;
 
-    const canConfirmDelete =
-        !hasSchedulers ||
-        schedulerAction === SchedulerAction.DELETE ||
-        (schedulerAction === SchedulerAction.REASSIGN && selectedNewOwner);
+    const needsNewOwnerSelection =
+        (hasSchedulers && schedulerAction === SchedulerAction.REASSIGN) ||
+        (hasOwnedContent && ownershipAction === OwnershipAction.REASSIGN);
+
+    const canConfirmDelete = !needsNewOwnerSelection || !!selectedNewOwner;
+
+    const ownedContentText =
+        ownershipSummary?.totalCount === 1
+            ? '1 dashboard'
+            : `${ownershipSummary?.totalCount} dashboards`;
 
     const schedulerText =
         schedulersSummary?.totalCount === 1
@@ -182,6 +228,15 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
         )
             return;
         setSchedulerAction(value);
+    }, []);
+
+    const handleOwnershipActionChange = useCallback((value: string) => {
+        if (
+            value !== OwnershipAction.UNASSIGN &&
+            value !== OwnershipAction.REASSIGN
+        )
+            return;
+        setOwnershipAction(value);
     }, []);
 
     return (
@@ -353,35 +408,6 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                                     />
                                 </Stack>
                             </Radio.Group>
-
-                            {schedulerAction === SchedulerAction.REASSIGN && (
-                                <Stack gap="xs">
-                                    <UserSelect
-                                        label="New owner"
-                                        value={selectedNewOwner}
-                                        onChange={setSelectedNewOwner}
-                                        excludedUserUuid={user.userUuid}
-                                        requireGoogleToken={
-                                            schedulersSummary?.hasGsheetsSchedulers
-                                        }
-                                    />
-                                    {schedulersSummary?.hasGsheetsSchedulers && (
-                                        <Group gap="xs" wrap="nowrap">
-                                            <MantineIcon
-                                                icon={IconInfoCircle}
-                                                color="ldGray.6"
-                                                size="lg"
-                                            />
-                                            <Text fz="xs" c="dimmed">
-                                                You can only transfer ownership
-                                                of a Google Sheets sync to a
-                                                user with an active Google
-                                                connection.
-                                            </Text>
-                                        </Group>
-                                    )}
-                                </Stack>
-                            )}
                         </>
                     ) : (
                         <Group gap="xs">
@@ -393,6 +419,71 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                                 This user has no scheduled deliveries.
                             </Text>
                         </Group>
+                    )}
+
+                    {hasOwnedContent && (
+                        <>
+                            <Alert
+                                color="orange"
+                                icon={<MantineIcon icon={IconAlertCircle} />}
+                            >
+                                <Text fz="sm">
+                                    This user is the assigned owner of{' '}
+                                    {ownedContentText}.
+                                </Text>
+                            </Alert>
+
+                            <Radio.Group
+                                key={ownershipAction}
+                                name="ownershipAction"
+                                value={ownershipAction}
+                                onChange={handleOwnershipActionChange}
+                            >
+                                <Stack gap="sm">
+                                    <Radio
+                                        value={OwnershipAction.UNASSIGN}
+                                        label="Leave content without an owner"
+                                    />
+                                    <Radio
+                                        value={OwnershipAction.REASSIGN}
+                                        label="Transfer ownership to another user"
+                                    />
+                                </Stack>
+                            </Radio.Group>
+                        </>
+                    )}
+
+                    {needsNewOwnerSelection && (
+                        <Stack gap="xs">
+                            <UserSelect
+                                label="New owner"
+                                value={selectedNewOwner}
+                                onChange={setSelectedNewOwner}
+                                excludedUserUuid={user.userUuid}
+                                requireGoogleToken={
+                                    hasSchedulers &&
+                                    schedulerAction ===
+                                        SchedulerAction.REASSIGN &&
+                                    schedulersSummary?.hasGsheetsSchedulers
+                                }
+                            />
+                            {hasSchedulers &&
+                                schedulerAction === SchedulerAction.REASSIGN &&
+                                schedulersSummary?.hasGsheetsSchedulers && (
+                                    <Group gap="xs" wrap="nowrap">
+                                        <MantineIcon
+                                            icon={IconInfoCircle}
+                                            color="ldGray.6"
+                                            size="lg"
+                                        />
+                                        <Text fz="xs" c="dimmed">
+                                            You can only transfer ownership of a
+                                            Google Sheets sync to a user with an
+                                            active Google connection.
+                                        </Text>
+                                    </Group>
+                                )}
+                        </Stack>
                     )}
                 </Stack>
             </MantineModal>

--- a/packages/frontend/src/components/common/PageHeader/DashboardInfoOverlay.tsx
+++ b/packages/frontend/src/components/common/PageHeader/DashboardInfoOverlay.tsx
@@ -16,6 +16,8 @@ import {
     IconEye,
     IconFolder,
     IconHash,
+    IconUser,
+    IconUsersGroup,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
@@ -56,6 +58,22 @@ const DashboardInfoOverlay: FC<DashboardInfoOverlayProps> = ({
                 <InfoRow icon={IconEye} label="Views">
                     {(dashboard.views ?? 0).toLocaleString()}
                 </InfoRow>
+
+                {dashboard.ownership && (
+                    <InfoRow
+                        icon={
+                            dashboard.ownership.owner.type === 'group'
+                                ? IconUsersGroup
+                                : IconUser
+                        }
+                        label="Owner"
+                    >
+                        {dashboard.ownership.owner.type === 'user'
+                            ? `${dashboard.ownership.owner.firstName} ${dashboard.ownership.owner.lastName}`.trim() ||
+                              dashboard.ownership.owner.email
+                            : dashboard.ownership.owner.name}
+                    </InfoRow>
+                )}
 
                 {dashboard.spaceName && (
                     <InfoRow icon={IconFolder} label="Space">

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -2,6 +2,8 @@ import {
     type ApiError,
     type ApiOrganizationMemberProfiles,
     type ApiReassignUserSchedulersResponse,
+    type ApiReassignUserContentOwnershipResponse,
+    type ApiUserContentOwnershipSummaryResponse,
     type ApiUserSchedulersSummaryResponse,
     type KnexPaginateArgs,
 } from '@lightdash/common';
@@ -222,6 +224,66 @@ const reassignUserSchedulersQuery = async ({
         method: 'PATCH',
         body: JSON.stringify({ newOwnerUserUuid }),
     });
+
+const getUserContentOwnershipSummaryQuery = async (userUuid: string) =>
+    lightdashApi<ApiUserContentOwnershipSummaryResponse['results']>({
+        url: `/org/user/${userUuid}/content-ownership-summary`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useUserContentOwnershipSummary = (
+    userUuid: string,
+    enabled: boolean = true,
+) => {
+    const setErrorResponse = useQueryError();
+    return useQuery<
+        ApiUserContentOwnershipSummaryResponse['results'],
+        ApiError
+    >({
+        queryKey: ['user_content_ownership_summary', userUuid],
+        queryFn: () => getUserContentOwnershipSummaryQuery(userUuid),
+        onError: (result) => setErrorResponse(result),
+        enabled,
+    });
+};
+
+const reassignUserContentOwnershipQuery = async ({
+    userUuid,
+    newOwnerUserUuid,
+}: {
+    userUuid: string;
+    newOwnerUserUuid: string;
+}) =>
+    lightdashApi<ApiReassignUserContentOwnershipResponse['results']>({
+        url: `/org/user/${userUuid}/reassign-content-ownership`,
+        method: 'PATCH',
+        body: JSON.stringify({ newOwnerUserUuid }),
+    });
+
+export const useReassignUserContentOwnershipMutation = () => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<
+        ApiReassignUserContentOwnershipResponse['results'],
+        ApiError,
+        { userUuid: string; newOwnerUserUuid: string }
+    >(reassignUserContentOwnershipQuery, {
+        mutationKey: ['reassign_user_content_ownership'],
+        onSuccess: async (data) => {
+            showToastSuccess({
+                title: `Success! ${data.reassignedCount} ${
+                    data.reassignedCount === 1 ? 'dashboard' : 'dashboards'
+                } reassigned.`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: `Failed to reassign content ownership`,
+                apiError: error,
+            });
+        },
+    });
+};
 
 export const useReassignUserSchedulersMutation = () => {
     const { showToastSuccess, showToastApiError } = useToaster();


### PR DESCRIPTION
Part of [PROD-2585](https://linear.app/lightdash/issue/PROD-2585/i-want-to-be-able-to-assign-and-manage-dashboard-owners) — stacked on #25124

## Summary

Second slice of dashboard ownership: make the owner **visible** and **transferable when someone leaves**.

- **Owner in the dashboard info popover:** the header's info popup now shows an Owner row (user or group icon accordingly).
- **Leaver flow:** the delete-user modal now also surfaces *"This user is the assigned owner of N dashboards"* with a choice — leave the content unowned, or transfer everything to another user — mirroring the existing scheduled-deliveries reassignment, sharing the same "New owner" picker.
- **New endpoints** on `/org` (mirroring the scheduler pair):
  - `GET /user/{userUuid}/content-ownership-summary` — owned-content counts by project
  - `PATCH /user/{userUuid}/reassign-content-ownership` — bulk transfer to a new user
- **New `ContentOwnershipService`:** validates both users are org members and requires the caller to `manage` `Dashboard` in every project containing owned content (same per-project pattern as scheduler reassignment).

## Who is affected

- If nobody uses ownership, nothing changes (summary is 0, no new UI appears in the delete modal).
- Choosing "leave content without an owner" relies on the existing FK CASCADE — deleting the user removes the ownership rows.
- Group-owned content is untouched by user deletion.

## Testing

- `pnpm -F backend test:dev:nowatch` — 229 files / 3365 tests pass; typechecks clean; `generate-api` regenerated
- **Live-verified**: assigned an owner, called the summary endpoint (correct per-project counts), reassigned to another user (`reassignedCount: 1`, DB row updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1pqqmPUWMVUJPrnZYpdNV