### PR TITLE
feat: add instance-side backend proxy for roadmap data

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -210,6 +210,7 @@ export const lightdashConfigMock: LightdashConfig = {
     roadmap: {
         enabled: false,
         syncCron: '17 * * * *',
+        serviceUrl: null,
         linear: {
             apiKey: null,
             apiUrl: 'https://api.linear.app/graphql',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1278,6 +1278,7 @@ export type LightdashConfig = {
     roadmap: {
         enabled: boolean;
         syncCron: string;
+        serviceUrl: string | null;
         linear: {
             apiKey: string | null;
             apiUrl: string;
@@ -2436,6 +2437,7 @@ export const parseConfig = (): LightdashConfig => {
         roadmap: {
             enabled: process.env.ROADMAP_ENABLED === 'true',
             syncCron: process.env.ROADMAP_SYNC_CRON || '17 * * * *',
+            serviceUrl: process.env.ROADMAP_SERVICE_URL || null,
             linear: {
                 apiKey: process.env.ROADMAP_LINEAR_API_KEY || null,
                 apiUrl:

--- a/packages/backend/src/ee/controllers/orgRoadmapController.ts
+++ b/packages/backend/src/ee/controllers/orgRoadmapController.ts
@@ -1,0 +1,51 @@
+import {
+    ApiErrorPayload,
+    ApiRoadmapResponse,
+    assertRegisteredAccount,
+} from '@lightdash/common';
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import type { RoadmapProxyService } from '../services/RoadmapProxyService/RoadmapProxyService';
+
+@Route('/api/v1/org/roadmap')
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class OrgRoadmapController extends BaseController {
+    /**
+     * Get the curated, read-only roadmap for the authenticated user's
+     * organization. Proxied server-side from the central roadmap service;
+     * gated by the Roadmap feature flag.
+     * @summary Get the organization's roadmap
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getOrgRoadmap')
+    async getOrgRoadmap(
+        @Request() req: express.Request,
+    ): Promise<ApiRoadmapResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getRoadmapProxyService<RoadmapProxyService>()
+                .getRoadmapForUser(toSessionUser(req.account)),
+        };
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -92,6 +92,7 @@ import { PreviewDeploySetupService } from './services/PreviewDeploySetupService/
 import { ProjectContextService } from './services/ProjectContextService/ProjectContextService';
 import { ProjectHomepageService } from './services/ProjectHomepageService';
 import { provisionOnboardingHomepage } from './services/ProjectService/provisionOnboardingHomepage';
+import { RoadmapProxyService } from './services/RoadmapProxyService/RoadmapProxyService';
 import { SchedulerAiAugmentationService } from './services/SchedulerAiAugmentationService/SchedulerAiAugmentationService';
 import { RoadmapService } from './services/RoadmapService/RoadmapService';
 import { ScimService } from './services/ScimService/ScimService';
@@ -329,6 +330,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         : null,
                 });
             },
+            roadmapProxyService: ({ context, repository }) =>
+                new RoadmapProxyService({
+                    lightdashConfig: context.lightdashConfig,
+                    featureFlagService: repository.getFeatureFlagService(),
+                }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({
                     analytics: context.lightdashAnalytics,

--- a/packages/backend/src/ee/services/RoadmapProxyService/RoadmapProxyService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapProxyService/RoadmapProxyService.test.ts
@@ -1,0 +1,171 @@
+import {
+    ForbiddenError,
+    MissingConfigError,
+    RoadmapItemStatus,
+    SessionUser,
+    UnexpectedServerError,
+} from '@lightdash/common';
+import type { Mocked } from 'vitest';
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import type { LightdashConfig } from '../../../config/parseConfig';
+import type { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+import { RoadmapProxyService } from './RoadmapProxyService';
+
+const organizationUuid = '11111111-1111-1111-1111-111111111111';
+
+const user = {
+    userUuid: '22222222-2222-2222-2222-222222222222',
+    organizationUuid,
+} as SessionUser;
+
+const configuredConfig: LightdashConfig = {
+    ...lightdashConfigMock,
+    license: { licenseKey: 'license-key' },
+    roadmap: {
+        ...lightdashConfigMock.roadmap,
+        serviceUrl: 'https://roadmap.lightdash.com/',
+    },
+};
+
+const createFeatureFlagService = (
+    enabled: boolean,
+): Mocked<Pick<FeatureFlagService, 'get'>> => ({
+    get: vi.fn().mockResolvedValue({ id: 'roadmap', enabled }),
+});
+
+const buildService = (
+    featureFlagService: ReturnType<typeof createFeatureFlagService>,
+    config: LightdashConfig = configuredConfig,
+) =>
+    new RoadmapProxyService({
+        lightdashConfig: config,
+        featureFlagService: featureFlagService as unknown as FeatureFlagService,
+    });
+
+const curatedItem = {
+    title: 'Dark mode',
+    description: 'please',
+    status: RoadmapItemStatus.BUILDING,
+};
+
+describe('RoadmapProxyService', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    it('throws ForbiddenError when the feature flag is disabled', async () => {
+        const service = buildService(createFeatureFlagService(false));
+
+        await expect(service.getRoadmapForUser(user)).rejects.toThrow(
+            ForbiddenError,
+        );
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenError when the user has no organization', async () => {
+        const service = buildService(createFeatureFlagService(true));
+
+        await expect(
+            service.getRoadmapForUser({
+                userUuid: user.userUuid,
+            } as SessionUser),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('throws MissingConfigError when the service URL is not configured', async () => {
+        const service = buildService(createFeatureFlagService(true), {
+            ...configuredConfig,
+            roadmap: { ...configuredConfig.roadmap, serviceUrl: null },
+        });
+
+        await expect(service.getRoadmapForUser(user)).rejects.toThrow(
+            MissingConfigError,
+        );
+    });
+
+    it('throws MissingConfigError when the license key is not configured', async () => {
+        const service = buildService(createFeatureFlagService(true), {
+            ...configuredConfig,
+            license: { licenseKey: null },
+        });
+
+        await expect(service.getRoadmapForUser(user)).rejects.toThrow(
+            MissingConfigError,
+        );
+    });
+
+    it('fetches the org roadmap with the license key header', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ status: 'ok', results: [curatedItem] }),
+        });
+        const service = buildService(createFeatureFlagService(true));
+
+        const items = await service.getRoadmapForUser(user);
+
+        expect(items).toEqual([curatedItem]);
+        expect(fetchMock).toHaveBeenCalledWith(
+            `https://roadmap.lightdash.com/api/v1/roadmap/organizations/${organizationUuid}`,
+            { headers: { 'lightdash-license-key': 'license-key' } },
+        );
+    });
+
+    it('excludes items the redaction checkpoint rejects', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                status: 'ok',
+                results: [
+                    curatedItem,
+                    { ...curatedItem, title: 'Leaky', arr: 100000 },
+                ],
+            }),
+        });
+        const service = buildService(createFeatureFlagService(true));
+
+        const items = await service.getRoadmapForUser(user);
+
+        expect(items).toEqual([curatedItem]);
+    });
+
+    it('throws without forwarding upstream error details on non-ok responses', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+            text: async () => 'Invalid license key [SECRET_DETAIL]',
+        });
+        const service = buildService(createFeatureFlagService(true));
+
+        const error = await service.getRoadmapForUser(user).catch((e) => e);
+
+        expect(error).toBeInstanceOf(UnexpectedServerError);
+        expect(error.message).not.toContain('SECRET_DETAIL');
+    });
+
+    it('throws when the response has no results array', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ status: 'ok' }),
+        });
+        const service = buildService(createFeatureFlagService(true));
+
+        await expect(service.getRoadmapForUser(user)).rejects.toThrow(
+            UnexpectedServerError,
+        );
+    });
+
+    it('throws when the roadmap service is unreachable', async () => {
+        fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+        const service = buildService(createFeatureFlagService(true));
+
+        await expect(service.getRoadmapForUser(user)).rejects.toThrow(
+            'Could not reach the roadmap service',
+        );
+    });
+});

--- a/packages/backend/src/ee/services/RoadmapProxyService/RoadmapProxyService.ts
+++ b/packages/backend/src/ee/services/RoadmapProxyService/RoadmapProxyService.ts
@@ -1,0 +1,131 @@
+import {
+    FeatureFlags,
+    ForbiddenError,
+    getErrorMessage,
+    MissingConfigError,
+    redactRoadmapItems,
+    RoadmapItem,
+    SessionUser,
+    UnexpectedServerError,
+} from '@lightdash/common';
+import type { LightdashConfig } from '../../../config/parseConfig';
+import { BaseService } from '../../../services/BaseService';
+import type { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+import { ROADMAP_LICENSE_KEY_HEADER } from '../../controllers/authentication/roadmapServiceAuthentication';
+
+type Dependencies = {
+    lightdashConfig: LightdashConfig;
+    featureFlagService: FeatureFlagService;
+};
+
+/**
+ * Instance-side proxy to the central roadmap service (server-side proxy is the
+ * default v1 topology). Authenticates outbound requests with this instance's
+ * license key, which is how the central service resolves the organization —
+ * the same trust boundary as license verification, so self-hosted instances
+ * need no new egress rule.
+ */
+export class RoadmapProxyService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly featureFlagService: FeatureFlagService;
+
+    constructor(dependencies: Dependencies) {
+        super({ serviceName: 'RoadmapProxyService' });
+        this.lightdashConfig = dependencies.lightdashConfig;
+        this.featureFlagService = dependencies.featureFlagService;
+    }
+
+    /**
+     * Fetch the curated roadmap for the user's organization from the central
+     * roadmap service. Gated by the Roadmap feature flag. The response is run
+     * through the redaction checkpoint again before it reaches the browser —
+     * fail closed even if the upstream service misbehaves.
+     */
+    async getRoadmapForUser(user: SessionUser): Promise<RoadmapItem[]> {
+        const { userUuid, organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+
+        const flag = await this.featureFlagService.get({
+            user: { userUuid, organizationUuid },
+            featureFlagId: FeatureFlags.Roadmap,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError(
+                'Roadmap is not enabled for this organization',
+            );
+        }
+
+        const { serviceUrl } = this.lightdashConfig.roadmap;
+        const { licenseKey } = this.lightdashConfig.license;
+        if (!serviceUrl) {
+            throw new MissingConfigError(
+                'Roadmap service URL is not configured',
+            );
+        }
+        if (!licenseKey) {
+            throw new MissingConfigError('License key is not configured');
+        }
+
+        const url = `${serviceUrl.replace(
+            /\/+$/,
+            '',
+        )}/api/v1/roadmap/organizations/${organizationUuid}`;
+
+        let response: Response;
+        try {
+            response = await fetch(url, {
+                headers: { [ROADMAP_LICENSE_KEY_HEADER]: licenseKey },
+            });
+        } catch (error) {
+            this.logger.error(
+                `Roadmap proxy: could not reach the roadmap service: ${getErrorMessage(error)}`,
+            );
+            throw new UnexpectedServerError(
+                'Could not reach the roadmap service',
+            );
+        }
+
+        if (!response.ok) {
+            const body = await response.text().catch(() => '');
+            // Upstream errors are logged internally but never forwarded to
+            // the browser.
+            this.logger.error(
+                `Roadmap proxy: roadmap service responded with status ${response.status}${body ? `: ${body.slice(0, 500)}` : ''}`,
+            );
+            throw new UnexpectedServerError('Roadmap service request failed');
+        }
+
+        let results: unknown;
+        try {
+            const parsed = (await response.json()) as { results?: unknown };
+            results = parsed.results;
+        } catch (error) {
+            this.logger.error(
+                `Roadmap proxy: could not parse roadmap service response: ${getErrorMessage(error)}`,
+            );
+            throw new UnexpectedServerError('Roadmap service request failed');
+        }
+        if (!Array.isArray(results)) {
+            this.logger.error(
+                'Roadmap proxy: roadmap service response has no results array',
+            );
+            throw new UnexpectedServerError('Roadmap service request failed');
+        }
+
+        const { items, rejected } = redactRoadmapItems(
+            results as ReadonlyArray<Record<string, unknown>>,
+        );
+        if (rejected.length > 0) {
+            // The central service should only ever serve curated fields —
+            // rejections here mean its curation is broken. Alarm internally
+            // and withhold the affected items.
+            this.logger.error(
+                `Roadmap proxy: redaction rejected ${rejected.length} item(s) from the roadmap service for organization ${organizationUuid}`,
+            );
+        }
+        return items;
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -180,6 +180,7 @@ interface ServiceManifest {
     managedAgentService: unknown;
     mcpService: unknown;
     roadmapService: unknown;
+    roadmapProxyService: unknown;
     rolesService: RolesService;
     slackService: SlackService;
     organizationWarehouseCredentialsService: unknown;
@@ -1443,6 +1444,12 @@ export class ServiceRepository
 
     public getRoadmapService<RoadmapServiceImplT>(): RoadmapServiceImplT {
         return this.getService('roadmapService');
+    }
+
+    public getRoadmapProxyService<
+        RoadmapProxyServiceImplT,
+    >(): RoadmapProxyServiceImplT {
+        return this.getService('roadmapProxyService');
     }
 
     public getAiAgentService<AiAgentServiceImplT>(): AiAgentServiceImplT {


### PR DESCRIPTION
Adds the app-side backend path for the Roadmap page (CS-17), stacked on #24645.

- `RoadmapProxyService` (EE): fetches the org's curated roadmap from the central roadmap service, authenticating with the instance's license key (`lightdash-license-key` header) — same trust boundary as license verification, no new egress for self-hosted.
- `GET /api/v1/org/roadmap`: session-authenticated endpoint for the frontend (CS-18); hidden from public docs while pre-GA.
- Gated by the `Roadmap` feature flag; 403 when disabled.
- Fail-closed: the proxy re-runs `redactRoadmapItems` on the upstream response before anything reaches the browser, and upstream error bodies are logged internally, never forwarded.
- Config: `ROADMAP_SERVICE_URL`.

Linear: [CS-17](https://linear.app/lightdash/issue/CS-17/add-instance-side-backend-proxy-for-roadmap-data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoMa5ttbcLShFHGuySK7Lt