### PR TITLE
fix(cli): tolerate audit tiles missing chartName/exploreLabel

### DIFF
--- a/packages/cli/src/handlers/preAggregateAudit.test.ts
+++ b/packages/cli/src/handlers/preAggregateAudit.test.ts
@@ -1,3 +1,8 @@
+import {
+    DashboardTileTypes,
+    PreAggregateMissReason,
+    type TilePreAggregateAuditMiss,
+} from '@lightdash/common';
 import { testHelpers } from './preAggregateAudit';
 
 vi.mock('./dbt/apiClient', () => ({
@@ -28,6 +33,44 @@ describe('renderSingle JSON mode', () => {
             .mockImplementation(() => true);
         renderSingle(audit, { json: true, verbose: false });
         expect(spy).toHaveBeenCalledWith(`${JSON.stringify(audit, null, 2)}\n`);
+        spy.mockRestore();
+    });
+});
+
+describe('renderSingle human output', () => {
+    const missTileWithoutChartName = {
+        status: 'miss',
+        tileUuid: 't-1',
+        tileName: 'Orders over time',
+        tileType: DashboardTileTypes.SAVED_CHART,
+        savedChartUuid: 'sc-1',
+        exploreName: 'orders',
+        miss: { reason: PreAggregateMissReason.NO_PRE_AGGREGATES_DEFINED },
+        missFieldLabel: null,
+    } as unknown as TilePreAggregateAuditMiss;
+
+    it('does not crash when tiles lack chartName/exploreLabel', () => {
+        const audit = makeAudit({
+            summary: { hitCount: 0, missCount: 1, ineligibleCount: 0 },
+            tabs: [
+                {
+                    tabUuid: null,
+                    tabName: null,
+                    tiles: [missTileWithoutChartName],
+                },
+            ],
+        });
+        const writes: string[] = [];
+        const spy = vi
+            .spyOn(process.stdout, 'write')
+            .mockImplementation((chunk: string | Uint8Array) => {
+                writes.push(String(chunk));
+                return true;
+            });
+        expect(() =>
+            renderSingle(audit, { json: false, verbose: false }),
+        ).not.toThrow();
+        expect(writes.join('')).toContain('Orders over time');
         spy.mockRestore();
     });
 });

--- a/packages/cli/src/handlers/preAggregateAudit.ts
+++ b/packages/cli/src/handlers/preAggregateAudit.ts
@@ -84,9 +84,10 @@ function buildExploreGroups(audit: DashboardPreAggregateAudit): ExploreGroups {
 
     const byLabel = new Map<string, EligibleTile[]>();
     for (const tile of eligible) {
-        const arr = byLabel.get(tile.exploreLabel) ?? [];
+        const label = tile.exploreLabel ?? tile.exploreName;
+        const arr = byLabel.get(label) ?? [];
         arr.push(tile);
-        byLabel.set(tile.exploreLabel, arr);
+        byLabel.set(label, arr);
     }
 
     let anyCollapsed = false;
@@ -95,9 +96,10 @@ function buildExploreGroups(audit: DashboardPreAggregateAudit): ExploreGroups {
         .map(([exploreLabel, tiles]) => {
             const byName = new Map<string, EligibleTile[]>();
             for (const tile of tiles) {
-                const arr = byName.get(tile.chartName) ?? [];
+                const name = tile.chartName ?? tile.tileName;
+                const arr = byName.get(name) ?? [];
                 arr.push(tile);
-                byName.set(tile.chartName, arr);
+                byName.set(name, arr);
             }
             const charts = [...byName.entries()]
                 .sort(([a], [b]) => a.localeCompare(b))


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8679/improved-pre-aggregate-audit-crashes-rendering-a-dashboard-with-misses

### Description:
pre-aggregate-audit crashed rendering a dashboard when the backend predates the additive chartName/exploreLabel fields, since renderSingle read chartName.length off undefined. Fall back to tileName/exploreName when grouping so the human output degrades instead of throwing.
