### PR TITLE
feat(sandbox): output caps + Azure secret handling [3/3]

### DIFF
--- a/packages/backend/src/ee/services/SandboxRuntime/AzureContainerAppsSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/AzureContainerAppsSandboxProvider.ts
@@ -1,4 +1,7 @@
-import { AzureSandboxExecChannel } from './AzureSandboxExecChannel';
+import {
+    assertValidEnvKeys,
+    AzureSandboxExecChannel,
+} from './AzureSandboxExecChannel';
 import { createGitOverCommands } from './gitOverCommands';
 import {
     type PersistOptions,
@@ -346,6 +349,9 @@ export class AzureContainerAppsSandboxProvider implements SandboxProvider {
     ) {}
 
     async create(spec: SandboxSpec): Promise<SandboxHandle> {
+        // Validate create-time env keys up front — they are passed natively to
+        // the sandbox (spec.envs → `environment`), never via a command line.
+        if (spec.envs) assertValidEnvKeys(spec.envs);
         const { cpu, memory } =
             TIER_RESOURCES[this.config.resourceTier] ?? TIER_RESOURCES.M;
         const { sandboxId, state } = await this.controlPlane.createSandbox({

--- a/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto';
+import { capOutput } from './commandOutput';
 import { SandboxCommandError, SandboxTimeoutError } from './errors';
 import { shQuote } from './gitOverCommands';
 import {
@@ -7,20 +9,43 @@ import {
     type SandboxFiles,
 } from './types';
 
+/** A valid POSIX shell identifier — the only accepted env var name shape. */
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /**
- * Fold `cwd`/`envs` into a single `/bin/sh -c` command line. The native exec
- * takes only a command (no cwd/env fields), so a `cd …` prefix and per-var
- * `export`s make `RunOptions.cwd`/`envs` work on any exec surface.
+ * Reject environment variable names that are not valid shell identifiers before
+ * they are staged into the sourced env file. A malformed key could otherwise
+ * break out of its `export` assignment.
  */
-const buildCommandLine = (command: string, options?: RunOptions): string => {
-    const parts: string[] = [];
-    if (options?.cwd) parts.push(`cd ${shQuote(options.cwd)} &&`);
-    if (options?.envs) {
-        const exports = Object.entries(options.envs)
-            .map(([key, value]) => `${key}=${shQuote(value)}`)
-            .join(' ');
-        if (exports) parts.push(`export ${exports};`);
+export const assertValidEnvKeys = (envs: Record<string, string>): void => {
+    for (const key of Object.keys(envs)) {
+        if (!ENV_KEY_PATTERN.test(key)) {
+            throw new Error(
+                `Invalid environment variable name for the Azure sandbox: ${JSON.stringify(
+                    key,
+                )}`,
+            );
+        }
     }
+};
+
+/**
+ * Fold `cwd` (and a sourced env file, when staged) into a single `/bin/sh -c`
+ * command line. The native exec takes only a command (no cwd/env fields), so a
+ * `cd …` prefix makes `RunOptions.cwd` work on any exec surface. Env vars are
+ * NOT interpolated here — their values are written out-of-band to a file the
+ * command `source`s, so secrets never reach the exec request's command line
+ * (and thus never land in the process's `/proc/<pid>/cmdline`).
+ */
+const buildCommandLine = (
+    command: string,
+    options: { cwd?: string; envFilePath: string | null },
+): string => {
+    const parts: string[] = [];
+    if (options.envFilePath) {
+        parts.push(`. ${shQuote(options.envFilePath)} &&`);
+    }
+    if (options.cwd) parts.push(`cd ${shQuote(options.cwd)} &&`);
     parts.push(command);
     return parts.join(' ');
 };
@@ -144,11 +169,32 @@ export class AzureSandboxExecChannel {
         return response;
     }
 
+    /**
+     * Write the per-command env vars to a throwaway file inside the sandbox so
+     * the command can `source` them, keeping secret values out of the exec
+     * request's command line (and `/proc/<pid>/cmdline`). Returns the file path,
+     * or null when there is nothing to stage. The caller removes the file after.
+     */
+    private async stageEnvFile(
+        envs: Record<string, string> | undefined,
+    ): Promise<string | null> {
+        if (!envs || Object.keys(envs).length === 0) return null;
+        assertValidEnvKeys(envs);
+        const path = `/tmp/.ld-env-${randomBytes(8).toString('hex')}`;
+        const lines = Object.entries(envs).map(
+            ([key, value]) => `export ${key}=${shQuote(value)}`,
+        );
+        const contents = `${lines.join('\n')}\n`;
+        await this.files.write(path, contents);
+        return path;
+    }
+
     readonly commands: SandboxCommands = {
         run: async (
             command: string,
             options?: RunOptions,
         ): Promise<CommandResult> => {
+            const envFilePath = await this.stageEnvFile(options?.envs);
             const controller = new AbortController();
             // Give the native exec a 5s grace period over the caller's timeout so
             // the server's own timeout error surfaces before this client-side abort.
@@ -166,7 +212,10 @@ export class AzureSandboxExecChannel {
                         method: 'POST',
                         headers: { 'content-type': 'application/json' },
                         body: JSON.stringify({
-                            command: buildCommandLine(command, options),
+                            command: buildCommandLine(command, {
+                                cwd: options?.cwd,
+                                envFilePath,
+                            }),
                         }),
                     },
                     controller.signal,
@@ -178,7 +227,14 @@ export class AzureSandboxExecChannel {
                         '',
                     );
                 }
-                const result = decodeExecResponse(await response.json());
+                const raw = decodeExecResponse(await response.json());
+                // Cap captured output so a command that floods stdout/stderr
+                // cannot exhaust the worker's heap or bloat the error logs.
+                const result: ExecResponse = {
+                    stdout: capOutput(raw.stdout),
+                    stderr: capOutput(raw.stderr),
+                    exitCode: raw.exitCode,
+                };
                 // Native exec is buffered — replay the captured output through the
                 // streaming callbacks once so downstream line-parsers still see it.
                 if (result.stdout) options?.onStdout?.(result.stdout);
@@ -203,6 +259,12 @@ export class AzureSandboxExecChannel {
                 throw error;
             } finally {
                 if (timer) clearTimeout(timer);
+                // Best-effort cleanup; never mask the command result/error.
+                if (envFilePath) {
+                    await this.files
+                        .remove(envFilePath)
+                        .catch(() => undefined);
+                }
             }
         },
     };

--- a/packages/backend/src/ee/services/SandboxRuntime/DockerSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/DockerSandboxProvider.ts
@@ -2,7 +2,11 @@ import type Docker from 'dockerode';
 import type { Container } from 'dockerode';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { posix } from 'node:path';
-import { Writable } from 'node:stream';
+import { PassThrough, Writable, type Readable } from 'node:stream';
+import {
+    CappedOutput,
+    MAX_CAPTURED_OUTPUT_BYTES,
+} from './commandOutput';
 import { SandboxCommandError, SandboxTimeoutError } from './errors';
 import { createGitOverCommands, shQuote } from './gitOverCommands';
 import { type SnapshotStore } from './SnapshotStore';
@@ -60,6 +64,12 @@ class DockerSandboxHandle implements SandboxHandle {
             envs?: Record<string, string>;
             timeoutMs?: number;
             stdin?: Buffer;
+            /**
+             * Per-stream byte cap for the captured stdout/stderr (protects the
+             * worker's heap from a command that floods output). Omit for the
+             * uncapped file-read path, where the full bytes are the result.
+             */
+            maxOutputBytes?: number;
             onStdout?: (chunk: Buffer) => void;
             onStderr?: (chunk: Buffer) => void;
         },
@@ -79,18 +89,19 @@ class DockerSandboxHandle implements SandboxHandle {
             stdin: opts.stdin !== undefined,
         });
 
-        const stdoutChunks: Buffer[] = [];
-        const stderrChunks: Buffer[] = [];
+        const cap = opts.maxOutputBytes ?? Number.POSITIVE_INFINITY;
+        const stdout = new CappedOutput(cap);
+        const stderr = new CappedOutput(cap);
         const stdoutSink = new Writable({
             write: (chunk: Buffer, _enc, cb) => {
-                stdoutChunks.push(chunk);
+                stdout.append(chunk);
                 opts.onStdout?.(chunk);
                 cb();
             },
         });
         const stderrSink = new Writable({
             write: (chunk: Buffer, _enc, cb) => {
-                stderrChunks.push(chunk);
+                stderr.append(chunk);
                 opts.onStderr?.(chunk);
                 cb();
             },
@@ -128,10 +139,37 @@ class DockerSandboxHandle implements SandboxHandle {
 
         const info = await exec.inspect();
         return {
-            stdout: Buffer.concat(stdoutChunks),
-            stderr: Buffer.concat(stderrChunks),
+            stdout: stdout.toBuffer(),
+            stderr: stderr.toBuffer(),
             exitCode: info.ExitCode ?? 0,
         };
+    }
+
+    /**
+     * Stream a file's raw bytes out of the container via `cat`, demuxed from the
+     * exec stream. Used to pipe a large artifact (the snapshot tarball) straight
+     * to object storage without buffering the whole file in the worker's heap.
+     * `stderr` is drained; a `cat` failure surfaces as a stream error.
+     */
+    async openReadStream(path: string): Promise<Readable> {
+        const exec = await this.container.exec({
+            Cmd: ['cat', path],
+            AttachStdout: true,
+            AttachStderr: true,
+            AttachStdin: false,
+            Tty: false,
+        });
+        const stream = await exec.start({ hijack: true, stdin: false });
+        const stdout = new PassThrough();
+        const stderr = new PassThrough();
+        stderr.resume();
+        this.container.modem.demuxStream(stream, stdout, stderr);
+        stream.on('end', () => {
+            stdout.end();
+            stderr.end();
+        });
+        stream.on('error', (error) => stdout.destroy(error));
+        return stdout;
     }
 
     readonly commands = {
@@ -143,6 +181,7 @@ class DockerSandboxHandle implements SandboxHandle {
                 cwd: options?.cwd,
                 envs: options?.envs,
                 timeoutMs: options?.timeoutMs,
+                maxOutputBytes: MAX_CAPTURED_OUTPUT_BYTES,
                 onStdout: options?.onStdout
                     ? (chunk) => options.onStdout!(chunk.toString('utf8'))
                     : undefined,
@@ -331,9 +370,16 @@ export class DockerSandboxProvider implements SandboxProvider {
         await handle.commands.run(
             `tar czf ${shQuote(archivePath)} --ignore-failed-read ${excludeFlags} -C / ${includeArgs}`,
         );
+        if (!(handle instanceof DockerSandboxHandle)) {
+            throw new Error(
+                'DockerSandboxProvider.persist requires a DockerSandboxHandle',
+            );
+        }
         try {
-            const archive = await handle.files.readBytes(archivePath);
-            await this.snapshotStore.put(snapshotKey, archive);
+            // Stream the tarball straight from the container to object storage
+            // rather than buffering the whole archive in the worker's heap.
+            const archiveStream = await handle.openReadStream(archivePath);
+            await this.snapshotStore.putStream(snapshotKey, archiveStream);
         } finally {
             await handle.files.remove(archivePath);
         }

--- a/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
@@ -1,4 +1,5 @@
 import { ALL_TRAFFIC, CommandExitError, Sandbox, TimeoutError } from 'e2b';
+import { capOutput } from './commandOutput';
 import { SandboxCommandError, SandboxTimeoutError } from './errors';
 import { createGitOverCommands } from './gitOverCommands';
 import {
@@ -28,8 +29,8 @@ const normalizeError = (error: unknown): never => {
     if (error instanceof CommandExitError) {
         throw new SandboxCommandError(
             error.exitCode,
-            error.stderr,
-            error.stdout,
+            capOutput(error.stderr),
+            capOutput(error.stdout),
         );
     }
     if (error instanceof TimeoutError) {
@@ -59,8 +60,8 @@ class E2bSandboxHandle implements SandboxHandle {
                     onStderr: options?.onStderr,
                 });
                 return {
-                    stdout: result.stdout,
-                    stderr: result.stderr,
+                    stdout: capOutput(result.stdout),
+                    stderr: capOutput(result.stderr),
                     exitCode: result.exitCode,
                 };
             } catch (error) {

--- a/packages/backend/src/ee/services/SandboxRuntime/LambdaExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/LambdaExecChannel.ts
@@ -1,3 +1,4 @@
+import { CappedOutput } from './commandOutput';
 import { SandboxCommandError, SandboxTimeoutError } from './errors';
 import {
     type CommandResult,
@@ -58,8 +59,11 @@ const consumeExecStream = async (
     const chunks = body as unknown as AsyncIterable<Uint8Array>;
     const decoder = new TextDecoder();
     let buffered = '';
-    let stdout = '';
-    let stderr = '';
+    // Cap the captured output so a command that floods stdout/stderr cannot
+    // exhaust the worker's heap; the streaming callbacks below still see every
+    // chunk. See {@link CappedOutput}.
+    const stdout = new CappedOutput();
+    const stderr = new CappedOutput();
 
     const handleEvent = (event: ExecEvent): CommandResult | null => {
         if ('timeout' in event) {
@@ -69,16 +73,24 @@ const consumeExecStream = async (
         }
         if ('exitCode' in event) {
             if (event.exitCode !== 0) {
-                throw new SandboxCommandError(event.exitCode, stderr, stdout);
+                throw new SandboxCommandError(
+                    event.exitCode,
+                    stderr.toString(),
+                    stdout.toString(),
+                );
             }
-            return { stdout, stderr, exitCode: event.exitCode };
+            return {
+                stdout: stdout.toString(),
+                stderr: stderr.toString(),
+                exitCode: event.exitCode,
+            };
         }
         const text = Buffer.from(event.data, 'base64').toString('utf8');
         if (event.stream === 'stdout') {
-            stdout += text;
+            stdout.append(text);
             options?.onStdout?.(text);
         } else {
-            stderr += text;
+            stderr.append(text);
             options?.onStderr?.(text);
         }
         return null;
@@ -96,14 +108,14 @@ const consumeExecStream = async (
             throw new SandboxCommandError(
                 -1,
                 `exec agent emitted a non-JSON frame: ${trimmed.slice(0, 200)}`,
-                stdout,
+                stdout.toString(),
             );
         }
         if (!isExecEvent(parsed)) {
             throw new SandboxCommandError(
                 -1,
                 `exec agent emitted an unknown frame: ${trimmed.slice(0, 200)}`,
-                stdout,
+                stdout.toString(),
             );
         }
         return handleEvent(parsed);
@@ -127,7 +139,7 @@ const consumeExecStream = async (
     throw new SandboxCommandError(
         -1,
         `exec agent stream ended without an exit code for: ${command}`,
-        stdout,
+        stdout.toString(),
     );
 };
 

--- a/packages/backend/src/ee/services/SandboxRuntime/SnapshotStore.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SnapshotStore.ts
@@ -1,10 +1,11 @@
 import {
     DeleteObjectCommand,
     GetObjectCommand,
-    PutObjectCommand,
     type S3,
 } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
 import { MissingConfigError } from '@lightdash/common';
+import { type Readable } from 'node:stream';
 import { S3BaseClient } from '../../../clients/Aws/S3BaseClient';
 import { type LightdashConfig } from '../../../config/parseConfig';
 
@@ -15,7 +16,12 @@ import { type LightdashConfig } from '../../../config/parseConfig';
  * backing store without touching provider code.
  */
 export interface SnapshotStore {
-    put(key: string, body: Buffer): Promise<void>;
+    /**
+     * Upload a snapshot by streaming its bytes to storage, so a large archive is
+     * never buffered whole in the worker's heap. The body is a byte stream (e.g.
+     * a tarball piped out of the sandbox container).
+     */
+    putStream(key: string, body: Readable): Promise<void>;
     get(key: string): Promise<Buffer>;
     delete(key: string): Promise<void>;
 }
@@ -44,16 +50,20 @@ export class S3SnapshotStore extends S3BaseClient implements SnapshotStore {
         return { client: this.s3, bucket: this.bucket };
     }
 
-    async put(key: string, body: Buffer): Promise<void> {
+    async putStream(key: string, body: Readable): Promise<void> {
         const { client, bucket } = this.requireClient();
-        await client.send(
-            new PutObjectCommand({
+        // lib-storage's Upload multiparts an unknown-length stream, so the whole
+        // archive is never materialized in memory here.
+        const upload = new Upload({
+            client,
+            params: {
                 Bucket: bucket,
                 Key: key,
                 Body: body,
                 ContentType: 'application/gzip',
-            }),
-        );
+            },
+        });
+        await upload.done();
     }
 
     async get(key: string): Promise<Buffer> {

--- a/packages/backend/src/ee/services/SandboxRuntime/commandOutput.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/commandOutput.test.ts
@@ -1,0 +1,58 @@
+import {
+    capOutput,
+    CappedOutput,
+    MAX_CAPTURED_OUTPUT_BYTES,
+} from './commandOutput';
+
+describe('commandOutput cap', () => {
+    describe('CappedOutput', () => {
+        it('passes small output through unchanged', () => {
+            const out = new CappedOutput(1024);
+            out.append('hello ');
+            out.append(Buffer.from('world'));
+            expect(out.isTruncated).toBe(false);
+            expect(out.toString()).toBe('hello world');
+        });
+
+        it('caps accumulated output and appends a truncation marker', () => {
+            const out = new CappedOutput(10);
+            out.append('abcdefg');
+            out.append('hijklmnop'); // pushes past the 10-byte cap
+            expect(out.isTruncated).toBe(true);
+            const text = out.toString();
+            expect(text.startsWith('abcdefghij')).toBe(true);
+            expect(text).toContain('output truncated');
+            // Only the first 10 bytes are retained before the marker.
+            expect(text.split('\n')[0]).toBe('abcdefghij');
+        });
+
+        it('drops entire chunks once the cap is exhausted', () => {
+            const out = new CappedOutput(4);
+            out.append('abcd');
+            out.append('efgh');
+            expect(out.isTruncated).toBe(true);
+            expect(out.toString().split('\n')[0]).toBe('abcd');
+        });
+
+        it('defaults to the shared 10 MB cap', () => {
+            const out = new CappedOutput();
+            out.append('x'.repeat(MAX_CAPTURED_OUTPUT_BYTES + 5));
+            expect(out.isTruncated).toBe(true);
+            expect(Buffer.byteLength(out.toString().split('\n')[0])).toBe(
+                MAX_CAPTURED_OUTPUT_BYTES,
+            );
+        });
+    });
+
+    describe('capOutput', () => {
+        it('returns short strings unchanged', () => {
+            expect(capOutput('ok', 1024)).toBe('ok');
+        });
+
+        it('truncates long strings and marks them', () => {
+            const result = capOutput('abcdefghij', 4);
+            expect(result.startsWith('abcd')).toBe(true);
+            expect(result).toContain('output truncated');
+        });
+    });
+});

--- a/packages/backend/src/ee/services/SandboxRuntime/commandOutput.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/commandOutput.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared cap on captured command output. Every data plane accumulates a command's
+ * full stdout/stderr in memory to build a {@link CommandResult} (and to attach to
+ * {@link SandboxCommandError} on failure). Untrusted code runs inside the sandbox,
+ * so a single command (`yes | head -c 10G`) could otherwise exhaust the worker's
+ * heap and dump gigabytes into the error logs. The channels funnel their captured
+ * output through here so no single command can grow past
+ * {@link MAX_CAPTURED_OUTPUT_BYTES}, and truncation is made visible in the
+ * returned/logged text.
+ */
+
+/** Per-stream cap (stdout and stderr are capped independently). 10 MB. */
+export const MAX_CAPTURED_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+const truncationMarker = (droppedBytes: number, maxBytes: number): string =>
+    `\n[output truncated: ${droppedBytes} byte(s) dropped, capped at ${maxBytes} bytes]`;
+
+/**
+ * A byte-bounded accumulator for one output stream. Appended chunks (text or raw
+ * bytes) are kept until {@link MAX_CAPTURED_OUTPUT_BYTES} is reached, after which
+ * further bytes are counted but discarded. {@link toBuffer}/{@link toString}
+ * append a truncation marker when anything was dropped. Used by the streaming
+ * (Lambda) and buffered (Docker) data planes; the buffered SDK planes (E2B/Azure)
+ * cap their already-materialized strings with {@link capOutput}.
+ */
+export class CappedOutput {
+    private readonly chunks: Buffer[] = [];
+
+    private keptBytes = 0;
+
+    private droppedBytes = 0;
+
+    constructor(private readonly maxBytes: number = MAX_CAPTURED_OUTPUT_BYTES) {}
+
+    append(chunk: string | Buffer): void {
+        const buffer =
+            typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk;
+        const remaining = this.maxBytes - this.keptBytes;
+        if (remaining <= 0) {
+            this.droppedBytes += buffer.length;
+            return;
+        }
+        if (buffer.length <= remaining) {
+            this.chunks.push(buffer);
+            this.keptBytes += buffer.length;
+            return;
+        }
+        this.chunks.push(buffer.subarray(0, remaining));
+        this.keptBytes += remaining;
+        this.droppedBytes += buffer.length - remaining;
+    }
+
+    get isTruncated(): boolean {
+        return this.droppedBytes > 0;
+    }
+
+    toBuffer(): Buffer {
+        const body = Buffer.concat(this.chunks);
+        if (this.droppedBytes === 0) {
+            return body;
+        }
+        return Buffer.concat([
+            body,
+            Buffer.from(
+                truncationMarker(this.droppedBytes, this.maxBytes),
+                'utf8',
+            ),
+        ]);
+    }
+
+    toString(): string {
+        return this.toBuffer().toString('utf8');
+    }
+}
+
+/**
+ * Cap an already-buffered output string (from an SDK/REST call that returned the
+ * whole payload at once). Truncates to {@link maxBytes} and appends the same
+ * marker when anything was dropped.
+ */
+export const capOutput = (
+    text: string,
+    maxBytes: number = MAX_CAPTURED_OUTPUT_BYTES,
+): string => {
+    const buffer = Buffer.from(text, 'utf8');
+    if (buffer.length <= maxBytes) {
+        return text;
+    }
+    return (
+        buffer.subarray(0, maxBytes).toString('utf8') +
+        truncationMarker(buffer.length - maxBytes, maxBytes)
+    );
+};


### PR DESCRIPTION
Closes: PROD-8632, PROD-8633

**Stack 3 of 3** — based on `pr/sandbox-a` (#25127). Merge #25126 then #25127 first.

### Description:

Data-plane hardening across the sandbox providers, no contract changes.

- **PROD-8632** — untrusted code could OOM the backend via unbounded output: a shared `commandOutput.ts` caps captured stdout/stderr (10 MB, truncate-with-marker) across all four data planes, and the Docker snapshot tarball now streams to S3 instead of being buffered whole (`SnapshotStore.putStream`).
- **PROD-8633** — Azure secrets on the command line: per-command envs are written to a throwaway file the command `source`s (not `export KEY=…` on argv / in the exec request body), and env keys are validated.

New `commandOutput.test.ts`: 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7rE8uFYjbDpFYiJ3TxYWN)_