### PR TITLE
fix(users): avatar changes no longer render stale after apply

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -196,7 +196,8 @@ export class UserModel {
     }
 
     // Per-pod eviction: other pods keep their entry until the 30s TTL expires
-    static invalidateSessionUserCache(userUuid: string): void {
+    // eslint-disable-next-line class-methods-use-this
+    invalidateSessionUserCache(userUuid: string): void {
         const cache = sessionUserCache;
         if (!cache) return;
         const prefix = `${userUuid}::`;
@@ -552,7 +553,7 @@ export class UserModel {
         if (isActive === false) {
             PatSessionCache.invalidate();
         }
-        UserModel.invalidateSessionUserCache(userUuid);
+        this.invalidateSessionUserCache(userUuid);
         return this.getUserDetailsByUuid(userUuid);
     }
 
@@ -561,7 +562,7 @@ export class UserModel {
             .where('user_uuid', userUuid)
             .delete();
         PatSessionCache.invalidate();
-        UserModel.invalidateSessionUserCache(userUuid);
+        this.invalidateSessionUserCache(userUuid);
     }
 
     async getUserProjectRoles(

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -195,6 +195,17 @@ export class UserModel {
         return this.lightdashConfig.mode !== LightdashMode.CLOUD_BETA;
     }
 
+    // Per-pod eviction: other pods keep their entry until the 30s TTL expires
+    static invalidateSessionUserCache(userUuid: string): void {
+        const cache = sessionUserCache;
+        if (!cache) return;
+        const prefix = `${userUuid}::`;
+        cache
+            .keys()
+            .filter((key) => key.startsWith(prefix))
+            .forEach((key) => cache.del(key));
+    }
+
     async getSessionUserFromCacheOrDB(
         userUuid: string,
         organizationUuid: string,
@@ -541,6 +552,7 @@ export class UserModel {
         if (isActive === false) {
             PatSessionCache.invalidate();
         }
+        UserModel.invalidateSessionUserCache(userUuid);
         return this.getUserDetailsByUuid(userUuid);
     }
 
@@ -549,6 +561,7 @@ export class UserModel {
             .where('user_uuid', userUuid)
             .delete();
         PatSessionCache.invalidate();
+        UserModel.invalidateSessionUserCache(userUuid);
     }
 
     async getUserProjectRoles(

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1497,6 +1497,7 @@ export class UserService extends BaseService {
     ): Promise<{ avatarUrl: string }> {
         const { image, contentHash } = await processAvatarImage(body);
         await this.userAvatarModel.upsert(user.userUuid, image, contentHash);
+        UserModel.invalidateSessionUserCache(user.userUuid);
         this.analytics.track({
             userId: user.userUuid,
             event: 'user_avatar.updated',
@@ -1509,6 +1510,7 @@ export class UserService extends BaseService {
 
     async deleteAvatar(user: SessionUser): Promise<void> {
         await this.userAvatarModel.delete(user.userUuid);
+        UserModel.invalidateSessionUserCache(user.userUuid);
     }
 
     async getAvatarImage(

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1497,7 +1497,7 @@ export class UserService extends BaseService {
     ): Promise<{ avatarUrl: string }> {
         const { image, contentHash } = await processAvatarImage(body);
         await this.userAvatarModel.upsert(user.userUuid, image, contentHash);
-        UserModel.invalidateSessionUserCache(user.userUuid);
+        this.userModel.invalidateSessionUserCache(user.userUuid);
         this.analytics.track({
             userId: user.userUuid,
             event: 'user_avatar.updated',
@@ -1510,7 +1510,7 @@ export class UserService extends BaseService {
 
     async deleteAvatar(user: SessionUser): Promise<void> {
         await this.userAvatarModel.delete(user.userUuid);
-        UserModel.invalidateSessionUserCache(user.userUuid);
+        this.userModel.invalidateSessionUserCache(user.userUuid);
     }
 
     async getAvatarImage(

--- a/packages/frontend/src/hooks/user/useAvatarMutations.ts
+++ b/packages/frontend/src/hooks/user/useAvatarMutations.ts
@@ -2,6 +2,7 @@ import { type ApiError, type ApiUserAvatarResponse } from '@lightdash/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
 import { downscaleAvatarImage } from './downscaleAvatarImage';
+import { type UserWithAbility } from './useUser';
 
 const uploadAvatar = async (
     file: File,
@@ -20,8 +21,12 @@ export const useAvatarUploadMutation = () => {
     return useMutation<ApiUserAvatarResponse['results'], ApiError, File>({
         mutationKey: ['user_avatar_upload'],
         mutationFn: uploadAvatar,
-        onSuccess: async () => {
-            await queryClient.refetchQueries(['user']);
+        onSuccess: async (data) => {
+            queryClient.setQueryData<UserWithAbility>(['user'], (previous) =>
+                previous
+                    ? { ...previous, avatarUrl: data.avatarUrl }
+                    : previous,
+            );
             await queryClient.invalidateQueries(['organization_users']);
         },
     });
@@ -40,7 +45,9 @@ export const useAvatarDeleteMutation = () => {
         mutationKey: ['user_avatar_delete'],
         mutationFn: deleteAvatar,
         onSuccess: async () => {
-            await queryClient.refetchQueries(['user']);
+            queryClient.setQueryData<UserWithAbility>(['user'], (previous) =>
+                previous ? { ...previous, avatarUrl: null } : previous,
+            );
             await queryClient.invalidateQueries(['organization_users']);
         },
     });

--- a/packages/frontend/src/hooks/user/useUserUpdateMutation.ts
+++ b/packages/frontend/src/hooks/user/useUserUpdateMutation.ts
@@ -9,6 +9,7 @@ import {
     type UseMutationOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
+import { type UserWithAbility } from './useUser';
 
 const updateUserQuery = async (data: Partial<UpdateUserArgs>) =>
     lightdashApi<LightdashUser>({
@@ -30,7 +31,10 @@ export const useUserUpdateMutation = (
         mutationFn: updateUserQuery,
         ...useMutationOptions,
         onSuccess: async (data, variables, context) => {
-            await queryClient.refetchQueries(['user']);
+            // The PATCH response is fresh; a refetch can race a stale server-side session cache
+            queryClient.setQueryData<UserWithAbility>(['user'], (previous) =>
+                previous ? { ...previous, ...data } : previous,
+            );
             await queryClient.refetchQueries(['email_status']);
 
             useMutationOptions?.onSuccess?.(data, variables, context);


### PR DESCRIPTION
## Problem

Applying an avatar gradient (or uploading/removing a photo) shows the *previous* value for up to ~30s; a reload "fixes" it.

Reproduced on cloud with instrumented browser polling: after `PATCH /api/v1/user/me` saved the new gradient, the immediate `GET /api/v1/user` refetch returned the **pre-update** user (old gradient, old `updatedAt`), so the UI rendered exactly one change behind.

## Root cause

`GET /api/v1/user` returns `req.account`, built from the passport-deserialized session user, which is served from `sessionUserCache` in `UserModel` — a per-pod NodeCache with 30s TTL (enabled via `EXPERIMENTAL_CACHE=true` on cloud). Nothing ever invalidated it.

Worse, the PATCH request itself runs `deserializeUser` *before* the handler writes to the DB, repopulating the cache with the old row — so the refetch fired by the mutation's `onSuccess` was **guaranteed** stale, not a race you could win.

## Fix

**Backend** — evict the user's `sessionUserCache` entries whenever the user row (or their avatar, whose hash is part of the session user) mutates:
- `UserModel.updateUser` / `UserModel.delete`
- `UserService.updateAvatar` / `UserService.deleteAvatar`

**Frontend** — the profile-update and avatar upload/delete mutations now merge the fresh mutation response into the `['user']` query cache via `setQueryData` instead of refetching. Instant UI update, immune to cross-pod cache staleness, and one fewer full user+ability build per update.

## Who is affected / regression analysis

- The read-path cache is untouched: eviction only happens on self-profile/avatar writes (rare), costing one extra deserialize (DB read + ability build) for that user on their next request. No change to steady-state hit rate — this cache exists because ability builds were a perf hotspot, and that mitigation is preserved.
- Eviction is per-pod: another pod can still serve the old session user until the existing 30s TTL expires — same staleness the TTL already accepts by design, and the frontend no longer depends on that read for correctness.
- Self-hosted instances without `EXPERIMENTAL_CACHE` never had the bug; the invalidation helper is a no-op there.

Closes: ZAP-589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoQyAYKaVSrLmW48UduNMj
