### PR TITLE
feat(backend): persist and validate declared app dependencies per version [GLITCH-601]

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -376,6 +376,7 @@ export const lightdashConfigMock: LightdashConfig = {
         cspAllowedOrigins: [],
         s3: null,
         e2bApiKey: null,
+        customDependenciesEnabled: true,
         e2bTemplateName: 'lightdash-data-app',
         e2bTemplateTag: '',
         e2bAiWritebackTemplateName: 'lightdash-ai-writeback',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1750,6 +1750,14 @@ export type AppRuntimeConfig = {
      */
     e2bCodingAgentTemplateName: string;
     e2bCodingAgentTemplateTag: string;
+    /**
+     * When false, uploads that declare a non-empty custom dependency set are
+     * rejected at the API boundary with a clear error. Template-only uploads
+     * (no declared dependencies) are always accepted. Env var
+     * `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED`; defaults to `false` while
+     * the feature rolls out — set to `true` to enable on an instance.
+     */
+    customDependenciesEnabled: boolean;
 };
 
 export type IntercomConfig = {
@@ -2053,6 +2061,8 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             'lightdash-ai-coding-agent',
         e2bCodingAgentTemplateTag:
             process.env.E2B_CODING_AGENT_TEMPLATE_TAG ?? (VERSION as string),
+        customDependenciesEnabled:
+            process.env.LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED === 'true',
     };
 };
 

--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -1,4 +1,5 @@
 import {
+    type AppVersionDependencies,
     type AppVersionResources,
     type AppVersionStatus,
     type DataAppTemplate,
@@ -85,6 +86,8 @@ export type DbAppVersion = {
     status_message: string | null;
     status_updated_at: Date | null;
     resources: AppVersionResources | null;
+    // Declared-dependency summary for the version's build; null = template set.
+    dependencies: AppVersionDependencies | null;
     // Declared schema for data-app-viz versions; null otherwise.
     viz_schema: DataAppVizSchema | null;
     created_at: Date;
@@ -98,7 +101,10 @@ export type AppVersionsTable = Knex.CompositeTableType<
         'app_id' | 'version' | 'prompt' | 'status' | 'created_by_user_uuid'
     > &
         Partial<
-            Pick<DbAppVersion, 'app_version_id' | 'resources' | 'viz_schema'>
+            Pick<
+                DbAppVersion,
+                'app_version_id' | 'resources' | 'dependencies' | 'viz_schema'
+            >
         >,
     Partial<
         Pick<

--- a/packages/backend/src/database/migrations/20260706115817_add_app_version_dependencies.ts
+++ b/packages/backend/src/database/migrations/20260706115817_add_app_version_dependencies.ts
@@ -1,0 +1,15 @@
+import { type Knex } from 'knex';
+
+// Declared-dependency summary for the version's build:
+// { custom: [{ name, version }], lockfileHash }. Null = template dependency set.
+export const up = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable('app_versions', (table) => {
+        table.jsonb('dependencies').nullable();
+    });
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable('app_versions', (table) => {
+        table.dropColumn('dependencies');
+    });
+};

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -2,10 +2,13 @@ import {
     ParameterError,
     TooManyRequestsError,
     type DataAppCode,
+    type DataAppDependencies,
     type ImportAppCodeRequestBody,
 } from '@lightdash/common';
+import { createHash } from 'node:crypto';
 import { extract as tarExtract } from 'tar-stream';
 import { AppGenerateService } from './AppGenerateService';
+import { TEMPLATE_DEPENDENCIES } from './templateDependencies';
 
 vi.mock('e2b', () => ({
     Sandbox: class {},
@@ -52,9 +55,26 @@ const makeCode = (files?: DataAppCode['files']): DataAppCode => ({
     ],
 });
 
+const makeDeps = (
+    customDeps: Record<string, string> = {},
+    opts: { sdkVersion?: string; lockfile?: string } = {},
+): DataAppDependencies => {
+    const dependencies = {
+        ...TEMPLATE_DEPENDENCIES,
+        '@lightdash/query-sdk': opts.sdkVersion ?? '0.999.0',
+        ...customDeps,
+    };
+    return {
+        packageJson: JSON.stringify({ dependencies }),
+        lockfile:
+            opts.lockfile ??
+            `lockfileVersion: '9.0'\n# ${Object.keys(dependencies).join(' ')}\n`,
+    };
+};
+
 const s3SendSpy = vi.fn().mockResolvedValue({});
 
-function buildService() {
+function buildService(opts: { customDependenciesEnabled?: boolean } = {}) {
     const appModel = {
         findApp: vi.fn(),
         getApp: vi.fn(),
@@ -87,8 +107,14 @@ function buildService() {
         getSpaceAccessContext: vi.fn().mockResolvedValue({}),
     };
 
+    const lightdashConfig = {
+        appRuntime: {
+            customDependenciesEnabled: opts.customDependenciesEnabled ?? true,
+        },
+    };
+
     const service = new AppGenerateService({
-        lightdashConfig: {} as never,
+        lightdashConfig: lightdashConfig as never,
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
@@ -156,6 +182,7 @@ describe('AppGenerateService.importAppCode', () => {
             { version: 1, prompt: '' },
             'pending',
             expect.any(Object),
+            undefined, // no declared dependencies
         );
 
         // S3 PutObjectCommand sent for source.tar
@@ -210,6 +237,7 @@ describe('AppGenerateService.importAppCode', () => {
             'pending',
             USER_UUID,
             expect.any(Object),
+            undefined, // no declared dependencies
         );
 
         // scheduler enqueued with version 5 and project org, not user's org
@@ -369,6 +397,47 @@ describe('AppGenerateService.importAppCode', () => {
         } as ImportAppCodeRequestBody);
 
         expect(appModel.updateApp).not.toHaveBeenCalled();
+    });
+
+    it('throws ParameterError when custom deps are present but customDependenciesEnabled is false', async () => {
+        const { service, appModel } = buildService({
+            customDependenciesEnabled: false,
+        });
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        const codeWithCustomDep = {
+            ...makeCode(),
+            dependencies: makeDeps({ 'deck.gl': '9.3.5' }),
+        };
+
+        await expect(
+            service.importAppCode(makeUser(), PROJECT_UUID, {
+                code: codeWithCustomDep,
+            } as ImportAppCodeRequestBody),
+        ).rejects.toThrow(ParameterError);
+
+        await expect(
+            service.importAppCode(makeUser(), PROJECT_UUID, {
+                code: codeWithCustomDep,
+            } as ImportAppCodeRequestBody),
+        ).rejects.toThrow('LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED');
+    });
+
+    it('accepts template-only upload when customDependenciesEnabled is false', async () => {
+        const { service, appModel, schedulerClient } = buildService({
+            customDependenciesEnabled: false,
+        });
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        // Template-only = no custom deps above the baseline
+        const result = await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: { ...makeCode(), dependencies: makeDeps() },
+        } as ImportAppCodeRequestBody);
+
+        expect(result.action).toBe('create');
+        expect(schedulerClient.appBuildFromSource).toHaveBeenCalledOnce();
     });
 
     it('create mode: source.tar contains only src/ entries when bundle has mixed files', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -284,6 +284,11 @@ describe('AppGenerateService.getAppCode', () => {
         const appModel = {
             getApp: vi.fn().mockResolvedValue(fakeApp),
             getLatestReadyVersion: vi.fn(),
+            getVersion: vi.fn().mockResolvedValue({
+                ...fakeAppVersion,
+                version: EXPLICIT_VERSION,
+                dependencies: null,
+            }),
         };
 
         const svc = buildService({ appModel, s3ClientOverride: fakeS3 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -29,8 +29,10 @@ import {
     NotFoundError,
     ParameterError,
     QueryExecutionContext,
+    sanitizeAppPackageJsonScripts,
     TooManyRequestsError,
     validateDataAppCode,
+    validateDataAppDependencies,
     type AnonymousAccount,
     type AppBuildFromSourceJobPayload,
     type AppChartReference,
@@ -39,6 +41,7 @@ import {
     type AppExternalConnectionReference,
     type AppGeneratePipelineJobPayload,
     type AppVersionChartResource,
+    type AppVersionDependencies,
     type AppVersionExternalConnectionResource,
     type AppVersionResources,
     type ChartReference,
@@ -49,6 +52,7 @@ import {
     type DataAppCode,
     type DataAppCodeDownload,
     type DataAppContext,
+    type DataAppDependencies,
     type DataAppTemplate,
     type DataAppViz,
     type DataAppVizSchema,
@@ -68,6 +72,7 @@ import {
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { Knex } from 'knex';
+import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import { PassThrough, Readable } from 'node:stream';
 import { extract, pack as tarPack, type Headers } from 'tar-stream';
@@ -87,6 +92,7 @@ import {
     isAppVersionInProgress,
     type AppVersionStatus,
     type DbApp,
+    type DbAppVersion,
 } from '../../../database/entities/apps';
 import { AnalyticsModel } from '../../../models/AnalyticsModel';
 import { AppModel } from '../../../models/AppModel';
@@ -151,6 +157,11 @@ import {
     type DesignSandboxCopyResult,
 } from './designSandboxCopy';
 import { readDesignForDownload } from './readDesignForDownload';
+import { readS3ObjectAsBuffer } from './s3Utils';
+import {
+    buildTemplateBaseline,
+    TEMPLATE_SCRIPTS,
+} from './templateDependencies';
 import { getTemplateInstructions } from './templates';
 
 /**
@@ -5594,6 +5605,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 lastName: string;
             } | null;
             resources: AppVersionResources | null;
+            dependencies?: { custom: AppVersionDependencies['custom'] };
         }[];
         hasMore: boolean;
     }> {
@@ -5656,6 +5668,10 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                         : null,
                 createdAt: v.created_at,
                 statusUpdatedAt: v.status_updated_at,
+                // Custom-deps summary only; the lockfile hash is internal.
+                ...(v.dependencies
+                    ? { dependencies: { custom: v.dependencies.custom } }
+                    : {}),
                 // LEFT JOIN may miss for hard-deleted users — collapse the
                 // whole object to null in that case rather than expose
                 // individually-nullable fields to API consumers.
@@ -6783,8 +6799,10 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         await this.assertCanViewApp(user, app);
 
         let resolvedVersion: number;
+        let versionRow: DbAppVersion | null;
         if (version !== undefined) {
             resolvedVersion = version;
+            versionRow = await this.appModel.getVersion(app.app_id, version);
         } else {
             const latestReady = await this.appModel.getLatestReadyVersion(
                 app.app_id,
@@ -6795,6 +6813,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 );
             }
             resolvedVersion = latestReady.version;
+            versionRow = latestReady;
         }
 
         const { client: s3Client, bucket } = this.getS3Client();
@@ -6885,7 +6904,36 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             app.organization_uuid,
         );
 
-        return { manifest, files, context };
+        // Round-trip the declared dependency files when this version was
+        // uploaded with a custom dependency set. Failures propagate: silently
+        // dropping the files would make a re-upload build with template deps.
+        let dependencies: DataAppDependencies | undefined;
+        if (versionRow?.dependencies) {
+            const depsPrefix = `${versionPrefix(appUuid, resolvedVersion)}deps/`;
+            const [packageJsonBuffer, lockfileBuffer] = await Promise.all([
+                readS3ObjectAsBuffer(
+                    s3Client,
+                    bucket,
+                    `${depsPrefix}package.json`,
+                ),
+                readS3ObjectAsBuffer(
+                    s3Client,
+                    bucket,
+                    `${depsPrefix}pnpm-lock.yaml`,
+                ),
+            ]);
+            dependencies = {
+                packageJson: packageJsonBuffer.toString('utf-8'),
+                lockfile: lockfileBuffer.toString('utf-8'),
+            };
+        }
+
+        return {
+            manifest,
+            files,
+            ...(dependencies !== undefined ? { dependencies } : {}),
+            context,
+        };
     }
 
     private async assembleAppContext(
@@ -7012,6 +7060,43 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             );
         }
 
+        // Validate the declared dependency set against the template baseline.
+        // An empty custom set is treated as no-dependencies (some CLIs attach
+        // the template set redundantly) and nothing is stored.
+        let dependencySummary: AppVersionDependencies | undefined;
+        if (code.dependencies !== undefined) {
+            let customDeps: Record<string, string>;
+            try {
+                ({ customDeps } = validateDataAppDependencies(
+                    code.dependencies,
+                    {
+                        templateDependencies: buildTemplateBaseline(
+                            code.dependencies.packageJson,
+                        ),
+                    },
+                ));
+            } catch (err) {
+                throw new ParameterError(getErrorMessage(err));
+            }
+            if (Object.keys(customDeps).length > 0) {
+                if (
+                    !this.lightdashConfig.appRuntime.customDependenciesEnabled
+                ) {
+                    throw new ParameterError(
+                        'Custom app dependencies are disabled on this instance (LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED). Remove the added packages or ask an admin to enable them.',
+                    );
+                }
+                dependencySummary = {
+                    custom: Object.entries(customDeps).map(
+                        ([name, version]) => ({ name, version }),
+                    ),
+                    lockfileHash: createHash('sha256')
+                        .update(code.dependencies.lockfile)
+                        .digest('hex'),
+                };
+            }
+        }
+
         // Determine mode: append to existing app or create new one
         const existingApp = body.targetAppUuid
             ? await this.appModel.findApp(body.targetAppUuid, projectUuid)
@@ -7067,6 +7152,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 'pending',
                 user.userUuid,
                 AppGenerateService.buildCopiedResources(null),
+                dependencySummary,
             );
         } else {
             this.assertDataAppAbility(
@@ -7104,6 +7190,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 { version: newVersion, prompt: '' },
                 'pending',
                 AppGenerateService.buildCopiedResources(null),
+                dependencySummary,
             );
             newAppUuid = app.app_id;
         }
@@ -7144,6 +7231,37 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 ContentType: 'application/x-tar',
             }),
         );
+
+        // Store the declared dependency files next to the source archive so
+        // download can round-trip them (builds consume them in a later slice).
+        // The stored package.json carries the TRUSTED template scripts, not
+        // the uploader's — the sandbox `pnpm build` and every downstream
+        // download read this file, so script commands must stay server-owned.
+        if (
+            dependencySummary !== undefined &&
+            code.dependencies !== undefined
+        ) {
+            const depsPrefix = `${versionPrefix(newAppUuid, newVersion)}deps/`;
+            await client.send(
+                new PutObjectCommand({
+                    Bucket: bucket,
+                    Key: `${depsPrefix}package.json`,
+                    Body: sanitizeAppPackageJsonScripts(
+                        code.dependencies.packageJson,
+                        TEMPLATE_SCRIPTS,
+                    ),
+                    ContentType: 'application/json',
+                }),
+            );
+            await client.send(
+                new PutObjectCommand({
+                    Bucket: bucket,
+                    Key: `${depsPrefix}pnpm-lock.yaml`,
+                    Body: code.dependencies.lockfile,
+                    ContentType: 'text/yaml',
+                }),
+            );
+        }
 
         // Enqueue the build-only pipeline
         await this.schedulerClient.appBuildFromSource({

--- a/packages/backend/src/ee/services/AppGenerateService/templateDependencies.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templateDependencies.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import {
+    buildTemplateBaseline,
+    QUERY_SDK_PACKAGE,
+    TEMPLATE_DEPENDENCIES,
+    TEMPLATE_SCRIPTS,
+} from './templateDependencies';
+
+describe('TEMPLATE_DEPENDENCIES', () => {
+    it('matches the dependencies of sandboxes/data-apps/template/package.json (drift guard)', () => {
+        const templatePackageJsonPath = path.join(
+            __dirname,
+            '..',
+            '..',
+            '..',
+            '..',
+            '..',
+            '..',
+            'sandboxes',
+            'data-apps',
+            'template',
+            'package.json',
+        );
+        const parsed = JSON.parse(
+            readFileSync(templatePackageJsonPath, 'utf-8'),
+        ) as {
+            dependencies: Record<string, string>;
+            scripts: Record<string, string>;
+        };
+
+        expect(TEMPLATE_DEPENDENCIES).toEqual(parsed.dependencies);
+        expect(TEMPLATE_SCRIPTS).toEqual(parsed.scripts);
+    });
+});
+
+describe('buildTemplateBaseline', () => {
+    it('mirrors the declared @lightdash/query-sdk spec so any SDK version is template', () => {
+        const packageJson = JSON.stringify({
+            dependencies: { [QUERY_SDK_PACKAGE]: '0.1234.0' },
+        });
+        const baseline = buildTemplateBaseline(packageJson);
+        expect(baseline[QUERY_SDK_PACKAGE]).toBe('0.1234.0');
+        // Everything else is untouched
+        expect(baseline.react).toBe(TEMPLATE_DEPENDENCIES.react);
+    });
+
+    it('falls back to the template SDK spec when the declared one is missing', () => {
+        const baseline = buildTemplateBaseline(
+            JSON.stringify({ dependencies: {} }),
+        );
+        expect(baseline[QUERY_SDK_PACKAGE]).toBe(
+            TEMPLATE_DEPENDENCIES[QUERY_SDK_PACKAGE],
+        );
+    });
+
+    it('returns the plain template baseline for unparseable packageJson', () => {
+        expect(buildTemplateBaseline('not json')).toEqual(
+            TEMPLATE_DEPENDENCIES,
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/templateDependencies.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templateDependencies.ts
@@ -1,0 +1,71 @@
+export const QUERY_SDK_PACKAGE = '@lightdash/query-sdk';
+
+// Copy of the template's `scripts` — the stored/served package.json always
+// carries these instead of the uploader's, so `pnpm build` never runs an
+// uploader-controlled command (drift-guarded like TEMPLATE_DEPENDENCIES).
+export const TEMPLATE_SCRIPTS: Record<string, string> = {
+    dev: 'vite',
+    build: 'vite build',
+    preview: 'vite preview',
+};
+
+// Copy of sandboxes/data-apps/template/package.json `dependencies` — the
+// baseline against which uploaded dependency sets are diffed. The template is
+// not shipped in production backend builds, so it is checked in here;
+// templateDependencies.test.ts asserts this stays in sync with the template.
+export const TEMPLATE_DEPENDENCIES: Record<string, string> = {
+    '@lightdash/query-sdk': 'workspace:*',
+    '@radix-ui/react-dialog': '1.1.15',
+    '@radix-ui/react-label': '2.1.8',
+    '@radix-ui/react-popover': '1.1.15',
+    '@radix-ui/react-select': '2.2.6',
+    '@radix-ui/react-separator': '1.1.8',
+    '@radix-ui/react-slot': '1.2.4',
+    '@radix-ui/react-tabs': '1.1.13',
+    '@radix-ui/react-tooltip': '1.2.8',
+    '@tanstack/react-query': '5.64.2',
+    '@tanstack/react-table': '8.21.3',
+    '@tanstack/react-virtual': '3.13.23',
+    'class-variance-authority': '0.7.1',
+    clsx: '2.1.1',
+    d3: '7.9.0',
+    'd3-cloud': '1.2.9',
+    'd3-sankey': '0.12.3',
+    'date-fns': '3.6.0',
+    'html-to-image': '1.11.13',
+    jspdf: '4.2.1',
+    'lodash-es': '4.18.1',
+    'lucide-react': '0.469.0',
+    react: '19.2.5',
+    'react-dom': '19.2.5',
+    'react-resizable-panels': '4.10.0',
+    recharts: '2.15.3',
+    'tailwind-merge': '3.5.0',
+    'tailwindcss-animate': '1.0.7',
+};
+
+/**
+ * Baseline for validating an uploaded dependency set. `@lightdash/query-sdk`
+ * is always treated as template — the CLI pins its version per release, so the
+ * declared spec is mirrored into the baseline and never counts as custom.
+ */
+export const buildTemplateBaseline = (
+    packageJson: string,
+): Record<string, string> => {
+    let declaredSdkSpec: string | undefined;
+    try {
+        const parsed = JSON.parse(packageJson) as {
+            dependencies?: Record<string, unknown>;
+        };
+        const spec = parsed.dependencies?.[QUERY_SDK_PACKAGE];
+        if (typeof spec === 'string') declaredSdkSpec = spec;
+    } catch {
+        // Unparseable packageJson — validateDataAppDependencies reports it.
+    }
+    return {
+        ...TEMPLATE_DEPENDENCIES,
+        ...(declaredSdkSpec !== undefined
+            ? { [QUERY_SDK_PACKAGE]: declaredSdkSpec }
+            : {}),
+    };
+};

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10055,11 +10055,36 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AppVersionDependencyEntry: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                version: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAppVersionSummary: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                dependencies: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        custom: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'AppVersionDependencyEntry',
+                            },
+                            required: true,
+                        },
+                    },
+                },
                 resources: {
                     dataType: 'union',
                     subSchemas: [
@@ -12437,8 +12462,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -13086,8 +13111,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -15736,13 +15761,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -15835,10 +15860,10 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                fieldValueType:
+                                                                                isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
-                                                                                            'string',
+                                                                                            'boolean',
                                                                                         required: true,
                                                                                     },
                                                                                 caseSensitiveFilters:
@@ -15871,19 +15896,53 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
                                                                                 fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -15908,45 +15967,11 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                             },
                                                                     },
                                                                     required: true,
@@ -16229,17 +16254,17 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 name: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
+                                                uuid: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -16586,13 +16611,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -16705,25 +16730,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16804,6 +16810,25 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 type: {
                                                                     dataType:
                                                                         'union',
@@ -16813,14 +16838,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11419,8 +11419,32 @@
                 ],
                 "type": "object"
             },
+            "AppVersionDependencyEntry": {
+                "properties": {
+                    "version": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["version", "name"],
+                "type": "object"
+            },
             "ApiAppVersionSummary": {
                 "properties": {
+                    "dependencies": {
+                        "properties": {
+                            "custom": {
+                                "items": {
+                                    "$ref": "#/components/schemas/AppVersionDependencyEntry"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["custom"],
+                        "type": "object"
+                    },
                     "resources": {
                         "allOf": [
                             {
@@ -14045,7 +14069,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -14675,7 +14699,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16931,19 +16955,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -16987,8 +17011,8 @@
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
                                                                                 },
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
@@ -16998,47 +17022,47 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
                                                                                 "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "fieldValueType",
-                                                                                "caseSensitiveFilters",
                                                                                 "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
                                                                                 "fieldFilterType",
+                                                                                "fieldValueType",
                                                                                 "table",
-                                                                                "description",
                                                                                 "fieldType",
+                                                                                "fieldId",
                                                                                 "label",
-                                                                                "name",
-                                                                                "fieldId"
+                                                                                "description",
+                                                                                "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -17227,16 +17251,16 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "uuid": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "uuid": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
@@ -17244,9 +17268,9 @@
                                                     "warnings",
                                                     "href",
                                                     "slug",
-                                                    "uuid",
+                                                    "status",
                                                     "name",
-                                                    "status"
+                                                    "uuid"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17350,20 +17374,20 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
                                                     "slug",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17403,10 +17427,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17443,19 +17463,23 @@
                                                                 },
                                                                 "type": "array"
                                                             },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -2,6 +2,7 @@ import {
     DATA_APP_VIZ_TEMPLATE,
     NotFoundError,
     ProjectType,
+    type AppVersionDependencies,
     type AppVersionResources,
     type DataAppVizSchema,
     type KnexPaginateArgs,
@@ -57,6 +58,7 @@ export class AppModel {
         version: Pick<DbAppVersion, 'version' | 'prompt'>,
         status: AppVersionStatus,
         resources?: AppVersionResources,
+        dependencies?: AppVersionDependencies,
     ): Promise<{ app: DbApp; version: DbAppVersion }> {
         return this.database.transaction(async (trx) => {
             const [appRow] = await trx(AppsTableName)
@@ -73,6 +75,13 @@ export class AppModel {
                               resources: JSON.stringify(
                                   resources,
                               ) as unknown as AppVersionResources,
+                          }
+                        : {}),
+                    ...(dependencies
+                        ? {
+                              dependencies: JSON.stringify(
+                                  dependencies,
+                              ) as unknown as AppVersionDependencies,
                           }
                         : {}),
                 })
@@ -306,6 +315,7 @@ export class AppModel {
         status: AppVersionStatus,
         createdByUserUuid: string,
         resources?: AppVersionResources,
+        dependencies?: AppVersionDependencies,
     ): Promise<DbAppVersion> {
         const [row] = await this.database(AppVersionsTableName)
             .insert({
@@ -318,6 +328,13 @@ export class AppModel {
                           resources: JSON.stringify(
                               resources,
                           ) as unknown as AppVersionResources,
+                      }
+                    : {}),
+                ...(dependencies
+                    ? {
+                          dependencies: JSON.stringify(
+                              dependencies,
+                          ) as unknown as AppVersionDependencies,
                       }
                     : {}),
             })

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -166,6 +166,19 @@ export const retargetManifest = async (
 };
 
 /**
+ * Writes server-provided dependency files as the app folder's package.json +
+ * pnpm-lock.yaml. Called after the scaffold write so they override the
+ * scaffold's template package.json and the folder round-trips on re-upload.
+ */
+export const writeDependenciesToDir = async (
+    dir: string,
+    deps: DataAppDependencies,
+): Promise<void> => {
+    await fs.writeFile(path.join(dir, 'package.json'), deps.packageJson);
+    await fs.writeFile(path.join(dir, 'pnpm-lock.yaml'), deps.lockfile);
+};
+
+/**
  * Reads package.json + pnpm-lock.yaml from the app folder root when both are
  * present. Returns null when neither file exists (no declared deps).
  * Throws when exactly one of the two files is present (incomplete pair).

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -50,6 +50,7 @@ import {
     retargetManifest,
     writeBundleToDir,
     writeContextToDir,
+    writeDependenciesToDir,
     writeFilesToDir,
 } from './apps/appCodeFiles';
 import {
@@ -1163,6 +1164,15 @@ export const downloadHandler = async (
                                 sdkVersion: CLI_VERSION,
                             }),
                         );
+                        // Server-provided deps override the scaffold's
+                        // template package.json so re-uploads round-trip.
+                        if (code.dependencies) {
+                            // eslint-disable-next-line no-await-in-loop
+                            await writeDependenciesToDir(
+                                appDir,
+                                code.dependencies,
+                            );
+                        }
                         // eslint-disable-next-line no-await-in-loop
                         await writeContextToDir(appDir, code.context);
                         appSuccessCount += 1;

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -245,6 +245,20 @@ export type AppVersionResources = {
     vizSchema?: DataAppVizSchema | null;
 };
 
+export type AppVersionDependencyEntry = {
+    name: string;
+    version: string;
+};
+
+// Persisted on app_versions.dependencies (jsonb). Null on the row = the
+// version builds with the template dependency set.
+export type AppVersionDependencies = {
+    // Packages that differ from the template baseline (new or version override).
+    custom: AppVersionDependencyEntry[];
+    // sha256 of the stored pnpm-lock.yaml, for integrity checks.
+    lockfileHash: string;
+};
+
 export type ApiAppImageUrlResponse = ApiSuccess<{
     imageUrl: string;
 }>;
@@ -276,6 +290,9 @@ export type ApiAppVersionSummary = {
         lastName: string;
     } | null;
     resources: AppVersionResources | null;
+    // Declared-dependency summary when the version was uploaded with a custom
+    // dependency set; absent for template-dependency versions.
+    dependencies?: { custom: AppVersionDependencyEntry[] };
 };
 
 export type ApiGetAppResponse = ApiSuccess<{


### PR DESCRIPTION
Part 2/4 of Data Apps declared dependencies (3b).

- Migration: `app_versions.dependencies jsonb` — `{custom: [{name, version}], lockfileHash}`, `null` = template-only.
- `importAppCode` validates declared deps against a checked-in template baseline (`templateDependencies.ts`, with a drift test against the sandbox template's `package.json`) and persists `deps/package.json` + `deps/pnpm-lock.yaml` to S3 under the version prefix.
- Stored `package.json` is sanitized: uploader `scripts` are replaced with the trusted template scripts (`TEMPLATE_SCRIPTS`, drift-guarded against the sandbox template) — the sandbox `pnpm build` and every download read this file, so the build command is never uploader-controlled.
- `getAppCode` round-trips the stored dep files so `lightdash download` returns exactly what was uploaded.
- Rollout gate ships HERE, at the bottom of the stack, so each PR can merge dark: `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED` defaults to **false**; when off, uploads declaring custom deps are rejected with a clear 400 (template-only uploads unaffected). Parts 3–4 add kill-switch re-checks in the build/iterate paths.

Closes GLITCH-601

🤖 Generated with [Claude Code](https://claude.com/claude-code)