### PR TITLE
feat: distinguish unmapped orgs from empty roadmaps

### DIFF
--- a/packages/backend/src/ee/services/RoadmapProxyService/RoadmapProxyService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapProxyService/RoadmapProxyService.test.ts
@@ -103,13 +103,16 @@ describe('RoadmapProxyService', () => {
         fetchMock.mockResolvedValueOnce({
             ok: true,
             status: 200,
-            json: async () => ({ status: 'ok', results: [curatedItem] }),
+            json: async () => ({
+                status: 'ok',
+                results: { mapped: true, items: [curatedItem] },
+            }),
         });
         const service = buildService(createFeatureFlagService(true));
 
-        const items = await service.getRoadmapForUser(user);
+        const result = await service.getRoadmapForUser(user);
 
-        expect(items).toEqual([curatedItem]);
+        expect(result).toEqual({ mapped: true, items: [curatedItem] });
         expect(fetchMock).toHaveBeenCalledWith(
             `https://roadmap.lightdash.com/api/v1/roadmap/organizations/${organizationUuid}`,
             { headers: { 'lightdash-license-key': 'license-key' } },
@@ -122,12 +125,15 @@ describe('RoadmapProxyService', () => {
             status: 200,
             json: async () => ({
                 status: 'ok',
-                results: [{ ...curatedItem, id: 'leak', sortOrder: 3 }],
+                results: {
+                    mapped: true,
+                    items: [{ ...curatedItem, id: 'leak', sortOrder: 3 }],
+                },
             }),
         });
         const service = buildService(createFeatureFlagService(true));
 
-        const items = await service.getRoadmapForUser(user);
+        const { items } = await service.getRoadmapForUser(user);
 
         expect(items).toEqual([curatedItem]);
         expect(Object.keys(items[0]).sort()).toEqual([
@@ -145,15 +151,18 @@ describe('RoadmapProxyService', () => {
             status: 200,
             json: async () => ({
                 status: 'ok',
-                results: [
-                    curatedItem,
-                    { ...curatedItem, title: 'Leaky', arr: 100000 },
-                ],
+                results: {
+                    mapped: true,
+                    items: [
+                        curatedItem,
+                        { ...curatedItem, title: 'Leaky', arr: 100000 },
+                    ],
+                },
             }),
         });
         const service = buildService(createFeatureFlagService(true));
 
-        const items = await service.getRoadmapForUser(user);
+        const { items } = await service.getRoadmapForUser(user);
 
         expect(items).toEqual([curatedItem]);
     });
@@ -172,18 +181,48 @@ describe('RoadmapProxyService', () => {
         expect(error.message).not.toContain('SECRET_DETAIL');
     });
 
-    it('throws when the response has no results array', async () => {
+    it('passes through mapped:false for an unmapped org', async () => {
         fetchMock.mockResolvedValueOnce({
             ok: true,
             status: 200,
-            json: async () => ({ status: 'ok' }),
+            json: async () => ({
+                status: 'ok',
+                results: { mapped: false, items: [] },
+            }),
         });
         const service = buildService(createFeatureFlagService(true));
 
-        await expect(service.getRoadmapForUser(user)).rejects.toThrow(
-            UnexpectedServerError,
-        );
+        const result = await service.getRoadmapForUser(user);
+
+        expect(result).toEqual({ mapped: false, items: [] });
     });
+
+    it.each([
+        ['no results', { status: 'ok' }],
+        ['results is an array (old shape)', { status: 'ok', results: [] }],
+        [
+            'mapped is not a boolean',
+            { status: 'ok', results: { mapped: 'yes', items: [] } },
+        ],
+        [
+            'items is not an array',
+            { status: 'ok', results: { mapped: true, items: {} } },
+        ],
+    ])(
+        'throws when the response shape is invalid: %s',
+        async (_label, body) => {
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => body,
+            });
+            const service = buildService(createFeatureFlagService(true));
+
+            await expect(service.getRoadmapForUser(user)).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        },
+    );
 
     it('throws when the roadmap service is unreachable', async () => {
         fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));

--- a/packages/backend/src/ee/services/RoadmapProxyService/RoadmapProxyService.ts
+++ b/packages/backend/src/ee/services/RoadmapProxyService/RoadmapProxyService.ts
@@ -40,9 +40,13 @@ export class RoadmapProxyService extends BaseService {
      * Fetch the curated roadmap for the user's organization from the central
      * roadmap service. Gated by the Roadmap feature flag. The response is run
      * through the redaction checkpoint again before it reaches the browser —
-     * fail closed even if the upstream service misbehaves.
+     * fail closed even if the upstream service misbehaves. `mapped: false`
+     * means the org has no roadmap channel set up yet (onboarding gap), as
+     * opposed to a connected org with no requests.
      */
-    async getRoadmapForUser(user: SessionUser): Promise<RoadmapItem[]> {
+    async getRoadmapForUser(
+        user: SessionUser,
+    ): Promise<{ mapped: boolean; items: RoadmapItem[] }> {
         const { userUuid, organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('User is not part of an organization');
@@ -108,15 +112,24 @@ export class RoadmapProxyService extends BaseService {
             );
             throw new UnexpectedServerError('Roadmap service request failed');
         }
-        if (!Array.isArray(results)) {
+        if (
+            typeof results !== 'object' ||
+            results === null ||
+            typeof (results as { mapped?: unknown }).mapped !== 'boolean' ||
+            !Array.isArray((results as { items?: unknown }).items)
+        ) {
             this.logger.error(
-                'Roadmap proxy: roadmap service response has no results array',
+                'Roadmap proxy: roadmap service response has an unexpected shape',
             );
             throw new UnexpectedServerError('Roadmap service request failed');
         }
+        const { mapped, items: rawItems } = results as {
+            mapped: boolean;
+            items: unknown[];
+        };
 
         const { items, rejected } = redactRoadmapItems(
-            results as ReadonlyArray<Record<string, unknown>>,
+            rawItems as ReadonlyArray<Record<string, unknown>>,
         );
         if (rejected.length > 0) {
             // The central service should only ever serve curated fields —
@@ -126,6 +139,6 @@ export class RoadmapProxyService extends BaseService {
                 `Roadmap proxy: redaction rejected ${rejected.length} item(s) from the roadmap service for organization ${organizationUuid}`,
             );
         }
-        return items;
+        return { mapped, items };
     }
 }

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -247,14 +247,14 @@ describe('RoadmapService', () => {
     });
 
     describe('getRoadmapForOrg', () => {
-        it('returns an empty list when the org has no mapped customer', async () => {
+        it('returns mapped:false when the org has no mapped customer', async () => {
             const roadmapModel = createRoadmapModel();
             roadmapModel.findCustomerLinkForOrg.mockResolvedValue(null);
             const service = buildService(roadmapModel, createLinearClient());
 
             const result = await service.getRoadmapForOrg({ organizationUuid });
 
-            expect(result).toEqual([]);
+            expect(result).toEqual({ mapped: false, items: [] });
             expect(roadmapModel.getRoadmapItemsForOrg).not.toHaveBeenCalled();
         });
 
@@ -279,15 +279,18 @@ describe('RoadmapService', () => {
 
             const result = await service.getRoadmapForOrg({ organizationUuid });
 
-            expect(result).toEqual([
-                {
-                    title: 'Dark mode',
-                    description: 'Please',
-                    status: RoadmapItemStatus.BUILDING,
-                    issueUrl: null,
-                    pullRequestUrl: null,
-                },
-            ]);
+            expect(result).toEqual({
+                mapped: true,
+                items: [
+                    {
+                        title: 'Dark mode',
+                        description: 'Please',
+                        status: RoadmapItemStatus.BUILDING,
+                        issueUrl: null,
+                        pullRequestUrl: null,
+                    },
+                ],
+            });
         });
 
         it('excludes stored items that fail the redaction checkpoint', async () => {
@@ -318,7 +321,8 @@ describe('RoadmapService', () => {
 
             const result = await service.getRoadmapForOrg({ organizationUuid });
 
-            expect(result).toEqual([
+            expect(result.mapped).toBe(true);
+            expect(result.items).toEqual([
                 {
                     title: 'Safe',
                     description: null,

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -223,19 +223,24 @@ export class RoadmapService extends BaseService {
     }
 
     /**
-     * Serve the curated roadmap for an organization from the mirror. Returns an
-     * empty list when the org has no mapped customer or no items. Runs the
-     * stored items through the redaction checkpoint as a final defensive
-     * boundary before they leave the service.
+     * Serve the curated roadmap for an organization from the mirror. An org
+     * with no mapped Linear customer gets `mapped: false` and no items — and
+     * the fetch is logged, because a licensed instance asking for an unmapped
+     * roadmap usually means an enterprise onboarding gap someone should fix.
+     * Runs the stored items through the redaction checkpoint as a final
+     * defensive boundary before they leave the service.
      */
     async getRoadmapForOrg(params: {
         organizationUuid: string;
-    }): Promise<RoadmapItem[]> {
+    }): Promise<{ mapped: boolean; items: RoadmapItem[] }> {
         const { organizationUuid } = params;
         const link =
             await this.roadmapModel.findCustomerLinkForOrg(organizationUuid);
         if (link === null) {
-            return [];
+            this.logger.warn(
+                `Roadmap: organization ${organizationUuid} fetched its roadmap but has no mapped Linear customer — likely an enterprise onboarding gap`,
+            );
+            return { mapped: false, items: [] };
         }
 
         const stored =
@@ -248,6 +253,6 @@ export class RoadmapService extends BaseService {
                 `Roadmap redaction rejected ${rejected.length} stored item(s) for organization ${organizationUuid}`,
             );
         }
-        return items;
+        return { mapped: true, items };
     }
 }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -264,6 +264,7 @@ import { type QueryHistoryStatus } from './queryHistory';
 import { type ApiRenameFieldsResponse, type ApiRenameResponse } from './rename';
 import { type MostPopularAndRecentlyUpdated } from './resourceViewItem';
 import { type ResultColumns, type ResultRow } from './results';
+import { type ApiRoadmapResponse } from './roadmap';
 import {
     type ApiCustomRoleAsCodeListResponse,
     type ApiCustomRoleAsCodeUpsertResponse,
@@ -1319,7 +1320,8 @@ type ApiResults =
     | ExternalConnectionSample[]
     | AppExternalConnectionLink
     | AppExternalConnectionLink[]
-    | ExternalFetchResponse;
+    | ExternalFetchResponse
+    | ApiRoadmapResponse['results'];
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'
 

--- a/packages/common/src/types/roadmap.ts
+++ b/packages/common/src/types/roadmap.ts
@@ -349,5 +349,13 @@ export const redactRoadmapItems = (
 
 export type ApiRoadmapResponse = {
     status: 'ok';
-    results: RoadmapItem[];
+    results: {
+        /**
+         * False when the organization has no mapped Linear customer yet —
+         * the roadmap channel hasn't been set up (an onboarding gap), as
+         * opposed to a connected org that simply has no requests.
+         */
+        mapped: boolean;
+        items: RoadmapItem[];
+    };
 };

--- a/packages/frontend/src/hooks/useOrgRoadmap.ts
+++ b/packages/frontend/src/hooks/useOrgRoadmap.ts
@@ -1,16 +1,16 @@
-import type { ApiError, RoadmapItem } from '@lightdash/common';
+import type { ApiError, ApiRoadmapResponse } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 
 const getOrgRoadmap = async () =>
-    lightdashApi<RoadmapItem[]>({
+    lightdashApi<ApiRoadmapResponse['results']>({
         url: '/org/roadmap',
         method: 'GET',
         body: undefined,
     });
 
 export const useOrgRoadmap = (enabled: boolean) =>
-    useQuery<RoadmapItem[], ApiError>({
+    useQuery<ApiRoadmapResponse['results'], ApiError>({
         queryKey: ['org-roadmap'],
         queryFn: getOrgRoadmap,
         enabled,

--- a/packages/frontend/src/pages/Roadmap.tsx
+++ b/packages/frontend/src/pages/Roadmap.tsx
@@ -19,6 +19,7 @@ import {
     IconBrandGithub,
     IconGitPullRequest,
     IconRoad,
+    IconRoadOff,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { useMemo, type FC } from 'react';
@@ -173,7 +174,7 @@ const Roadmap: FC = () => {
     const roadmapQuery = useOrgRoadmap(flagQuery.data?.enabled === true);
 
     const sections = useMemo(() => {
-        const items = roadmapQuery.data ?? [];
+        const items = roadmapQuery.data?.items ?? [];
         return STATUS_ORDER.map((status) => ({
             status,
             items: items.filter((item) => item.status === status),
@@ -206,6 +207,12 @@ const Roadmap: FC = () => {
                         icon={IconAlertCircle}
                         title="Could not load your roadmap"
                         description="Something went wrong fetching your roadmap. Try again in a few minutes, or contact support if it keeps happening."
+                    />
+                ) : roadmapQuery.data?.mapped === false ? (
+                    <SuboptimalState
+                        icon={IconRoadOff}
+                        title="Your roadmap isn't connected yet"
+                        description="Your organization's feature requests haven't been linked to this page. Contact your Lightdash team and we'll get it set up."
                     />
                 ) : sections.length === 0 ? (
                     <SuboptimalState


### PR DESCRIPTION
Closes out CS-19's open decision, stacked on #25144.

An org with no mapped Linear customer (an onboarding gap) previously looked identical to a connected org with zero requests — for an enterprise account that fell through onboarding, the page confidently said "no items yet" while their requests existed but weren't linked. That's silently wrong in a trust-critical feature.

- **Contract**: `ApiRoadmapResponse.results` becomes `{ mapped: boolean, items: RoadmapItem[] }`. `mapped: false` carries nothing sensitive — just "no roadmap channel set up".
- **Central service**: unmapped fetches return `mapped: false` and log a warning — a licensed instance requesting an unmapped roadmap is exactly "an enterprise customer just looked at a roadmap we forgot to connect", i.e. a free CS alert. Post-backfill this should be near-silent, so any occurrence is signal.
- **Proxy**: validates the new response shape (fail closed on anything unexpected) and passes `mapped` through; items still re-redacted.
- **Page**: distinct state for unmapped ("Your roadmap isn't connected yet — contact your Lightdash team") vs empty ("No roadmap items yet").

Live-verified all three states on the dev instance (items / unmapped incl. the warn log with org uuid / restored) plus browser render of the new state. 24 service/proxy tests pass, typecheck clean across common/backend/frontend.

Linear: [CS-19](https://linear.app/lightdash/issue/CS-19/handle-orgs-without-a-mapped-customer-or-roadmap-items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoMa5ttbcLShFHGuySK7Lt