### PR TITLE
feat: surface app dependency changes; instance toggle for custom deps [GLITCH-603]

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -885,7 +885,7 @@ Opt-in flags on the existing `lightdash download` / `lightdash upload` commands 
 ### Constraints & notes
 
 - **Enterprise-only** (`APP_RUNTIME_ENABLED`); the caller needs `view` / `create` / `manage:DataApp`.
-- **Fixed dependency set:** upload rebuilds against the sandbox template's pre-installed libraries — you can edit source but can't add libraries the sandbox lacks (a future "bring your own libraries" phase covers that via local builds).
+- **Declared dependencies:** apps can declare custom npm packages in their `package.json`. The CLI validates the declared set (registry-only specs, no git/file/url, up to 60 direct deps, `pnpm-lock.yaml` must be committed) and warns which packages will be installed in the build sandbox before uploading. Install scripts never run. The instance-level flag `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED` (default `false` during rollout) gates this feature; when disabled, uploads with a non-empty custom dependency set are rejected at the API with a clear error, and builds/iterations of versions that already store custom deps refuse to run (template-only uploads are always accepted). The AI builder and in-app UI cannot change the dependency set — dependencies are declared by editing `package.json` and re-uploading. The dependency summary (name + version) is shown as a chip on the assistant bubble in the chat UI so the author can confirm what was installed.
 - **Semantic-layer coupling:** a moved app's queries run against the **target project's** fields *by name*; fields missing in the target surface as in-app query errors, not upload failures.
 - **Security:** because the server only ever builds source in its trusted, network-locked sandbox and never serves client-supplied *built* code, the runtime trust model is unchanged from AI-generated apps. See [Security Model](#security-model). (Follow-up: the query bridge runs as the *viewing* user — a pre-existing consideration for any app, generated or uploaded.)
 
@@ -931,7 +931,7 @@ If the org design linked to the app has more than **30 asset files**, the theme 
 #### Out of scope (Phase 3)
 
 - **Local preview against real data** — `pnpm build` is a compile check only, not a live data preview.
-- **Bring-your-own libraries** — running `pnpm add` locally has no effect on the server's sandbox. This is the "future bring your own libraries" path noted in [Constraints & notes](#constraints--notes).
+- **Org-level custom-dependency toggle** — the `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED` flag is instance-wide only; per-org control is not implemented.
 
 ---
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1752,8 +1752,9 @@ export type AppRuntimeConfig = {
     e2bCodingAgentTemplateTag: string;
     /**
      * When false, uploads that declare a non-empty custom dependency set are
-     * rejected at the API boundary with a clear error. Template-only uploads
-     * (no declared dependencies) are always accepted. Env var
+     * rejected at the API boundary with a clear error, and builds/iterations
+     * of versions with stored custom deps refuse to run. Template-only
+     * uploads (no declared dependencies) are always accepted. Env var
      * `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED`; defaults to `false` while
      * the feature rolls out — set to `true` to enable on an instance.
      */

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1415,6 +1415,14 @@ export class AppGenerateService extends BaseService {
         version: number,
         versionDeps: AppVersionDependencies,
     ): Promise<number> {
+        // Kill-switch: enforced at upload time too, but re-checked here so
+        // flipping it off also stops installs of previously-approved dep sets
+        // (iterations and rebuilds), not just new uploads.
+        if (!this.lightdashConfig.appRuntime.customDependenciesEnabled) {
+            throw new Error(
+                'Custom app dependencies are disabled on this instance (LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED); this app version declares custom packages so it cannot be built.',
+            );
+        }
         const start = performance.now();
         const depsPrefix = `apps/${appUuid}/versions/${version}/deps/`;
 
@@ -4469,6 +4477,13 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         // to the newest version whose files actually exist.
         let carriedDependencies: AppVersionDependencies | undefined;
         if (latestVersion?.dependencies) {
+            // Kill-switch: iterations restore the stored dep set, so they must
+            // stop too when custom dependencies are disabled instance-wide.
+            if (!this.lightdashConfig.appRuntime.customDependenciesEnabled) {
+                throw new ParameterError(
+                    'Custom app dependencies are disabled on this instance (LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED). This app declares custom packages, so it cannot be iterated until they are re-enabled.',
+                );
+            }
             carriedDependencies = latestVersion.dependencies;
             const { client, bucket } = this.getS3Client();
             const toPrefix = versionPrefix(appUuid, newVersion);

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -53,7 +53,10 @@ const buildCspHeader = (
 
     const directives: string[] = [
         `default-src 'none'`,
-        `script-src ${sources()}`,
+        // blob: in script-src is required for blob workers to EXECUTE — the
+        // inherited CSP checks the worker's own script against script-src,
+        // while worker-src below only gates its creation.
+        `script-src ${sources('blob:')}`,
         `style-src ${sources("'unsafe-inline'", ...cspAllowedOrigins)}`,
         // Allow same-origin fetch so html-to-image can inline @font-face
         // sources and <img>/background URLs when capturing screenshots.
@@ -62,6 +65,13 @@ const buildCspHeader = (
         // exfiltrate user data — the postMessage bridge remains the only
         // path to the authenticated Lightdash API.
         `connect-src ${sources()}`,
+        // Many libraries (canvas-confetti, deck.gl, comlink) run animation or
+        // compute in workers created from blob: URLs. Blob workers execute the
+        // app's own already-running code and inherit this CSP, so allowing
+        // them adds no new network or exfiltration path. child-src is the
+        // worker fallback on older Safari.
+        `worker-src ${sources('blob:')}`,
+        `child-src ${sources('blob:')}`,
         `img-src ${sources('data:')}`,
         `font-src ${sources(...cspAllowedOrigins)}`,
         `frame-ancestors ${frameAncestors.join(' ')}`,

--- a/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
@@ -7,3 +7,7 @@ Two skills in `.claude/skills/` describe how to edit this app:
 Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
 
 The local `pnpm install && pnpm build` is an optional pre-check. If install fails, skip it and upload — never modify machine config, npmrc, or dependency files to force it; the server rebuild is authoritative.
+
+Exception: adding a dependency requires a matching `pnpm-lock.yaml`, so `pnpm add <pkg>` (or `pnpm install --lockfile-only`) must succeed locally. If it fails, stop and report the error — hand-editing `package.json` without the lockfile makes the upload fail.
+
+`.npmrc` sets `ignore-scripts=true` — never remove it or run installs with scripts enabled; this app may be authored by someone else and their dependencies' lifecycle scripts must not run here.

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -8,6 +8,10 @@ Downloaded with `lightdash download --apps`.
 3. `lightdash upload --apps` — Lightdash rebuilds and serves the app.
 
 ## What's read-only
-Everything outside `src/` is reference: root config, `.lightdash/context/` (the project's semantic layer, parameters, prompt history, theme), and the `.claude/skills/` guidance. The server rebuilds against a trusted template, so local config edits don't change the deployed app. Bringing your own libraries / a local preview is a later phase.
+Most root config is read-only: `vite.config.js`, `tailwind.config.js`, `tsconfig.json`, etc. The server rebuilds against a trusted template, so local edits to those files don't change the deployed app.
 
-The context under `.lightdash/context/` is a snapshot of the source project at download time; re-download to refresh it.
+`package.json` is partially editable when custom dependencies are enabled on your Lightdash instance: run `pnpm add <pkg>` to declare extra npm dependencies (registry packages, plain semver versions only, up to 60 direct deps). `pnpm-lock.yaml` must be updated to match — `pnpm add` does this; if you edit `package.json` by hand, run `pnpm install --lockfile-only`. Upload rejects new dependencies without a matching lockfile. On upload the CLI warns which packages will be installed in the build sandbox; install scripts never run, and the server replaces `scripts` with the trusted template's (the sandbox build command is not uploader-controlled). The AI builder and in-app UI cannot change the dependency set — dependencies are declared by editing `package.json` and re-uploading.
+
+`.npmrc` sets `ignore-scripts=true` so dependencies' lifecycle scripts never run on your machine either — downloaded apps may be authored by someone else. Keep it; explicit `pnpm build`/`pnpm dev` still work.
+
+`.lightdash/context/` is a point-in-time snapshot of the source project; re-download to refresh it.

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -23,6 +23,8 @@ You are editing a Lightdash **data app** that was downloaded with `lightdash dow
 - If `pnpm install` fails (registry policy, an unavailable pinned SDK version, no network access), **skip the local build entirely and go straight to upload**. The server rebuild is authoritative and surfaces build errors on the app page.
 - Do **not** modify machine configuration, `.npmrc` files, registry settings, or the project's dependency files to force an install to work.
 - A missing `node_modules` is a normal state, not a problem to fix. Never run installs just because it is absent.
+- **Exception — adding a dependency.** Upload rejects new dependencies unless `pnpm-lock.yaml` was regenerated to match `package.json`, so dependency resolution MUST succeed locally. Use `pnpm add <pkg>`, or after editing `package.json` run `pnpm install --lockfile-only` (updates the lockfile without installing). If resolution fails, **stop and report the exact pnpm error to the user** — never hand-edit `package.json` and proceed without the lockfile; the upload will fail.
+- **Never run dependency lifecycle scripts.** The app's `.npmrc` sets `ignore-scripts=true` — leave it. A downloaded app can be authored by someone else, and their dependencies' install scripts must not execute on this machine. Explicit `pnpm build`/`pnpm dev` still work.
 
 ## Project context (read-only reference)
 
@@ -35,4 +37,6 @@ You are editing a Lightdash **data app** that was downloaded with `lightdash dow
 
 ## Read-only files
 
-Root config (`package.json`, `vite.config.js`, `tailwind.config.js`, `tsconfig.json`, etc.) is reference only. Editing it has **no effect** — the server rebuilds against its trusted template. Adding dependencies or changing the build is not supported yet.
+Most root config is reference only — editing it has **no effect** because the server rebuilds against its trusted template. This applies to `vite.config.js`, `tailwind.config.js`, `tsconfig.json`, and other build/tooling files.
+
+`package.json` is **partially editable** when custom dependencies are enabled on the Lightdash instance (upload says clearly if they are not): you may add npm dependencies with `pnpm add <pkg>` — registry packages with plain semver versions only (no git/file/url specs), up to 60 direct dependencies, and `pnpm-lock.yaml` must be updated alongside (see the exception above — this is the one step that must succeed locally). On upload the CLI warns which packages will be installed in the build sandbox; install scripts never run. Other root config (vite/tailwind/tsconfig) remains read-only.

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -9,6 +9,7 @@ import {
     type AppClarification,
     type AppDashboardReference,
     type AppExternalConnectionReference,
+    type AppVersionDependencyEntry,
     type DataAppClaudeModel,
     type DataAppTemplate,
     type DataAppVizContext,
@@ -37,6 +38,7 @@ import {
     IconArrowBackUp,
     IconLayoutDashboard,
     IconLink,
+    IconPackage,
     IconPlayerStop,
     IconRestore,
     IconPlugConnected,
@@ -407,6 +409,37 @@ const ConnectionChip: FC<{ name: string; onRemove: () => void }> = ({
     >
         {name}
     </Badge>
+);
+
+/** A small informational badge shown on assistant bubbles for versions that
+ *  were uploaded with a custom dependency set. Lists `name@version` per line
+ *  in the tooltip so the author can confirm what was installed. */
+const DepsChip: FC<{ deps: AppVersionDependencyEntry[] }> = ({ deps }) => (
+    <Tooltip
+        withArrow
+        position="top-start"
+        label={
+            <Stack gap={2}>
+                <Text size="xs" fw={600}>
+                    Installed in the build sandbox
+                </Text>
+                {deps.map((d) => (
+                    <Text key={d.name} size="xs">
+                        {d.name}@{d.version}
+                    </Text>
+                ))}
+            </Stack>
+        }
+    >
+        <Badge
+            variant="light"
+            color="gray"
+            size="sm"
+            leftSection={<MantineIcon icon={IconPackage} size={10} />}
+        >
+            {deps.length} {deps.length === 1 ? 'package' : 'packages'}
+        </Badge>
+    </Tooltip>
 );
 
 /** A status pill (theme-pill style) listing the connections this app can call. */
@@ -921,6 +954,16 @@ const AppGenerate: FC = () => {
             return msgs;
         });
     }, [allVersions, activeAppUuid]);
+
+    // Lookup table: version number → full version summary. Used to retrieve
+    // declared-dependency metadata when rendering assistant bubbles.
+    const versionByNumber = useMemo(
+        () =>
+            new Map<number, ApiAppVersionSummary>(
+                allVersions.map((v) => [v.version, v]),
+            ),
+        [allVersions],
+    );
 
     // Highest server-known version number, used by `mergeChatMessages` to drop
     // optimistic local bubbles whose corresponding server version has already
@@ -2260,6 +2303,29 @@ const AppGenerate: FC = () => {
                                                                     : undefined
                                                             }
                                                         />
+                                                        {msg.version !== null &&
+                                                            (() => {
+                                                                const vDeps =
+                                                                    versionByNumber.get(
+                                                                        msg.version,
+                                                                    )
+                                                                        ?.dependencies
+                                                                        ?.custom;
+                                                                return vDeps &&
+                                                                    vDeps.length >
+                                                                        0 ? (
+                                                                    <Group
+                                                                        gap="xs"
+                                                                        mt={4}
+                                                                    >
+                                                                        <DepsChip
+                                                                            deps={
+                                                                                vDeps
+                                                                            }
+                                                                        />
+                                                                    </Group>
+                                                                ) : null;
+                                                            })()}
                                                         {msg.vizSchema ? (
                                                             msg.version !==
                                                                 null &&

--- a/sandboxes/data-apps/template/.npmrc
+++ b/sandboxes/data-apps/template/.npmrc
@@ -1,2 +1,7 @@
 shamefully-hoist=true
 ignore-workspace-root-check=true
+# The pinned SDK version is often <3 days old; exempt it from release-age policies
+minimum-release-age-exclude[]=@lightdash/query-sdk
+# Downloaded apps may be authored by someone else — never run their
+# dependencies' lifecycle scripts locally (explicit `pnpm run` still works)
+ignore-scripts=true


### PR DESCRIPTION
Part 4/4 of Data Apps declared dependencies (3b).

- Version timeline shows a package chip for versions with custom deps (tooltip lists `name@version` installed in the build sandbox).
- Kill-switch re-checks: the instance toggle (introduced default-OFF in part 2) is re-enforced inside `restoreDepsToSandbox` and on the AI-iterate carry-forward path, so flipping it off also stops installs of previously-approved dep sets — not just new uploads. Registry hosts and install timeout are configurable via env (part 3).
- Docs + local-authoring skill/README updated: `pnpm add <pkg>` is now allowed (registry semver only, lockfile committed alongside); other root config stays read-only. Scaffolded `.npmrc` exempts the pinned `@lightdash/query-sdk` from pnpm release-age policies (releases are often <3 days old).
- App-serving CSP now allows `blob:` in `script-src`/`worker-src`/`child-src` so libraries that render via blob-URL workers (canvas-confetti, deck.gl, comlink) work. Blob workers execute the app's own already-running code and inherit the page CSP, so this adds no new network or exfiltration path. Note both directives are needed: `worker-src` gates creation, but the worker's inherited CSP checks its own script against `script-src` (that violation only logs in the worker console). Verified live with canvas-confetti.

- Kill-switch hardening: `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED=false` is now re-checked on the AI-iterate carry-forward path (clear error before a version is created) and inside `restoreDepsToSandbox` — flipping it off stops installs of previously-approved dep sets, not just new uploads.
- Scaffolded `.npmrc` sets `ignore-scripts=true`: downloaded apps can be authored by someone else, so their dependencies' lifecycle scripts never run on a developer machine (verified `pnpm install` + `pnpm build` still work). Skill/README/AGENTS docs updated accordingly.

Closes GLITCH-603

🤖 Generated with [Claude Code](https://claude.com/claude-code)