### PR TITLE
fix(frontend): log the real error behind the generic NetworkError

### DIFF
--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -110,6 +110,9 @@ const handleError = (err: any): ApiError => {
         }
         return err;
     }
+    // Surface the real transport error (abort, CORS, DNS, connection reset)
+    // instead of silently masking it as the generic message below.
+    console.error('Failed to reach the Lightdash server:', err);
     return {
         status: 'error',
         error: {


### PR DESCRIPTION
Relates to #25110

## Description

`handleError` collapses every non-API failure — `fetch` aborts, CORS blocks, DNS failures, connection resets — into one generic `NetworkError` ("We are currently unable to reach the Lightdash server. Please try again in a few moments.") and drops the real error into an unused `data` field. Nothing logs it, so the true cause is invisible in the browser console. This adds a `console.error` of the underlying error at that collapse point. The user-facing message and all behaviour are unchanged.

This masking cost days on a recent embed investigation: the card said "unable to reach the server" while the real errors were client-side request cancellations and CORS.

```
Before:  request fails → console: (nothing)                                        → UI: "unable to reach the Lightdash server"
After:   request fails → console: "Failed to reach the Lightdash server: <error>"  → UI: unchanged
```

## Test plan

- Trigger a failed request (go offline, or point at a blocked/invalid host) and confirm the console now shows `Failed to reach the Lightdash server: <real error>` (e.g. `TypeError: Failed to fetch`) while the UI message stays the same.
- `pnpm -F frontend typecheck:fast` passes; pre-commit lint/format pass.
