### PR TITLE
fix: hide fields from metadata lookup

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
@@ -139,6 +139,28 @@ describe('getMetadata explore field listing', () => {
         expect(result.result).not.toContain('orders_secret');
     });
 
+    it('does not return hidden fields when requested directly', async () => {
+        const explore = makeExplore({});
+        explore.tables.orders.dimensions.secret = {
+            ...explore.tables.orders.dimensions.status,
+            name: 'secret',
+            label: 'Secret',
+            hidden: true,
+        };
+
+        const result = await execute(explore, [
+            {
+                type: 'field',
+                fields: [{ exploreId: 'sales', fieldId: 'orders_secret' }],
+            },
+        ]);
+
+        expect(result.metadata).toEqual({ status: 'success' });
+        expect(result.result).toBe(
+            'Field "orders_secret" not found in explore "sales".',
+        );
+    });
+
     it('truncates very wide base tables with a "+N more" marker', async () => {
         const explore = makeExplore({});
         for (let i = 0; i < 150; i += 1) {

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.ts
@@ -90,7 +90,7 @@ const findField = (
             ...Object.values(table.metrics ?? {}),
         ];
         for (const field of fields) {
-            if (`${field.table}_${field.name}` === fieldId) {
+            if (!field.hidden && `${field.table}_${field.name}` === fieldId) {
                 return {
                     field,
                     isJoined: field.table !== explore.baseTable,


### PR DESCRIPTION
Closes: #25180

### Description:

Hidden fields can no longer be retrieved directly by field ID when the AI `getMetadata` tool resolves field lookups. Previously, a hidden field could be returned if its ID was requested explicitly. Now, the `findField` function skips any field marked as `hidden`, returning a "not found" response instead.
