### PR TITLE
ci: speed up release job with Depot runner and Turbo cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,15 @@ jobs:
         run: pnpm build
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 20
     needs: build-and-test
     concurrency: ${{ github.ref }}
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_API: https://cache.depot.dev
+      NODE_OPTIONS: '--max-old-space-size=8192'
     permissions:
       contents: read
       id-token: write  # Required for OIDC authentication with npm

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
         "dev:fast": "pnpm -r --stream --parallel -F common -F warehouses -F backend -F frontend run dev:fast",
         "build": "turbo run build --filter=@lightdash/common --filter=@lightdash/warehouses --filter=backend --filter=@lightdash/frontend",
         "build:fast": "turbo run build:fast --filter=@lightdash/common --filter=@lightdash/warehouses --filter=backend --filter=@lightdash/frontend",
-        "build-published-packages": "pnpm -r --stream --sequential -F common -F warehouses -F query-sdk -F cli -F formula build && pnpm frontend-build-sdk",
+        "build-published-packages": "turbo run build --filter=@lightdash/common --filter=@lightdash/warehouses --filter=@lightdash/query-sdk --filter=@lightdash/cli --filter=@lightdash/formula && pnpm frontend-build-sdk",
         "build-published-packages:fast": "pnpm -r --stream --sequential -F common -F warehouses -F query-sdk -F cli -F formula build:fast && pnpm frontend-build-sdk:fast",
         "release-packages": "pnpm -r --stream --sequential -F common -F warehouses -F query-sdk -F cli -F frontend release",
         "start": "pnpm run backend-start",


### PR DESCRIPTION
Closes:

### Description:
Speeds up the release CI job by running it on a Depot runner (`depot-ubuntu-24.04-8`) with the Turbo remote cache enabled, and switches `build-published-packages` to `turbo run build` so it also benefits from caching. Also raises Node's heap limit for the release job.
