### PR TITLE
feat(sandbox): provider-config factory + git simplification [1/3]

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -53,15 +53,14 @@ import type {
 } from '../../models/AiWritebackThreadModel';
 import type { SandboxRegistryModel } from '../../models/SandboxRegistryModel';
 import {
-    createSandboxManager,
-    S3SnapshotStore,
+    resolveSandboxRuntime,
     SandboxCommandError,
     SandboxExpiredError,
     SandboxManager,
     SandboxTimeoutError,
-    type AzureSandboxesConfig,
     type PersistentWorkspace,
     type SandboxHandle,
+    type SandboxRuntime,
     type SandboxSpec,
 } from '../SandboxRuntime';
 import {
@@ -122,7 +121,6 @@ import {
     progressTextForStage,
     resolvePrMetadataValue,
     resolveSandboxDbtVersion,
-    resolveSandboxTemplateRef,
     splitStreamBuffer,
     summarizeToolInput,
 } from './utils';
@@ -292,8 +290,8 @@ export class AiWritebackService extends BaseService {
 
     private readonly projectService: ProjectService;
 
-    /** Memoized sandbox provider (e2b | docker), selected by SANDBOX_PROVIDER. */
-    private sandboxManager: SandboxManager | undefined;
+    /** Memoized sandbox runtime (manager + template ref), selected by SANDBOX_PROVIDER. */
+    private sandboxRuntime: SandboxRuntime | undefined;
 
     constructor({
         lightdashConfig,
@@ -954,116 +952,34 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * The sandbox manager over the provider selected by `SANDBOX_PROVIDER`
-     * (e2b | docker). Memoized — the feature talks only to the manager for
-     * lifecycle and to the returned {@link SandboxHandle} for the data plane.
-     * See docs/sandbox-runtime.md.
+     * The sandbox runtime (manager + image/template ref) over the provider
+     * selected by `SANDBOX_PROVIDER`. Memoized — the feature talks only to the
+     * manager for lifecycle and to the returned {@link SandboxHandle} for the
+     * data plane. See docs/sandbox-runtime.md.
      */
-    private getSandboxManager(): SandboxManager {
-        if (!this.sandboxManager) {
-            const { sandboxProvider } = this.lightdashConfig.appRuntime;
-            this.sandboxManager = createSandboxManager({
-                provider: sandboxProvider,
-                e2bApiKey: this.lightdashConfig.appRuntime.e2bApiKey,
-                dockerImage:
-                    this.lightdashConfig.appRuntime
-                        .sandboxAiWritebackDockerImage,
-                lambdaMicroVm: this.lightdashConfig.appRuntime.lambdaMicroVm,
-                azureSandboxes:
-                    sandboxProvider === 'azure-sandboxes'
-                        ? this.getAzureSandboxesConfig()
-                        : null,
-                // Object-store snapshots are only for the Docker backend (no
-                // native pause); native-pause providers (E2B, Lambda, Azure
-                // Sandboxes) never touch S3, so don't construct a client.
-                snapshotStore:
-                    sandboxProvider === 'docker'
-                        ? new S3SnapshotStore({
-                              lightdashConfig: this.lightdashConfig,
-                          })
-                        : null,
+    private getSandboxRuntime(): SandboxRuntime {
+        if (!this.sandboxRuntime) {
+            this.sandboxRuntime = resolveSandboxRuntime({
+                lightdashConfig: this.lightdashConfig,
+                feature: 'ai-writeback',
                 registryModel: this.sandboxRegistryModel,
                 logger: this.logger,
             });
         }
-        return this.sandboxManager;
+        return this.sandboxRuntime;
+    }
+
+    private getSandboxManager(): SandboxManager {
+        return this.getSandboxRuntime().manager;
     }
 
     private buildSandboxSpec(): SandboxSpec {
         return {
-            templateRef: this.getSandboxTemplateRef(),
+            templateRef: this.getSandboxRuntime().templateRef,
             timeoutMs: SANDBOX_TIMEOUT_MS,
             egress: {
                 allow: ['api.anthropic.com', 'github.com', 'gitlab.com'],
             },
-        };
-    }
-
-    /**
-     * Resolve the template/image ref the active provider launches from. E2B
-     * composes the writeback `name:tag`; Docker uses the writeback-specific
-     * local image (separate from the data-app image — different toolchain).
-     */
-    private getSandboxTemplateRef(): string {
-        const { sandboxProvider } = this.lightdashConfig.appRuntime;
-        if (sandboxProvider === 'docker') {
-            return this.lightdashConfig.appRuntime
-                .sandboxAiWritebackDockerImage;
-        }
-        if (sandboxProvider === 'lambda-microvm') {
-            const imageArn =
-                this.lightdashConfig.appRuntime
-                    .lambdaMicroVmAiWritebackImageArn;
-            if (!imageArn) {
-                throw new MissingConfigError(
-                    'Lambda MicroVM AI writeback image ARN is not configured (LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN)',
-                );
-            }
-            return imageArn;
-        }
-        if (sandboxProvider === 'azure-sandboxes') {
-            const diskImage =
-                this.lightdashConfig.appRuntime
-                    .azureSandboxesAiWritebackDiskImage;
-            if (!diskImage) {
-                throw new MissingConfigError(
-                    'Azure AI writeback sandbox disk image is not configured (AZURE_SANDBOXES_AI_WRITEBACK_DISK_IMAGE)',
-                );
-            }
-            return diskImage;
-        }
-        return resolveSandboxTemplateRef({
-            name: this.lightdashConfig.appRuntime.e2bAiWritebackTemplateName,
-            tag: this.lightdashConfig.appRuntime.e2bAiWritebackTemplateTag,
-        });
-    }
-
-    /** Assemble the `azure-sandboxes` provider config for the AI writeback
-     * pipeline (the writeback sandbox group + shared subscription/region settings). */
-    private getAzureSandboxesConfig(): AzureSandboxesConfig {
-        const {
-            azureSandboxes,
-            azureSandboxesAiWritebackGroup,
-            sandboxIdleTimeoutMs,
-        } = this.lightdashConfig.appRuntime;
-        if (
-            !azureSandboxes.subscriptionId ||
-            !azureSandboxes.resourceGroup ||
-            !azureSandboxesAiWritebackGroup
-        ) {
-            throw new MissingConfigError(
-                'Azure Sandboxes is not configured (AZURE_SANDBOXES_SUBSCRIPTION_ID / AZURE_SANDBOXES_RESOURCE_GROUP / AZURE_SANDBOXES_AI_WRITEBACK_GROUP)',
-            );
-        }
-        return {
-            subscriptionId: azureSandboxes.subscriptionId,
-            resourceGroup: azureSandboxes.resourceGroup,
-            region: azureSandboxes.region,
-            sandboxGroup: azureSandboxesAiWritebackGroup,
-            apiVersion: azureSandboxes.apiVersion,
-            tokenScope: azureSandboxes.tokenScope,
-            resourceTier: azureSandboxes.resourceTier,
-            autoSuspendIdleSeconds: Math.floor(sandboxIdleTimeoutMs / 1000),
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -106,13 +106,12 @@ import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient'
 import { getModel } from '../ai/models';
 import { getAiCallTelemetry } from '../ai/utils/aiCallTelemetry';
 import {
-    createSandboxManager,
-    S3SnapshotStore,
+    resolveSandboxRuntime,
     SandboxCommandError,
     SandboxManager,
-    type AzureSandboxesConfig,
     type PersistentWorkspace,
     type SandboxHandle,
+    type SandboxRuntime,
     type SandboxSpec,
 } from '../SandboxRuntime';
 import { assertCanViewApp as assertUserCanViewApp } from './appAuthz';
@@ -276,7 +275,7 @@ export class AppGenerateService extends BaseService {
     private readonly sandboxRegistryModel: SandboxRegistryModel;
 
     // Lazily built from config on first use; memoized for the service lifetime.
-    private sandboxManager: SandboxManager | undefined;
+    private sandboxRuntime: SandboxRuntime | undefined;
 
     constructor({
         lightdashConfig,
@@ -456,109 +455,31 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
-     * The sandbox manager over the provider selected by `SANDBOX_PROVIDER`
-     * (e2b | docker). Memoized — the feature talks only to the manager for
-     * lifecycle (acquire/resume/suspend/destroy via the stable `sandbox_uuid`)
-     * and to the returned {@link SandboxHandle} for the data plane.
-     * See docs/sandbox-runtime.md.
+     * The sandbox runtime (manager + image/template ref) over the provider
+     * selected by `SANDBOX_PROVIDER`. Memoized — the feature talks only to the
+     * manager for lifecycle (acquire/resume/suspend/destroy via the stable
+     * `sandbox_uuid`) and to the returned {@link SandboxHandle} for the data
+     * plane. See docs/sandbox-runtime.md.
      */
-    private getSandboxManager(): SandboxManager {
-        if (!this.sandboxManager) {
-            const { sandboxProvider } = this.lightdashConfig.appRuntime;
-            this.sandboxManager = createSandboxManager({
-                provider: sandboxProvider,
-                e2bApiKey: this.lightdashConfig.appRuntime.e2bApiKey,
-                dockerImage: this.lightdashConfig.appRuntime.sandboxDockerImage,
-                lambdaMicroVm: this.lightdashConfig.appRuntime.lambdaMicroVm,
-                azureSandboxes:
-                    sandboxProvider === 'azure-sandboxes'
-                        ? this.getAzureSandboxesConfig()
-                        : null,
-                // Object-store snapshots are only for the Docker backend (no
-                // native pause); native-pause providers (E2B, Lambda, Azure
-                // Sandboxes) never touch S3, so don't construct a client.
-                snapshotStore:
-                    sandboxProvider === 'docker'
-                        ? new S3SnapshotStore({
-                              lightdashConfig: this.lightdashConfig,
-                          })
-                        : null,
+    private getSandboxRuntime(): SandboxRuntime {
+        if (!this.sandboxRuntime) {
+            this.sandboxRuntime = resolveSandboxRuntime({
+                lightdashConfig: this.lightdashConfig,
+                feature: 'data-app',
                 registryModel: this.sandboxRegistryModel,
                 logger: this.logger,
             });
         }
-        return this.sandboxManager;
+        return this.sandboxRuntime;
     }
 
-    /**
-     * Resolve the template/image ref the active provider launches from. E2B
-     * composes `name:tag`; Docker uses the local image name.
-     */
-    private getSandboxTemplateRef(): string {
-        const { sandboxProvider, e2bTemplateName, e2bTemplateTag } =
-            this.lightdashConfig.appRuntime;
-        if (sandboxProvider === 'docker') {
-            return this.lightdashConfig.appRuntime.sandboxDockerImage;
-        }
-        if (sandboxProvider === 'lambda-microvm') {
-            const imageArn =
-                this.lightdashConfig.appRuntime.lambdaMicroVmDataAppImageArn;
-            if (!imageArn) {
-                throw new MissingConfigError(
-                    'Lambda MicroVM data-app image ARN is not configured (LAMBDA_MICROVM_DATA_APP_IMAGE_ARN)',
-                );
-            }
-            return imageArn;
-        }
-        if (sandboxProvider === 'azure-sandboxes') {
-            const diskImage =
-                this.lightdashConfig.appRuntime.azureSandboxesDataAppDiskImage;
-            if (!diskImage) {
-                throw new MissingConfigError(
-                    'Azure data-app sandbox disk image is not configured (AZURE_SANDBOXES_DATA_APP_DISK_IMAGE)',
-                );
-            }
-            return diskImage;
-        }
-        // E2B treats `name` and `name:default` interchangeably, so an empty
-        // tag is fine — it just resolves to the implicit `default` build.
-        return e2bTemplateTag
-            ? `${e2bTemplateName}:${e2bTemplateTag}`
-            : e2bTemplateName;
-    }
-
-    /** Assemble the `azure-sandboxes` provider config for the data-app pipeline
-     * (the data-app sandbox group + shared subscription/region settings). */
-    private getAzureSandboxesConfig(): AzureSandboxesConfig {
-        const {
-            azureSandboxes,
-            azureSandboxesDataAppGroup,
-            sandboxIdleTimeoutMs,
-        } = this.lightdashConfig.appRuntime;
-        if (
-            !azureSandboxes.subscriptionId ||
-            !azureSandboxes.resourceGroup ||
-            !azureSandboxesDataAppGroup
-        ) {
-            throw new MissingConfigError(
-                'Azure Sandboxes is not configured (AZURE_SANDBOXES_SUBSCRIPTION_ID / AZURE_SANDBOXES_RESOURCE_GROUP / AZURE_SANDBOXES_DATA_APP_GROUP)',
-            );
-        }
-        return {
-            subscriptionId: azureSandboxes.subscriptionId,
-            resourceGroup: azureSandboxes.resourceGroup,
-            region: azureSandboxes.region,
-            sandboxGroup: azureSandboxesDataAppGroup,
-            apiVersion: azureSandboxes.apiVersion,
-            tokenScope: azureSandboxes.tokenScope,
-            resourceTier: azureSandboxes.resourceTier,
-            autoSuspendIdleSeconds: Math.floor(sandboxIdleTimeoutMs / 1000),
-        };
+    private getSandboxManager(): SandboxManager {
+        return this.getSandboxRuntime().manager;
     }
 
     private buildSandboxSpec(): SandboxSpec {
         return {
-            templateRef: this.getSandboxTemplateRef(),
+            templateRef: this.getSandboxRuntime().templateRef,
             timeoutMs: 60 * 60 * 1000,
             egress: {
                 allow: claudeCodeAllowedHosts(this.lightdashConfig.ai.copilot),

--- a/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
@@ -1,12 +1,8 @@
 import { ALL_TRAFFIC, CommandExitError, Sandbox, TimeoutError } from 'e2b';
 import { SandboxCommandError, SandboxTimeoutError } from './errors';
+import { createGitOverCommands } from './gitOverCommands';
 import {
     type CommandResult,
-    type GitAddTarget,
-    type GitCloneOptions,
-    type GitCommitOptions,
-    type GitPushOptions,
-    type GitStatus,
     type PersistOptions,
     type RunOptions,
     type SandboxCapabilities,
@@ -97,61 +93,11 @@ class E2bSandboxHandle implements SandboxHandle {
         },
     };
 
-    // Near 1:1 passthrough to the E2B git helper. Errors surface as the SDK's
-    // own git errors (auth/upstream) — those are control-plane failures the
-    // feature already handles, not the command/timeout pair the shim normalizes.
-    readonly git: SandboxGit = {
-        clone: async (url: string, options: GitCloneOptions): Promise<void> => {
-            await this.sandbox.git.clone(url, {
-                path: options.path,
-                username: options.username,
-                password: options.password,
-                ...(options.depth !== undefined
-                    ? { depth: options.depth }
-                    : {}),
-                ...(options.timeoutMs !== undefined
-                    ? { timeoutMs: options.timeoutMs }
-                    : {}),
-                ...(options.branch !== undefined
-                    ? { branch: options.branch }
-                    : {}),
-            });
-        },
-        status: async (path: string): Promise<GitStatus> => {
-            const status = await this.sandbox.git.status(path);
-            return {
-                currentBranch: status.currentBranch ?? null,
-                hasChanges: status.hasChanges,
-            };
-        },
-        createBranch: async (path: string, branch: string): Promise<void> => {
-            await this.sandbox.git.createBranch(path, branch);
-        },
-        add: async (path: string, target: GitAddTarget): Promise<void> => {
-            await this.sandbox.git.add(path, target);
-        },
-        commit: async (
-            path: string,
-            message: string,
-            options: GitCommitOptions,
-        ): Promise<void> => {
-            await this.sandbox.git.commit(path, message, {
-                authorName: options.authorName,
-                authorEmail: options.authorEmail,
-            });
-        },
-        push: async (path: string, options: GitPushOptions): Promise<void> => {
-            await this.sandbox.git.push(path, {
-                remote: options.remote,
-                branch: options.branch,
-                username: options.username,
-                password: options.password,
-                ...(options.setUpstream !== undefined
-                    ? { setUpstream: options.setUpstream }
-                    : {}),
-            });
-        },
-    };
+    // Build git on top of the (error-normalizing) `commands`/`files` data plane
+    // via the shared helper, so a git failure surfaces as `SandboxCommandError`
+    // like every other command — rather than leaking the E2B SDK's own git
+    // error types the way the previous passthrough did.
+    readonly git: SandboxGit = createGitOverCommands(this.commands, this.files);
 }
 
 /**

--- a/packages/backend/src/ee/services/SandboxRuntime/gitOverCommands.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/gitOverCommands.ts
@@ -15,23 +15,36 @@ export const shQuote = (value: string): string =>
     `'${value.replace(/'/g, `'\\''`)}'`;
 
 /**
- * Build a `git -c http.extraHeader=...` prefix carrying HTTPS basic-auth
- * credentials. Passed per-invocation (never written to the repo's `.git/config`),
- * so the cloned remote URL stays clean.
- * The same pattern GitHub Actions uses for token-authenticated checkouts.
+ * Build the per-invocation env that carries HTTPS basic-auth credentials to git
+ * as an `http.extraHeader` config entry, injected via `GIT_CONFIG_COUNT`/`_KEY`/
+ * `_VALUE` (git 2.31+) rather than `-c` on the command line. This keeps the
+ * short-lived token out of argv — where it would otherwise be world-readable via
+ * `/proc/<pid>/cmdline` to any process in the sandbox for the life of the git
+ * command — and off disk (never written to the repo's `.git/config`). The env is
+ * scoped to the single clone/push exec the host drives, so the untrusted in-
+ * sandbox agent's own processes never inherit it. A fresh token is passed on
+ * each invocation; nothing here caches or reuses it across turns.
  */
-const gitAuthPrefix = (username: string, password: string): string => {
+const gitAuthEnv = (
+    username: string,
+    password: string,
+): Record<string, string> => {
     const token = Buffer.from(`${username}:${password}`).toString('base64');
-    return `git -c ${shQuote(`http.extraHeader=AUTHORIZATION: basic ${token}`)}`;
+    return {
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'http.extraHeader',
+        GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${token}`,
+    };
 };
 
 /**
  * Implement {@link SandboxGit} on top of a sandbox's `commands`/`files` data
- * plane, using the system `git` binary inside the sandbox. Providers without a
- * native git SDK (Docker, Lambda MicroVMs) share this — `commands.run` throws
- * `SandboxCommandError` on a non-zero exit, so each operation fails loudly.
- * Credentials are supplied per-invocation via an
- * auth header and never persisted to the repo (see {@link gitAuthPrefix}).
+ * plane, using the system `git` binary inside the sandbox. Every provider shares
+ * this — including E2B, which routes through it rather than its vendor git SDK so
+ * failures surface as `SandboxCommandError` (thrown by `commands.run` on a non-
+ * zero exit) instead of leaking a vendor error type. Credentials are supplied
+ * per-invocation via the process env and never persisted to the repo or placed
+ * on argv (see {@link gitAuthEnv}).
  */
 export const createGitOverCommands = (
     commands: SandboxCommands,
@@ -47,10 +60,13 @@ export const createGitOverCommands = (
             .filter(Boolean)
             .join(' ');
         await commands.run(
-            `${gitAuthPrefix(options.username, options.password)} clone ${flags} ${shQuote(url)} ${shQuote(options.path)}`,
-            options.timeoutMs !== undefined
-                ? { timeoutMs: options.timeoutMs }
-                : undefined,
+            `git clone ${flags} ${shQuote(url)} ${shQuote(options.path)}`,
+            {
+                envs: gitAuthEnv(options.username, options.password),
+                ...(options.timeoutMs !== undefined
+                    ? { timeoutMs: options.timeoutMs }
+                    : {}),
+            },
         );
     },
     status: async (path: string): Promise<GitStatus> => {
@@ -104,8 +120,9 @@ export const createGitOverCommands = (
     push: async (path: string, options: GitPushOptions): Promise<void> => {
         const upstream = options.setUpstream ? '-u ' : '';
         await commands.run(
-            `${gitAuthPrefix(options.username, options.password)} -C ${shQuote(path)} ` +
+            `git -C ${shQuote(path)} ` +
                 `push ${upstream}${shQuote(options.remote)} ${shQuote(options.branch)}`,
+            { envs: gitAuthEnv(options.username, options.password) },
         );
     },
 });

--- a/packages/backend/src/ee/services/SandboxRuntime/index.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/index.ts
@@ -1,6 +1,7 @@
 import { LambdaMicrovms } from '@aws-sdk/client-lambda-microvms';
 import { DefaultAzureCredential } from '@azure/identity';
-import { MissingConfigError } from '@lightdash/common';
+import { assertUnreachable, MissingConfigError } from '@lightdash/common';
+import { type LightdashConfig } from '../../../config/parseConfig';
 import {
     AzureContainerAppsSandboxProvider,
     AzureSandboxGroupControlPlane,
@@ -14,7 +15,7 @@ import {
     type LambdaMicroVmConfig,
 } from './LambdaMicroVmSandboxProvider';
 import { SandboxManager, type SandboxRegistryStore } from './SandboxManager';
-import { type SnapshotStore } from './SnapshotStore';
+import { S3SnapshotStore, type SnapshotStore } from './SnapshotStore';
 import { type SandboxLogger, type SandboxProvider } from './types';
 
 export * from './AzureContainerAppsSandboxProvider';
@@ -34,27 +35,35 @@ export interface LambdaMicroVmProviderConfig extends LambdaMicroVmConfig {
     region: string;
 }
 
-export interface CreateSandboxProviderOptions {
-    provider: SandboxProviderKind;
-    e2bApiKey: string | null;
-    dockerImage: string;
-    /** Required when `provider === 'lambda-microvm'`; ignored otherwise. */
-    lambdaMicroVm: LambdaMicroVmProviderConfig | null;
-    /**
-     * Required when `provider === 'azure-sandboxes'`; ignored otherwise. The
-     * per-feature sandbox group is resolved by the caller (one group + disk image
-     * per feature, like the split Docker images / Lambda ARNs).
-     */
-    azureSandboxes: AzureSandboxesConfig | null;
-    /**
-     * Backing store for object-store snapshots. Required only by the Docker
-     * provider (no native memory snapshot); native-pause providers (E2B, Lambda,
-     * Azure Sandboxes) keep the snapshot in the provider and pass `null` so no S3
-     * client is constructed on those paths.
-     */
-    snapshotStore: SnapshotStore | null;
-    logger: SandboxLogger;
-}
+/**
+ * Provider-construction options, one variant per `SANDBOX_PROVIDER`. Keyed on
+ * `provider` so each backend only carries the config it actually uses: invalid
+ * combinations (a Docker image without a snapshot store, Lambda config on the
+ * E2B path, …) are unrepresentable rather than "ignored otherwise".
+ */
+export type CreateSandboxProviderOptions =
+    | {
+          provider: 'e2b';
+          e2bApiKey: string | null;
+          logger: SandboxLogger;
+      }
+    | {
+          provider: 'docker';
+          dockerImage: string;
+          /** Backing store for object-store snapshots — Docker-only. */
+          snapshotStore: SnapshotStore;
+          logger: SandboxLogger;
+      }
+    | {
+          provider: 'lambda-microvm';
+          lambdaMicroVm: LambdaMicroVmProviderConfig;
+          logger: SandboxLogger;
+      }
+    | {
+          provider: 'azure-sandboxes';
+          azureSandboxes: AzureSandboxesConfig;
+          logger: SandboxLogger;
+      };
 
 /**
  * Build the sandbox provider selected by `SANDBOX_PROVIDER`. Throws a clear
@@ -72,11 +81,6 @@ export const createSandboxProvider = (
             }
             return new E2bSandboxProvider(options.e2bApiKey);
         case 'docker':
-            if (!options.snapshotStore) {
-                throw new MissingConfigError(
-                    'Docker sandbox provider requires an object store for snapshots',
-                );
-            }
             return new DockerSandboxProvider(
                 options.dockerImage,
                 options.logger,
@@ -84,11 +88,6 @@ export const createSandboxProvider = (
             );
         case 'lambda-microvm': {
             const config = options.lambdaMicroVm;
-            if (!config) {
-                throw new MissingConfigError(
-                    'Lambda MicroVMs is not configured (LAMBDA_MICROVM_*)',
-                );
-            }
             if (!config.ingressConnectorArn || !config.egressConnectorArn) {
                 throw new MissingConfigError(
                     'Lambda MicroVMs ingress/egress connector ARNs are not configured',
@@ -105,7 +104,7 @@ export const createSandboxProvider = (
         }
         case 'azure-sandboxes': {
             const config = options.azureSandboxes;
-            if (!config || !config.sandboxGroup) {
+            if (!config.sandboxGroup) {
                 throw new MissingConfigError(
                     'Azure Sandboxes is not configured (AZURE_SANDBOXES_*)',
                 );
@@ -124,45 +123,199 @@ export const createSandboxProvider = (
             );
         }
         default:
-            throw new MissingConfigError(
-                `Unknown SANDBOX_PROVIDER: ${options.provider as string}`,
+            return assertUnreachable(
+                options,
+                `Unknown SANDBOX_PROVIDER: ${
+                    (options as { provider: string }).provider
+                }`,
             );
     }
 };
 
-export interface CreateSandboxManagerOptions {
-    provider: SandboxProviderKind;
-    e2bApiKey: string | null;
-    dockerImage: string;
-    lambdaMicroVm: LambdaMicroVmProviderConfig | null;
-    /** Required when `provider === 'azure-sandboxes'`. */
-    azureSandboxes: AzureSandboxesConfig | null;
-    /** Forwarded to the provider; the Docker backend only (null otherwise). */
-    snapshotStore: SnapshotStore | null;
+/** The two sandboxed features; each launches from its own image/template. */
+export type SandboxFeature = 'data-app' | 'ai-writeback';
+
+/** A configured lifecycle surface plus the image/template it launches from. */
+export interface SandboxRuntime {
+    manager: SandboxManager;
+    templateRef: string;
+}
+
+export interface ResolveSandboxRuntimeOptions {
+    lightdashConfig: LightdashConfig;
+    feature: SandboxFeature;
     registryModel: SandboxRegistryStore;
     logger: SandboxLogger;
 }
 
+/** E2B treats `name` and `name:default` interchangeably, so an empty tag is fine. */
+const composeE2bTemplateRef = (name: string, tag: string): string =>
+    tag ? `${name}:${tag}` : name;
+
+/** Resolve the image/template the active provider launches `feature` from. */
+const resolveTemplateRef = (
+    appRuntime: LightdashConfig['appRuntime'],
+    feature: SandboxFeature,
+): string => {
+    const isDataApp = feature === 'data-app';
+    switch (appRuntime.sandboxProvider) {
+        case 'docker':
+            return isDataApp
+                ? appRuntime.sandboxDockerImage
+                : appRuntime.sandboxAiWritebackDockerImage;
+        case 'lambda-microvm': {
+            const arn = isDataApp
+                ? appRuntime.lambdaMicroVmDataAppImageArn
+                : appRuntime.lambdaMicroVmAiWritebackImageArn;
+            if (!arn) {
+                throw new MissingConfigError(
+                    isDataApp
+                        ? 'Lambda MicroVM data-app image ARN is not configured (LAMBDA_MICROVM_DATA_APP_IMAGE_ARN)'
+                        : 'Lambda MicroVM AI writeback image ARN is not configured (LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN)',
+                );
+            }
+            return arn;
+        }
+        case 'azure-sandboxes': {
+            const diskImage = isDataApp
+                ? appRuntime.azureSandboxesDataAppDiskImage
+                : appRuntime.azureSandboxesAiWritebackDiskImage;
+            if (!diskImage) {
+                throw new MissingConfigError(
+                    isDataApp
+                        ? 'Azure data-app sandbox disk image is not configured (AZURE_SANDBOXES_DATA_APP_DISK_IMAGE)'
+                        : 'Azure AI writeback sandbox disk image is not configured (AZURE_SANDBOXES_AI_WRITEBACK_DISK_IMAGE)',
+                );
+            }
+            return diskImage;
+        }
+        case 'e2b':
+            return isDataApp
+                ? composeE2bTemplateRef(
+                      appRuntime.e2bTemplateName,
+                      appRuntime.e2bTemplateTag,
+                  )
+                : composeE2bTemplateRef(
+                      appRuntime.e2bAiWritebackTemplateName,
+                      appRuntime.e2bAiWritebackTemplateTag,
+                  );
+        default:
+            return assertUnreachable(
+                appRuntime.sandboxProvider,
+                `Unknown SANDBOX_PROVIDER: ${
+                    appRuntime.sandboxProvider as string
+                }`,
+            );
+    }
+};
+
 /**
- * Build a {@link SandboxManager} over the configured provider. The single entry
- * point feature services and the reaper use to get a lifecycle surface.
+ * Assemble the Azure Sandboxes config for `feature`. One sandbox group + disk
+ * image per feature (like the split Docker images / Lambda ARNs), sharing the
+ * subscription/region settings.
  */
-export const createSandboxManager = (
-    options: CreateSandboxManagerOptions,
-): SandboxManager => {
-    const provider = createSandboxProvider({
-        provider: options.provider,
-        e2bApiKey: options.e2bApiKey,
-        dockerImage: options.dockerImage,
-        lambdaMicroVm: options.lambdaMicroVm,
-        azureSandboxes: options.azureSandboxes,
-        snapshotStore: options.snapshotStore,
-        logger: options.logger,
-    });
-    return new SandboxManager({
+const buildAzureSandboxesConfig = (
+    appRuntime: LightdashConfig['appRuntime'],
+    feature: SandboxFeature,
+): AzureSandboxesConfig => {
+    const { azureSandboxes, sandboxIdleTimeoutMs } = appRuntime;
+    const isDataApp = feature === 'data-app';
+    const sandboxGroup = isDataApp
+        ? appRuntime.azureSandboxesDataAppGroup
+        : appRuntime.azureSandboxesAiWritebackGroup;
+    if (
+        !azureSandboxes.subscriptionId ||
+        !azureSandboxes.resourceGroup ||
+        !sandboxGroup
+    ) {
+        throw new MissingConfigError(
+            isDataApp
+                ? 'Azure Sandboxes is not configured (AZURE_SANDBOXES_SUBSCRIPTION_ID / AZURE_SANDBOXES_RESOURCE_GROUP / AZURE_SANDBOXES_DATA_APP_GROUP)'
+                : 'Azure Sandboxes is not configured (AZURE_SANDBOXES_SUBSCRIPTION_ID / AZURE_SANDBOXES_RESOURCE_GROUP / AZURE_SANDBOXES_AI_WRITEBACK_GROUP)',
+        );
+    }
+    return {
+        subscriptionId: azureSandboxes.subscriptionId,
+        resourceGroup: azureSandboxes.resourceGroup,
+        region: azureSandboxes.region,
+        sandboxGroup,
+        apiVersion: azureSandboxes.apiVersion,
+        tokenScope: azureSandboxes.tokenScope,
+        resourceTier: azureSandboxes.resourceTier,
+        autoSuspendIdleSeconds: Math.floor(sandboxIdleTimeoutMs / 1000),
+    };
+};
+
+/** Assemble the per-provider construction options for `feature`. */
+const buildProviderOptions = (
+    lightdashConfig: LightdashConfig,
+    feature: SandboxFeature,
+    logger: SandboxLogger,
+): CreateSandboxProviderOptions => {
+    const { appRuntime } = lightdashConfig;
+    switch (appRuntime.sandboxProvider) {
+        case 'e2b':
+            return {
+                provider: 'e2b',
+                e2bApiKey: appRuntime.e2bApiKey,
+                logger,
+            };
+        case 'docker':
+            return {
+                provider: 'docker',
+                dockerImage:
+                    feature === 'data-app'
+                        ? appRuntime.sandboxDockerImage
+                        : appRuntime.sandboxAiWritebackDockerImage,
+                // Object-store snapshots are Docker-only; native-pause providers
+                // never touch S3, so a client is constructed only on this path.
+                snapshotStore: new S3SnapshotStore({ lightdashConfig }),
+                logger,
+            };
+        case 'lambda-microvm':
+            return {
+                provider: 'lambda-microvm',
+                lambdaMicroVm: appRuntime.lambdaMicroVm,
+                logger,
+            };
+        case 'azure-sandboxes':
+            return {
+                provider: 'azure-sandboxes',
+                azureSandboxes: buildAzureSandboxesConfig(appRuntime, feature),
+                logger,
+            };
+        default:
+            return assertUnreachable(
+                appRuntime.sandboxProvider,
+                `Unknown SANDBOX_PROVIDER: ${
+                    appRuntime.sandboxProvider as string
+                }`,
+            );
+    }
+};
+
+/**
+ * Build the {@link SandboxRuntime} (a {@link SandboxManager} + the feature's
+ * image/template ref) for the provider selected by `SANDBOX_PROVIDER`. The
+ * single entry point feature services use to get a lifecycle surface —
+ * snapshot-store construction is hidden inside, so callers never branch on the
+ * provider or touch S3.
+ */
+export const resolveSandboxRuntime = ({
+    lightdashConfig,
+    feature,
+    registryModel,
+    logger,
+}: ResolveSandboxRuntimeOptions): SandboxRuntime => {
+    const { appRuntime } = lightdashConfig;
+    const provider = createSandboxProvider(
+        buildProviderOptions(lightdashConfig, feature, logger),
+    );
+    const manager = new SandboxManager({
         provider,
-        providerKind: options.provider,
-        registryModel: options.registryModel,
-        logger: options.logger,
+        providerKind: appRuntime.sandboxProvider,
+        registryModel,
+        logger,
     });
+    return { manager, templateRef: resolveTemplateRef(appRuntime, feature) };
 };


### PR DESCRIPTION
Closes: PROD-8641, PROD-8637, PROD-8638, PROD-8635

**Stack 1 of 3** — base of the sandbox-runtime hardening stack. Review order: this → `pr/sandbox-a` → `pr/sandbox-b`.

### Description:

Simplification of the sandbox runtime (`packages/backend/src/ee/services/SandboxRuntime/`), no contract changes.

- **PROD-8641** — `CreateSandboxProviderOptions` becomes a discriminated union on `provider`, so invalid combinations (Docker image without a snapshot store, Lambda config on the E2B path, …) are unrepresentable instead of "ignored otherwise".
- **PROD-8637** — the ~100-line per-feature provider-config block duplicated across `AppGenerateService` and `AiWritebackService` collapses into a single `resolveSandboxRuntime` factory; snapshot-store construction is hidden inside, so feature code never branches on the provider or touches S3. All four backends (E2B / Docker / Lambda MicroVM / Azure) construct through one path.
- **PROD-8638** — E2B git goes through the shared `createGitOverCommands` helper; the passthrough that leaked the vendor SDK's git error types is removed.
- **PROD-8635** — git credential hygiene: the auth token moves off git's argv to per-invocation `GIT_CONFIG_*` env, scoped to the single clone/push and never reused across turns (covers E2B too, via 8638).

Verified green as part of the combined integration (typecheck / lint / `SandboxManager` + `commandOutput` + `AiWritebackService` tests). Draft pending per-slice CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7rE8uFYjbDpFYiJ3TxYWN)_