### PR TITLE
feat: add AI agent thread history and resume support for embed SDK

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -844,8 +844,21 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Query() allUsers?: boolean,
     ): Promise<ApiAiAgentThreadSummaryListResponse> {
-        assertRegisteredAccount(req.account);
         this.setStatus(200);
+
+        if (req.account?.authentication.type === 'jwt') {
+            assertEmbeddedAuth(req.account);
+            return {
+                status: 'ok',
+                results: await this.getAiAgentService().listEmbedAgentThreads(
+                    req.account,
+                    projectUuid,
+                    agentUuid,
+                ),
+            };
+        }
+
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.getAiAgentService().listAgentThreads(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4447,6 +4447,46 @@ export class AiAgentService extends BaseService {
         return this.getAgentThread(user, agentUuid, threadUuid);
     }
 
+    async listEmbedAgentThreads(
+        account: AnonymousAccount,
+        projectUuid: string,
+        agentUuid: string,
+    ): Promise<AiAgentThreadSummary[]> {
+        const { user, runtimeOptions } = await this.getEmbedAgent(
+            account,
+            projectUuid,
+            agentUuid,
+        );
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError();
+        }
+
+        const threads = await this.aiAgentModel.findThreads({
+            organizationUuid,
+            agentUuid,
+            userUuid: user.userUuid,
+            createdFrom: ['web_app'],
+        });
+
+        const threadsWithEmbedSpace = await Promise.all(
+            threads.map(async (thread) => ({
+                thread,
+                embedSpaceUuid:
+                    await this.aiAgentModel.getWebAppThreadEmbedSpace(
+                        thread.uuid,
+                    ),
+            })),
+        );
+
+        return threadsWithEmbedSpace
+            .filter(
+                ({ embedSpaceUuid }) =>
+                    embedSpaceUuid === runtimeOptions.embedSpaceUuid,
+            )
+            .map(({ thread }) => thread);
+    }
+
     async createEmbedAgentThread(
         account: AnonymousAccount,
         projectUuid: string,

--- a/packages/frontend/sdk/api.ts
+++ b/packages/frontend/sdk/api.ts
@@ -1,4 +1,7 @@
-import type { ApiContentResponse } from '@lightdash/common';
+import type {
+    ApiAiAgentThreadSummaryListResponse,
+    ApiContentResponse,
+} from '@lightdash/common';
 
 export type LightdashSdkContentType =
     | 'chart'
@@ -39,6 +42,15 @@ export type ListContentOptions = {
 
 export type LightdashContentResults = ApiContentResponse['results'];
 export type LightdashContentItem = LightdashContentResults['data'][number];
+
+export type ListAiAgentThreadsOptions = {
+    agentUuid: string;
+    projectUuid?: string;
+};
+
+export type LightdashAiAgentThreadResults =
+    ApiAiAgentThreadSummaryListResponse['results'];
+export type LightdashAiAgentThread = LightdashAiAgentThreadResults[number];
 
 export class LightdashSdkApiError extends Error {
     statusCode: number | null;
@@ -166,7 +178,24 @@ export const createLightdashApiClient = (config: LightdashApiClientConfig) => {
         });
     };
 
+    const listAiAgentThreads = async (options: ListAiAgentThreadsOptions) => {
+        const projectUuid = options.projectUuid ?? config.projectUuid;
+
+        if (!projectUuid) {
+            throw new LightdashSdkApiError(
+                'projectUuid is required to list AI agent threads',
+                null,
+                null,
+            );
+        }
+
+        return request<LightdashAiAgentThreadResults>({
+            path: `/api/v1/projects/${projectUuid}/aiAgents/${options.agentUuid}/threads`,
+        });
+    };
+
     return {
+        listAiAgentThreads,
         listContent,
     };
 };

--- a/packages/frontend/sdk/hooks.tsx
+++ b/packages/frontend/sdk/hooks.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     createLightdashApiClient,
+    type LightdashAiAgentThreadResults,
     type LightdashApiClientConfig,
     type LightdashContentResults,
+    type ListAiAgentThreadsOptions,
     type ListContentOptions,
 } from './api';
-import type { ApiError } from '@lightdash/common';
 
 type UseLightdashApiState<T> = {
     data: T | null;
@@ -76,7 +77,7 @@ const useLightdashApiQuery = <T,>(
                 if (abortController.signal.aborted) return;
                 setState({ data, error: null, isLoading: false });
             })
-            .catch((error: ApiError | Error | unknown) => {
+            .catch((error: unknown) => {
                 if (abortController.signal.aborted) return;
                 setState({
                     data: null,
@@ -126,5 +127,30 @@ export const useLightdashContent = (
         key,
         enabled,
         useCallback(() => client.listContent(args), [args, client]),
+    );
+};
+
+export const useLightdashAiAgentThreads = (
+    config: LightdashApiClientConfig,
+    args: ListAiAgentThreadsOptions,
+    options: UseLightdashApiOptions = {},
+): UseLightdashApiResult<LightdashAiAgentThreadResults> => {
+    const client = useLightdashApiClient(config);
+    const key = JSON.stringify([
+        'ai-agent-threads',
+        config.instanceUrl,
+        config.projectUuid ?? null,
+        config.auth ?? null,
+        args,
+    ]);
+    const enabled =
+        options.enabled !== false &&
+        args.agentUuid.length > 0 &&
+        !!(args.projectUuid ?? config.projectUuid);
+
+    return useLightdashApiQuery(
+        key,
+        enabled,
+        useCallback(() => client.listAiAgentThreads(args), [args, client]),
     );
 };

--- a/packages/frontend/sdk/index.test.tsx
+++ b/packages/frontend/sdk/index.test.tsx
@@ -125,7 +125,7 @@ vi.mock('../src/features/comments', () => ({
 }));
 
 import { FilterOperator } from '@lightdash/common';
-import { AiAgent, Dashboard } from './index';
+import { AiAgent, Dashboard, createLightdashApiClient } from './index';
 
 describe('SDK Dashboard - URL Sync Behavior', () => {
     const mockToken =
@@ -344,6 +344,125 @@ describe('SDK AI agent', () => {
 
         expect(container.querySelector('iframe')?.getAttribute('src')).toBe(
             `${mockInstanceUrl}/embed/test-project-uuid/ai-agents/test-agent-uuid/threads#${mockToken}`,
+        );
+    });
+
+    it('renders an existing embed AI agent thread when threadUuid is provided', async () => {
+        const { container } = render(
+            <AiAgent
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                agentUuid="test-agent-uuid"
+                threadUuid="test-thread-uuid"
+            />,
+        );
+
+        await waitFor(() => {
+            expect(container.querySelector('iframe')).toBeTruthy();
+        });
+
+        expect(container.querySelector('iframe')?.getAttribute('src')).toBe(
+            `${mockInstanceUrl}/embed/test-project-uuid/ai-agents/test-agent-uuid/threads/test-thread-uuid#${mockToken}`,
+        );
+    });
+
+    it('calls onThreadChange for matching embed AI agent thread messages', async () => {
+        const onThreadChange = vi.fn();
+        const { container } = render(
+            <AiAgent
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                agentUuid="test-agent-uuid"
+                onThreadChange={onThreadChange}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(container.querySelector('iframe')).toBeTruthy();
+        });
+
+        const iframeSrc = new URL(
+            container.querySelector('iframe')?.getAttribute('src') ?? '',
+        );
+        expect(iframeSrc.searchParams.get('targetOrigin')).toBe(
+            window.location.origin,
+        );
+
+        window.dispatchEvent(
+            new MessageEvent('message', {
+                origin: mockInstanceUrl,
+                data: {
+                    type: 'lightdash:aiAgentThreadChanged',
+                    payload: {
+                        projectUuid: 'test-project-uuid',
+                        agentUuid: 'test-agent-uuid',
+                        threadUuid: 'test-thread-uuid',
+                    },
+                    timestamp: Date.now(),
+                },
+            }),
+        );
+
+        expect(onThreadChange).toHaveBeenCalledWith({
+            threadUuid: 'test-thread-uuid',
+        });
+    });
+});
+
+describe('SDK API client', () => {
+    it('lists AI agent threads with the embed token header', async () => {
+        const threads = [
+            {
+                uuid: 'test-thread-uuid',
+                agentUuid: 'test-agent-uuid',
+                createdAt: '2026-07-06T08:00:00.000Z',
+                createdFrom: 'web_app',
+                title: 'Revenue check',
+                titleGeneratedAt: null,
+                firstMessage: {
+                    uuid: 'test-message-uuid',
+                    message: 'How is revenue looking?',
+                },
+                user: {
+                    uuid: 'test-user-uuid',
+                    name: 'Test User',
+                },
+            },
+        ];
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    status: 'ok',
+                    results: threads,
+                }),
+                { status: 200 },
+            ),
+        );
+        const client = createLightdashApiClient({
+            instanceUrl: 'https://example.lightdash.cloud/',
+            projectUuid: 'test-project-uuid',
+            auth: {
+                type: 'embedToken',
+                token: 'test-embed-token',
+            },
+            fetch: fetchMock,
+        });
+
+        await expect(
+            client.listAiAgentThreads({ agentUuid: 'test-agent-uuid' }),
+        ).resolves.toEqual(threads);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://example.lightdash.cloud/api/v1/projects/test-project-uuid/aiAgents/test-agent-uuid/threads',
+            {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'lightdash-embed-token': 'test-embed-token',
+                },
+                body: undefined,
+                signal: undefined,
+            },
         );
     });
 });

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -37,13 +37,16 @@ import TrackingProvider from '../src/providers/Tracking/TrackingProvider';
 import { setToInMemoryStorage } from '../src/utils/inMemoryStorage';
 import {
     createLightdashApiClient,
+    type LightdashAiAgentThread,
+    type LightdashAiAgentThreadResults,
     type LightdashApiClientConfig,
     type LightdashContentItem,
     type LightdashContentResults,
     type LightdashSdkApiAuth,
+    type ListAiAgentThreadsOptions,
     type ListContentOptions,
 } from './api';
-import { useLightdashContent } from './hooks';
+import { useLightdashAiAgentThreads, useLightdashContent } from './hooks';
 const LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY =
     '__lightdash_sdk_instance_url';
 const LIGHTDASH_SDK_VERSION_LOCAL_STORAGE_KEY = '__lightdash_sdk_version';
@@ -76,6 +79,7 @@ type AiAgentProps = Omit<
     'contentOverrides' | 'filters' | 'onExplore'
 > & {
     agentUuid: string;
+    onThreadChange?: (options: { threadUuid: string }) => void;
     threadUuid?: string;
 };
 
@@ -183,6 +187,7 @@ const getAiAgentEmbedUrl = ({
     agentUuid,
     instanceUrl,
     projectUuid,
+    targetOrigin,
     theme,
     threadUuid,
     token,
@@ -190,6 +195,7 @@ const getAiAgentEmbedUrl = ({
     agentUuid: string;
     instanceUrl: string;
     projectUuid: string;
+    targetOrigin?: string;
     theme: AiAgentProps['theme'];
     threadUuid?: string;
     token: string;
@@ -205,10 +211,41 @@ const getAiAgentEmbedUrl = ({
     if (theme) {
         url.searchParams.set('theme', theme);
     }
+    if (targetOrigin) {
+        url.searchParams.set('targetOrigin', targetOrigin);
+    }
 
     url.hash = token;
     return url.toString();
 };
+
+const AI_AGENT_THREAD_CHANGED_EVENT = 'lightdash:aiAgentThreadChanged';
+
+type AiAgentThreadChangedMessage = {
+    type: typeof AI_AGENT_THREAD_CHANGED_EVENT;
+    payload: {
+        agentUuid: string;
+        projectUuid: string;
+        threadUuid: string;
+    };
+};
+
+const isAiAgentThreadChangedMessage = (
+    data: unknown,
+): data is AiAgentThreadChangedMessage =>
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    data.type === AI_AGENT_THREAD_CHANGED_EVENT &&
+    'payload' in data &&
+    typeof data.payload === 'object' &&
+    data.payload !== null &&
+    'agentUuid' in data.payload &&
+    typeof data.payload.agentUuid === 'string' &&
+    'projectUuid' in data.payload &&
+    typeof data.payload.projectUuid === 'string' &&
+    'threadUuid' in data.payload &&
+    typeof data.payload.threadUuid === 'string';
 
 const SdkProviders: FC<
     PropsWithChildren<{
@@ -616,12 +653,44 @@ const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
 const AiAgent: FC<AiAgentProps> = ({
     agentUuid,
     instanceUrl,
+    onThreadChange,
     styles,
     theme,
     threadUuid,
     token: tokenOrTokenPromise,
 }) => {
     const tokenContext = useEmbedTokenContext(instanceUrl, tokenOrTokenPromise);
+    const instanceOrigin = new URL(instanceUrl).origin;
+    const targetOrigin =
+        typeof window !== 'undefined' && onThreadChange
+            ? window.location.origin
+            : undefined;
+
+    useEffect(() => {
+        if (!tokenContext || !onThreadChange) {
+            return undefined;
+        }
+
+        const handleMessage = (event: MessageEvent) => {
+            if (event.origin !== instanceOrigin) {
+                return;
+            }
+            if (!isAiAgentThreadChangedMessage(event.data)) {
+                return;
+            }
+            if (
+                event.data.payload.projectUuid !== tokenContext.projectUuid ||
+                event.data.payload.agentUuid !== agentUuid
+            ) {
+                return;
+            }
+
+            onThreadChange({ threadUuid: event.data.payload.threadUuid });
+        };
+
+        window.addEventListener('message', handleMessage);
+        return () => window.removeEventListener('message', handleMessage);
+    }, [agentUuid, instanceOrigin, onThreadChange, tokenContext]);
 
     if (!tokenContext) {
         return null;
@@ -634,6 +703,7 @@ const AiAgent: FC<AiAgentProps> = ({
                 agentUuid,
                 instanceUrl,
                 projectUuid: tokenContext.projectUuid,
+                targetOrigin,
                 theme,
                 threadUuid,
                 token: tokenContext.token,
@@ -658,6 +728,7 @@ const Lightdash = {
     Chart,
     FilterOperator,
     createLightdashApiClient,
+    useLightdashAiAgentThreads,
     useLightdashContent,
 };
 
@@ -670,13 +741,17 @@ export {
     Explore,
     FilterOperator,
     createLightdashApiClient,
+    useLightdashAiAgentThreads,
     useLightdashContent,
 };
 export type {
+    LightdashAiAgentThread,
+    LightdashAiAgentThreadResults,
     LightdashApiClientConfig,
     LightdashContentItem,
     LightdashContentResults,
     LightdashSdkApiAuth,
+    ListAiAgentThreadsOptions,
     ListContentOptions,
 };
 // ts-unused-exports:disable-next-line

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/embedAiAgentThreadChange.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/embedAiAgentThreadChange.ts
@@ -1,0 +1,51 @@
+const AI_AGENT_THREAD_CHANGED_EVENT = 'lightdash:aiAgentThreadChanged';
+
+type EmbedAiAgentThreadChange = {
+    agentUuid: string;
+    projectUuid: string;
+    threadUuid: string;
+};
+
+const getTargetOrigin = () => {
+    const targetOrigin = new URLSearchParams(window.location.search).get(
+        'targetOrigin',
+    );
+
+    if (!targetOrigin) {
+        return null;
+    }
+
+    try {
+        return new URL(targetOrigin).origin;
+    } catch {
+        return null;
+    }
+};
+
+export const emitEmbedAiAgentThreadChange = ({
+    agentUuid,
+    projectUuid,
+    threadUuid,
+}: EmbedAiAgentThreadChange) => {
+    if (typeof window === 'undefined' || window.parent === window) {
+        return;
+    }
+
+    const targetOrigin = getTargetOrigin();
+    if (!targetOrigin) {
+        return;
+    }
+
+    window.parent.postMessage(
+        {
+            type: AI_AGENT_THREAD_CHANGED_EVENT,
+            payload: {
+                agentUuid,
+                projectUuid,
+                threadUuid,
+            },
+            timestamp: Date.now(),
+        },
+        targetOrigin,
+    );
+};

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -433,8 +433,11 @@ const data = {
     userAttributes: {{userAttributes}},
 {{writeActionsSnippet}}
 };
-const token = jwt.sign(data, LIGHTDASH_EMBED_SECRET, { expiresIn: '{{expiresIn}}' });
-const url = \`{{siteUrl}}/embed/\${projectUuid}/ai-agents/\${agentUuid}/threads#\${token}\`;
+const embedJwt = jwt.sign(data, LIGHTDASH_EMBED_SECRET, { expiresIn: '{{expiresIn}}' });
+const threadUuid = undefined; // Set this to resume an existing conversation.
+const url = threadUuid
+    ? \`{{siteUrl}}/embed/\${projectUuid}/ai-agents/\${agentUuid}/threads/\${threadUuid}#\${embedJwt}\`
+    : \`{{siteUrl}}/embed/\${projectUuid}/ai-agents/\${agentUuid}/threads#\${embedJwt}\`;
 `,
     [SnippetLanguage.PYTHON]: `import datetime
 import jwt # pip install pyjwt
@@ -458,8 +461,13 @@ data = {
     "userAttributes": {{userAttributes}},
 {{writeActionsSnippet}}
 };
-token = jwt.encode(data, key, algorithm="HS256")
-url = f"{{siteUrl}}/embed/{projectUuid}/ai-agents/{agentUuid}/threads#{token}"
+embedJwt = jwt.encode(data, key, algorithm="HS256")
+threadUuid = None # Set this to resume an existing conversation.
+url = (
+    f"{{siteUrl}}/embed/{projectUuid}/ai-agents/{agentUuid}/threads/{threadUuid}#{embedJwt}"
+    if threadUuid
+    else f"{{siteUrl}}/embed/{projectUuid}/ai-agents/{agentUuid}/threads#{embedJwt}"
+)
 `,
     [SnippetLanguage.GO]: `
 package main
@@ -525,13 +533,136 @@ func main() {
     }
 
     token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-    signedToken, err := token.SignedString([]byte(LIGHTDASH_EMBED_SECRET))
+    embedJwt, err := token.SignedString([]byte(LIGHTDASH_EMBED_SECRET))
     if err != nil {
         panic(err)
     }
 
-    url := fmt.Sprintf("{{siteUrl}}/embed/%s/ai-agents/%s/threads#%s", projectUuid, agentUuid, signedToken)
+    threadUuid := "" // Set this to resume an existing conversation.
+    path := fmt.Sprintf("{{siteUrl}}/embed/%s/ai-agents/%s/threads", projectUuid, agentUuid)
+    if threadUuid != "" {
+        path = fmt.Sprintf("%s/%s", path, threadUuid)
+    }
+    url := fmt.Sprintf("%s#%s", path, embedJwt)
     fmt.Println("URL:", url)
+}
+`,
+};
+
+const aiAgentSdkCodeTemplates: Record<SnippetLanguage, string> = {
+    [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
+const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
+const projectUuid = '{{projectUuid}}';
+const agentUuid = '{{agentUuid}}';
+const data = {
+    content: {
+        type: 'aiAgent',
+        projectUuid: projectUuid,
+        agentUuid: agentUuid,
+    },
+    user: {
+        externalId: {{externalId}},
+        email: {{email}}
+    },
+    userAttributes: {{userAttributes}},
+{{writeActionsSnippet}}
+};
+const embedJwt = jwt.sign(data, LIGHTDASH_EMBED_SECRET, { expiresIn: '{{expiresIn}}' });
+`,
+    [SnippetLanguage.PYTHON]: `import datetime
+import jwt # pip install pyjwt
+
+key = "secret" # replace with your secret
+projectUuid = '{{projectUuid}}'
+agentUuid = '{{agentUuid}}'
+
+data = {
+    "exp": datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(hours=1), # replace with your expiration time,
+    "iat": datetime.datetime.now(tz=datetime.timezone.utc),
+    "content": {
+        "type": "aiAgent",
+        "projectUuid": projectUuid,
+        "agentUuid": agentUuid,
+    },
+    "user": {
+        "externalId": {{externalId}},
+        "email": {{email}}
+    },
+    "userAttributes": {{userAttributes}},
+{{writeActionsSnippet}}
+};
+embedJwt = jwt.encode(data, key, algorithm="HS256")
+`,
+    [SnippetLanguage.GO]: `
+package main
+
+import (
+    "fmt"
+    "time"
+
+    jwt "github.com/dgrijalva/jwt-go"
+)
+
+const LIGHTDASH_EMBED_SECRET = "secret" // replace with your secret
+const projectUuid = "{{projectUuid}}"
+const agentUuid = "{{agentUuid}}"
+
+func main() {
+    {{externalIdDef}}
+    {{emailDef}}
+
+    type CustomClaims struct {
+        Content struct {
+            Type        string \`json:"type"\`
+            ProjectUuid string \`json:"projectUuid"\`
+            AgentUuid   string \`json:"agentUuid"\`
+        } \`json:"content"\`
+        UserAttributes map[string]string \`json:"userAttributes"\`
+        WriteActions *struct {
+            ServiceAccountUserUuid string \`json:"serviceAccountUserUuid,omitempty"\`
+            UserUuid               string \`json:"userUuid,omitempty"\`
+            SpaceUuid              string \`json:"spaceUuid"\`
+        } \`json:"writeActions,omitempty"\`
+        jwt.StandardClaims
+        User *struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        } \`json:"user,omitempty"\`
+    }
+
+    claims := CustomClaims{
+        Content: struct {
+            Type        string \`json:"type"\`
+            ProjectUuid string \`json:"projectUuid"\`
+            AgentUuid   string \`json:"agentUuid"\`
+        }{
+            Type:        "aiAgent",
+            ProjectUuid: projectUuid,
+            AgentUuid:   agentUuid,
+        },
+        User: &struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        }{
+            ExternalId: {{externalIdUsage}},
+            Email:      {{emailUsage}},
+        },
+        UserAttributes: map[string]string{{userAttributes}},
+        // ServiceAccountUserUuid is the selected service account's user UUID.
+        // To run actions as a user instead, set UserUuid and leave ServiceAccountUserUuid empty.
+        WriteActions: {{writeActionsGo}},
+        StandardClaims: jwt.StandardClaims{
+            ExpiresAt: time.Now().Add(time.Hour).Unix(), // replace with your expiration
+        },
+    }
+
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+    embedJwt, err := token.SignedString([]byte(LIGHTDASH_EMBED_SECRET))
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println("JWT:", embedJwt)
 }
 `,
 };
@@ -1102,8 +1233,10 @@ const getBackendCodeSnippet = (
         // component for them yet.
         codeTemplate = dataAppIframeCodeTemplates[language];
     } else if (data.content.type === 'aiAgent') {
-        // AI agent embeds are iframe-only.
-        codeTemplate = aiAgentIframeCodeTemplates[language];
+        codeTemplate =
+            mode === 'iframe'
+                ? aiAgentIframeCodeTemplates[language]
+                : aiAgentSdkCodeTemplates[language];
     } else {
         codeTemplate =
             mode === 'iframe'
@@ -1354,8 +1487,42 @@ export const EmbeddedChart = ({ embedJwt }: EmbeddedChartProps) => (
     />
 );
 `;
-        case 'dataApp':
         case 'aiAgent':
+            return `import '@lightdash/sdk/sdk.css';
+import Lightdash from '@lightdash/sdk';
+import { useState } from 'react';
+
+type EmbeddedAiAgentProps = {
+    embedJwt: string;
+};
+
+export const EmbeddedAiAgent = ({ embedJwt }: EmbeddedAiAgentProps) => {
+    const [threadUuid, setThreadUuid] = useState<string | undefined>();
+
+    return (
+        <Lightdash.AiAgent
+            instanceUrl="${siteUrl}"
+            token={embedJwt}
+            agentUuid="${
+                'agentUuid' in data.content
+                    ? data.content.agentUuid || '<AGENT_UUID>'
+                    : '<AGENT_UUID>'
+            }"
+            threadUuid={threadUuid}
+            onThreadChange={({ threadUuid: nextThreadUuid }) => {
+                // Persist this value in your app if users should resume later.
+                setThreadUuid(nextThreadUuid);
+            }}
+            styles={{
+                // Optional: customize supported SDK styles here:
+                // backgroundColor: '#fff',
+                // fontFamily: 'Inter, sans-serif',
+            }}
+        />
+    );
+};
+`;
+        case 'dataApp':
         case 'apiAccess':
             return '';
         default:

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewAiAgentForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewAiAgentForm.tsx
@@ -358,6 +358,23 @@ const EmbedPreviewAiAgentForm: FC<{
                     data={convertFormValuesToCreateEmbedJwt(formValues)}
                 />
             </Stack>
+
+            <Stack gap="md" mb="md">
+                <Stack gap="xs">
+                    <Title order={5}>React SDK embed code</Title>
+                    <Text c="dimmed" fz="sm">
+                        Use this to mount the AI agent with the React SDK,
+                        resume a known thread UUID, and persist newly-created
+                        thread UUIDs.
+                    </Text>
+                </Stack>
+                <EmbedCodeSnippet
+                    mode="sdk"
+                    projectUuid={projectUuid}
+                    siteUrl={siteUrl}
+                    data={convertFormValuesToCreateEmbedJwt(formValues)}
+                />
+            </Stack>
         </form>
     );
 };

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { Box, Center, Flex, Loader } from '@mantine-8/core';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import useApp from '../../../providers/App/useApp';
 import { ReviewVerificationPanel } from '../../features/aiCopilot/components/Admin/ReviewVerificationPanel';
@@ -11,6 +11,7 @@ import {
     mergeContentMentionSuggestionItems,
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import { isEmbedAiAgentRoute } from '../../features/aiCopilot/hooks/aiAgentRouting';
+import { emitEmbedAiAgentThreadChange } from '../../features/aiCopilot/hooks/embedAiAgentThreadChange';
 import {
     useAiAgentReviewItemByPreviewThread,
     useUpdateAiAgentReviewItemStatus,
@@ -48,6 +49,18 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         isLoading: isLoadingThread,
         refetch,
     } = useAiAgentThread(projectUuid!, agentUuid, threadUuid);
+
+    useEffect(() => {
+        if (!isEmbed || !projectUuid || !agentUuid || !threadUuid || !thread) {
+            return;
+        }
+
+        emitEmbedAiAgentThreadChange({
+            projectUuid,
+            agentUuid,
+            threadUuid,
+        });
+    }, [agentUuid, isEmbed, projectUuid, thread, threadUuid]);
 
     // Handle artifact selection based on thread changes
     useAiAgentThreadArtifact({

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -28,6 +28,7 @@ import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPro
 import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedContextCard/PinnedContextCard';
 import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
 import { isEmbedAiAgentRoute } from '../../features/aiCopilot/hooks/aiAgentRouting';
+import { emitEmbedAiAgentThreadChange } from '../../features/aiCopilot/hooks/embedAiAgentThreadChange';
 import { useAiAgentModelSelection } from '../../features/aiCopilot/hooks/useAiAgentModelSelection';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
@@ -98,6 +99,13 @@ const AiAgentNewThreadPage: FC = () => {
                     uuid: thread.uuid,
                     title: thread.firstMessage.message,
                 };
+                if (isEmbed && projectUuid && agentUuid) {
+                    emitEmbedAiAgentThreadChange({
+                        projectUuid,
+                        agentUuid,
+                        threadUuid: thread.uuid,
+                    });
+                }
                 dispatch(
                     setThreadSqlMode({
                         threadUuid: thread.uuid,

--- a/packages/sdk-test-app/src/examples/AiAgentExamplePage.tsx
+++ b/packages/sdk-test-app/src/examples/AiAgentExamplePage.tsx
@@ -1,8 +1,18 @@
-import Lightdash from '@lightdash/sdk';
+import Lightdash, {
+    useLightdashAiAgentThreads,
+    type LightdashAiAgentThread,
+    type LightdashApiClientConfig,
+    type ListAiAgentThreadsOptions,
+} from '@lightdash/sdk';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { ExampleLayout } from '../components/ExampleLayout';
 import type { EmbedConfigState } from '../hooks/useEmbedConfig';
 import { getRepoSourceUrl } from '../lib/repo';
-import { emptyStateBoxStyle, emptyStateStyle } from '../styles';
+import {
+    emptyStateBoxStyle,
+    emptyStateStyle,
+    monoFontFamily,
+} from '../styles';
 import {
     dashboardContainerStyle,
     sectionDescStyle,
@@ -13,11 +23,149 @@ type AiAgentExamplePageProps = {
     embedConfig: EmbedConfigState;
 };
 
+type JwtPayload = {
+    content: {
+        projectUuid: string;
+    };
+};
+
 const sourceUrl = getRepoSourceUrl(
     'packages/sdk-test-app/src/examples/AiAgentExamplePage.tsx',
 );
 
 const defaultAiAgentEmbedUrl = import.meta.env.VITE_AI_AGENT_EMBED_URL ?? '';
+const latestAiAgentThreadStorageKey = 'lightdash:sdk-test-app:ai-agent-thread';
+const EMPTY_AI_AGENT_THREADS: LightdashAiAgentThread[] = [];
+
+const isJwtPayload = (payload: unknown): payload is JwtPayload => {
+    if (typeof payload !== 'object' || payload === null) return false;
+    if (!('content' in payload)) return false;
+
+    const { content } = payload;
+
+    return (
+        typeof content === 'object' &&
+        content !== null &&
+        'projectUuid' in content &&
+        typeof content.projectUuid === 'string' &&
+        content.projectUuid.length > 0
+    );
+};
+
+const threadHistoryStyle: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(240px, 420px) minmax(0, 1fr)',
+    gap: '12px',
+    alignItems: 'center',
+    marginBottom: '12px',
+};
+
+const threadSelectStyle: CSSProperties = {
+    width: '100%',
+    minHeight: '40px',
+    padding: '0 12px',
+    border: '1px solid #d4d4d4',
+    borderRadius: '6px',
+    backgroundColor: '#fff',
+    color: '#171717',
+};
+
+const threadStatusStyle: CSSProperties = {
+    color: '#737373',
+    fontFamily: monoFontFamily,
+    fontSize: '12px',
+};
+
+const explainerSectionStyle: CSSProperties = {
+    marginTop: '24px',
+    paddingTop: '20px',
+    borderTop: '1px solid #e5e5e5',
+};
+
+const explainerGridStyle: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(240px, 360px) minmax(0, 1fr)',
+    gap: '20px',
+    alignItems: 'start',
+};
+
+const explainerListStyle: CSSProperties = {
+    margin: 0,
+    paddingLeft: '18px',
+    color: '#525252',
+    fontSize: '13px',
+    lineHeight: 1.6,
+};
+
+const codeBlockStyle: CSSProperties = {
+    margin: 0,
+    padding: '14px',
+    overflowX: 'auto',
+    border: '1px solid #e5e5e5',
+    borderRadius: '8px',
+    backgroundColor: '#171717',
+    color: '#f5f5f5',
+    fontFamily: monoFontFamily,
+    fontSize: '12px',
+    lineHeight: 1.6,
+};
+
+const aiAgentThreadSnippet = `import Lightdash, {
+    useLightdashAiAgentThreads,
+    type LightdashApiClientConfig,
+} from '@lightdash/sdk';
+
+const apiConfig: LightdashApiClientConfig = {
+    instanceUrl,
+    projectUuid,
+    auth: { type: 'embedToken', token },
+};
+
+const threads = useLightdashAiAgentThreads(apiConfig, {
+    projectUuid,
+    agentUuid,
+});
+
+const [threadUuid, setThreadUuid] = useState<string>();
+
+return (
+    <>
+        <select onChange={(event) => setThreadUuid(event.target.value)}>
+            <option value="">Start a new thread</option>
+            {threads.data?.map((thread) => (
+                <option key={thread.uuid} value={thread.uuid}>
+                    {thread.title ?? thread.firstMessage.message}
+                </option>
+            ))}
+        </select>
+
+        <Lightdash.AiAgent
+            instanceUrl={instanceUrl}
+            token={token}
+            agentUuid={agentUuid}
+            threadUuid={threadUuid}
+            onThreadChange={({ threadUuid }) => {
+                setThreadUuid(threadUuid);
+                threads.refetch();
+            }}
+        />
+    </>
+);`;
+
+const truncateThreadLabel = (label: string) =>
+    label.length > 96 ? `${label.slice(0, 93)}...` : label;
+
+const getThreadLabel = (thread: LightdashAiAgentThread) =>
+    truncateThreadLabel(thread.title ?? thread.firstMessage.message);
+
+const getProjectUuid = (
+    aiAgentEmbedProjectUuid: string | null,
+    embedConfig: EmbedConfigState,
+) =>
+    aiAgentEmbedProjectUuid ??
+    (isJwtPayload(embedConfig.parsedJwt?.payload)
+        ? embedConfig.parsedJwt.payload.content.projectUuid
+        : null);
 
 const parseEmbedUrl = (
     value: string,
@@ -25,11 +173,19 @@ const parseEmbedUrl = (
     instanceUrl: string | null;
     token: string | null;
     agentUuid: string | null;
+    projectUuid: string | null;
+    threadUuid: string | null;
 } => {
     const trimmedValue = value.trim();
 
     if (!trimmedValue) {
-        return { instanceUrl: null, token: null, agentUuid: null };
+        return {
+            instanceUrl: null,
+            token: null,
+            agentUuid: null,
+            projectUuid: null,
+            threadUuid: null,
+        };
     }
 
     try {
@@ -45,11 +201,15 @@ const parseEmbedUrl = (
             : `${instancePath}/`;
 
         const agentMatch = url.pathname.match(/\/ai-agents\/([^/]+)/);
+        const projectMatch = url.pathname.match(/\/embed\/([^/]+)/);
+        const threadMatch = url.pathname.match(/\/threads\/([^/]+)/);
 
         return {
             instanceUrl: `${url.origin}${normalizedPath}`,
             token: url.hash ? url.hash.slice(1) : null,
             agentUuid: agentMatch?.[1] ?? null,
+            projectUuid: projectMatch?.[1] ?? null,
+            threadUuid: threadMatch?.[1] ?? null,
         };
     } catch {
         const [instancePart, tokenPart] = trimmedValue.split('#');
@@ -59,11 +219,15 @@ const parseEmbedUrl = (
                 ? instancePart.slice(0, embedSegmentIndex)
                 : instancePart;
         const agentMatch = instancePart.match(/\/ai-agents\/([^/]+)/);
+        const projectMatch = instancePart.match(/\/embed\/([^/]+)/);
+        const threadMatch = instancePart.match(/\/threads\/([^/]+)/);
 
         return {
             instanceUrl: maybeInstanceUrl || null,
             token: tokenPart || null,
             agentUuid: agentMatch?.[1] ?? null,
+            projectUuid: projectMatch?.[1] ?? null,
+            threadUuid: threadMatch?.[1] ?? null,
         };
     }
 };
@@ -74,9 +238,73 @@ export function AiAgentExamplePage({ embedConfig }: AiAgentExamplePageProps) {
         aiAgentEmbedConfig.instanceUrl ?? embedConfig.instanceUrl;
     const token = aiAgentEmbedConfig.token ?? embedConfig.token;
     const agentUuid = aiAgentEmbedConfig.agentUuid?.trim() ?? null;
-    const remountKey = defaultAiAgentEmbedUrl || embedConfig.remountKey;
+    const projectUuid = getProjectUuid(
+        aiAgentEmbedConfig.projectUuid,
+        embedConfig,
+    );
+    const defaultThreadUuid = aiAgentEmbedConfig.threadUuid ?? '';
+    const [latestThreadUuid, setLatestThreadUuid] = useState('');
+    const [resumeThreadUuid, setResumeThreadUuid] = useState(defaultThreadUuid);
+    const remountKey = `${defaultAiAgentEmbedUrl || embedConfig.remountKey}:${
+        resumeThreadUuid || 'new'
+    }`;
 
     const hasRequiredConfig = !!instanceUrl && !!token && !!agentUuid;
+    const apiInstanceUrl =
+        import.meta.env.DEV && typeof window !== 'undefined'
+            ? `${window.location.origin}/sdk-test-app-api/lightdash`
+            : instanceUrl ?? '';
+    const apiConfig = useMemo<LightdashApiClientConfig>(
+        () => ({
+            instanceUrl: apiInstanceUrl,
+            projectUuid: projectUuid ?? undefined,
+            auth: token
+                ? {
+                      type: 'embedToken',
+                      token,
+                  }
+                : undefined,
+        }),
+        [apiInstanceUrl, projectUuid, token],
+    );
+    const aiAgentThreadArgs = useMemo<ListAiAgentThreadsOptions>(
+        () => ({
+            agentUuid: agentUuid ?? '',
+            projectUuid: projectUuid ?? undefined,
+        }),
+        [agentUuid, projectUuid],
+    );
+    const aiAgentThreadsQuery = useLightdashAiAgentThreads(
+        apiConfig,
+        aiAgentThreadArgs,
+        {
+            enabled: hasRequiredConfig && !!projectUuid,
+        },
+    );
+    const aiAgentThreads =
+        aiAgentThreadsQuery.data ?? EMPTY_AI_AGENT_THREADS;
+    const threadStatus = !projectUuid
+        ? 'Thread history needs a project UUID in the embed URL or token'
+        : aiAgentThreadsQuery.isLoading
+        ? 'Loading threads'
+        : aiAgentThreadsQuery.error
+        ? aiAgentThreadsQuery.error.message
+        : `${aiAgentThreads.length} previous ${
+              aiAgentThreads.length === 1 ? 'thread' : 'threads'
+          }`;
+
+    useEffect(() => {
+        const storedThreadUuid =
+            localStorage.getItem(latestAiAgentThreadStorageKey) ?? '';
+        setLatestThreadUuid(storedThreadUuid);
+        setResumeThreadUuid(defaultThreadUuid || storedThreadUuid);
+    }, [defaultThreadUuid]);
+
+    const handleThreadChange = ({ threadUuid }: { threadUuid: string }) => {
+        setLatestThreadUuid(threadUuid);
+        localStorage.setItem(latestAiAgentThreadStorageKey, threadUuid);
+        aiAgentThreadsQuery.refetch();
+    };
 
     return (
         <ExampleLayout
@@ -102,6 +330,66 @@ export function AiAgentExamplePage({ embedConfig }: AiAgentExamplePageProps) {
                             The agent and write-action scope come from the
                             configured AI-agent embed URL and JWT.
                         </p>
+                        <div
+                            style={{
+                                display: 'flex',
+                                flexWrap: 'wrap',
+                                gap: 8,
+                                marginBottom: 12,
+                            }}
+                        >
+                            <input
+                                aria-label="AI agent thread UUID"
+                                placeholder="Thread UUID to resume"
+                                value={resumeThreadUuid}
+                                onChange={(event) =>
+                                    setResumeThreadUuid(event.target.value)
+                                }
+                                style={{
+                                    flex: '1 1 320px',
+                                    minWidth: 0,
+                                    padding: '8px 10px',
+                                }}
+                            />
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    setResumeThreadUuid(latestThreadUuid)
+                                }
+                                disabled={!latestThreadUuid}
+                            >
+                                Use latest
+                            </button>
+                        </div>
+                        <div style={threadHistoryStyle}>
+                            <select
+                                aria-label="AI agent thread history"
+                                value=""
+                                disabled={
+                                    !projectUuid ||
+                                    aiAgentThreadsQuery.isLoading ||
+                                    !!aiAgentThreadsQuery.error ||
+                                    aiAgentThreads.length === 0
+                                }
+                                onChange={(event) => {
+                                    setResumeThreadUuid(event.target.value);
+                                }}
+                                style={threadSelectStyle}
+                            >
+                                <option value="">Select a previous thread</option>
+                                {aiAgentThreads.map((thread) => (
+                                    <option
+                                        key={thread.uuid}
+                                        value={thread.uuid}
+                                    >
+                                        {getThreadLabel(thread)}
+                                    </option>
+                                ))}
+                            </select>
+                            <span style={threadStatusStyle}>
+                                {threadStatus}
+                            </span>
+                        </div>
                         {hasRequiredConfig ? (
                             <div style={dashboardContainerStyle}>
                                 <Lightdash.AiAgent
@@ -109,6 +397,10 @@ export function AiAgentExamplePage({ embedConfig }: AiAgentExamplePageProps) {
                                     instanceUrl={instanceUrl}
                                     token={token}
                                     agentUuid={agentUuid}
+                                    threadUuid={
+                                        resumeThreadUuid.trim() || undefined
+                                    }
+                                    onThreadChange={handleThreadChange}
                                 />
                             </div>
                         ) : (
@@ -119,6 +411,43 @@ export function AiAgentExamplePage({ embedConfig }: AiAgentExamplePageProps) {
                                 </div>
                             </div>
                         )}
+                    </section>
+                    <section style={explainerSectionStyle}>
+                        <h3 style={sectionTitleStyle}>
+                            Resuming previous threads
+                        </h3>
+                        <div style={explainerGridStyle}>
+                            <div>
+                                <p style={sectionDescStyle}>
+                                    Use <code>useLightdashAiAgentThreads</code>{' '}
+                                    to fetch the AI-agent threads available to
+                                    the current embed token. Passing a selected{' '}
+                                    <code>threadUuid</code> to{' '}
+                                    <code>Lightdash.AiAgent</code> resumes that
+                                    conversation; leaving it empty starts a new
+                                    one.
+                                </p>
+                                <ol style={explainerListStyle}>
+                                    <li>
+                                        The hook uses the same embed JWT as the
+                                        iframe.
+                                    </li>
+                                    <li>
+                                        Results are scoped to the token actor and
+                                        embedded space.
+                                    </li>
+                                    <li>
+                                        <code>onThreadChange</code> fires when a
+                                        new thread is created or opened, so the
+                                        host app can store the latest thread UUID
+                                        or refresh the list.
+                                    </li>
+                                </ol>
+                            </div>
+                            <pre style={codeBlockStyle}>
+                                <code>{aiAgentThreadSnippet}</code>
+                            </pre>
+                        </div>
                     </section>
                 </>
             ) : (


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-542/i-want-to-be-able-to-resume-an-embed-ai-agent-conversation-and-see  
  
![CleanShot 2026-07-06 at 10.51.57.png](https://app.graphite.com/user-attachments/assets/12a26ef8-23df-4cc8-92ae-a9df97e25a31.png)



### Description:

Adds thread persistence and resumption support to the embedded AI agent, enabling host applications to save and restore conversation state across sessions.

**Backend:**

- The `listAgentThreads` endpoint now handles JWT-authenticated (embed) requests via a new `listEmbedAgentThreads` service method, which scopes returned threads to the authenticated embed user and their associated embed space.

**SDK API client & hooks:**

- Adds `listAiAgentThreads` to the API client, calling the threads endpoint with the embed token header.
- Adds a `useLightdashAiAgentThreads` hook for fetching the thread list in React.
- Exports related types: `LightdashAiAgentThread`, `LightdashAiAgentThreadResults`, `ListAiAgentThreadsOptions`.

**`AiAgent`** **SDK component:**

- Adds an `onThreadChange` callback prop that fires when a new thread is created or an existing one is opened inside the iframe.
- Passes a `targetOrigin` query parameter to the iframe so the embedded page knows where to post messages.
- Listens for `lightdash:aiAgentThreadChanged` `postMessage` events from the iframe and invokes `onThreadChange` with the new thread UUID.
- Adds a `threadUuid` prop to resume a specific conversation on mount.

**Embedded AI agent pages:**

- Emits `lightdash:aiAgentThreadChanged` via `postMessage` to the parent window when a thread is created (`AiAgentNewThreadPage`) or loaded (`AgentThreadPage`), using the `targetOrigin` from the URL search params.

**Embed code snippets & settings UI:**

- Updates iframe code snippets (Node, Python, Go) to show how to optionally include a `threadUuid` in the embed URL.
- Adds SDK-mode backend code snippet templates for all three languages, generating only the JWT without constructing an iframe URL.
- Adds a React SDK frontend snippet for `aiAgent` content type showing `useLightdashAiAgentThreads` + `onThreadChange` usage.
- Surfaces the SDK embed code section in the AI agent embed preview settings form.

**SDK test app:**

- Demonstrates the full thread persistence flow: fetches previous threads via `useLightdashAiAgentThreads`, lets the user select one to resume, stores the latest thread UUID in `localStorage`, and refreshes the thread list on `onThreadChange`.