### PR TITLE
feat(sandbox): harden SandboxManager lifecycle [2/3]

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1043,7 +1043,6 @@ export class AiWritebackService extends BaseService {
             await this.getSandboxManager().suspend({
                 sandboxUuid,
                 handle: sandbox,
-                workspace: WRITEBACK_WORKSPACE,
             });
             const durationMs = AiWritebackService.elapsed(start);
             this.logger.info('AI writeback sandbox suspended', {
@@ -1067,12 +1066,15 @@ export class AiWritebackService extends BaseService {
 
     private async resumeSandbox(
         sandboxUuid: string,
+        organizationUuid: string,
         projectUuid: string,
     ): Promise<{ sandbox: SandboxHandle; durationMs: number }> {
         const start = performance.now();
         const sandbox = await this.getSandboxManager().resume({
             sandboxUuid,
             spec: this.buildSandboxSpec(),
+            expectedOrganizationUuid: organizationUuid,
+            expectedProjectUuid: projectUuid,
         });
         const durationMs = AiWritebackService.elapsed(start);
         this.logger.info('AI writeback sandbox resumed', {
@@ -1488,6 +1490,7 @@ export class AiWritebackService extends BaseService {
                     sandboxUuid,
                     sandbox,
                     pauseOnExit,
+                    turn.organizationUuid,
                     projectUuid,
                 );
             }
@@ -1978,6 +1981,7 @@ export class AiWritebackService extends BaseService {
             try {
                 const { sandbox } = await this.resumeSandbox(
                     existingRow.sandbox_uuid,
+                    organizationUuid,
                     projectUuid,
                 );
                 return { sandbox, sandboxUuid: existingRow.sandbox_uuid };
@@ -1992,6 +1996,8 @@ export class AiWritebackService extends BaseService {
                 if (!(error instanceof SandboxExpiredError)) {
                     await this.getSandboxManager().destroy({
                         sandboxUuid: existingRow.sandbox_uuid,
+                        expectedOrganizationUuid: organizationUuid,
+                        expectedProjectUuid: projectUuid,
                     });
                 }
                 await this.aiWritebackThreadModel.deleteByAiThreadUuid(
@@ -2723,6 +2729,7 @@ export class AiWritebackService extends BaseService {
         sandboxUuid: string,
         sandbox: SandboxHandle,
         shouldPause: boolean,
+        organizationUuid: string,
         projectUuid: string,
     ): Promise<void> {
         if (shouldPause) {
@@ -2735,6 +2742,8 @@ export class AiWritebackService extends BaseService {
             await this.getSandboxManager().destroy({
                 sandboxUuid,
                 handle: sandbox,
+                expectedOrganizationUuid: organizationUuid,
+                expectedProjectUuid: projectUuid,
             });
         } catch (error) {
             this.logger.warn(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1223,7 +1223,6 @@ export class AppGenerateService extends BaseService {
             await this.getSandboxManager().suspend({
                 sandboxUuid,
                 handle: sandbox,
-                workspace: DATA_APP_WORKSPACE,
             });
             const durationMs = AppGenerateService.elapsed(start);
             this.logger.info(
@@ -1239,11 +1238,15 @@ export class AppGenerateService extends BaseService {
     private async resumeSandbox(
         sandboxUuid: string,
         appUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
     ): Promise<{ sandbox: SandboxHandle; durationMs: number }> {
         const start = performance.now();
         const sandbox = await this.getSandboxManager().resume({
             sandboxUuid,
             spec: this.buildSandboxSpec(),
+            expectedOrganizationUuid: organizationUuid,
+            expectedProjectUuid: projectUuid,
         });
         const durationMs = AppGenerateService.elapsed(start);
         this.logger.info(
@@ -1318,6 +1321,8 @@ export class AppGenerateService extends BaseService {
                 const result = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
+                    organizationUuid,
+                    projectUuid,
                 );
                 durations.resumeMs = result.durationMs;
                 return {
@@ -2786,6 +2791,8 @@ export class AppGenerateService extends BaseService {
                 const result = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
+                    app.organization_uuid,
+                    app.project_uuid,
                 );
                 sandbox = result.sandbox;
                 sandboxUuid = app.sandbox_id;
@@ -4285,6 +4292,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 const resumed = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
+                    app.organization_uuid,
+                    app.project_uuid,
                 );
                 sandbox = resumed.sandbox;
                 await this.resyncSandboxFromS3(
@@ -5422,7 +5431,11 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         // so no spurious failed analytics event fires on top of the cancel.
         if (app.sandbox_id) {
             try {
-                await this.getSandboxManager().suspendByUuid(app.sandbox_id);
+                await this.getSandboxManager().suspendByUuid({
+                    sandboxUuid: app.sandbox_id,
+                    expectedOrganizationUuid: app.organization_uuid,
+                    expectedProjectUuid: app.project_uuid,
+                });
                 this.logger.info(
                     `App ${appUuid}: sandbox suspended after cancel (sandboxUuid=${app.sandbox_id})`,
                 );
@@ -5891,10 +5904,20 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             // Suspending the sandbox interrupts any in-flight pipeline so it
             // doesn't keep running against a now-hidden app, while preserving
             // its state in case the app is restored.
-            await this.suspendSandboxIfExists(app.sandbox_id, appUuid);
+            await this.suspendSandboxIfExists(
+                app.sandbox_id,
+                appUuid,
+                app.organization_uuid,
+                app.project_uuid,
+            );
             await this.appModel.softDelete(appUuid, projectUuid, user.userUuid);
         } else {
-            await this.killSandboxIfExists(app.sandbox_id, appUuid);
+            await this.killSandboxIfExists(
+                app.sandbox_id,
+                appUuid,
+                app.organization_uuid,
+                app.project_uuid,
+            );
             await this.deleteAppS3Prefix(appUuid);
             await this.appModel.permanentDelete(appUuid, projectUuid);
         }
@@ -5987,7 +6010,12 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             );
         }
 
-        await this.killSandboxIfExists(app.sandbox_id, appUuid);
+        await this.killSandboxIfExists(
+            app.sandbox_id,
+            appUuid,
+            app.organization_uuid,
+            app.project_uuid,
+        );
         await this.deleteAppS3Prefix(appUuid);
         await this.appModel.permanentDelete(appUuid, projectUuid);
 
@@ -6006,10 +6034,16 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     private async suspendSandboxIfExists(
         sandboxUuid: string | null,
         appUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
     ): Promise<void> {
         if (!sandboxUuid) return;
         try {
-            await this.getSandboxManager().suspendByUuid(sandboxUuid);
+            await this.getSandboxManager().suspendByUuid({
+                sandboxUuid,
+                expectedOrganizationUuid: organizationUuid,
+                expectedProjectUuid: projectUuid,
+            });
             this.logger.info(
                 `App ${appUuid}: sandbox suspended during delete (sandboxUuid=${sandboxUuid})`,
             );
@@ -6023,10 +6057,16 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     private async killSandboxIfExists(
         sandboxUuid: string | null,
         appUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
     ): Promise<void> {
         if (!sandboxUuid) return;
         try {
-            await this.getSandboxManager().destroy({ sandboxUuid });
+            await this.getSandboxManager().destroy({
+                sandboxUuid,
+                expectedOrganizationUuid: organizationUuid,
+                expectedProjectUuid: projectUuid,
+            });
             this.logger.info(
                 `App ${appUuid}: sandbox killed during hard delete (sandboxUuid=${sandboxUuid})`,
             );

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.test.ts
@@ -136,15 +136,22 @@ describe('SandboxManager', () => {
     });
 
     describe('suspend', () => {
-        it('object-store backend snapshots then destroys the container', async () => {
+        it('object-store backend snapshots (workspace from the row) then destroys the container', async () => {
             const provider = makeProvider(false);
             const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: 'live-1',
+                snapshotRef: null,
+                workspace,
+            });
             const manager = makeManager(provider, registry);
 
             await manager.suspend({
                 sandboxUuid: 'sb-1',
                 handle: makeHandle('live-1'),
-                workspace,
             });
 
             expect(provider.persist).toHaveBeenCalledWith(
@@ -164,12 +171,19 @@ describe('SandboxManager', () => {
         it('native-pause backend keeps the sandbox alive', async () => {
             const provider = makeProvider(true);
             const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: 'live-1',
+                snapshotRef: null,
+                workspace,
+            });
             const manager = makeManager(provider, registry);
 
             await manager.suspend({
                 sandboxUuid: 'sb-1',
                 handle: makeHandle('live-1'),
-                workspace,
             });
 
             expect(provider.persist).toHaveBeenCalledTimes(1);
@@ -178,6 +192,70 @@ describe('SandboxManager', () => {
                 snapshotRef: { kind: 'e2b-paused', sandboxId: 'live-1' },
                 providerSandboxId: 'live-1',
             });
+        });
+
+        it('object-store suspend→resume→suspend deletes the blob the resume consumed (no leak)', async () => {
+            const provider = makeProvider(false);
+            const registry = makeRegistry();
+            const manager = makeManager(provider, registry);
+
+            // Turn 1: fresh sandbox, no prior snapshot on the row → key A.
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: 'live-1',
+                snapshotRef: null,
+                workspace,
+            });
+            provider.persist.mockResolvedValueOnce({ kind: 's3-tar', key: 'A' });
+            await manager.suspend({
+                sandboxUuid: 'sb-1',
+                handle: makeHandle('live-1'),
+            });
+            expect(provider.deleteSnapshot).not.toHaveBeenCalled();
+
+            // Turn 2: the row now carries key A; resume consumes it, then a
+            // second suspend writes key B and must GC the now-orphaned A.
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: null,
+                snapshotRef: { kind: 's3-tar', key: 'A' },
+                workspace,
+            });
+            await manager.resume({
+                sandboxUuid: 'sb-1',
+                spec,
+                expectedOrganizationUuid: 'org-1',
+                expectedProjectUuid: 'proj-1',
+            });
+            provider.persist.mockResolvedValueOnce({ kind: 's3-tar', key: 'B' });
+            await manager.suspend({
+                sandboxUuid: 'sb-1',
+                handle: makeHandle('live-restored'),
+            });
+
+            expect(provider.deleteSnapshot).toHaveBeenCalledWith({
+                kind: 's3-tar',
+                key: 'A',
+            });
+        });
+
+        it('throws SandboxExpiredError when the row is gone', async () => {
+            const provider = makeProvider(false);
+            const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue(null);
+            const manager = makeManager(provider, registry);
+
+            await expect(
+                manager.suspend({
+                    sandboxUuid: 'sb-1',
+                    handle: makeHandle('live-1'),
+                }),
+            ).rejects.toBeInstanceOf(SandboxExpiredError);
+            expect(provider.persist).not.toHaveBeenCalled();
         });
     });
 
@@ -195,7 +273,11 @@ describe('SandboxManager', () => {
             });
             const manager = makeManager(provider, registry);
 
-            await manager.suspendByUuid('sb-1');
+            await manager.suspendByUuid({
+                sandboxUuid: 'sb-1',
+                expectedOrganizationUuid: 'org-1',
+                expectedProjectUuid: 'proj-1',
+            });
 
             expect(provider.connect).toHaveBeenCalledWith('live-running');
             expect(provider.persist).toHaveBeenCalledTimes(1);
@@ -207,6 +289,30 @@ describe('SandboxManager', () => {
                 },
                 providerSandboxId: null,
             });
+        });
+
+        it('treats a row owned by a different org/project as not-found (no-op)', async () => {
+            const provider = makeProvider(false);
+            const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: 'live-running',
+                snapshotRef: null,
+                workspace,
+            });
+            const manager = makeManager(provider, registry);
+
+            await manager.suspendByUuid({
+                sandboxUuid: 'sb-1',
+                expectedOrganizationUuid: 'org-OTHER',
+                expectedProjectUuid: 'proj-1',
+            });
+
+            expect(provider.connect).not.toHaveBeenCalled();
+            expect(provider.persist).not.toHaveBeenCalled();
+            expect(registry.markSuspended).not.toHaveBeenCalled();
         });
 
         it('GCs a row that has no live sandbox to preserve', async () => {
@@ -222,7 +328,11 @@ describe('SandboxManager', () => {
             });
             const manager = makeManager(provider, registry);
 
-            await manager.suspendByUuid('sb-1');
+            await manager.suspendByUuid({
+                sandboxUuid: 'sb-1',
+                expectedOrganizationUuid: 'org-1',
+                expectedProjectUuid: 'proj-1',
+            });
 
             expect(provider.connect).not.toHaveBeenCalled();
             expect(provider.persist).not.toHaveBeenCalled();
@@ -240,7 +350,11 @@ describe('SandboxManager', () => {
             registry.findBySandboxUuid.mockResolvedValue(null);
             const manager = makeManager(provider, registry);
 
-            await manager.suspendByUuid('sb-1');
+            await manager.suspendByUuid({
+                sandboxUuid: 'sb-1',
+                expectedOrganizationUuid: 'org-1',
+                expectedProjectUuid: 'proj-1',
+            });
 
             expect(provider.connect).not.toHaveBeenCalled();
             expect(registry.deleteBySandboxUuid).not.toHaveBeenCalled();
@@ -261,7 +375,12 @@ describe('SandboxManager', () => {
             });
             const manager = makeManager(provider, registry);
 
-            const handle = await manager.resume({ sandboxUuid: 'sb-1', spec });
+            const handle = await manager.resume({
+                sandboxUuid: 'sb-1',
+                spec,
+                expectedOrganizationUuid: 'org-1',
+                expectedProjectUuid: 'proj-1',
+            });
 
             expect(provider.resume).toHaveBeenCalledWith(
                 { kind: 's3-tar', key: 'k' },
@@ -272,6 +391,30 @@ describe('SandboxManager', () => {
                 'live-restored',
             );
             expect(handle.sandboxId).toBe('live-restored');
+        });
+
+        it('treats a row owned by a different org/project as not-found', async () => {
+            const provider = makeProvider(false);
+            const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: null,
+                snapshotRef: { kind: 's3-tar', key: 'k' },
+                workspace,
+            });
+            const manager = makeManager(provider, registry);
+
+            await expect(
+                manager.resume({
+                    sandboxUuid: 'sb-1',
+                    spec,
+                    expectedOrganizationUuid: 'org-1',
+                    expectedProjectUuid: 'proj-OTHER',
+                }),
+            ).rejects.toBeInstanceOf(SandboxExpiredError);
+            expect(provider.resume).not.toHaveBeenCalled();
         });
 
         it('resumes a migration-backfilled E2B thread by reconnecting to the paused sandbox', async () => {
@@ -291,7 +434,12 @@ describe('SandboxManager', () => {
             });
             const manager = makeManager(provider, registry);
 
-            const handle = await manager.resume({ sandboxUuid: 'sb-1', spec });
+            const handle = await manager.resume({
+                sandboxUuid: 'sb-1',
+                spec,
+                expectedOrganizationUuid: 'org-1',
+                expectedProjectUuid: 'proj-1',
+            });
 
             // The paused VM is the snapshot — resume goes straight through the
             // provider with no object storage (the Manager holds no store).
@@ -313,35 +461,70 @@ describe('SandboxManager', () => {
             const manager = makeManager(provider, registry);
 
             await expect(
-                manager.resume({ sandboxUuid: 'sb-1', spec }),
+                manager.resume({
+                    sandboxUuid: 'sb-1',
+                    spec,
+                    expectedOrganizationUuid: 'org-1',
+                    expectedProjectUuid: 'proj-1',
+                }),
             ).rejects.toBeInstanceOf(SandboxExpiredError);
         });
     });
 
-    it('destroy kills the sandbox, GCs the snapshot and drops the row', async () => {
-        const provider = makeProvider(false);
-        const registry = makeRegistry();
-        registry.findBySandboxUuid.mockResolvedValue({
-            sandboxUuid: 'sb-1',
-            organizationUuid: 'org-1',
-            projectUuid: 'proj-1',
-            providerSandboxId: null,
-            snapshotRef: { kind: 's3-tar', key: 'k' },
-            workspace,
-        });
-        const manager = makeManager(provider, registry);
+    describe('destroy', () => {
+        it('kills the sandbox, GCs the snapshot and drops the row', async () => {
+            const provider = makeProvider(false);
+            const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: null,
+                snapshotRef: { kind: 's3-tar', key: 'k' },
+                workspace,
+            });
+            const manager = makeManager(provider, registry);
 
-        await manager.destroy({
-            sandboxUuid: 'sb-1',
-            handle: makeHandle('live-1'),
+            await manager.destroy({
+                sandboxUuid: 'sb-1',
+                handle: makeHandle('live-1'),
+                expectedOrganizationUuid: 'org-1',
+                expectedProjectUuid: 'proj-1',
+            });
+
+            expect(provider.destroy).toHaveBeenCalledWith('live-1');
+            // Storage cleanup is delegated to the provider, not the Manager.
+            expect(provider.deleteSnapshot).toHaveBeenCalledWith({
+                kind: 's3-tar',
+                key: 'k',
+            });
+            expect(registry.deleteBySandboxUuid).toHaveBeenCalledWith('sb-1');
         });
 
-        expect(provider.destroy).toHaveBeenCalledWith('live-1');
-        // Storage cleanup is delegated to the provider, not the Manager.
-        expect(provider.deleteSnapshot).toHaveBeenCalledWith({
-            kind: 's3-tar',
-            key: 'k',
+        it('refuses (SandboxExpiredError) and leaves a mismatched-owner row untouched', async () => {
+            const provider = makeProvider(false);
+            const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: 'live-1',
+                snapshotRef: { kind: 's3-tar', key: 'k' },
+                workspace,
+            });
+            const manager = makeManager(provider, registry);
+
+            await expect(
+                manager.destroy({
+                    sandboxUuid: 'sb-1',
+                    expectedOrganizationUuid: 'org-OTHER',
+                    expectedProjectUuid: 'proj-1',
+                }),
+            ).rejects.toBeInstanceOf(SandboxExpiredError);
+
+            expect(provider.destroy).not.toHaveBeenCalled();
+            expect(provider.deleteSnapshot).not.toHaveBeenCalled();
+            expect(registry.deleteBySandboxUuid).not.toHaveBeenCalled();
         });
-        expect(registry.deleteBySandboxUuid).toHaveBeenCalledWith('sb-1');
     });
 });

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
@@ -116,19 +116,45 @@ export class SandboxManager {
 
     /**
      * Re-materialize a previously-suspended sandbox by its stable id, restoring
-     * from the recorded snapshot (or reconnecting to a still-live one).
+     * from the recorded snapshot (or reconnecting to a still-live one). A row
+     * owned by a different org/project is treated as not-found.
      */
     async resume(input: {
         sandboxUuid: string;
         spec: SandboxSpec;
+        expectedOrganizationUuid: string;
+        expectedProjectUuid: string;
     }): Promise<SandboxHandle> {
         const row = await this.registry.findBySandboxUuid(input.sandboxUuid);
-        if (!row) {
+        if (
+            !row ||
+            !SandboxManager.ownedBy(
+                row,
+                input.expectedOrganizationUuid,
+                input.expectedProjectUuid,
+            )
+        ) {
             throw new SandboxExpiredError(input.sandboxUuid);
         }
         const handle = await this.resumeRow(row, input.spec);
         await this.registry.markRunning(input.sandboxUuid, handle.sandboxId);
         return handle;
+    }
+
+    /**
+     * Ownership guard: a caller proves which org/project a sandbox belongs to,
+     * so a stable id leaked or guessed across tenants can't be resumed,
+     * suspended, or destroyed. A mismatch is treated exactly like a missing row.
+     */
+    private static ownedBy(
+        row: SandboxRegistryRecord,
+        organizationUuid: string,
+        projectUuid: string,
+    ): boolean {
+        return (
+            row.organizationUuid === organizationUuid &&
+            row.projectUuid === projectUuid
+        );
     }
 
     private async resumeRow(
@@ -147,35 +173,70 @@ export class SandboxManager {
     /**
      * End-of-turn suspend. Native-pause backends pause in place; object-store
      * backends snapshot the workspace then destroy the container (the snapshot
-     * is the resumable state). The workspace is passed in (or read from the
-     * registry row by {@link suspendByUuid}) so a caller holding no handle can
-     * still suspend.
+     * is the resumable state). The workspace to capture is read from the
+     * registry row (recorded at {@link acquire}) — the single source of truth —
+     * so a caller holding no handle can still suspend.
      */
     async suspend(input: {
         sandboxUuid: string;
         handle: SandboxHandle;
-        workspace: PersistentWorkspace;
     }): Promise<void> {
+        const row = await this.registry.findBySandboxUuid(input.sandboxUuid);
+        if (!row) {
+            throw new SandboxExpiredError(input.sandboxUuid);
+        }
+        // The snapshot a prior turn left on the row is about to be overwritten
+        // by the new one below. Object-store backends write a fresh key each
+        // suspend, so the old blob would leak unless we GC it once the row
+        // points at its replacement.
+        const priorRef = row.snapshotRef;
         const ref = await this.provider.persist(input.handle, {
-            workspace: input.workspace,
+            workspace: row.workspace,
         });
         if (this.provider.capabilities.pauseResume) {
             await this.registry.markSuspended(input.sandboxUuid, {
                 snapshotRef: ref,
                 providerSandboxId: input.handle.sandboxId,
             });
+        } else {
+            // Destroy before marking suspended, not after: if destroy throws,
+            // the row stays `running` with its live `providerSandboxId`. That is
+            // deliberately retryable — resume still works by reconnecting to the
+            // live container. The row is only marked `suspended` (promising the
+            // snapshot is the resumable state) once the container is actually
+            // gone.
+            await this.provider.destroy(input.handle.sandboxId);
+            await this.registry.markSuspended(input.sandboxUuid, {
+                snapshotRef: ref,
+                providerSandboxId: null,
+            });
+        }
+        await this.gcConsumedSnapshot(priorRef, ref);
+    }
+
+    /**
+     * GC the snapshot a resumed turn consumed, now that the row points at its
+     * replacement. Best-effort — a leaked blob must never fail an otherwise
+     * successful suspend. A no-op for native-pause backends (their snapshot is
+     * the suspended sandbox itself, reclaimed by `destroy`) and when the prior
+     * ref is unchanged.
+     */
+    private async gcConsumedSnapshot(
+        priorRef: SnapshotRef | null,
+        newRef: SnapshotRef,
+    ): Promise<void> {
+        if (!priorRef || JSON.stringify(priorRef) === JSON.stringify(newRef)) {
             return;
         }
-        // Destroy before marking suspended, not after: if destroy throws, the
-        // row stays `running` with its live `providerSandboxId`. That is
-        // deliberately retryable — resume still works by reconnecting to the
-        // live container. The row is only marked `suspended` (promising the
-        // snapshot is the resumable state) once the container is actually gone.
-        await this.provider.destroy(input.handle.sandboxId);
-        await this.registry.markSuspended(input.sandboxUuid, {
-            snapshotRef: ref,
-            providerSandboxId: null,
-        });
+        try {
+            await this.provider.deleteSnapshot(priorRef);
+        } catch (error) {
+            this.logger.warn(
+                `Failed to delete prior snapshot after suspend: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+        }
     }
 
     /**
@@ -185,20 +246,47 @@ export class SandboxManager {
      * state for a later resume. A row with no live sandbox is GC'd (nothing to
      * preserve); an already-gone row is a no-op.
      */
-    async suspendByUuid(sandboxUuid: string): Promise<void> {
-        const row = await this.registry.findBySandboxUuid(sandboxUuid);
-        if (!row) {
+    async suspendByUuid(input: {
+        sandboxUuid: string;
+        expectedOrganizationUuid: string;
+        expectedProjectUuid: string;
+    }): Promise<void> {
+        const row = await this.registry.findBySandboxUuid(input.sandboxUuid);
+        if (
+            !row ||
+            !SandboxManager.ownedBy(
+                row,
+                input.expectedOrganizationUuid,
+                input.expectedProjectUuid,
+            )
+        ) {
             return;
         }
         await this.suspendOrphan(row);
     }
 
-    /** Permanently dispose of a sandbox: kill it, GC its snapshot, drop the row. */
+    /**
+     * Permanently dispose of a sandbox: kill it, GC its snapshot, drop the row.
+     * A row owned by a different org/project is treated as not-found and left
+     * untouched (throws {@link SandboxExpiredError}).
+     */
     async destroy(input: {
         sandboxUuid: string;
         handle?: SandboxHandle;
+        expectedOrganizationUuid: string;
+        expectedProjectUuid: string;
     }): Promise<void> {
         const row = await this.registry.findBySandboxUuid(input.sandboxUuid);
+        if (
+            row &&
+            !SandboxManager.ownedBy(
+                row,
+                input.expectedOrganizationUuid,
+                input.expectedProjectUuid,
+            )
+        ) {
+            throw new SandboxExpiredError(input.sandboxUuid);
+        }
         const liveId =
             input.handle?.sandboxId ?? row?.providerSandboxId ?? null;
         if (liveId) {
@@ -212,15 +300,19 @@ export class SandboxManager {
 
     private async suspendOrphan(row: SandboxRegistryRecord): Promise<void> {
         if (!row.providerSandboxId) {
-            // No live sandbox to snapshot — nothing to preserve.
-            await this.destroy({ sandboxUuid: row.sandboxUuid });
+            // No live sandbox to snapshot — nothing to preserve. The row's own
+            // org/project trivially satisfy the ownership guard.
+            await this.destroy({
+                sandboxUuid: row.sandboxUuid,
+                expectedOrganizationUuid: row.organizationUuid,
+                expectedProjectUuid: row.projectUuid,
+            });
             return;
         }
         const handle = await this.provider.connect(row.providerSandboxId);
         await this.suspend({
             sandboxUuid: row.sandboxUuid,
             handle,
-            workspace: row.workspace,
         });
     }
 }


### PR DESCRIPTION
Closes: PROD-8630, PROD-8640, PROD-8636

**Stack 2 of 3** — based on `pr/sandbox-c` (#25126). Merge that first; GitHub will retarget this to `main` afterwards.

### Description:

Registry-lifecycle hardening in `SandboxManager`, no contract changes.

- **PROD-8630** (bug) — object-store snapshot blob leak: `suspend` now GCs the prior `snapshotRef` after a successful `markSuspended`, so a suspend→resume→suspend cycle no longer orphans a tarball of the user's working tree. Best-effort — a GC failure only warns, never fails the suspend. New leak test.
- **PROD-8640** — `suspend` reads the `PersistentWorkspace` from the registry row (recorded at `acquire`) instead of taking it as an argument, removing a second source of truth.
- **PROD-8636** — `resume`/`destroy` require and enforce `expectedOrganizationUuid`/`expectedProjectUuid`; `suspendByUuid` treats a mismatch as a no-op. Callers thread the app's/turn's org+project through.

`SandboxManager.test.ts`: 17/17 including the new leak + ownership cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7rE8uFYjbDpFYiJ3TxYWN)_