### PR TITLE
fix: use token-aware pre-grep matching

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
@@ -9,6 +9,7 @@ import {
     buildExploreIndex,
     buildFieldIndex,
     compileMatcher,
+    selectCandidateFields,
 } from './grepFieldsIndex';
 
 type FieldSpec = {
@@ -175,5 +176,23 @@ describe('buildExploreIndex', () => {
         const matches = compileMatcher('comment');
         const hits = index.filter((e) => matches(e.haystack));
         expect(hits.map((e) => e.exploreName)).toEqual(['learner_reviews']);
+    });
+});
+
+describe('selectCandidateFields', () => {
+    it('uses token-aware matching for short keywords', () => {
+        const index = buildFieldIndex([
+            makeExplore({
+                name: 'events',
+                fields: [
+                    { name: 'canceled_date', label: 'Canceled date' },
+                    { name: 'sales_led_flag', label: 'Sales-led flag' },
+                ],
+            }),
+        ]);
+
+        expect(
+            selectCandidateFields(index, ['led']).map((field) => field.path),
+        ).toEqual(['events/events_sales_led_flag']);
     });
 });

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
@@ -266,11 +266,12 @@ export const selectCandidateFields = (
     limit = 25,
 ): FieldEntry[] => {
     if (keywords.length === 0) return [];
+    const matchers = keywords.map((keyword) => compileMatcher(keyword));
     const scored: { entry: FieldEntry; score: number }[] = [];
     for (const entry of index) {
         let score = 0;
-        for (const keyword of keywords) {
-            if (entry.haystack.includes(keyword)) score += 1;
+        for (const matches of matchers) {
+            if (matches(entry.haystack)) score += 1;
         }
         if (score > 0) scored.push({ entry, score });
     }


### PR DESCRIPTION
Closes: #25182

### Description:

Replaces the plain `String.includes` check in `selectCandidateFields` with `compileMatcher`, enabling token-aware matching when filtering candidate fields. This means short keywords like `"led"` correctly match fields such as `sales_led_flag` by matching against individual tokens, without also matching unrelated longer words like `canceled`.

A test case has been added to verify this behaviour.
