### PR TITLE
fix: prune stale ai launcher dock items

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
@@ -1,5 +1,5 @@
 import { type AiAgentSummary } from '@lightdash/common';
-import { useMemo, type FC } from 'react';
+import { useEffect, useMemo, type FC } from 'react';
 import {
     openPanel,
     type LauncherDockItem,
@@ -30,8 +30,20 @@ export const LauncherDock: FC<Props> = ({ projectUuid, agents }) => {
         () => new Map(agents.map((a) => [a.uuid, a])),
         [agents],
     );
+    const visibleDock = useMemo(
+        () => dock.filter((item) => agentsByUuid.has(item.agentUuid)),
+        [agentsByUuid, dock],
+    );
 
-    if (dock.length === 0) return null;
+    useEffect(() => {
+        dock.forEach((item) => {
+            if (!agentsByUuid.has(item.agentUuid)) {
+                removeItem(item.threadId);
+            }
+        });
+    }, [agentsByUuid, dock, removeItem]);
+
+    if (visibleDock.length === 0) return null;
 
     const handleSelect = (item: LauncherDockItem) => {
         dispatch(
@@ -49,11 +61,11 @@ export const LauncherDock: FC<Props> = ({ projectUuid, agents }) => {
 
     return (
         <div className={styles.dock}>
-            {dock.map((item) => (
+            {visibleDock.map((item) => (
                 <DockTab
                     key={item.threadId}
                     item={item}
-                    agent={agentsByUuid.get(item.agentUuid) ?? null}
+                    agent={agentsByUuid.get(item.agentUuid)!}
                     isActive={isPanelOpen && item.threadId === activeThreadId}
                     onSelect={handleSelect}
                     onClose={handleClose}


### PR DESCRIPTION
### Description

Filters AI launcher dock items to agents that still exist in the current project, and prunes stale dock entries from local storage so deleted-agent threads do not leave inert bubbles behind.

### Testing

- `CI=true corepack pnpm -F @lightdash/frontend typecheck:fast`
- Browser validation: injected a stale dock entry for a missing agent, reloaded the dashboard, and verified it was not visible/pruned while a valid dock item remained.

Closes: #25161
