### PR TITLE
fix(ui): soften the default Mantine border color

### DIFF
--- a/packages/frontend/src/mantine8CssVariablesResolver.ts
+++ b/packages/frontend/src/mantine8CssVariablesResolver.ts
@@ -35,6 +35,11 @@ export const cssVariablesResolver: CSSVariablesResolver = () => ({
         '--dashboard-tab-height': `${DASHBOARD_TAB_HEIGHT}px`,
         '--dashboard-tabs-zindex': `${DASHBOARD_TABS_ZINDEX}`,
     },
-    light: {},
-    dark: {},
+    light: {
+        // Mantine's default (gray-4) reads too heavy against our surfaces
+        '--mantine-color-default-border': 'var(--mantine-color-ldGray-2)',
+    },
+    dark: {
+        '--mantine-color-default-border': 'var(--mantine-color-dark-5)',
+    },
 });


### PR DESCRIPTION
Mantine's default border token (\`gray-4\`) reads too heavy against our surfaces. This overrides \`--mantine-color-default-border\` in the CSS variables resolver: \`ldGray-2\` in light mode, \`dark-5\` in dark mode.


🤖 Generated with [Claude Code](https://claude.com/claude-code)