### PR TITLE
refactor(ai-reviews): remove two-tier judge escalation — eval showed no precision lift

### DIFF
--- a/packages/backend/src/ee/repl/scripts/reviewClassifierScoreboard.ts
+++ b/packages/backend/src/ee/repl/scripts/reviewClassifierScoreboard.ts
@@ -601,8 +601,6 @@ export function getReviewClassifierScoreboardScripts(
         outPath?: string;
         limit?: number;
         concurrency?: number;
-        /** false = A/B the fast gate tier alone (no strong-model escalation) */
-        escalation?: boolean;
     }): Promise<ScoreboardMetrics> {
         const service = getService();
         let entries: ScoreboardFixtureEntry[];
@@ -642,9 +640,7 @@ export function getReviewClassifierScoreboardScripts(
                     };
                 }
                 try {
-                    const result = await service.replayJudge(entry.input, {
-                        escalationEnabled: args.escalation ?? true,
-                    });
+                    const result = await service.replayJudge(entry.input);
                     console.log(
                         `[${index + 1}/${entries.length}] ${
                             entry.label.signalUuid

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
@@ -19,13 +19,8 @@ vi.mock('./ai/utils/aiCallTelemetry', () => ({
 const generateObjectMock = vi.mocked(generateObject);
 const getModelMock = vi.mocked(getModel);
 
-const GATE_MODEL = {
+const JUDGE_MODEL = {
     model: { modelId: 'claude-haiku-4-5' },
-    callOptions: {},
-    providerOptions: {},
-};
-const ESCALATION_MODEL = {
-    model: { modelId: 'claude-sonnet-4-6' },
     callOptions: {},
     providerOptions: {},
 };
@@ -149,120 +144,42 @@ const makeService = () =>
         aiAgentReviewNotificationService: {} as never,
     });
 
-describe('two-tier judge escalation', () => {
+describe('single-tier judge', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        getModelMock.mockImplementation(
-            (_config, options) =>
-                (options?.useFastModel
-                    ? GATE_MODEL
-                    : ESCALATION_MODEL) as never,
-        );
+        getModelMock.mockReturnValue(JUDGE_MODEL as never);
     });
 
-    it('returns the gate output without escalating when not promoted', async () => {
-        const gateOutput = judgeOutput({
+    it('judges with the fast model in a single call when not promoted', async () => {
+        const output = judgeOutput({
             promotedToFinding: false,
             promotionReason: null,
             primaryRootCause: 'not_a_failure',
             signal: 'acceptance_or_continuation',
             implicitSignalSources: [],
         });
-        generateObjectMock.mockResolvedValueOnce({
-            object: gateOutput,
-        } as never);
+        generateObjectMock.mockResolvedValueOnce({ object: output } as never);
 
         const result = await makeService().replayJudge(replayInput);
 
         expect(generateObjectMock).toHaveBeenCalledTimes(1);
+        expect(getModelMock).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ useFastModel: true }),
+        );
         expect(generateObjectMock).toHaveBeenCalledWith(
-            expect.objectContaining({ model: GATE_MODEL.model }),
+            expect.objectContaining({ model: JUDGE_MODEL.model }),
         );
-        expect(result.judgeOutput).toEqual(gateOutput);
+        expect(result.judgeOutput).toEqual(output);
     });
 
-    it('escalates promoted turns to the strong model and returns its verdict', async () => {
-        const escalatedOutput = judgeOutput({
-            primaryRootCause: 'agent_configuration',
-        });
-        generateObjectMock
-            .mockResolvedValueOnce({ object: judgeOutput() } as never)
-            .mockResolvedValueOnce({ object: escalatedOutput } as never);
-
-        const result = await makeService().replayJudge(replayInput);
-
-        expect(generateObjectMock).toHaveBeenCalledTimes(2);
-        expect(generateObjectMock).toHaveBeenLastCalledWith(
-            expect.objectContaining({ model: ESCALATION_MODEL.model }),
-        );
-        expect(result.judgeOutput).toEqual(escalatedOutput);
-    });
-
-    it('lets the strong model demote a gate promotion', async () => {
-        const demoted = judgeOutput({
-            promotedToFinding: false,
-            promotionReason: null,
-            primaryRootCause: 'not_a_failure',
-            signal: 'acceptance_or_continuation',
-            implicitSignalSources: [],
-        });
-        generateObjectMock
-            .mockResolvedValueOnce({ object: judgeOutput() } as never)
-            .mockResolvedValueOnce({ object: demoted } as never);
-
-        const result = await makeService().replayJudge(replayInput);
-
-        expect(result.judgeOutput?.promotedToFinding).toBe(false);
-    });
-
-    it('skips escalation when disabled via options', async () => {
-        const gateOutput = judgeOutput();
-        generateObjectMock.mockResolvedValueOnce({
-            object: gateOutput,
-        } as never);
-
-        const result = await makeService().replayJudge(replayInput, {
-            escalationEnabled: false,
-        });
-
-        expect(generateObjectMock).toHaveBeenCalledTimes(1);
-        expect(result.judgeOutput).toEqual(gateOutput);
-    });
-
-    it('skips escalation when the strong model is the same as the gate model', async () => {
-        getModelMock.mockImplementation(() => GATE_MODEL as never);
-        const gateOutput = judgeOutput();
-        generateObjectMock.mockResolvedValueOnce({
-            object: gateOutput,
-        } as never);
+    it('judges promoted turns with the same single fast-model call', async () => {
+        const output = judgeOutput();
+        generateObjectMock.mockResolvedValueOnce({ object: output } as never);
 
         const result = await makeService().replayJudge(replayInput);
 
         expect(generateObjectMock).toHaveBeenCalledTimes(1);
-        expect(result.judgeOutput).toEqual(gateOutput);
-    });
-});
-
-describe('two-tier judge escalation resilience', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-        getModelMock.mockImplementation(
-            (_config, options) =>
-                (options?.useFastModel
-                    ? GATE_MODEL
-                    : ESCALATION_MODEL) as never,
-        );
-    });
-
-    it('keeps the gate verdict when the escalation call fails', async () => {
-        const gateOutput = judgeOutput();
-        generateObjectMock
-            .mockResolvedValueOnce({ object: gateOutput } as never)
-            .mockRejectedValueOnce(new Error('rate limited'));
-
-        const result = await makeService().replayJudge(replayInput);
-
-        expect(generateObjectMock).toHaveBeenCalledTimes(2);
-        expect(result.judgeOutput).toEqual(gateOutput);
+        expect(result.judgeOutput).toEqual(output);
     });
 });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -73,16 +73,9 @@ export const resolveReviewJudgeProvider = (
 ): LightdashConfig['ai']['copilot']['defaultProvider'] | undefined =>
     copilot.providers.anthropic ? 'anthropic' : undefined;
 
-export type AiAgentReviewJudgeOptions = {
-    // Escalate promoted turns to the strong (non-fast) model. Defaults to
-    // true; the replay scoreboard passes false to A/B the gate tier alone.
-    escalationEnabled?: boolean;
-};
-
 type AiAgentReviewClassifierJudge = (
     candidate: AiAgentReviewClassifierTurnCandidate,
     evidencePacket: AiAgentReviewJudgeEvidencePacket,
-    opts?: AiAgentReviewJudgeOptions,
 ) => Promise<AiAgentReviewClassifierJudgeOutput>;
 
 type AiAgentReviewClassifierJudgeTargetRef =
@@ -310,8 +303,8 @@ export class AiAgentReviewClassifierService extends BaseService {
         this.lightdashConfig = dependencies.lightdashConfig;
         this.judgeTurn =
             dependencies.judgeTurn ??
-            ((candidate, evidencePacket, opts) =>
-                this.judgeTurnWithLlm(candidate, evidencePacket, opts));
+            ((candidate, evidencePacket) =>
+                this.judgeTurnWithLlm(candidate, evidencePacket));
     }
 
     private debugLog(context: string, payload: Record<string, unknown>): void {
@@ -400,7 +393,6 @@ export class AiAgentReviewClassifierService extends BaseService {
      */
     async replayJudge(
         input: AiAgentReviewJudgeReplayInput,
-        opts?: AiAgentReviewJudgeOptions,
     ): Promise<AiAgentReviewJudgeReplayResult> {
         const successfulWritebackEvidence =
             AiAgentReviewClassifierService.getSuccessfulWritebackEvidence(
@@ -412,7 +404,6 @@ export class AiAgentReviewClassifierService extends BaseService {
         const judgeOutput = await this.judgeTurn(
             input.candidate,
             input.evidencePacket,
-            opts,
         );
         return {
             suppressed: null,
@@ -1526,22 +1517,17 @@ export class AiAgentReviewClassifierService extends BaseService {
     private async judgeTurnWithLlm(
         candidate: AiAgentReviewClassifierTurnCandidate,
         evidencePacket: AiAgentReviewJudgeEvidencePacket,
-        opts?: AiAgentReviewJudgeOptions & {
-            tier?: 'gate' | 'escalation';
-        },
     ): Promise<AiAgentReviewClassifierJudgeOutput> {
-        const tier = opts?.tier ?? 'gate';
         const model = getModel(this.lightdashConfig.ai.copilot, {
             provider: resolveReviewJudgeProvider(
                 this.lightdashConfig.ai.copilot,
             ),
-            useFastModel: tier === 'gate',
+            useFastModel: true,
         });
 
         this.debugLog('JudgeRequest', {
             promptUuid: candidate.subject.assistantPromptUuid,
             threadUuid: candidate.subject.threadUuid,
-            tier,
             judgeModelId: model.model.modelId,
             modelProvider: candidate.modelMetadata.provider,
             modelName: candidate.modelMetadata.model,
@@ -1565,10 +1551,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             ...model.callOptions,
             providerOptions: model.providerOptions,
             experimental_telemetry: getAiCallTelemetry({
-                functionId:
-                    tier === 'gate'
-                        ? 'aiAgentReviewClassifierJudge'
-                        : 'aiAgentReviewClassifierJudgeEscalation',
+                functionId: 'aiAgentReviewClassifierJudge',
                 feature: 'review-classifier',
                 organizationUuid: candidate.subject.organizationUuid,
                 projectUuid: candidate.subject.projectUuid,
@@ -1688,66 +1671,7 @@ Existing review items — dedup rules. The evidence packet field existingReviewI
             ],
         });
 
-        const output = result.object as AiAgentReviewClassifierJudgeOutput;
-
-        // Two-tier judge: the fast model is a promotion gate; turns it wants
-        // to promote re-run through the strong model, whose verdict wins —
-        // root cause and targetRefs are what mint review items and route PRs.
-        const escalationEnabled = opts?.escalationEnabled ?? true;
-        if (
-            tier === 'gate' &&
-            escalationEnabled &&
-            output.promotedToFinding &&
-            this.hasDistinctEscalationJudgeModel(model.model.modelId)
-        ) {
-            try {
-                const escalatedOutput = await this.judgeTurnWithLlm(
-                    candidate,
-                    evidencePacket,
-                    { tier: 'escalation' },
-                );
-                this.debugLog('JudgeEscalationCompleted', {
-                    promptUuid: candidate.subject.assistantPromptUuid,
-                    threadUuid: candidate.subject.threadUuid,
-                    gatePromoted: output.promotedToFinding,
-                    gateRootCause: output.primaryRootCause,
-                    escalatedPromoted: escalatedOutput.promotedToFinding,
-                    escalatedRootCause: escalatedOutput.primaryRootCause,
-                });
-                return escalatedOutput;
-            } catch (error) {
-                // The gate verdict is still a valid classification — never
-                // lose the turn because the strong model was unavailable.
-                Logger.error(
-                    'AI review judge escalation failed; keeping gate verdict',
-                    {
-                        promptUuid: candidate.subject.assistantPromptUuid,
-                        threadUuid: candidate.subject.threadUuid,
-                        errorMessage:
-                            error instanceof Error
-                                ? error.message
-                                : String(error),
-                    },
-                );
-                return output;
-            }
-        }
-
-        return output;
-    }
-
-    private hasDistinctEscalationJudgeModel(gateModelId: string): boolean {
-        try {
-            const escalationModel = getModel(this.lightdashConfig.ai.copilot, {
-                provider: resolveReviewJudgeProvider(
-                    this.lightdashConfig.ai.copilot,
-                ),
-                useFastModel: false,
-            });
-            return escalationModel.model.modelId !== gateModelId;
-        } catch {
-            return false;
-        }
+        return result.object as AiAgentReviewClassifierJudgeOutput;
     }
 
     private async isEnabled(args: {


### PR DESCRIPTION
## Summary

Removes the two-tier judge escalation from the AI review classifier: promoted turns no longer re-run through the strong (non-fast) model — the fast-tier judge's verdict is final. Shipped as an experiment in #25080; the offline replay eval says it isn't earning its cost.

## Why

Replayed 124–125 human-labeled analytics-org turns (the audit corpus, recaptured through the deployed v15 packet builder via the #25082 endpoint) through both arms of the deployed judge:

| Metric | v15 gate-only | v15 two-tier |
|---|---|---|
| Promotion precision | **88.5%** | 88.3% |
| Should-promote recall | 61.4% | 60.2% |
| Root-cause accuracy (evaluable promoted) | 83.8% (31/37) | 88.9% (32/36) |
| Strong-model calls | 0 | **63** |

The decision gate for keeping escalation always-on was a ≥ +10 pt promoted-precision lift; measured **−0.2 pts**. The root-cause gain (+5.1 pts) is ~2 turns on a 36-turn evaluable subset — inside noise. Both arms clear the v10 baseline identically (71.0% → ~88.5% precision; both audit FP drivers regress to ≈0). The escalation tier costs a Sonnet call on every promoted turn (~half of scored turns) for no measurable quality gain — the prompt/packet improvements (#25064–#25079, #25108) are what carry v15, not the bigger model.

## What changed

- `AiAgentReviewClassifierService.judgeTurnWithLlm`: single fast-model call; removed the `tier` machinery, the escalation re-run block, and `hasDistinctEscalationJudgeModel`.
- Removed `AiAgentReviewJudgeOptions` (`escalationEnabled` was its only member); `replayJudge` no longer takes options.
- Replay scoreboard REPL script: dropped the `escalation` A/B arg.
- Tests: replaced the escalation describes with single-tier judge coverage.

## Who is affected

Orgs with AI reviews enabled and a configured strong model stop getting the Sonnet re-judgement on promoted turns — verdicts now always come from the fast-tier model. Per the eval this changes promotion/root-cause quality by ≈0 while cutting one strong-model call per promoted turn. No API, schema, or judge-prompt changes (`JUDGE_PROMPT_HASH` unchanged — both tiers used the same prompt), so replay fixtures and historical runs remain comparable. Service accounts, custom roles, and non-review paths are untouched.

Relates: ZAP-556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1gZhVN8rGpUKWZBeNRPzK
