### PR TITLE
feat: resolve lightdash-prefixed org external ids on Linear customers

### DIFF
--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -146,6 +146,51 @@ describe('RoadmapService', () => {
             });
         });
 
+        it('resolves a lightdash-prefixed external id among other ids', async () => {
+            const roadmapModel = createRoadmapModel();
+            const linearClient = createLinearClient();
+            linearClient.listCustomers.mockResolvedValue([
+                {
+                    id: 'cust-1',
+                    name: 'Acme',
+                    externalIds: [
+                        'attio-record-id',
+                        `lightdash:${organizationUuid}`,
+                    ],
+                },
+            ]);
+            linearClient.getCustomerFeatureRequests.mockResolvedValue([]);
+
+            const service = buildService(roadmapModel, linearClient);
+            const summary = await service.syncMirror();
+
+            expect(summary.skippedCustomers).toBe(0);
+            expect(roadmapModel.replaceCustomerMirror).toHaveBeenCalledWith(
+                expect.objectContaining({ organizationUuid }),
+            );
+        });
+
+        it('skips customers with more than one lightdash-prefixed id', async () => {
+            const roadmapModel = createRoadmapModel();
+            const linearClient = createLinearClient();
+            linearClient.listCustomers.mockResolvedValue([
+                {
+                    id: 'cust-1',
+                    name: 'Acme',
+                    externalIds: [
+                        `lightdash:${organizationUuid}`,
+                        'lightdash:22222222-2222-2222-2222-222222222222',
+                    ],
+                },
+            ]);
+
+            const service = buildService(roadmapModel, linearClient);
+            const summary = await service.syncMirror();
+
+            expect(summary.skippedCustomers).toBe(1);
+            expect(roadmapModel.replaceCustomerMirror).not.toHaveBeenCalled();
+        });
+
         it('skips customers that do not resolve to exactly one org', async () => {
             const roadmapModel = createRoadmapModel();
             const linearClient = createLinearClient();

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -146,6 +146,38 @@ describe('RoadmapService', () => {
             });
         });
 
+        it('mirrors an issue once when multiple needs reference it', async () => {
+            const roadmapModel = createRoadmapModel();
+            const linearClient = createLinearClient();
+            linearClient.listCustomers.mockResolvedValue([
+                {
+                    id: 'cust-1',
+                    name: 'Acme',
+                    externalIds: [organizationUuid],
+                },
+            ]);
+            const issue = {
+                id: 'issue-1',
+                title: 'Dark mode',
+                description: null,
+                state: { name: 'In Progress', type: 'started' },
+                issueUrl: 'https://github.com/lightdash/lightdash/issues/1',
+                pullRequestUrl: null,
+            };
+            linearClient.getCustomerFeatureRequests.mockResolvedValue([
+                issue,
+                issue,
+            ]);
+
+            const service = buildService(roadmapModel, linearClient);
+            const summary = await service.syncMirror();
+
+            expect(summary.syncedItems).toBe(1);
+            expect(
+                roadmapModel.replaceCustomerMirror.mock.calls[0][0].items,
+            ).toHaveLength(1);
+        });
+
         it('resolves a lightdash-prefixed external id among other ids', async () => {
             const roadmapModel = createRoadmapModel();
             const linearClient = createLinearClient();

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -15,6 +15,13 @@ type Dependencies = {
     linearClient: LinearClient | null;
 };
 
+/**
+ * Prefix marking a Linear customer external id as a Lightdash organization
+ * uuid (`lightdash:<org uuid>`). Lets the org mapping coexist with ids other
+ * systems (e.g. the CRM) store on the same customer.
+ */
+export const LIGHTDASH_ORG_EXTERNAL_ID_PREFIX = 'lightdash:';
+
 export type RoadmapSyncSummary = {
     customers: number;
     skippedCustomers: number;
@@ -56,12 +63,23 @@ export class RoadmapService extends BaseService {
 
     /**
      * Resolve a Linear customer's external ids to the single Lightdash
-     * organization it maps to. A customer with no (or multiple) org-shaped
-     * external ids can't be resolved unambiguously and is skipped.
+     * organization it maps to.
+     *
+     * Preferred convention: a `lightdash:<org uuid>` external id — explicit,
+     * and unambiguous even when other systems store their own ids on the
+     * customer. Legacy convention: the customer's only external id is the org
+     * uuid. A customer matching neither (or matching the prefix more than
+     * once) can't be resolved unambiguously and is skipped.
      */
     private static resolveOrganizationUuid(
         externalIds: string[],
     ): string | null {
+        const prefixed = externalIds
+            .filter((id) => id.startsWith(LIGHTDASH_ORG_EXTERNAL_ID_PREFIX))
+            .map((id) => id.slice(LIGHTDASH_ORG_EXTERNAL_ID_PREFIX.length));
+        if (prefixed.length > 0) {
+            return prefixed.length === 1 ? prefixed[0] : null;
+        }
         return externalIds.length === 1 ? externalIds[0] : null;
     }
 

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -171,7 +171,15 @@ export class RoadmapService extends BaseService {
         const items: CuratedRoadmapItem[] = [];
         let rejectedItems = 0;
         let nonPublicItems = 0;
+        // Multiple customer needs can point at the same Linear issue; mirror
+        // each issue once or the batch insert violates the per-link unique
+        // constraint on linear_issue_id.
+        const seenIssueIds = new Set<string>();
         issues.forEach((issue) => {
+            if (seenIssueIds.has(issue.id)) {
+                return;
+            }
+            seenIssueIds.add(issue.id);
             if (issue.issueUrl === null) {
                 nonPublicItems += 1;
                 this.logger.debug(


### PR DESCRIPTION
Supports the Linear customer externalIds backfill, stacked on #25143.

Linear `Customer.externalIds` is append-only via the tooling used to maintain it, and some customers already carry ids from other systems (CRM record ids) — so the legacy "exactly one external id = the org uuid" rule can't resolve them and destructive rewrites aren't acceptable.

**New preferred convention**: a `lightdash:<org uuid>` external id, which coexists with other systems' ids. Resolution order: exactly one `lightdash:`-prefixed id wins; more than one → skip (ambiguous, as before); none → fall back to the legacy exactly-one rule, so already-resolved customers are untouched.

**Also fixes a latent sync bug this surfaced**: multiple customer needs can reference the same Linear issue, which produced duplicate `linear_issue_id`s in one mirror batch and violated the per-link unique constraint — silently failing the whole customer's sync. Issues are now mirrored once per customer.

Verified with unit tests (prefixed id among other ids resolves; multiple prefixed ids skip; duplicate needs mirror once) and a live workspace sync after backfilling 19 customers: org resolution went from **193 to 268 mirrored customer links** — the backfilled 19 plus dozens of customers previously failing on the duplicate-needs bug.

Linear: [CS-27](https://linear.app/lightdash/issue/CS-27/create-enterprise-cs-onboarding-checklist-ensure-linear-customer) (the onboarding checklist should adopt the prefixed form going forward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoMa5ttbcLShFHGuySK7Lt