### PR TITLE
chore(api-tests): add required enabled/includeLinks to scheduler create body

### DIFF
--- a/packages/api-tests/tests/scheduler.test.ts
+++ b/packages/api-tests/tests/scheduler.test.ts
@@ -24,10 +24,7 @@ import { login, loginAsEditor, loginAsViewer } from '../helpers/auth';
 const apiUrl = '/api/v1';
 
 const cron = '59 23 * * *';
-const createSchedulerBody: Omit<
-    CreateSchedulerAndTargetsWithoutIds,
-    'enabled' | 'includeLinks'
-> = {
+const createSchedulerBody: CreateSchedulerAndTargetsWithoutIds = {
     name: 'test',
     cron,
     targets: [{ channel: 'C1' }, { channel: 'C2' }],
@@ -36,6 +33,8 @@ const createSchedulerBody: Omit<
     timezone: 'UTC', // Explicitly set the timezone to be UTC since the project default might have been changed which will make the tests fail
     appUuid: null,
     appName: null,
+    enabled: true,
+    includeLinks: true,
 };
 
 const getUpdateSchedulerBody = (


### PR DESCRIPTION
Closes: <!-- no Linear ticket -->

### Description:

The scheduler api-tests started failing after #23052 added a typed `@Body()` to `createSavedChartScheduler`, which made TSOA validate the request body at the boundary and reject payloads missing the required `enabled` and `includeLinks` fields. The shared `createSchedulerBody` in `scheduler.test.ts` deliberately `Omit`ted those two fields, so every saved-chart scheduler create now returned a 422. This adds `enabled: true` and `includeLinks: true` to the body (typed as the full `CreateSchedulerAndTargetsWithoutIds`), restoring the suite.