### PR TITLE
ci: run release job on GitHub-hosted runner for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
         run: pnpm build
 
   release:
-    runs-on: depot-ubuntu-24.04-8
+    # npm provenance publishing only works on GitHub-hosted runners; Depot
+    # runners report as "self-hosted" and the registry rejects the bundle (E422).
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build-and-test
     concurrency: ${{ github.ref }}


### PR DESCRIPTION
Closes:

### Description:
Fixes the release pipeline broken by #25169. Publishing packages with npm provenance only works on GitHub-hosted runners, but that PR moved the `release` job to a Depot runner, which reports as `self-hosted` — so `npm publish` fails with `E422 ... Only "github-hosted" runners are supported when publishing with provenance`, failing every `fix:`/`feat:` release. This reverts just the `release` job runner back to `ubuntu-latest` while keeping the Turbo remote-cache env and `build-published-packages` turbo change.
