### PR TITLE
fix(spaces): clear row selection when navigating between nested space

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -508,6 +508,7 @@ const InfiniteResourceTable = ({
     const table = useContentTable({
         columns: ResourceColumns,
         data: tableData,
+        getRowId: (item) => `${item.type}-${item.data.uuid}`,
         enableColumnResizing: true,
         enableRowNumbers: false,
         positionActionsColumn: 'last',
@@ -831,6 +832,11 @@ const InfiniteResourceTable = ({
             size: 'sm',
         },
     });
+
+    const spaceUuidsKey = (filters.spaceUuids ?? []).join(',');
+    useEffect(() => {
+        table.resetRowSelection();
+    }, [spaceUuidsKey, table]);
 
     const {
         mutateAsync: contentBulkAction,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8682/row-selection-state-persists-across-space-navigation-selecting-wrong

### Description:
Row selection in the space contents table was keyed by row index (no getRowId) and its internal state survived nested-space navigation, since the same Space route/component instance is reused. Selecting items in a sub-space then going back highlighted whichever items landed at the same positions in the parent space.

Key selection by item identity (type + uuid) and reset it when the space changes so it never leaks into another space.
