### PR TITLE
feat: add Redshift IAM authentication support for user warehouse credentials

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14957,11 +14957,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -15019,11 +15019,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -15459,6 +15459,21 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 pagination:
                                                                                     {
                                                                                         dataType:
@@ -15501,21 +15516,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -15795,6 +15795,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15839,13 +15858,13 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
+                                                                                fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
+                                                                                fieldValueType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -15917,25 +15936,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -16077,17 +16077,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -16310,6 +16310,77 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16387,77 +16458,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16489,12 +16489,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -16502,6 +16496,12 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16644,6 +16644,10 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['timeout'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -16653,10 +16657,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['timeout'],
                                                         },
                                                     ],
                                                     required: true,
@@ -25123,11 +25123,57 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiProviderApiKeysSet: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                openai: { dataType: 'boolean', required: true },
+                anthropic: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiProviderApiKeyHints: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                openai: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                anthropic: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiOrganizationSettings: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                providerApiKeyHints: {
+                    ref: 'AiProviderApiKeyHints',
+                    required: true,
+                },
+                providerApiKeysSet: {
+                    ref: 'AiProviderApiKeysSet',
+                    required: true,
+                },
                 defaultAiAgentModelConfig: {
                     dataType: 'union',
                     subSchemas: [
@@ -25209,38 +25255,23 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiOrganizationSettings_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Omit_AiOrganizationSettings.organizationUuid__': {
+    UpdateAiProviderApiKeys: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                aiAgentsVisible: {
+                openai: {
                     dataType: 'union',
                     subSchemas: [
-                        { dataType: 'boolean' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                aiAgentReviewsEnabled: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'boolean' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                mcpContentWritesEnabled: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'boolean' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                defaultAiAgentModelConfig: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'AiAgentModelConfig' },
+                        { dataType: 'string' },
                         { dataType: 'enum', enums: [null] },
-                        { dataType: 'undefined' },
+                    ],
+                },
+                anthropic: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
                     ],
                 },
             },
@@ -25251,7 +25282,20 @@ const models: TsoaRoute.Models = {
     UpdateAiOrganizationSettings: {
         dataType: 'refAlias',
         type: {
-            ref: 'Partial_Omit_AiOrganizationSettings.organizationUuid__',
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                providerApiKeys: { ref: 'UpdateAiProviderApiKeys' },
+                defaultAiAgentModelConfig: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentModelConfig' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                mcpContentWritesEnabled: { dataType: 'boolean' },
+                aiAgentReviewsEnabled: { dataType: 'boolean' },
+                aiAgentsVisible: { dataType: 'boolean' },
+            },
             validators: {},
         },
     },
@@ -25987,7 +26031,34 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateRedshiftCredentials-or-CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_':
+    'Pick_CreateRedshiftCredentials.type-or-user-or-authenticationType-or-assumeRoleArn_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: { ref: 'WarehouseTypes.REDSHIFT', required: true },
+                    user: { dataType: 'string', required: true },
+                    authenticationType: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'RedshiftAuthenticationType' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    assumeRoleArn: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_':
         {
             dataType: 'refAlias',
             type: {
@@ -25997,7 +26068,6 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { ref: 'WarehouseTypes.POSTGRES' },
-                            { ref: 'WarehouseTypes.REDSHIFT' },
                             { ref: 'WarehouseTypes.SNOWFLAKE' },
                             { ref: 'WarehouseTypes.TRINO' },
                             { ref: 'WarehouseTypes.CLICKHOUSE' },
@@ -26089,7 +26159,10 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         {
-                            ref: 'Pick_CreateRedshiftCredentials-or-CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_',
+                            ref: 'Pick_CreateRedshiftCredentials.type-or-user-or-authenticationType-or-assumeRoleArn_',
+                        },
+                        {
+                            ref: 'Pick_CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_',
                         },
                         { ref: 'Pick_CreateBigqueryCredentials.type_' },
                         { ref: 'Pick_CreateDatabricksCredentials.type_' },
@@ -26126,6 +26199,61 @@ const models: TsoaRoute.Models = {
             validators: {},
         },
     },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CreateRedshiftCredentials.type-or-user-or-authenticationType-or-accessKeyId-or-secretAccessKey-or-sessionToken-or-assumeRoleArn-or-assumeRoleExternalId_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: { ref: 'WarehouseTypes.REDSHIFT', required: true },
+                    user: { dataType: 'string', required: true },
+                    accessKeyId: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    secretAccessKey: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    sessionToken: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    authenticationType: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'RedshiftAuthenticationType' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    assumeRoleArn: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    assumeRoleExternalId: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                },
+                validators: {},
+            },
+        },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_CreatePostgresCredentials.type-or-user-or-password_': {
         dataType: 'refAlias',
@@ -26342,6 +26470,9 @@ const models: TsoaRoute.Models = {
                     subSchemas: [
                         {
                             ref: 'Pick_CreateRedshiftCredentials.type-or-user-or-password_',
+                        },
+                        {
+                            ref: 'Pick_CreateRedshiftCredentials.type-or-user-or-authenticationType-or-accessKeyId-or-secretAccessKey-or-sessionToken-or-assumeRoleArn-or-assumeRoleExternalId_',
                         },
                         {
                             ref: 'Pick_CreatePostgresCredentials.type-or-user-or-password_',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16564,8 +16564,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16623,8 +16623,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16803,6 +16803,9 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "pagination": {
                                                                             "properties": {
                                                                                 "totalPageCount": {
@@ -16829,9 +16832,6 @@
                                                                                 "page"
                                                                             ],
                                                                             "type": "object"
-                                                                        },
-                                                                        "error": {
-                                                                            "type": "string"
                                                                         },
                                                                         "status": {
                                                                             "type": "string",
@@ -16965,6 +16965,10 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -16979,10 +16983,10 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
-                                                                                "fieldValueType": {
+                                                                                "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldFilterType": {
+                                                                                "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldType": {
@@ -17012,8 +17016,8 @@
                                                                             "required": [
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
-                                                                                "fieldValueType",
                                                                                 "fieldFilterType",
+                                                                                "fieldValueType",
                                                                                 "fieldType",
                                                                                 "description",
                                                                                 "label",
@@ -17024,10 +17028,6 @@
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -17099,8 +17099,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "fields",
                                                                     "rationale",
+                                                                    "fields",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -17114,10 +17114,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -17125,8 +17125,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -17237,6 +17237,32 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "search",
+                                                                        "edit",
+                                                                        "compile",
+                                                                        "read",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17264,32 +17290,6 @@
                                                         ],
                                                         "nullable": true
                                                     },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17309,9 +17309,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
-                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
+                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -17374,10 +17374,10 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "timeout",
                                                             "error",
                                                             "rejected",
-                                                            "success",
-                                                            "timeout"
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -25311,8 +25311,40 @@
             "UpdateAiReviewNotificationSettings": {
                 "$ref": "#/components/schemas/Pick_AiReviewNotificationSettings.enabled-or-slackChannelId_"
             },
+            "AiProviderApiKeysSet": {
+                "properties": {
+                    "openai": {
+                        "type": "boolean"
+                    },
+                    "anthropic": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["openai", "anthropic"],
+                "type": "object"
+            },
+            "AiProviderApiKeyHints": {
+                "properties": {
+                    "openai": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "anthropic": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["openai", "anthropic"],
+                "type": "object"
+            },
             "AiOrganizationSettings": {
                 "properties": {
+                    "providerApiKeyHints": {
+                        "$ref": "#/components/schemas/AiProviderApiKeyHints"
+                    },
+                    "providerApiKeysSet": {
+                        "$ref": "#/components/schemas/AiProviderApiKeysSet"
+                    },
                     "defaultAiAgentModelConfig": {
                         "allOf": [
                             {
@@ -25335,6 +25367,8 @@
                     }
                 },
                 "required": [
+                    "providerApiKeyHints",
+                    "providerApiKeysSet",
                     "defaultAiAgentModelConfig",
                     "mcpContentWritesEnabled",
                     "aiAgentReviewsEnabled",
@@ -25406,16 +25440,23 @@
             "ApiUpdateAiOrganizationSettingsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiOrganizationSettings_"
             },
-            "Partial_Omit_AiOrganizationSettings.organizationUuid__": {
+            "UpdateAiProviderApiKeys": {
                 "properties": {
-                    "aiAgentsVisible": {
-                        "type": "boolean"
+                    "openai": {
+                        "type": "string",
+                        "nullable": true
                     },
-                    "aiAgentReviewsEnabled": {
-                        "type": "boolean"
-                    },
-                    "mcpContentWritesEnabled": {
-                        "type": "boolean"
+                    "anthropic": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateAiOrganizationSettings": {
+                "properties": {
+                    "providerApiKeys": {
+                        "$ref": "#/components/schemas/UpdateAiProviderApiKeys"
                     },
                     "defaultAiAgentModelConfig": {
                         "allOf": [
@@ -25424,13 +25465,18 @@
                             }
                         ],
                         "nullable": true
+                    },
+                    "mcpContentWritesEnabled": {
+                        "type": "boolean"
+                    },
+                    "aiAgentReviewsEnabled": {
+                        "type": "boolean"
+                    },
+                    "aiAgentsVisible": {
+                        "type": "boolean"
                     }
                 },
-                "type": "object",
-                "description": "Make all properties in T optional"
-            },
-            "UpdateAiOrganizationSettings": {
-                "$ref": "#/components/schemas/Partial_Omit_AiOrganizationSettings.organizationUuid__"
+                "type": "object"
             },
             "ApiJobScheduledResponse": {
                 "properties": {
@@ -26186,15 +26232,31 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_CreateRedshiftCredentials-or-CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_": {
+            "Pick_CreateRedshiftCredentials.type-or-user-or-authenticationType-or-assumeRoleArn_": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
+                    },
+                    "user": {
+                        "type": "string"
+                    },
+                    "authenticationType": {
+                        "$ref": "#/components/schemas/RedshiftAuthenticationType"
+                    },
+                    "assumeRoleArn": {
+                        "type": "string"
+                    }
+                },
+                "required": ["type", "user"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Pick_CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_": {
                 "properties": {
                     "type": {
                         "anyOf": [
                             {
                                 "$ref": "#/components/schemas/WarehouseTypes.POSTGRES"
-                            },
-                            {
-                                "$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
                             },
                             {
                                 "$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
@@ -26287,7 +26349,10 @@
                     "credentials": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/Pick_CreateRedshiftCredentials-or-CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_"
+                                "$ref": "#/components/schemas/Pick_CreateRedshiftCredentials.type-or-user-or-authenticationType-or-assumeRoleArn_"
+                            },
+                            {
+                                "$ref": "#/components/schemas/Pick_CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_"
                             },
                             {
                                 "$ref": "#/components/schemas/Pick_CreateBigqueryCredentials.type_"
@@ -26341,6 +26406,37 @@
                         "type": "string"
                     },
                     "password": {
+                        "type": "string"
+                    }
+                },
+                "required": ["type", "user"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Pick_CreateRedshiftCredentials.type-or-user-or-authenticationType-or-accessKeyId-or-secretAccessKey-or-sessionToken-or-assumeRoleArn-or-assumeRoleExternalId_": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
+                    },
+                    "user": {
+                        "type": "string"
+                    },
+                    "accessKeyId": {
+                        "type": "string"
+                    },
+                    "secretAccessKey": {
+                        "type": "string"
+                    },
+                    "sessionToken": {
+                        "type": "string"
+                    },
+                    "authenticationType": {
+                        "$ref": "#/components/schemas/RedshiftAuthenticationType"
+                    },
+                    "assumeRoleArn": {
+                        "type": "string"
+                    },
+                    "assumeRoleExternalId": {
                         "type": "string"
                     }
                 },
@@ -26506,6 +26602,9 @@
                         "anyOf": [
                             {
                                 "$ref": "#/components/schemas/Pick_CreateRedshiftCredentials.type-or-user-or-password_"
+                            },
+                            {
+                                "$ref": "#/components/schemas/Pick_CreateRedshiftCredentials.type-or-user-or-authenticationType-or-accessKeyId-or-secretAccessKey-or-sessionToken-or-assumeRoleArn-or-assumeRoleExternalId_"
                             },
                             {
                                 "$ref": "#/components/schemas/Pick_CreatePostgresCredentials.type-or-user-or-password_"
@@ -43393,7 +43492,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3320.0",
+        "version": "0.3321.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -9,6 +9,8 @@ import {
     NotFoundError,
     ParameterError,
     ProjectType,
+    RedshiftAuthenticationType,
+    redshiftIamUserCredentialsSchema,
     SnowflakeAuthenticationType,
     snowflakeSsoUserCredentialsSchema,
     SnowflakeTokenError,
@@ -81,6 +83,19 @@ export class UserWarehouseCredentialsModel {
 
             switch (credentialsWithSecrets.type) {
                 case WarehouseTypes.REDSHIFT:
+                    credentials = {
+                        type: credentialsWithSecrets.type,
+                        user: credentialsWithSecrets.user,
+                        ...('authenticationType' in credentialsWithSecrets
+                            ? {
+                                  authenticationType:
+                                      credentialsWithSecrets.authenticationType,
+                                  assumeRoleArn:
+                                      credentialsWithSecrets.assumeRoleArn,
+                              }
+                            : {}),
+                    };
+                    break;
                 case WarehouseTypes.POSTGRES:
                 case WarehouseTypes.TRINO:
                 case WarehouseTypes.SNOWFLAKE:
@@ -441,6 +456,22 @@ export class UserWarehouseCredentialsModel {
             if (!result.success) {
                 throw new ParameterError(
                     'BigQuery credentials require a valid keyfile. Please reauthenticate with Google.',
+                );
+            }
+        }
+
+        if (
+            data.credentials.type === WarehouseTypes.REDSHIFT &&
+            'authenticationType' in data.credentials &&
+            data.credentials.authenticationType ===
+                RedshiftAuthenticationType.IAM
+        ) {
+            const result = redshiftIamUserCredentialsSchema.safeParse(
+                data.credentials,
+            );
+            if (!result.success) {
+                throw new ParameterError(
+                    'Redshift IAM credentials require an assume-role ARN or AWS access keys.',
                 );
             }
         }

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -15,6 +15,7 @@ import {
     ParameterError,
     PreAggregateMissReason,
     ProjectType,
+    RedshiftAuthenticationType,
     RequestMethod,
     SessionUser,
     SupportedDbtAdapter,
@@ -589,6 +590,93 @@ describe('ProjectService', () => {
     });
 
     describe('user warehouse credentials override', () => {
+        test('should use user Redshift IAM identity when requireUserCredentials is true', async () => {
+            service.warehouseClients = {};
+
+            const projectRedshiftCredentials = {
+                type: WarehouseTypes.REDSHIFT,
+                host: 'cluster.redshift.amazonaws.com',
+                user: 'shared_project_user',
+                password: 'shared-project-password',
+                port: 5439,
+                dbname: 'dev',
+                schema: 'public',
+                authenticationType: RedshiftAuthenticationType.IAM,
+                region: 'us-east-1',
+                clusterIdentifier: 'analytics-cluster',
+                accessKeyId: 'PROJECT_KEY',
+                secretAccessKey: 'PROJECT_SECRET',
+                assumeRoleArn: 'arn:aws:iam::111:role/project-role',
+                requireUserCredentials: true,
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as import('vitest').Mock
+            ).mockImplementation(async () => projectRedshiftCredentials);
+
+            const userCredentials = {
+                uuid: 'user-redshift-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.REDSHIFT,
+                    authenticationType: RedshiftAuthenticationType.IAM,
+                    user: '',
+                    assumeRoleArn: 'arn:aws:iam::222:role/viewer-role',
+                    assumeRoleExternalId: 'viewer-external-id',
+                },
+            };
+
+            const findForProjectWithSecretsMock = vi.fn(
+                async () => userCredentials,
+            );
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: import('vitest').Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets =
+                findForProjectWithSecretsMock;
+
+            const mergedCredentials = await (
+                service as unknown as {
+                    getWarehouseCredentials: (args: {
+                        projectUuid: string;
+                        userId: string;
+                        isRegisteredUser: boolean;
+                    }) => Promise<Record<string, unknown>>;
+                }
+            ).getWarehouseCredentials({
+                projectUuid,
+                userId: sessionAccount.user.id,
+                isRegisteredUser: true,
+            });
+
+            expect(findForProjectWithSecretsMock).toHaveBeenCalledWith(
+                projectUuid,
+                sessionAccount.user.id,
+                WarehouseTypes.REDSHIFT,
+            );
+            expect(mergedCredentials).toEqual(
+                expect.objectContaining({
+                    type: WarehouseTypes.REDSHIFT,
+                    user: '',
+                    authenticationType: RedshiftAuthenticationType.IAM,
+                    region: 'us-east-1',
+                    clusterIdentifier: 'analytics-cluster',
+                    assumeRoleArn: 'arn:aws:iam::222:role/viewer-role',
+                    assumeRoleExternalId: 'viewer-external-id',
+                    userWarehouseCredentialsUuid: 'user-redshift-creds-uuid',
+                }),
+            );
+            expect(mergedCredentials).not.toEqual(
+                expect.objectContaining({
+                    password: 'shared-project-password',
+                    accessKeyId: 'PROJECT_KEY',
+                    secretAccessKey: 'PROJECT_SECRET',
+                    assumeRoleArn: 'arn:aws:iam::111:role/project-role',
+                }),
+            );
+        });
+
         test('should use user refreshToken instead of project refreshToken when requireUserCredentials is true', async () => {
             // clear in memory cache so new mock is applied
             service.warehouseClients = {};

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1454,11 +1454,22 @@ export class ProjectService extends BaseService {
             }
             case WarehouseTypes.POSTGRES:
             case WarehouseTypes.TRINO:
-            case WarehouseTypes.CLICKHOUSE:
-            case WarehouseTypes.REDSHIFT: {
+            case WarehouseTypes.CLICKHOUSE: {
                 return {
                     ...credentials,
                     password: '',
+                };
+            }
+            case WarehouseTypes.REDSHIFT: {
+                return {
+                    ...credentials,
+                    user: '',
+                    password: '',
+                    accessKeyId: '',
+                    secretAccessKey: '',
+                    sessionToken: '',
+                    assumeRoleArn: '',
+                    assumeRoleExternalId: '',
                 };
             }
             case WarehouseTypes.ATHENA: {

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -764,6 +764,20 @@ export class BigqueryTokenError extends LightdashError {
     }
 }
 
+/* This specific error will be used in the frontend
+to show a "reauthenticate" button in the UI
+*/
+export class RedshiftIamTokenError extends LightdashError {
+    constructor(message: string) {
+        super({
+            message,
+            name: 'RedshiftIamTokenError',
+            statusCode: 401,
+            data: {},
+        });
+    }
+}
+
 export class CustomSqlQueryForbiddenError extends LightdashError {
     constructor(
         message: string = 'User cannot run queries with custom SQL dimensions',

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
     DatabricksAuthenticationType,
+    RedshiftAuthenticationType,
     SnowflakeAuthenticationType,
     WarehouseTypes,
     type CreateAthenaCredentials,
@@ -30,7 +31,10 @@ export type UserWarehouseCredentials = {
     updatedAt: Date;
     credentials:
         | Pick<
-              | CreateRedshiftCredentials
+              CreateRedshiftCredentials,
+              'type' | 'user' | 'authenticationType' | 'assumeRoleArn'
+          >
+        | Pick<
               | CreatePostgresCredentials
               | CreateSnowflakeCredentials
               | CreateTrinoCredentials
@@ -50,6 +54,17 @@ export type UserWarehouseCredentialsWithSecrets = Pick<
 > & {
     credentials:
         | Pick<CreateRedshiftCredentials, 'type' | 'user' | 'password'>
+        | Pick<
+              CreateRedshiftCredentials,
+              | 'type'
+              | 'user'
+              | 'authenticationType'
+              | 'accessKeyId'
+              | 'secretAccessKey'
+              | 'sessionToken'
+              | 'assumeRoleArn'
+              | 'assumeRoleExternalId'
+          >
         | Pick<CreatePostgresCredentials, 'type' | 'user' | 'password'>
         | Pick<
               CreateSnowflakeCredentials,
@@ -133,3 +148,39 @@ export const bigquerySsoUserCredentialsSchema = z
             .passthrough(),
     })
     .passthrough();
+
+export const redshiftIamUserCredentialsSchema = z
+    .object({
+        type: z.literal(WarehouseTypes.REDSHIFT),
+        authenticationType: z.literal(RedshiftAuthenticationType.IAM),
+        user: z.string().optional(),
+        password: z.string().optional(),
+        accessKeyId: z.string().optional(),
+        secretAccessKey: z.string().optional(),
+        sessionToken: z.string().optional(),
+        assumeRoleArn: z.string().optional(),
+        assumeRoleExternalId: z.string().optional(),
+    })
+    .strict()
+    .superRefine((credentials, ctx) => {
+        const hasAccessKeyId = !!credentials.accessKeyId;
+        const hasSecretAccessKey = !!credentials.secretAccessKey;
+        const hasStaticCredentials = hasAccessKeyId && hasSecretAccessKey;
+        const hasAssumeRole = !!credentials.assumeRoleArn;
+
+        if (hasAccessKeyId !== hasSecretAccessKey) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                    'Redshift IAM credentials require both AWS access key ID and secret access key.',
+            });
+        }
+
+        if (!hasStaticCredentials && !hasAssumeRole) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                    'Redshift IAM credentials require an assume-role ARN or AWS access keys.',
+            });
+        }
+    });

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -113,6 +113,17 @@ const UserCredentialsSwitcher = () => {
                         setShowCreateModalOnPageLoad(true);
                         setIsCreatingCredentials(true);
                     }
+                    if (
+                        error?.error?.name === 'RedshiftIamTokenError' &&
+                        activeProject?.warehouseConnection?.type ===
+                            'redshift' &&
+                        activeProject?.warehouseConnection
+                            ?.requireUserCredentials
+                    ) {
+                        console.info('Triggering reauth modal for Redshift');
+                        setShowCreateModalOnPageLoad(true);
+                        setIsCreatingCredentials(true);
+                    }
                 }
             }
         });

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -1,4 +1,5 @@
 import {
+    RedshiftAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
@@ -38,6 +39,7 @@ const defaultCredentials: Record<
         type: WarehouseTypes.REDSHIFT,
         user: '',
         password: '',
+        authenticationType: RedshiftAuthenticationType.PASSWORD,
     },
     [WarehouseTypes.SNOWFLAKE]: {
         type: WarehouseTypes.SNOWFLAKE,

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -19,6 +19,13 @@ const getCredentialsWithPlaceholders = (
 ): UpsertUserWarehouseCredentials['credentials'] => {
     switch (credentials.type) {
         case WarehouseTypes.REDSHIFT:
+            return {
+                ...credentials,
+                password: '',
+                accessKeyId: '',
+                secretAccessKey: '',
+                sessionToken: '',
+            };
         case WarehouseTypes.SNOWFLAKE:
         case WarehouseTypes.POSTGRES:
         case WarehouseTypes.TRINO:

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -1,13 +1,30 @@
 import {
+    RedshiftAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
 } from '@lightdash/common';
-import { PasswordInput, TextInput } from '@mantine-8/core';
+import {
+    Alert,
+    Button,
+    Code,
+    Collapse,
+    PasswordInput,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
-import { type FC } from 'react';
+import {
+    IconChevronDown,
+    IconChevronRight,
+    IconInfoCircle,
+} from '@tabler/icons-react';
+import { type FC, useState } from 'react';
 import { useGoogleLoginPopup } from '../../../hooks/gdrive/useGdrive';
 import { useDatabricksLoginPopup } from '../../../hooks/useDatabricks';
 import { useSnowflakeLoginPopup } from '../../../hooks/useSnowflake';
+import MantineIcon from '../../common/MantineIcon';
 import { BigQuerySSOInput } from '../../ProjectConnection/WarehouseForms/BigQueryForm';
 import { DatabricksSSOInput } from '../../ProjectConnection/WarehouseForms/DatabricksForm';
 import { SnowflakeSSOInput } from '../../ProjectConnection/WarehouseForms/SnowflakeForm';
@@ -72,6 +89,120 @@ const DatabricksFormInput: FC<{
     );
 };
 
+const RedshiftIamFormInputs: FC<{
+    disabled: boolean;
+    form: UseFormReturnType<UpsertUserWarehouseCredentials>;
+}> = ({ disabled, form }) => {
+    const redshiftCredentials =
+        form.values.credentials.type === WarehouseTypes.REDSHIFT
+            ? form.values.credentials
+            : undefined;
+    const hasAdvancedIamOptions =
+        redshiftCredentials !== undefined &&
+        'assumeRoleArn' in redshiftCredentials &&
+        (!!redshiftCredentials.assumeRoleArn ||
+            !!redshiftCredentials.assumeRoleExternalId);
+    const [isAdvancedOpen, setIsAdvancedOpen] = useState(
+        !!redshiftCredentials?.user || hasAdvancedIamOptions,
+    );
+
+    return (
+        <Stack gap="xs">
+            <Alert
+                color="blue"
+                icon={<MantineIcon icon={IconInfoCircle} size="lg" />}
+            >
+                <Stack gap="xxs">
+                    <Text fz="xs">
+                        Paste temporary AWS credentials generated from your
+                        terminal. For AWS SSO, log in first, then export the
+                        credentials.
+                    </Text>
+                    <Code fz="xs">
+                        aws configure export-credentials --format env-no-export
+                    </Code>
+                    <Text fz="xs">
+                        For a named SSO profile, add{' '}
+                        <Code fz="xs">--profile your-profile</Code>.
+                    </Text>
+                    <Text fz="xs">
+                        Or use the advanced options to provide an IAM role that
+                        Lightdash can assume.
+                    </Text>
+                </Stack>
+            </Alert>
+
+            <TextInput
+                withAsterisk
+                size="xs"
+                label="AWS access key ID"
+                description="Paste AWS_ACCESS_KEY_ID from the export command."
+                disabled={disabled}
+                {...form.getInputProps('credentials.accessKeyId')}
+            />
+            <PasswordInput
+                withAsterisk
+                size="xs"
+                label="AWS secret access key"
+                description="Paste AWS_SECRET_ACCESS_KEY from the export command."
+                disabled={disabled}
+                {...form.getInputProps('credentials.secretAccessKey')}
+            />
+            <PasswordInput
+                size="xs"
+                label="AWS session token"
+                description="Paste AWS_SESSION_TOKEN. Required for AWS SSO and temporary credentials."
+                disabled={disabled}
+                {...form.getInputProps('credentials.sessionToken')}
+            />
+
+            <Button
+                size="compact-xs"
+                variant="subtle"
+                color="gray"
+                leftSection={
+                    <MantineIcon
+                        icon={
+                            isAdvancedOpen ? IconChevronDown : IconChevronRight
+                        }
+                    />
+                }
+                onClick={() => setIsAdvancedOpen((isOpen) => !isOpen)}
+            >
+                Advanced IAM options
+            </Button>
+
+            <Collapse in={isAdvancedOpen}>
+                <Stack gap="xs">
+                    <TextInput
+                        size="xs"
+                        label="Database user"
+                        description="Optional. Leave blank to use the IAM identity as the Redshift database user."
+                        disabled={disabled}
+                        {...form.getInputProps('credentials.user')}
+                    />
+                    <TextInput
+                        size="xs"
+                        label="Assume role ARN"
+                        description="Optional. IAM role to assume before requesting Redshift credentials."
+                        disabled={disabled}
+                        {...form.getInputProps('credentials.assumeRoleArn')}
+                    />
+                    <TextInput
+                        size="xs"
+                        label="Assume role external ID"
+                        description="Optional. Only required when the IAM role trust policy requires it."
+                        disabled={disabled}
+                        {...form.getInputProps(
+                            'credentials.assumeRoleExternalId',
+                        )}
+                    />
+                </Stack>
+            </Collapse>
+        </Stack>
+    );
+};
+
 export const WarehouseFormInputs: FC<{
     disabled: boolean;
     form: UseFormReturnType<UpsertUserWarehouseCredentials>;
@@ -87,10 +218,17 @@ export const WarehouseFormInputs: FC<{
     projectName,
     databricksCredentialsName,
 }) => {
+    const redshiftAuthenticationType =
+        form.values.credentials.type === WarehouseTypes.REDSHIFT
+            ? 'authenticationType' in form.values.credentials
+                ? (form.values.credentials.authenticationType ??
+                  RedshiftAuthenticationType.PASSWORD)
+                : RedshiftAuthenticationType.PASSWORD
+            : undefined;
+
     switch (form.values.credentials.type) {
         case WarehouseTypes.SNOWFLAKE:
             return <SnowflakeFormInput onClose={onClose} />;
-        case WarehouseTypes.REDSHIFT:
         case WarehouseTypes.POSTGRES:
         case WarehouseTypes.TRINO:
         case WarehouseTypes.CLICKHOUSE:
@@ -110,6 +248,55 @@ export const WarehouseFormInputs: FC<{
                         disabled={disabled}
                         {...form.getInputProps('credentials.password')}
                     />
+                </>
+            );
+        case WarehouseTypes.REDSHIFT:
+            return (
+                <>
+                    <Select
+                        required
+                        size="xs"
+                        label="Authentication type"
+                        data={[
+                            {
+                                value: RedshiftAuthenticationType.PASSWORD,
+                                label: 'Username & password',
+                            },
+                            {
+                                value: RedshiftAuthenticationType.IAM,
+                                label: 'AWS IAM',
+                            },
+                        ]}
+                        disabled={disabled}
+                        {...form.getInputProps(
+                            'credentials.authenticationType',
+                        )}
+                    />
+
+                    {redshiftAuthenticationType ===
+                    RedshiftAuthenticationType.IAM ? (
+                        <RedshiftIamFormInputs
+                            disabled={disabled}
+                            form={form}
+                        />
+                    ) : (
+                        <>
+                            <TextInput
+                                required
+                                size="xs"
+                                label="Username/email"
+                                disabled={disabled}
+                                {...form.getInputProps('credentials.user')}
+                            />
+                            <PasswordInput
+                                required
+                                size="xs"
+                                label="Password"
+                                disabled={disabled}
+                                {...form.getInputProps('credentials.password')}
+                            />
+                        </>
+                    )}
                 </>
             );
         case WarehouseTypes.BIGQUERY:

--- a/packages/frontend/src/hooks/useInfiniteQueryResults.test.tsx
+++ b/packages/frontend/src/hooks/useInfiniteQueryResults.test.tsx
@@ -160,6 +160,49 @@ describe('useInfiniteQueryResults', () => {
         expect(result.current.error?.error?.message).toBeTruthy();
     });
 
+    it('surfaces expired Redshift IAM async query failures as token errors', async () => {
+        const errorResponse: ApiGetAsyncQueryResults = {
+            queryUuid: 'q1',
+            status: QueryHistoryStatus.ERROR,
+            error: 'Failed to mint Redshift IAM credentials: The security token included in the request is expired',
+            erroredAt: new Date(),
+        };
+        mockGetResultsPage.mockResolvedValue(errorResponse);
+
+        const { result } = renderHook(
+            () => useInfiniteQueryResults('p1', 'q1'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).not.toBeNull();
+        });
+
+        expect(result.current.error?.error?.name).toBe('RedshiftIamTokenError');
+        expect(result.current.error?.error?.statusCode).toBe(401);
+    });
+
+    it('surfaces friendly Redshift IAM expiry messages as token errors', async () => {
+        const errorResponse: ApiGetAsyncQueryResults = {
+            queryUuid: 'q1',
+            status: QueryHistoryStatus.ERROR,
+            error: 'Your Redshift IAM AWS session has expired. Generate new AWS credentials and log in to Redshift again.',
+            erroredAt: new Date(),
+        };
+        mockGetResultsPage.mockResolvedValue(errorResponse);
+
+        const { result } = renderHook(
+            () => useInfiniteQueryResults('p1', 'q1'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).not.toBeNull();
+        });
+
+        expect(result.current.error?.error?.name).toBe('RedshiftIamTokenError');
+    });
+
     it('resets pages when queryUuid changes', async () => {
         const page1Q1 = makeReadyPage(1, { queryUuid: 'q1', rows: 5 });
         const page1Q2 = makeReadyPage(1, { queryUuid: 'q2', rows: 3 });

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -54,6 +54,30 @@ export type ReadyQueryResultsPageWithClientFetchTimeMs =
         clientFetchTimeMs: number;
     };
 
+const isRedshiftIamTokenErrorMessage = (message: string): boolean => {
+    const normalizedMessage = message.toLowerCase();
+    return (
+        normalizedMessage.includes('redshift iam') &&
+        normalizedMessage.includes('expired')
+    );
+};
+
+const getAsyncQueryError = (message: string | null): ApiError => {
+    const errorMessage = message || 'Query failed';
+    const isRedshiftIamTokenError =
+        isRedshiftIamTokenErrorMessage(errorMessage);
+
+    return {
+        status: 'error',
+        error: {
+            name: isRedshiftIamTokenError ? 'RedshiftIamTokenError' : 'Error',
+            statusCode: isRedshiftIamTokenError ? 401 : 500,
+            message: errorMessage,
+            data: {},
+        },
+    };
+};
+
 const executeAsyncMetricQuery = async (
     projectUuid: string,
     data: ExecuteAsyncMetricQueryRequestParams,
@@ -402,15 +426,7 @@ export const useInfiniteQueryResults = (
                 case QueryHistoryStatus.ERROR:
                 case QueryHistoryStatus.EXPIRED: {
                     backoffRef.current = 250;
-                    throw <ApiError>{
-                        status: 'error',
-                        error: {
-                            name: 'Error',
-                            statusCode: 500,
-                            message: results.error || 'Query failed',
-                            data: {},
-                        },
-                    };
+                    throw getAsyncQueryError(results.error);
                 }
                 case QueryHistoryStatus.CANCELLED: {
                     backoffRef.current = 250;

--- a/packages/warehouses/src/warehouseClients/redshiftIamCredentials.test.ts
+++ b/packages/warehouses/src/warehouseClients/redshiftIamCredentials.test.ts
@@ -16,6 +16,9 @@ vi.mock('@aws-sdk/client-redshift', () => ({
     GetClusterCredentialsCommand: vi.fn(function (input: unknown) {
         return { __command: 'cluster', input };
     }),
+    GetClusterCredentialsWithIAMCommand: vi.fn(function (input: unknown) {
+        return { __command: 'cluster-with-iam', input };
+    }),
 }));
 
 vi.mock('@aws-sdk/client-redshift-serverless', () => ({
@@ -149,6 +152,36 @@ describe('mintRedshiftIamCredentials', () => {
             expiration,
         });
         expect(mockClusterSend).toHaveBeenCalledTimes(1);
+        expect(mockServerlessSend).not.toHaveBeenCalled();
+    });
+
+    test('mints credentials from the IAM identity when no database user is provided', async () => {
+        const expiration = new Date('2026-01-01T00:00:00Z');
+        mockClusterSend.mockResolvedValue({
+            DbUser: 'IAMR:user-role',
+            DbPassword: 'temp-password',
+            Expiration: expiration,
+        });
+
+        const result = await mintRedshiftIamCredentials({
+            ...provisionedCredentials,
+            user: '',
+            assumeRoleArn: 'arn:aws:iam::123456789012:role/user-role',
+        });
+
+        expect(result).toEqual({
+            dbUser: 'IAMR:user-role',
+            dbPassword: 'temp-password',
+            expiration,
+        });
+        expect(mockClusterSend).toHaveBeenCalledWith({
+            __command: 'cluster-with-iam',
+            input: {
+                ClusterIdentifier: 'my-cluster',
+                DbName: 'dev',
+                DurationSeconds: 3600,
+            },
+        });
         expect(mockServerlessSend).not.toHaveBeenCalled();
     });
 

--- a/packages/warehouses/src/warehouseClients/redshiftIamCredentials.test.ts
+++ b/packages/warehouses/src/warehouseClients/redshiftIamCredentials.test.ts
@@ -2,6 +2,7 @@
 import {
     CreateRedshiftCredentials,
     RedshiftAuthenticationType,
+    RedshiftIamTokenError,
     WarehouseConnectionError,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -40,6 +41,7 @@ vi.mock('@aws-sdk/credential-providers', () => ({
 // eslint-disable-next-line import/first -- Must import after mocks are set up
 import {
     getRedshiftAwsCredentials,
+    isExpiredAwsTokenError,
     mintRedshiftIamCredentials,
 } from './redshiftIamCredentials';
 
@@ -229,5 +231,30 @@ describe('mintRedshiftIamCredentials', () => {
                 workgroupName: undefined,
             }),
         ).rejects.toThrow(WarehouseConnectionError);
+    });
+
+    test('throws RedshiftIamTokenError when the AWS session token has expired', async () => {
+        mockClusterSend.mockRejectedValue({
+            name: 'ExpiredTokenException',
+            message: 'The security token included in the request is expired',
+        });
+
+        await expect(
+            mintRedshiftIamCredentials(provisionedCredentials),
+        ).rejects.toThrow(RedshiftIamTokenError);
+    });
+});
+
+describe('isExpiredAwsTokenError', () => {
+    test('detects expired AWS tokens by name or message', () => {
+        expect(isExpiredAwsTokenError({ name: 'ExpiredToken' })).toBe(true);
+        expect(
+            isExpiredAwsTokenError(
+                new Error(
+                    'The security token included in the request is expired',
+                ),
+            ),
+        ).toBe(true);
+        expect(isExpiredAwsTokenError(new Error('Access denied'))).toBe(false);
     });
 });

--- a/packages/warehouses/src/warehouseClients/redshiftIamCredentials.ts
+++ b/packages/warehouses/src/warehouseClients/redshiftIamCredentials.ts
@@ -1,5 +1,6 @@
 import {
     GetClusterCredentialsCommand,
+    GetClusterCredentialsWithIAMCommand,
     RedshiftClient,
     type RedshiftClientConfig,
 } from '@aws-sdk/client-redshift';
@@ -126,15 +127,32 @@ export const mintRedshiftIamCredentials = async (
                 'Redshift IAM authentication requires a cluster identifier',
             );
         }
-        if (!credentials.user) {
-            throw new WarehouseConnectionError(
-                'Redshift IAM authentication requires a database user',
-            );
-        }
+
         const client = new RedshiftClient({
             region: credentials.region,
             credentials: awsCredentials,
         });
+
+        if (!credentials.user) {
+            const response = await client.send(
+                new GetClusterCredentialsWithIAMCommand({
+                    ClusterIdentifier: credentials.clusterIdentifier,
+                    DbName: credentials.dbname,
+                    DurationSeconds: CREDENTIALS_DURATION_SECONDS,
+                }),
+            );
+            if (!response.DbUser || !response.DbPassword) {
+                throw new WarehouseConnectionError(
+                    'Redshift did not return temporary credentials',
+                );
+            }
+            return {
+                dbUser: response.DbUser,
+                dbPassword: response.DbPassword,
+                expiration: response.Expiration,
+            };
+        }
+
         const response = await client.send(
             new GetClusterCredentialsCommand({
                 ClusterIdentifier: credentials.clusterIdentifier,

--- a/packages/warehouses/src/warehouseClients/redshiftIamCredentials.ts
+++ b/packages/warehouses/src/warehouseClients/redshiftIamCredentials.ts
@@ -12,6 +12,7 @@ import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import {
     CreateRedshiftCredentials,
     getErrorMessage,
+    RedshiftIamTokenError,
     WarehouseConnectionError,
 } from '@lightdash/common';
 
@@ -21,6 +22,23 @@ import {
 const CREDENTIALS_DURATION_SECONDS = 3600;
 
 const ROLE_SESSION_NAME = 'lightdash-redshift-session';
+
+const EXPIRED_AWS_TOKEN_ERROR_NAMES = new Set([
+    'ExpiredToken',
+    'ExpiredTokenException',
+]);
+
+export const isExpiredAwsTokenError = (error: unknown): boolean => {
+    const errorName = (error as { name?: string })?.name;
+    const errorMessage = getErrorMessage(error).toLowerCase();
+
+    return (
+        (!!errorName && EXPIRED_AWS_TOKEN_ERROR_NAMES.has(errorName)) ||
+        errorMessage.includes(
+            'security token included in the request is expired',
+        )
+    );
+};
 
 export type RedshiftIamDbCredentials = {
     dbUser: string;
@@ -179,6 +197,11 @@ export const mintRedshiftIamCredentials = async (
     } catch (e) {
         if (e instanceof WarehouseConnectionError) {
             throw e;
+        }
+        if (isExpiredAwsTokenError(e)) {
+            throw new RedshiftIamTokenError(
+                'Your Redshift IAM AWS session has expired. Generate new AWS credentials and log in to Redshift again.',
+            );
         }
         throw new WarehouseConnectionError(
             `Failed to mint Redshift IAM credentials: ${getErrorMessage(e)}`,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-551/support-per-user-redshift-iamsso-credential-pass-through-for-query



![CleanShot 2026-07-07 at 13.20.15.png](https://app.graphite.com/user-attachments/assets/76e212d8-4a20-488c-862b-397a7d03f18d.png)



### Description:

Adds AWS IAM authentication support for user warehouse credentials when connecting to Redshift. Previously, users could only authenticate with a username and password. Now they can choose between username/password or AWS IAM authentication.

**IAM authentication flow:**

- Users can provide temporary AWS credentials (access key ID, secret access key, and optional session token) obtained via `aws configure export-credentials`.
- Optionally, users can specify an IAM role ARN for Lightdash to assume, along with an optional external ID.
- When no database user is specified, Lightdash uses `GetClusterCredentialsWithIAMCommand` to mint credentials directly from the IAM identity rather than requiring an explicit Redshift database user.

**Credential handling:**

- The `UserWarehouseCredentials` type for Redshift is now split from the other warehouse types to expose IAM-specific fields (`authenticationType`, `assumeRoleArn`, `assumeRoleExternalId`, `accessKeyId`, `secretAccessKey`, `sessionToken`).
- A `redshiftIamUserCredentialsSchema` Zod schema validates that IAM credentials include either an assume-role ARN or AWS access keys (both key ID and secret are required together).
- When returning sanitized credentials to the frontend, Redshift-specific sensitive fields (`accessKeyId`, `secretAccessKey`, `sessionToken`, `assumeRoleArn`, `assumeRoleExternalId`) are cleared alongside the password.

**Frontend:**

- The Redshift credential form now includes an authentication type selector. Selecting AWS IAM shows fields for access key ID, secret access key, and session token, with an expandable "Advanced IAM options" section for database user, assume role ARN, and external ID.