### PR TITLE
fix(filters): commit typed filter value on blur and when Apply is clicked

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
@@ -16,6 +16,7 @@ const FilterMultiStringInput: FC<Props> = ({
     disabled,
     onChange,
     placeholder,
+    onBlur: onInputBlur,
     ...rest
 }) => {
     const [search, setSearch] = useState('');
@@ -45,6 +46,17 @@ const FilterMultiStringInput: FC<Props> = ({
             return newValue;
         },
         [handleChange, values],
+    );
+
+    const handleBlur = useCallback(
+        (event: React.FocusEvent<HTMLInputElement>) => {
+            if (search !== '' && !pastePopUpOpened) {
+                handleAdd(search);
+                handleResetSearch();
+            }
+            onInputBlur?.(event);
+        },
+        [handleAdd, handleResetSearch, onInputBlur, pastePopUpOpened, search],
     );
 
     const handleAddMultiple = useCallback(
@@ -148,6 +160,7 @@ const FilterMultiStringInput: FC<Props> = ({
                 onDropdownClose={handleResetSearch}
                 onChange={handleChange}
                 onCreate={handleAdd}
+                onBlur={handleBlur}
             />
         </MultiValuePastePopover>
     );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
@@ -176,6 +176,38 @@ describe('FilterStringAutoComplete', () => {
         });
     });
 
+    describe('commit on blur', () => {
+        it('adds the typed value when the input loses focus without pressing Enter', async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const values = createValues(2);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            const input = screen.getByRole('searchbox');
+            fireEvent.focus(input);
+            await user.type(input, 'typed-but-not-entered');
+            fireEvent.blur(input);
+
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalled();
+            });
+
+            const calledWith = onChange.mock.calls[0][0];
+            expect(calledWith).toContain('typed-but-not-entered');
+            expect(calledWith).toContain('value-0');
+            expect(calledWith).toContain('value-1');
+        });
+    });
+
     describe('summary mode', () => {
         it('shows summary text input when values exceed summary threshold', async () => {
             const values = createValues(600);

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -147,6 +147,7 @@ const FilterStringAutoComplete: FC<Props> = ({
     // The "(null)" option is only meaningful for multi-value filters.
     const showNull = !!showNullOption && !singleValue;
     const multiSelectRef = useRef<HTMLInputElement>(null);
+    const skipBlurCommitRef = useRef(false);
     const { projectUuid, getAutocompleteFilterGroup, parameterValues } =
         useFiltersContext();
     if (!projectUuid) {
@@ -233,7 +234,11 @@ const FilterStringAutoComplete: FC<Props> = ({
                 onChange(uniq(updatedValues));
             }
             if (singleValue) {
-                multiSelectRef.current?.blur();
+                const input = multiSelectRef.current;
+                if (input && document.activeElement === input) {
+                    skipBlurCommitRef.current = true;
+                    input.blur();
+                }
             }
         },
         [onChange, singleValue],
@@ -322,6 +327,19 @@ const FilterStringAutoComplete: FC<Props> = ({
             }
         },
         [handleAdd, handleResetSearch, search],
+    );
+
+    const handleBlur = useCallback(
+        (event: React.FocusEvent<HTMLInputElement>) => {
+            if (skipBlurCommitRef.current) {
+                skipBlurCommitRef.current = false;
+            } else if (search !== '' && !pastePopUpOpened) {
+                handleAdd(search);
+                handleResetSearch();
+            }
+            onInputBlur?.(event);
+        },
+        [handleAdd, handleResetSearch, onInputBlur, pastePopUpOpened, search],
     );
 
     const ValueComponent = useCallback(
@@ -651,6 +669,8 @@ const FilterStringAutoComplete: FC<Props> = ({
                         }}
                         onCreate={handleAdd}
                         onKeyDown={handleKeyDown}
+                        onFocus={onInputFocus}
+                        onBlur={handleBlur}
                     />
                 )}
             </MultiValuePastePopover>

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
@@ -1,0 +1,109 @@
+import {
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    type DashboardFilterableField,
+    type DashboardFilterRule,
+} from '@lightdash/common';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import FilterConfiguration from './index';
+
+vi.mock('../../../providers/Dashboard/useDashboardTileStatusContext', () => ({
+    default: vi.fn((selector) => selector({ sqlChartTilesMetadata: {} })),
+}));
+
+vi.mock('../../../components/common/Filters/useFiltersContext', () => ({
+    default: vi.fn(() => ({
+        projectUuid: 'test-project-uuid',
+        getAutocompleteFilterGroup: vi.fn(() => undefined),
+        getField: vi.fn(() => undefined),
+        parameterValues: {},
+    })),
+}));
+
+vi.mock('../../../hooks/useFieldValues', () => ({
+    MAX_AUTOCOMPLETE_RESULTS: 100,
+    useFieldValues: vi.fn(() => ({
+        isInitialLoading: false,
+        results: [],
+        refreshedAt: new Date(),
+        refetch: vi.fn(),
+        reset: vi.fn(),
+        error: null,
+        isError: false,
+    })),
+}));
+
+vi.mock('../../../hooks/health/useHealth', () => ({
+    default: vi.fn(() => ({
+        data: { hasCacheAutocompleResults: false },
+    })),
+}));
+
+const mockField = {
+    name: 'first_name',
+    type: DimensionType.STRING,
+    table: 'customers',
+    tableLabel: 'Customers',
+    label: 'First name',
+    fieldType: FieldType.DIMENSION,
+    sql: 'first_name',
+    hidden: false,
+} as unknown as DashboardFilterableField;
+
+const anyValueRule: DashboardFilterRule = {
+    id: 'filter-1',
+    target: {
+        fieldId: 'customers_first_name',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    label: undefined,
+};
+
+describe('FilterConfiguration', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('saves a value typed into the input when Apply is clicked without pressing Enter', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode={false}
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={anyValueRule}
+                originalFilterRule={anyValueRule}
+                onSave={onSave}
+            />,
+        );
+
+        const input = document.querySelector(
+            'input[data-autofocus]',
+        ) as HTMLInputElement;
+        expect(input).toBeTruthy();
+
+        fireEvent.focus(input);
+        await user.type(input, 'adam');
+
+        fireEvent.mouseDown(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({ values: ['adam'] }),
+        );
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -33,7 +33,8 @@ import {
 } from '@mantine/core';
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import { flushSync } from 'react-dom';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import FieldLabel from '../../../components/common/Filters/FieldLabel';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -100,6 +101,9 @@ const FilterConfiguration: FC<Props> = ({
     const [draftFilterRule, setDraftFilterRule] = useState<
         DashboardFilterRule | undefined
     >(defaultFilterRule);
+
+    const draftFilterRuleRef = useRef(draftFilterRule);
+    draftFilterRuleRef.current = draftFilterRule;
 
     const isFilterModified = useMemo(() => {
         if (!originalFilterRule || !draftFilterRule) return false;
@@ -348,6 +352,21 @@ const FilterConfiguration: FC<Props> = ({
         ],
     );
 
+    const handleApply = useCallback(() => {
+        setSelectedTabId(FilterTabs.SETTINGS);
+
+        const activeElement = document.activeElement;
+        if (
+            activeElement instanceof HTMLInputElement ||
+            activeElement instanceof HTMLTextAreaElement
+        ) {
+            flushSync(() => activeElement.blur());
+        }
+
+        const ruleToSave = draftFilterRuleRef.current;
+        if (ruleToSave) onSave(ruleToSave);
+    }, [onSave]);
+
     const isApplyDisabled = !isFilterEnabled(
         draftFilterRule,
         isEditMode,
@@ -573,10 +592,7 @@ const FilterConfiguration: FC<Props> = ({
                             // mousedown and the subsequent click event never
                             // reaches the Apply button — so a real-user click
                             // would otherwise need two presses to apply.
-                            onMouseDown={() => {
-                                setSelectedTabId(FilterTabs.SETTINGS);
-                                if (!!draftFilterRule) onSave(draftFilterRule);
-                            }}
+                            onMouseDown={handleApply}
                         >
                             Apply
                         </Button>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8401/filter-input-should-save-value-when-field-focus-changes

### Description:
Typing a value into a string filter input and then clicking away (or clicking
**Apply**) silently discarded it — the value was only committed on Enter or an
explicit dropdown pick.
