### PR TITLE
feat(common): add scope graph helpers

### DIFF
--- a/packages/common/src/authorization/scopes.test.ts
+++ b/packages/common/src/authorization/scopes.test.ts
@@ -1,0 +1,200 @@
+import {
+    getScopeAncestors,
+    getScopeDescendants,
+    getScopes,
+    getScopeSubstitutes,
+    getUnsatisfiedScopeDependencies,
+} from './scopes';
+
+describe('scope dependency graph helpers', () => {
+    describe('getScopeAncestors', () => {
+        it('returns direct and transitive dependencies for a scope', () => {
+            expect(getScopeAncestors('manage:Dashboard')).toEqual([
+                'view:Project',
+                'view:SavedChart',
+                'view:Space',
+            ]);
+        });
+
+        it('ignores unknown scopes', () => {
+            expect(getScopeAncestors('not:aScope')).toEqual([]);
+            expect(getScopeAncestors('not-a-scope')).toEqual([]);
+        });
+
+        it('normalizes scope names before traversing dependencies', () => {
+            expect(getScopeAncestors('manage:dashboard')).toEqual([
+                'view:Project',
+                'view:SavedChart',
+                'view:Space',
+            ]);
+        });
+
+        it('does not return the input scope when the graph cycles back to it', () => {
+            const ancestors = getScopeAncestors('manage:CompileProject');
+
+            expect(ancestors).toContain('create:Job');
+            expect(ancestors).not.toContain('manage:CompileProject');
+        });
+    });
+
+    describe('getScopeDescendants', () => {
+        it('returns direct and transitive dependents for a scope', () => {
+            const descendants = getScopeDescendants('view:SavedChart');
+
+            expect(descendants).toEqual(
+                expect.arrayContaining([
+                    'view:Dashboard',
+                    'manage:Dashboard',
+                    'manage:Dashboard@space',
+                    'manage:Dashboard@self',
+                ]),
+            );
+            expect(descendants).not.toContain('view:SavedChart');
+        });
+
+        it('ignores unknown scopes', () => {
+            expect(getScopeDescendants('not:aScope')).toEqual([]);
+            expect(getScopeDescendants('not-a-scope')).toEqual([]);
+        });
+
+        it('does not return the input scope when the graph cycles back to it', () => {
+            const descendants = getScopeDescendants('create:Job');
+
+            expect(descendants).toContain('manage:CompileProject');
+            expect(descendants).not.toContain('create:Job');
+        });
+    });
+
+    it('can traverse ancestors for every scope without looping forever', () => {
+        getScopes({ isEnterprise: true }).forEach((scope) => {
+            expect(
+                getScopeAncestors(scope.name, { isEnterprise: true }),
+            ).not.toContain(scope.name);
+        });
+    });
+
+    describe('getScopeSubstitutes', () => {
+        it('returns stronger scope variations that can replace a view requirement', () => {
+            expect(getScopeSubstitutes('view:Dashboard')).toEqual([
+                'manage:Dashboard',
+                'manage:Dashboard@space',
+                'manage:Dashboard@self',
+            ]);
+        });
+
+        it('does not treat promote as a substitute for view or manage', () => {
+            expect(getScopeSubstitutes('view:Dashboard')).not.toContain(
+                'promote:Dashboard',
+            );
+            expect(getScopeSubstitutes('manage:Dashboard@space')).not.toContain(
+                'promote:Dashboard@space',
+            );
+        });
+
+        it('returns broader same-action variants that can replace a scoped requirement', () => {
+            expect(getScopeSubstitutes('manage:Dashboard@space')).toContain(
+                'manage:Dashboard',
+            );
+            expect(
+                getScopeSubstitutes('view:DataApp@self', {
+                    isEnterprise: true,
+                }),
+            ).toContain('view:DataApp');
+        });
+
+        it('does not return weaker or narrower scopes as substitutes', () => {
+            expect(getScopeSubstitutes('manage:Dashboard')).not.toContain(
+                'view:Dashboard',
+            );
+            expect(getScopeSubstitutes('manage:Dashboard')).not.toContain(
+                'manage:Dashboard@space',
+            );
+        });
+
+        it('returns manage as a substitute for granular create and delete scopes', () => {
+            expect(getScopeSubstitutes('create:VirtualView')).toEqual([
+                'manage:VirtualView',
+            ]);
+            expect(getScopeSubstitutes('delete:VirtualView')).toEqual([
+                'manage:VirtualView',
+            ]);
+        });
+
+        it('returns stronger scoped variants for a scoped view requirement', () => {
+            expect(
+                getScopeSubstitutes('view:DataApp@self', {
+                    isEnterprise: true,
+                }),
+            ).toContain('manage:DataApp@self');
+        });
+
+        it('ignores unknown scopes', () => {
+            expect(getScopeSubstitutes('not:aScope')).toEqual([]);
+            expect(getScopeSubstitutes('not-a-scope')).toEqual([]);
+        });
+
+        it('normalizes scope names before finding substitutes', () => {
+            expect(getScopeSubstitutes('view:dashboard')).toEqual([
+                'manage:Dashboard',
+                'manage:Dashboard@space',
+                'manage:Dashboard@self',
+            ]);
+        });
+    });
+
+    describe('getUnsatisfiedScopeDependencies', () => {
+        it('returns missing dependencies for a new scope', () => {
+            expect(
+                getUnsatisfiedScopeDependencies(
+                    ['view:Project', 'view:SavedChart'],
+                    'manage:Dashboard',
+                ),
+            ).toEqual(['view:Space']);
+        });
+
+        it('treats substitute scopes as satisfying dependencies', () => {
+            expect(
+                getUnsatisfiedScopeDependencies(
+                    ['view:Project', 'manage:SavedChart', 'view:Space'],
+                    'manage:Dashboard',
+                ),
+            ).toEqual([]);
+        });
+
+        it('includes transitive dependencies', () => {
+            expect(
+                getUnsatisfiedScopeDependencies(
+                    ['view:Project', 'manage:SavedChart@space'],
+                    'manage:CustomFields',
+                ),
+            ).toEqual(['view:Space', 'manage:Explore']);
+        });
+
+        it('ignores unknown existing scopes and unknown new scopes', () => {
+            expect(
+                getUnsatisfiedScopeDependencies(
+                    ['not:aScope', 'view:Project'],
+                    'view:SavedChart',
+                ),
+            ).toEqual([]);
+            expect(
+                getUnsatisfiedScopeDependencies(['view:Project'], 'not:aScope'),
+            ).toEqual([]);
+            expect(
+                getUnsatisfiedScopeDependencies(
+                    ['not-a-scope', 'view:Project'],
+                    'not-a-scope',
+                ),
+            ).toEqual([]);
+        });
+
+        it('normalizes existing and new scope names before checking dependencies', () => {
+            expect(
+                getUnsatisfiedScopeDependencies(
+                    ['view:project', 'manage:saved_chart', 'view:space'],
+                    'manage:dashboard',
+                ),
+            ).toEqual([]);
+        });
+    });
+});

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1,13 +1,17 @@
+import camelCase from 'lodash/camelCase';
 import flow from 'lodash/flow';
+import upperFirst from 'lodash/upperFirst';
 import { ProjectType } from '../types/projects';
 import type { RoleLevel } from '../types/roles';
 import {
     ScopeGroup,
     type Scope,
     type ScopeContext,
+    type ScopeModifer,
     type ScopeName,
 } from '../types/scopes';
 import { SpaceMemberRole } from '../types/space';
+import { type AbilityAction, type CaslSubjectNames } from './types';
 
 /** Context can have either/or organizationUuid or projectUuid. Applies the one we have. */
 const addUuidCondition = (
@@ -1465,3 +1469,205 @@ export const getAllScopeMap = ({ isEnterprise = false } = {}): Record<
         },
         Object.create({}),
     );
+
+type ScopeGraphOptions = {
+    isEnterprise?: boolean;
+};
+
+type ScopeNameParts = {
+    action: AbilityAction;
+    subject: CaslSubjectNames;
+    modifier?: ScopeModifer;
+};
+
+const MANAGE_IMPLIED_ACTIONS = new Set<AbilityAction>([
+    'create',
+    'delete',
+    'export',
+    'update',
+    'view',
+]);
+
+const parseScopeNameParts = (scopeName: ScopeName): ScopeNameParts => {
+    const [action, subjectAndModifier] = scopeName.split(':');
+    const [subject, modifier] = subjectAndModifier.split('@');
+
+    return {
+        action: action as AbilityAction,
+        subject: subject as CaslSubjectNames,
+        modifier: modifier as ScopeModifer | undefined,
+    };
+};
+
+const normalizeScopeName = (scopeName: string): ScopeName | null => {
+    const [action, predicate] = scopeName.split(':');
+
+    if (!action || !predicate) return null;
+
+    const [subjectPart, modifier] = predicate.split('@');
+
+    return `${action}:${upperFirst(camelCase(subjectPart))}${
+        modifier ? `@${modifier}` : ''
+    }` as ScopeName;
+};
+
+const getValidScopeName = (
+    scopeName: string,
+    scopeMap: Record<ScopeName, Scope>,
+): ScopeName | null => {
+    const normalizedScopeName = normalizeScopeName(scopeName);
+
+    if (
+        normalizedScopeName &&
+        Object.prototype.hasOwnProperty.call(scopeMap, normalizedScopeName)
+    ) {
+        return normalizedScopeName;
+    }
+
+    return null;
+};
+
+const getValidScopeNames = (
+    scopeNames: string[],
+    scopeMap: Record<ScopeName, Scope>,
+): ScopeName[] =>
+    scopeNames
+        .map((scopeName) => getValidScopeName(scopeName, scopeMap))
+        .filter((scopeName): scopeName is ScopeName => scopeName !== null);
+
+const collectReachableScopes = (
+    rootScopeNames: ScopeName[],
+    getAdjacentScopeNames: (scopeName: ScopeName) => ScopeName[],
+): ScopeName[] => {
+    const visited = new Set<ScopeName>(rootScopeNames);
+    const reachableScopeNames: ScopeName[] = [];
+    const queue = [...rootScopeNames];
+    let queueIndex = 0;
+
+    while (queueIndex < queue.length) {
+        const scopeName = queue[queueIndex];
+        queueIndex += 1;
+
+        getAdjacentScopeNames(scopeName).forEach((adjacentScopeName) => {
+            if (visited.has(adjacentScopeName)) return;
+
+            visited.add(adjacentScopeName);
+            reachableScopeNames.push(adjacentScopeName);
+            queue.push(adjacentScopeName);
+        });
+    }
+
+    return reachableScopeNames;
+};
+
+export const getScopeAncestors = (
+    scopeName: string,
+    { isEnterprise = false }: ScopeGraphOptions = {},
+): ScopeName[] => {
+    const scopeMap = getAllScopeMap({ isEnterprise });
+    const rootScopeNames = getValidScopeNames([scopeName], scopeMap);
+
+    return collectReachableScopes(rootScopeNames, (dependencyRootScopeName) =>
+        scopeMap[dependencyRootScopeName].dependencies
+            .map(({ name }) => name)
+            .filter((dependencyName) => scopeMap[dependencyName]),
+    );
+};
+
+export const getScopeDescendants = (
+    scopeName: string,
+    { isEnterprise = false }: ScopeGraphOptions = {},
+): ScopeName[] => {
+    const scopeMap = getAllScopeMap({ isEnterprise });
+    const rootScopeNames = getValidScopeNames([scopeName], scopeMap);
+    const ancestorMap = getScopes({ isEnterprise }).reduce<
+        Record<ScopeName, ScopeName[]>
+    >((acc, scope) => {
+        scope.dependencies.forEach(({ name }) => {
+            if (!scopeMap[name]) return;
+
+            acc[name] = [...(acc[name] ?? []), scope.name];
+        });
+
+        return acc;
+    }, Object.create({}));
+
+    return collectReachableScopes(
+        rootScopeNames,
+        (ancestorRootScopeName) => ancestorMap[ancestorRootScopeName] ?? [],
+    );
+};
+
+const canSubstituteActionSatisfy = (
+    substituteAction: AbilityAction,
+    requiredAction: AbilityAction,
+): boolean =>
+    substituteAction === requiredAction ||
+    (substituteAction === 'manage' &&
+        MANAGE_IMPLIED_ACTIONS.has(requiredAction));
+
+const canSubstituteModifierSatisfy = (
+    substitute: ScopeNameParts,
+    required: ScopeNameParts,
+): boolean => {
+    if (substitute.modifier === required.modifier) return true;
+
+    if (!substitute.modifier) return true;
+
+    return !required.modifier && substitute.action !== required.action;
+};
+
+export const getScopeSubstitutes = (
+    scopeName: string,
+    { isEnterprise = false }: ScopeGraphOptions = {},
+): ScopeName[] => {
+    const scopeMap = getAllScopeMap({ isEnterprise });
+
+    const normalizedScopeName = getValidScopeName(scopeName, scopeMap);
+
+    if (!normalizedScopeName) return [];
+
+    const required = parseScopeNameParts(normalizedScopeName);
+
+    return getScopes({ isEnterprise })
+        .map(({ name }) => name)
+        .filter((substituteScopeName) => {
+            if (substituteScopeName === normalizedScopeName) return false;
+
+            const substitute = parseScopeNameParts(substituteScopeName);
+
+            return (
+                substitute.subject === required.subject &&
+                canSubstituteActionSatisfy(
+                    substitute.action,
+                    required.action,
+                ) &&
+                canSubstituteModifierSatisfy(substitute, required)
+            );
+        });
+};
+
+export const getUnsatisfiedScopeDependencies = (
+    existingScopeNames: string[],
+    scopeName: string,
+    { isEnterprise = false }: ScopeGraphOptions = {},
+): ScopeName[] => {
+    const scopeMap = getAllScopeMap({ isEnterprise });
+
+    const normalizedScopeName = getValidScopeName(scopeName, scopeMap);
+
+    if (!normalizedScopeName) return [];
+
+    const existingScopes = new Set(
+        getValidScopeNames(existingScopeNames, scopeMap),
+    );
+
+    return getScopeAncestors(normalizedScopeName, { isEnterprise }).filter(
+        (dependencyScopeName) =>
+            !existingScopes.has(dependencyScopeName) &&
+            !getScopeSubstitutes(dependencyScopeName, { isEnterprise }).some(
+                (substituteScopeName) =>
+                    existingScopes.has(substituteScopeName),
+            ),
+    );
+};


### PR DESCRIPTION
Closes: N/A

## Description:

Adds scope graph helpers in `@lightdash/common` for walking scope dependencies, finding dependent scopes, checking substitute scopes, and reporting unsatisfied dependencies before adding a new scope.

The helpers keep the permission hierarchy direction explicit:

```text
view:Project
  -> view:SavedChart
     -> manage:Dashboard

Ancestors: dependencies a scope requires
Descendants: scopes that depend on a scope
```

The dependency check also treats stronger substitute scopes as satisfying a dependency, so `manage:SavedChart` satisfies a `view:SavedChart` dependency.

Test plan:
- `pnpm -F @lightdash/common test src/authorization/scopes.test.ts src/authorization/parseScopes.test.ts src/authorization/scopeAbilityBuilder.test.ts`
- `pnpm -F @lightdash/common typecheck:fast`
- `pnpm -F @lightdash/common exec eslint -c .eslintrc.js src/authorization/scopes.ts src/authorization/scopes.test.ts`
