### PR TITLE
fix(ai-copilot): play merged-PR card shimmer once instead of looping forever

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.module.css
@@ -38,7 +38,7 @@
     );
     background-size: 250% 250%;
     background-repeat: no-repeat;
-    animation: mergedShimmer 5s ease-in-out infinite;
+    animation: mergedShimmer 5s ease-in-out 1 forwards;
 }
 
 @keyframes mergedShimmer {


### PR DESCRIPTION
## Summary
- The diagonal light-sweep shimmer on the merged AI-writeback pull-request card (`.cardMerged::after` in `AiEditDbtProjectToolCall.module.css`) ran with `animation: ... infinite`, so it looped forever instead of playing once on merge.
- Changed the iteration count to `1` with a `forwards` fill so it plays a single pass and settles on its final frame.
- This CSS module is shared by both the `editDbtProject` card (`AiEditDbtProjectToolCall.tsx`) and the newer `editRepo` card (`AiEditRepoToolCall.tsx`), so the fix covers both.

## Test plan
- [x] `pnpm -F frontend lint` — 0 errors
- [x] `pnpm -F frontend typecheck:fast` — clean
- [ ] Manually trigger an AI writeback PR merge and confirm the shimmer plays once and stops (not verified live in this session — no running dev instance was available)