### PR TITLE
feat: add read-only roadmap page

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -888,6 +888,23 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 },
             },
             {
+                path: '/roadmap',
+                lazy: async () => {
+                    const { default: Roadmap } =
+                        await import('./pages/Roadmap');
+                    return {
+                        Component: () => (
+                            <>
+                                <NavBar />
+                                <TrackPage name={PageName.ROADMAP}>
+                                    <Roadmap />
+                                </TrackPage>
+                            </>
+                        ),
+                    };
+                },
+            },
+            {
                 path: '/no-access',
                 handle: { hideAILauncher: true },
                 element: (

--- a/packages/frontend/src/components/NavBar/HelpMenu.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu.tsx
@@ -1,22 +1,26 @@
-import { LightdashMode } from '@lightdash/common';
+import { FeatureFlags, LightdashMode } from '@lightdash/common';
 import { Button, getDefaultZIndex, Menu } from '@mantine-8/core';
 import { modals } from '@mantine/modals';
 import {
     IconBook,
     IconHelp,
     IconMessages,
+    IconRoad,
     IconSos,
     IconUsers,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { Link } from 'react-router';
 import { useIntercom } from 'react-use-intercom';
 import useHealth from '../../hooks/health/useHealth';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import SupportDrawerContent from '../../providers/SupportDrawer/SupportDrawerContent';
 import LargeMenuItem from '../common/LargeMenuItem';
 import MantineIcon from '../common/MantineIcon';
 
 const HelpMenu: FC = () => {
     const health = useHealth();
+    const roadmapFlag = useServerFeatureFlag(FeatureFlags.Roadmap);
     const isCloudCustomer = health.data?.mode === LightdashMode.CLOUD_BETA;
     const isDevelopment = health.data?.mode === LightdashMode.DEV;
 
@@ -92,6 +96,16 @@ const HelpMenu: FC = () => {
                     description="Get advice share best practices with other users."
                     icon={IconUsers}
                 />
+
+                {roadmapFlag.data?.enabled && (
+                    <LargeMenuItem
+                        component={Link}
+                        to="/roadmap"
+                        title="View your roadmap"
+                        description="See the feature requests your organization has raised and their status"
+                        icon={IconRoad}
+                    />
+                )}
 
                 {(isCloudCustomer || isDevelopment) && (
                     <LargeMenuItem

--- a/packages/frontend/src/hooks/useOrgRoadmap.ts
+++ b/packages/frontend/src/hooks/useOrgRoadmap.ts
@@ -1,0 +1,18 @@
+import type { ApiError, RoadmapItem } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+const getOrgRoadmap = async () =>
+    lightdashApi<RoadmapItem[]>({
+        url: '/org/roadmap',
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useOrgRoadmap = (enabled: boolean) =>
+    useQuery<RoadmapItem[], ApiError>({
+        queryKey: ['org-roadmap'],
+        queryFn: getOrgRoadmap,
+        enabled,
+        retry: false,
+    });

--- a/packages/frontend/src/pages/Roadmap.module.css
+++ b/packages/frontend/src/pages/Roadmap.module.css
@@ -1,0 +1,8 @@
+.item {
+    background-color: var(--mantine-color-background);
+
+    & :global(.wmde-markdown) {
+        background-color: inherit;
+        color: inherit;
+    }
+}

--- a/packages/frontend/src/pages/Roadmap.tsx
+++ b/packages/frontend/src/pages/Roadmap.tsx
@@ -1,0 +1,185 @@
+import {
+    assertUnreachable,
+    FeatureFlags,
+    RoadmapItemStatus,
+    type RoadmapItem,
+} from '@lightdash/common';
+import {
+    Accordion,
+    Badge,
+    Group,
+    Stack,
+    Text,
+    Title,
+    useMantineTheme,
+} from '@mantine-8/core';
+import { IconAlertCircle, IconRoad } from '@tabler/icons-react';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import { useMemo, type FC } from 'react';
+import { Navigate } from 'react-router';
+import rehypeExternalLinks from 'rehype-external-links';
+import rehypeSanitize from 'rehype-sanitize';
+import EmptyStateLoader from '../components/common/EmptyStateLoader';
+import Page from '../components/common/Page/Page';
+import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
+import { useOrgRoadmap } from '../hooks/useOrgRoadmap';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import styles from './Roadmap.module.css';
+
+const STATUS_ORDER: RoadmapItemStatus[] = [
+    RoadmapItemStatus.BUILDING,
+    RoadmapItemStatus.PLANNED,
+    RoadmapItemStatus.BACKLOG,
+    RoadmapItemStatus.SHIPPED,
+    RoadmapItemStatus.NOT_PLANNED,
+];
+
+const getStatusColor = (status: RoadmapItemStatus): string => {
+    switch (status) {
+        case RoadmapItemStatus.BUILDING:
+            return 'blue';
+        case RoadmapItemStatus.PLANNED:
+            return 'violet';
+        case RoadmapItemStatus.SHIPPED:
+            return 'green';
+        case RoadmapItemStatus.BACKLOG:
+        case RoadmapItemStatus.NOT_PLANNED:
+            return 'ldGray';
+        default:
+            return assertUnreachable(status, `Unknown status ${status}`);
+    }
+};
+
+const RoadmapItemPanel: FC<{ item: RoadmapItem }> = ({ item }) => {
+    const theme = useMantineTheme();
+    if (!item.description) {
+        return (
+            <Text c="ldGray.6" fz="sm">
+                No further detail on this request yet.
+            </Text>
+        );
+    }
+    return (
+        <MarkdownPreview
+            source={item.description}
+            rehypePlugins={[
+                rehypeSanitize,
+                [rehypeExternalLinks, { target: '_blank' }],
+            ]}
+            style={{
+                fontSize: theme.fontSizes.sm,
+                backgroundColor: 'inherit',
+                color: 'inherit',
+            }}
+        />
+    );
+};
+
+const RoadmapStatusSection: FC<{
+    status: RoadmapItemStatus;
+    items: RoadmapItem[];
+}> = ({ status, items }) => (
+    <Stack gap="xs">
+        <Group gap="xs">
+            <Title order={4}>{status}</Title>
+            <Text c="ldGray.6" fz="sm">
+                {items.length}
+            </Text>
+        </Group>
+        <Accordion
+            variant="separated"
+            radius="md"
+            chevronPosition="right"
+            multiple
+        >
+            {items.map((item, index) => (
+                <Accordion.Item
+                    // Curated items expose no id, and titles can repeat.
+                    key={`${status}-${index}`}
+                    value={`${status}-${index}`}
+                    className={styles.item}
+                >
+                    <Accordion.Control>
+                        <Group gap="sm" wrap="nowrap">
+                            <Badge
+                                color={getStatusColor(item.status)}
+                                variant="light"
+                                size="sm"
+                                flex="none"
+                            >
+                                {item.status}
+                            </Badge>
+                            <Text fw={500} fz="sm" lineClamp={1}>
+                                {item.title}
+                            </Text>
+                        </Group>
+                    </Accordion.Control>
+                    <Accordion.Panel>
+                        <RoadmapItemPanel item={item} />
+                    </Accordion.Panel>
+                </Accordion.Item>
+            ))}
+        </Accordion>
+    </Stack>
+);
+
+const Roadmap: FC = () => {
+    const flagQuery = useServerFeatureFlag(FeatureFlags.Roadmap);
+    const roadmapQuery = useOrgRoadmap(flagQuery.data?.enabled === true);
+
+    const sections = useMemo(() => {
+        const items = roadmapQuery.data ?? [];
+        return STATUS_ORDER.map((status) => ({
+            status,
+            items: items.filter((item) => item.status === status),
+        })).filter((section) => section.items.length > 0);
+    }, [roadmapQuery.data]);
+
+    if (flagQuery.isInitialLoading) {
+        return <EmptyStateLoader />;
+    }
+
+    if (!flagQuery.data?.enabled) {
+        return <Navigate to="/" replace />;
+    }
+
+    return (
+        <Page title="Roadmap" withFixedContent withPaddedContent>
+            <Stack gap="lg">
+                <Stack gap="xs">
+                    <Title order={2}>Roadmap</Title>
+                    <Text c="ldGray.6">
+                        Every feature request your organization has raised with
+                        Lightdash, and where each one stands.
+                    </Text>
+                </Stack>
+
+                {roadmapQuery.isInitialLoading ? (
+                    <EmptyStateLoader title="Loading your roadmap" />
+                ) : roadmapQuery.isError ? (
+                    <SuboptimalState
+                        icon={IconAlertCircle}
+                        title="Could not load your roadmap"
+                        description="Something went wrong fetching your roadmap. Try again in a few minutes, or contact support if it keeps happening."
+                    />
+                ) : sections.length === 0 ? (
+                    <SuboptimalState
+                        icon={IconRoad}
+                        title="No roadmap items yet"
+                        description="When your organization raises feature requests with Lightdash, they'll show up here with their current status."
+                    />
+                ) : (
+                    sections.map((section) => (
+                        <RoadmapStatusSection
+                            key={section.status}
+                            status={section.status}
+                            items={section.items}
+                        />
+                    ))
+                )}
+            </Stack>
+        </Page>
+    );
+};
+
+export default Roadmap;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -60,6 +60,7 @@ export enum PageName {
     CATALOG = 'catalog',
     METRICS_CATALOG = 'metrics_catalog',
     FUNNEL_BUILDER = 'funnel_builder',
+    ROADMAP = 'roadmap',
 }
 
 export enum CategoryName {


### PR DESCRIPTION
Adds the customer-facing Roadmap page (CS-18), stacked on #25138.

- `/roadmap` route (org-level, NavBar layout, lazy-loaded); redirects home when the `Roadmap` feature flag is off.
- Items grouped by customer-facing status (Building / Planned / Backlog / Shipped / Not planned) as accordions — title + status badge in the control, sanitized markdown description in the panel.
- Loading (`EmptyStateLoader`), empty, and error (`SuboptimalState`) states.
- Flag-gated "View your roadmap" entry in the NavBar help menu.
- Consumes `GET /api/v1/org/roadmap` (the instance proxy from #25138); displays only `title`/`description`/`status`.

Linear: [CS-18](https://linear.app/lightdash/issue/CS-18/build-read-only-roadmap-page-in-the-product)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoMa5ttbcLShFHGuySK7Lt