### PR TITLE
ci: diff OpenAPI schemas structurally in the breaking-change check

### DIFF
--- a/.github/scripts/sanitize-openapi.mjs
+++ b/.github/scripts/sanitize-openapi.mjs
@@ -1,0 +1,68 @@
+/**
+ * Prepares a TSOA-generated OpenAPI spec for `oasdiff breaking --flatten-allof`.
+ *
+ * The breaking-change check compares schemas by structure instead of by name
+ * (TSOA encodes the picked field list into schema names, so adding one optional
+ * field renames the whole schema and looks like a removal). Structural
+ * comparison requires oasdiff to first merge every `allOf` composition into a
+ * single flat schema, but two TSOA quirks make that merge fail with
+ * "Type conflict: all Type values must be identical":
+ *
+ * 1. TS intersections with the empty object (`string & {}`, `NonNullable<T>`)
+ *    emit a no-op `{type: "object", properties: {}}` allOf member whose
+ *    "object" type conflicts with the real member's type. It constrains
+ *    nothing, so we drop it.
+ *
+ * 2. The TS `null` literal type emits `{type: "number", enum: [null]}`. The
+ *    only allowed value is null, so the bogus "number" carries no meaning but
+ *    conflicts with sibling declarations of the same property (e.g. a
+ *    discriminated-union member narrowing `dashboardUuid: string | null` to
+ *    `null`). We drop the type and keep `enum: [null]`.
+ *
+ * Usage: node sanitize-openapi.mjs <input-spec.json> <output-spec.json>
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const isNoopObjectSchema = (schema) => {
+    if (typeof schema !== 'object' || schema === null) return false;
+    const keys = Object.keys(schema).filter((k) => k !== 'description');
+    return (
+        keys.length === 2 &&
+        schema.type === 'object' &&
+        typeof schema.properties === 'object' &&
+        schema.properties !== null &&
+        Object.keys(schema.properties).length === 0
+    );
+};
+
+const isNullLiteralSchema = (schema) =>
+    Array.isArray(schema.enum) &&
+    schema.enum.length === 1 &&
+    schema.enum[0] === null &&
+    'type' in schema;
+
+const sanitize = (node) => {
+    if (Array.isArray(node)) {
+        node.forEach(sanitize);
+        return;
+    }
+    if (typeof node !== 'object' || node === null) return;
+
+    if (isNullLiteralSchema(node)) {
+        delete node.type;
+    }
+    if (Array.isArray(node.allOf)) {
+        node.allOf = node.allOf.filter((s) => !isNoopObjectSchema(s));
+    }
+    Object.values(node).forEach(sanitize);
+};
+
+const [inputPath, outputPath] = process.argv.slice(2);
+if (!inputPath || !outputPath) {
+    console.error('Usage: node sanitize-openapi.mjs <input.json> <output.json>');
+    process.exit(1);
+}
+
+const spec = JSON.parse(readFileSync(inputPath, 'utf-8'));
+sanitize(spec);
+writeFileSync(outputPath, JSON.stringify(spec));

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -206,6 +206,7 @@ jobs:
       - name: Generate OpenAPI schema
         run: pnpm generate-api
       - name: Check for OpenAPI breaking changes
+        id: oasdiff
         if: ${{ !contains(github.event.pull_request.body, 'allow-api-breaking-change') }}
         # --flatten-allof diffs schemas structurally instead of by name: TSOA
         # encodes field lists into schema names, so adding an optional field
@@ -214,10 +215,83 @@ jobs:
         run: |
           node .github/scripts/sanitize-openapi.mjs /tmp/main-swagger.json /tmp/main-swagger-clean.json
           node .github/scripts/sanitize-openapi.mjs packages/backend/src/generated/swagger.json /tmp/pr-swagger-clean.json
-          docker run --rm \
+          set +e
+          report=$(docker run --rm \
             -v /tmp:/tmp \
             tufin/oasdiff@sha256:1b878e413bfba39a9bbb2ce95d6a2ddf79bacd4eade9420ad422175b011a71c9 \
-            breaking --flatten-allof --fail-on ERR /tmp/main-swagger-clean.json /tmp/pr-swagger-clean.json
+            breaking --flatten-allof --fail-on ERR /tmp/main-swagger-clean.json /tmp/pr-swagger-clean.json 2>&1)
+          status=$?
+          set -e
+          echo "$report"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          {
+            echo 'report<<OASDIFF_REPORT_EOF'
+            echo "$report"
+            echo 'OASDIFF_REPORT_EOF'
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo '### OpenAPI breaking-change check'
+            echo '```'
+            echo "$report"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$status" -ne 0 ]; then
+            echo "::error title=OpenAPI breaking changes detected::${report//$'\n'/%0A}"
+          fi
+      - name: Comment OpenAPI breaking changes on PR
+        if: ${{ steps.oasdiff.outcome == 'success' }}
+        # Forked PRs get a read-only token, so a failed comment must not mask
+        # the check result.
+        continue-on-error: true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          OASDIFF_STATUS: ${{ steps.oasdiff.outputs.status }}
+          OASDIFF_REPORT: ${{ steps.oasdiff.outputs.report }}
+        with:
+          script: |
+            const marker = '<!-- openapi-breaking-change-comment -->';
+            const failed = process.env.OASDIFF_STATUS !== '0';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (!failed && !existing) return;
+
+            const body = failed
+              ? [
+                  marker,
+                  '## ⛔ OpenAPI breaking changes detected',
+                  '',
+                  '```',
+                  process.env.OASDIFF_REPORT,
+                  '```',
+                  '',
+                  'If this break is intentional, add `allow-api-breaking-change` to the PR description and re-run the check.',
+                ].join('\n')
+              : `${marker}\n## ✅ OpenAPI breaking changes resolved\n\nThe latest commit no longer introduces breaking API changes.`;
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+      - name: Fail on OpenAPI breaking changes
+        if: ${{ steps.oasdiff.outcome == 'success' && steps.oasdiff.outputs.status != '0' }}
+        run: exit 1
       - name: Report allowed OpenAPI breaking changes
         if: ${{ contains(github.event.pull_request.body, 'allow-api-breaking-change') }}
         run: echo "Skipping OpenAPI breaking-change check because allow-api-breaking-change is in the PR description."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -207,13 +207,17 @@ jobs:
         run: pnpm generate-api
       - name: Check for OpenAPI breaking changes
         if: ${{ !contains(github.event.pull_request.body, 'allow-api-breaking-change') }}
+        # --flatten-allof diffs schemas structurally instead of by name: TSOA
+        # encodes field lists into schema names, so adding an optional field
+        # renames the schema and a by-name diff misreads it as a removal.
+        # The sanitize script strips TSOA quirks that break oasdiff's flattener.
         run: |
+          node .github/scripts/sanitize-openapi.mjs /tmp/main-swagger.json /tmp/main-swagger-clean.json
+          node .github/scripts/sanitize-openapi.mjs packages/backend/src/generated/swagger.json /tmp/pr-swagger-clean.json
           docker run --rm \
-            -v "$PWD:/work" \
             -v /tmp:/tmp \
-            -w /work \
             tufin/oasdiff@sha256:1b878e413bfba39a9bbb2ce95d6a2ddf79bacd4eade9420ad422175b011a71c9 \
-            breaking --fail-on ERR /tmp/main-swagger.json packages/backend/src/generated/swagger.json
+            breaking --flatten-allof --fail-on ERR /tmp/main-swagger-clean.json /tmp/pr-swagger-clean.json
       - name: Report allowed OpenAPI breaking changes
         if: ${{ contains(github.event.pull_request.body, 'allow-api-breaking-change') }}
         run: echo "Skipping OpenAPI breaking-change check because allow-api-breaking-change is in the PR description."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -215,6 +215,9 @@ jobs:
         run: |
           node .github/scripts/sanitize-openapi.mjs /tmp/main-swagger.json /tmp/main-swagger-clean.json
           node .github/scripts/sanitize-openapi.mjs packages/backend/src/generated/swagger.json /tmp/pr-swagger-clean.json
+          # Pull ahead of the capturing run so image-pull progress (stderr)
+          # doesn't pollute the report.
+          docker pull -q tufin/oasdiff@sha256:1b878e413bfba39a9bbb2ce95d6a2ddf79bacd4eade9420ad422175b011a71c9 > /dev/null
           set +e
           report=$(docker run --rm \
             -v /tmp:/tmp \

--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -164,6 +164,9 @@ export class AiAgentAdminController extends BaseController {
     @OperationId('getAllAgents')
     async getAllAgents(
         @Request() req: express.Request,
+        // Temporary CI test param — a required addition is a breaking change
+        // the OpenAPI check must flag. Reverted before merge.
+        @Query() ciTestRequiredParam: string,
     ): Promise<ApiAiAgentSummaryResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -476,6 +476,8 @@ export class AiAgentModel {
                         '[]'::json
                     )
                 `),
+                // Temporary CI test field, no DB column — reverted before merge
+                ciTestOptionalFlag: this.database.raw('false'),
             } satisfies Record<keyof AiAgent, unknown>)
             .where(`${AiAgentTableName}.organization_uuid`, organizationUuid)
             .where(`${AiAgentTableName}.ai_agent_uuid`, agentUuid)

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12992,7 +12992,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-ciTestOptionalFlag-or-adminOnly-or-modelConfig-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -13088,6 +13088,13 @@ const models: TsoaRoute.Models = {
                     },
                     enableContentTools: { dataType: 'boolean', required: true },
                     enableUserContext: { dataType: 'boolean', required: true },
+                    ciTestOptionalFlag: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     adminOnly: { dataType: 'boolean', required: true },
                     modelConfig: {
                         dataType: 'union',
@@ -13106,7 +13113,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-ciTestOptionalFlag-or-adminOnly-or-modelConfig-or-version_',
             validators: {},
         },
     },
@@ -13711,7 +13718,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-ciTestOptionalFlag-or-adminOnly-or-modelConfig-or-version__':
         {
             dataType: 'refAlias',
             type: {
@@ -13847,6 +13854,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    ciTestOptionalFlag: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     adminOnly: {
                         dataType: 'union',
                         subSchemas: [
@@ -13880,7 +13894,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-ciTestOptionalFlag-or-adminOnly-or-modelConfig-or-version__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -57736,6 +57736,12 @@ export function RegisterRoutes(app: Router) {
         TsoaRoute.ParameterSchema
     > = {
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        ciTestRequiredParam: {
+            in: 'query',
+            name: 'ciTestRequiredParam',
+            required: true,
+            dataType: 'string',
+        },
     };
     app.get(
         '/api/v1/aiAgents/admin/agents',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14584,7 +14584,7 @@
             "ApiAiAgentProjectThreadSummaryListResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_AiAgentProjectThreadSummary-Array__"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-ciTestOptionalFlag-or-adminOnly-or-modelConfig-or-version_": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -14677,6 +14677,9 @@
                     "enableUserContext": {
                         "type": "boolean"
                     },
+                    "ciTestOptionalFlag": {
+                        "type": "boolean"
+                    },
                     "adminOnly": {
                         "type": "boolean"
                     },
@@ -14721,7 +14724,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-ciTestOptionalFlag-or-adminOnly-or-modelConfig-or-version_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -15336,7 +15339,7 @@
                     }
                 ]
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-ciTestOptionalFlag-or-adminOnly-or-modelConfig-or-version__": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -15410,6 +15413,9 @@
                     "enableUserContext": {
                         "type": "boolean"
                     },
+                    "ciTestOptionalFlag": {
+                        "type": "boolean"
+                    },
                     "adminOnly": {
                         "type": "boolean"
                     },
@@ -15432,7 +15438,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-adminOnly-or-modelConfig-or-version__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-enableUserContext-or-ciTestOptionalFlag-or-adminOnly-or-modelConfig-or-version__"
                     },
                     {
                         "properties": {
@@ -43220,7 +43226,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3303.0",
+        "version": "0.3305.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -50354,7 +50354,16 @@
                 "description": "Get all AI agents for admin",
                 "summary": "List AI agents",
                 "security": [],
-                "parameters": []
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "ciTestRequiredParam",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/aiAgents/admin/review-items": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -146,6 +146,9 @@ export const baseAgentSchema = z.object({
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
     enableUserContext: z.boolean(),
+    // Temporary CI test field — verifies the OpenAPI breaking-change check
+    // accepts an optional-field addition. Reverted before merge.
+    ciTestOptionalFlag: z.boolean().optional(),
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
@@ -174,6 +177,7 @@ export type AiAgent = Pick<
     | 'enableSelfImprovement'
     | 'enableContentTools'
     | 'enableUserContext'
+    | 'ciTestOptionalFlag'
     | 'adminOnly'
     | 'modelConfig'
     | 'version'
@@ -374,6 +378,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'enableSelfImprovement'
         | 'enableContentTools'
         | 'enableUserContext'
+        | 'ciTestOptionalFlag'
         | 'adminOnly'
         | 'modelConfig'
         | 'version'


### PR DESCRIPTION
## Problem

The OpenAPI breaking-change check produces false positives on non-breaking changes. TSOA encodes the picked field list into generated schema names (e.g. `Partial_Pick_AiAgent.projectUuid-or-tags-or-...`), so adding one **optional** field to a `Partial<Pick<...>>` request body renames the schema. oasdiff compares request-body `allOf` members by name, so it reads the rename as "removed one schema, added another" and fails with `request-body-all-of-added` — even though every request that validated before still validates.

This happened on #25069 and creates noise that erodes trust in the check.

## Solution

Pass `--flatten-allof` to oasdiff so it merges `allOf` compositions and diffs schema **contents** instead of names. As a bonus, real failures get much clearer messages (`added the new required request property 'enableUserContext'` instead of a 400-character mangled schema name).

TSOA emits two constructs that make oasdiff's flattener fail with a type conflict, so both specs are normalized first by `.github/scripts/sanitize-openapi.mjs`:

1. **No-op object members** — TS intersections like `string & {}` and `NonNullable<T>` emit `{type: "object", properties: {}}` in `allOf`, whose `object` type conflicts with the real member's type. It constrains nothing, so it's dropped.
2. **`null` literal types** — TSOA renders a TS `null` literal as `{type: "number", enum: [null]}`; the bogus `number` conflicts with sibling declarations of the same property in discriminated unions (e.g. the scheduler types). The meaningless `type` is dropped, keeping `enum: [null]`.

The sanitizer runs identically on both sides of the diff, so it cannot hide a difference between them. If TSOA ever emits a new quirk, the check fails loudly with a flattening error rather than passing silently.

## Verification

Tested locally with the exact pinned oasdiff image against #25069's spec diff:

- Adding an optional field to a `Partial<Pick<...>>` body (the false positive): old check ❌ → new check ✅
- Injected real break (new required request property): still fails, with a clearer message ✅
- Removed endpoint: still fails (`api-path-removed-without-deprecation`) ✅

This PR also carries temporary test commits (reverted before merge) to demonstrate both cases live in CI.

Relates: ZAP-472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
