### PR TITLE
feat(common): add provider API key types and feature flag for org AI keys

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -1,6 +1,7 @@
 import {
     type AiAgentModelConfig,
     type AiChartRuntimeOverrides,
+    type AiProviderApiKeyHints,
     type AiThreadCreatedFrom,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -397,6 +398,7 @@ export type DbAiOrganizationSettings = {
     mcp_content_writes_enabled: boolean;
     default_ai_agent_model_config: AiAgentModelConfig | null;
     encrypted_provider_api_keys: Buffer | null;
+    provider_api_key_hints: AiProviderApiKeyHints | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -411,6 +413,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
                 | 'mcp_content_writes_enabled'
                 | 'default_ai_agent_model_config'
                 | 'encrypted_provider_api_keys'
+                | 'provider_api_key_hints'
             >
         >,
     Partial<
@@ -421,6 +424,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
             | 'mcp_content_writes_enabled'
             | 'default_ai_agent_model_config'
             | 'encrypted_provider_api_keys'
+            | 'provider_api_key_hints'
         >
     >
 >;

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -396,6 +396,7 @@ export type DbAiOrganizationSettings = {
     ai_agent_reviews_enabled: boolean;
     mcp_content_writes_enabled: boolean;
     default_ai_agent_model_config: AiAgentModelConfig | null;
+    encrypted_provider_api_keys: Buffer | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -409,6 +410,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
                 | 'ai_agent_reviews_enabled'
                 | 'mcp_content_writes_enabled'
                 | 'default_ai_agent_model_config'
+                | 'encrypted_provider_api_keys'
             >
         >,
     Partial<
@@ -418,6 +420,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
             | 'ai_agent_reviews_enabled'
             | 'mcp_content_writes_enabled'
             | 'default_ai_agent_model_config'
+            | 'encrypted_provider_api_keys'
         >
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260706120000_add_provider_api_keys_to_ai_organization_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260706120000_add_provider_api_keys_to_ai_organization_settings.ts
@@ -5,11 +5,13 @@ const aiOrganizationSettings = 'ai_organization_settings';
 export async function up(knex: Knex): Promise<void> {
     await knex.schema.alterTable(aiOrganizationSettings, (table) => {
         table.binary('encrypted_provider_api_keys').nullable();
+        table.jsonb('provider_api_key_hints').nullable();
     });
 }
 
 export async function down(knex: Knex): Promise<void> {
     await knex.schema.alterTable(aiOrganizationSettings, (table) => {
         table.dropColumn('encrypted_provider_api_keys');
+        table.dropColumn('provider_api_key_hints');
     });
 }

--- a/packages/backend/src/ee/database/migrations/20260706120000_add_provider_api_keys_to_ai_organization_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260706120000_add_provider_api_keys_to_ai_organization_settings.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const aiOrganizationSettings = 'ai_organization_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiOrganizationSettings, (table) => {
+        table.binary('encrypted_provider_api_keys').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiOrganizationSettings, (table) => {
+        table.dropColumn('encrypted_provider_api_keys');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -804,8 +804,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
             schedulerAiAugmentationModel: ({ database }) =>
                 new SchedulerAiAugmentationModel({ database }),
             aiRouterModel: ({ database }) => new AiRouterModel({ database }),
-            aiOrganizationSettingsModel: ({ database }) =>
-                new AiOrganizationSettingsModel({ database }),
+            aiOrganizationSettingsModel: ({ database, utils }) =>
+                new AiOrganizationSettingsModel({
+                    database,
+                    encryptionUtil: utils.getEncryptionUtil(),
+                }),
             embedModel: ({ database }) => new EmbedModel({ database }),
             mcpContextModel: ({ database }) => new McpContextModel(database),
             dashboardSummaryModel: ({ database }) =>

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.test.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.test.ts
@@ -1,5 +1,9 @@
 import { ParameterError } from '@lightdash/common';
-import { applyProviderApiKeyUpdates } from './AiOrganizationSettingsModel';
+import {
+    applyProviderApiKeyUpdates,
+    buildProviderApiKeyHint,
+    buildProviderApiKeyHints,
+} from './AiOrganizationSettingsModel';
 
 describe('applyProviderApiKeyUpdates', () => {
     it('sets a new key and trims whitespace', () => {
@@ -30,5 +34,48 @@ describe('applyProviderApiKeyUpdates', () => {
         expect(() => applyProviderApiKeyUpdates({}, { openai: '   ' })).toThrow(
             ParameterError,
         );
+    });
+});
+
+describe('buildProviderApiKeyHint', () => {
+    it('formats an anthropic key like the Anthropic console', () => {
+        expect(
+            buildProviderApiKeyHint(
+                'sk-ant-api03-R2DAbcdefghijklmnopqrstuvwxyz0123456789igAA',
+            ),
+        ).toBe('sk-ant-api03-R2D...igAA');
+    });
+
+    it('formats an openai project key with prefix and last four', () => {
+        expect(
+            buildProviderApiKeyHint(
+                'sk-proj-Abcdefghijklmnopqrstuvwxyz0123456789j3kl',
+            ),
+        ).toBe('sk-proj-Abc...j3kl');
+    });
+
+    it('formats a legacy openai key', () => {
+        expect(
+            buildProviderApiKeyHint('sk-Abcdefghijklmnopqrstuvwxyz01234j3kl'),
+        ).toBe('sk-Abc...j3kl');
+    });
+
+    it('degrades safely for short or unknown keys', () => {
+        expect(buildProviderApiKeyHint('sk-short')).toBe('sk...');
+        expect(buildProviderApiKeyHint('mykey123')).toBe('my...');
+    });
+});
+
+describe('buildProviderApiKeyHints', () => {
+    it('returns null when no keys are set', () => {
+        expect(buildProviderApiKeyHints({})).toBeNull();
+    });
+
+    it('maps only the providers that are set', () => {
+        expect(
+            buildProviderApiKeyHints({
+                openai: 'sk-proj-Abcdefghijklmnopqrstuvwxyz0123456789j3kl',
+            }),
+        ).toEqual({ anthropic: null, openai: 'sk-proj-Abc...j3kl' });
     });
 });

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.test.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.test.ts
@@ -1,0 +1,34 @@
+import { ParameterError } from '@lightdash/common';
+import { applyProviderApiKeyUpdates } from './AiOrganizationSettingsModel';
+
+describe('applyProviderApiKeyUpdates', () => {
+    it('sets a new key and trims whitespace', () => {
+        expect(
+            applyProviderApiKeyUpdates({}, { anthropic: '  sk-ant-123  ' }),
+        ).toEqual({ anthropic: 'sk-ant-123' });
+    });
+
+    it('leaves absent providers unchanged', () => {
+        expect(
+            applyProviderApiKeyUpdates(
+                { anthropic: 'sk-ant-old', openai: 'sk-old' },
+                { openai: 'sk-new' },
+            ),
+        ).toEqual({ anthropic: 'sk-ant-old', openai: 'sk-new' });
+    });
+
+    it('removes a key on null', () => {
+        expect(
+            applyProviderApiKeyUpdates(
+                { anthropic: 'sk-ant-old', openai: 'sk-old' },
+                { anthropic: null },
+            ),
+        ).toEqual({ openai: 'sk-old' });
+    });
+
+    it('throws ParameterError on empty key', () => {
+        expect(() => applyProviderApiKeyUpdates({}, { openai: '   ' })).toThrow(
+            ParameterError,
+        );
+    });
+});

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
@@ -1,10 +1,15 @@
 import {
     AiOrganizationSettings,
+    BYO_AI_PROVIDERS,
     CreateAiOrganizationSettings,
     NotFoundError,
+    ParameterError,
     UpdateAiOrganizationSettings,
+    UpdateAiProviderApiKeys,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import Logger from '../../logging/logger';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     AiOrganizationSettingsTable,
     AiOrganizationSettingsTableName,
@@ -13,25 +18,82 @@ import {
 
 type Dependencies = {
     database: Knex;
+    encryptionUtil: EncryptionUtil;
+};
+
+export type AiOrgProviderApiKeys = {
+    anthropic?: string;
+    openai?: string;
+};
+
+export const applyProviderApiKeyUpdates = (
+    existing: AiOrgProviderApiKeys,
+    updates: UpdateAiProviderApiKeys,
+): AiOrgProviderApiKeys => {
+    const next: AiOrgProviderApiKeys = { ...existing };
+    BYO_AI_PROVIDERS.forEach((provider) => {
+        const update = updates[provider];
+        if (update === undefined) return;
+        if (update === null) {
+            delete next[provider];
+            return;
+        }
+        const trimmed = update.trim();
+        if (trimmed.length === 0) {
+            throw new ParameterError(`API key for ${provider} cannot be empty`);
+        }
+        next[provider] = trimmed;
+    });
+    return next;
 };
 
 export class AiOrganizationSettingsModel {
     private database: Knex;
 
+    private encryptionUtil: EncryptionUtil;
+
     constructor(dependencies: Dependencies) {
         this.database = dependencies.database;
+        this.encryptionUtil = dependencies.encryptionUtil;
     }
 
-    // eslint-disable-next-line class-methods-use-this
+    private decryptProviderApiKeys(
+        encrypted: Buffer | null,
+    ): AiOrgProviderApiKeys {
+        if (!encrypted) return {};
+        try {
+            return JSON.parse(
+                this.encryptionUtil.decrypt(encrypted),
+            ) as AiOrgProviderApiKeys;
+        } catch {
+            Logger.warn(
+                'Failed to decrypt AI provider API keys; treating as unset',
+            );
+            return {};
+        }
+    }
+
+    private encryptProviderApiKeys(keys: AiOrgProviderApiKeys): Buffer | null {
+        if (!keys.anthropic && !keys.openai) return null;
+        return this.encryptionUtil.encrypt(JSON.stringify(keys));
+    }
+
     private mapDbToEntity(
         db: DbAiOrganizationSettings,
     ): AiOrganizationSettings {
+        const keys = this.decryptProviderApiKeys(
+            db.encrypted_provider_api_keys,
+        );
         return {
             organizationUuid: db.organization_uuid,
             aiAgentsVisible: db.ai_agents_visible,
             aiAgentReviewsEnabled: db.ai_agent_reviews_enabled,
             mcpContentWritesEnabled: db.mcp_content_writes_enabled,
             defaultAiAgentModelConfig: db.default_ai_agent_model_config,
+            providerApiKeysSet: {
+                anthropic: Boolean(keys.anthropic),
+                openai: Boolean(keys.openai),
+            },
         };
     }
 
@@ -59,6 +121,24 @@ export class AiOrganizationSettingsModel {
         return settings;
     }
 
+    async findDecryptedProviderApiKeys(
+        organizationUuid: string,
+    ): Promise<AiOrgProviderApiKeys | null> {
+        const row = await this.database(AiOrganizationSettingsTableName)
+            .select('encrypted_provider_api_keys')
+            .where('organization_uuid', organizationUuid)
+            .first<
+                | Pick<DbAiOrganizationSettings, 'encrypted_provider_api_keys'>
+                | undefined
+            >();
+
+        if (!row?.encrypted_provider_api_keys) return null;
+        const keys = this.decryptProviderApiKeys(
+            row.encrypted_provider_api_keys,
+        );
+        return keys.anthropic || keys.openai ? keys : null;
+    }
+
     async create(
         data: CreateAiOrganizationSettings,
     ): Promise<AiOrganizationSettings> {
@@ -71,6 +151,9 @@ export class AiOrganizationSettingsModel {
                 ai_agent_reviews_enabled: data.aiAgentReviewsEnabled,
                 mcp_content_writes_enabled: data.mcpContentWritesEnabled,
                 default_ai_agent_model_config: data.defaultAiAgentModelConfig,
+                encrypted_provider_api_keys: this.encryptProviderApiKeys(
+                    applyProviderApiKeyUpdates({}, data.providerApiKeys ?? {}),
+                ),
             })
             .returning('*');
 
@@ -88,6 +171,7 @@ export class AiOrganizationSettingsModel {
                 | 'ai_agent_reviews_enabled'
                 | 'mcp_content_writes_enabled'
                 | 'default_ai_agent_model_config'
+                | 'encrypted_provider_api_keys'
             >
         > = {};
         if (data.aiAgentsVisible !== undefined) {
@@ -103,6 +187,54 @@ export class AiOrganizationSettingsModel {
         if (data.defaultAiAgentModelConfig !== undefined) {
             updateData.default_ai_agent_model_config =
                 data.defaultAiAgentModelConfig;
+        }
+        if (data.providerApiKeys !== undefined) {
+            const providerApiKeyUpdates = data.providerApiKeys;
+            return this.database.transaction(async (trx) => {
+                const currentRow = await trx(AiOrganizationSettingsTableName)
+                    .select('encrypted_provider_api_keys')
+                    .where('organization_uuid', organizationUuid)
+                    .forUpdate()
+                    .first<
+                        | Pick<
+                              DbAiOrganizationSettings,
+                              'encrypted_provider_api_keys'
+                          >
+                        | undefined
+                    >();
+
+                if (!currentRow) {
+                    throw new NotFoundError(
+                        `AI organization settings not found for organization ${organizationUuid}`,
+                    );
+                }
+
+                const existingKeys = this.decryptProviderApiKeys(
+                    currentRow.encrypted_provider_api_keys,
+                );
+                updateData.encrypted_provider_api_keys =
+                    this.encryptProviderApiKeys(
+                        applyProviderApiKeyUpdates(
+                            existingKeys,
+                            providerApiKeyUpdates,
+                        ),
+                    );
+
+                const [row] = await trx<AiOrganizationSettingsTable>(
+                    AiOrganizationSettingsTableName,
+                )
+                    .where('organization_uuid', organizationUuid)
+                    .update(updateData)
+                    .returning('*');
+
+                if (!row) {
+                    throw new NotFoundError(
+                        `AI organization settings not found for organization ${organizationUuid}`,
+                    );
+                }
+
+                return this.mapDbToEntity(row);
+            });
         }
         if (Object.keys(updateData).length === 0) {
             return this.getByOrganizationUuid(organizationUuid);
@@ -139,6 +271,7 @@ export class AiOrganizationSettingsModel {
             aiAgentReviewsEnabled: data.aiAgentReviewsEnabled ?? false,
             mcpContentWritesEnabled: data.mcpContentWritesEnabled ?? true,
             defaultAiAgentModelConfig: data.defaultAiAgentModelConfig ?? null,
+            providerApiKeys: data.providerApiKeys,
         });
     }
 

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
@@ -1,5 +1,6 @@
 import {
     AiOrganizationSettings,
+    AiProviderApiKeyHints,
     BYO_AI_PROVIDERS,
     CreateAiOrganizationSettings,
     NotFoundError,
@@ -45,6 +46,27 @@ export const applyProviderApiKeyUpdates = (
         next[provider] = trimmed;
     });
     return next;
+};
+
+export const buildProviderApiKeyHint = (key: string): string => {
+    const prefix = key.match(/^(sk-ant-[a-z0-9]+-|sk-proj-|sk-)/)?.[0] ?? '';
+    const headLength = prefix.length + 3;
+    if (key.length < headLength + 8) {
+        return `${key.slice(0, 2)}...`;
+    }
+    return `${key.slice(0, headLength)}...${key.slice(-4)}`;
+};
+
+export const buildProviderApiKeyHints = (
+    keys: AiOrgProviderApiKeys,
+): AiProviderApiKeyHints | null => {
+    if (!keys.anthropic && !keys.openai) return null;
+    return {
+        anthropic: keys.anthropic
+            ? buildProviderApiKeyHint(keys.anthropic)
+            : null,
+        openai: keys.openai ? buildProviderApiKeyHint(keys.openai) : null,
+    };
 };
 
 export class AiOrganizationSettingsModel {
@@ -94,6 +116,10 @@ export class AiOrganizationSettingsModel {
                 anthropic: Boolean(keys.anthropic),
                 openai: Boolean(keys.openai),
             },
+            providerApiKeyHints: db.provider_api_key_hints ?? {
+                anthropic: null,
+                openai: null,
+            },
         };
     }
 
@@ -142,6 +168,8 @@ export class AiOrganizationSettingsModel {
     async create(
         data: CreateAiOrganizationSettings,
     ): Promise<AiOrganizationSettings> {
+        const keys = applyProviderApiKeyUpdates({}, data.providerApiKeys ?? {});
+
         const [row] = await this.database<AiOrganizationSettingsTable>(
             AiOrganizationSettingsTableName,
         )
@@ -151,9 +179,8 @@ export class AiOrganizationSettingsModel {
                 ai_agent_reviews_enabled: data.aiAgentReviewsEnabled,
                 mcp_content_writes_enabled: data.mcpContentWritesEnabled,
                 default_ai_agent_model_config: data.defaultAiAgentModelConfig,
-                encrypted_provider_api_keys: this.encryptProviderApiKeys(
-                    applyProviderApiKeyUpdates({}, data.providerApiKeys ?? {}),
-                ),
+                encrypted_provider_api_keys: this.encryptProviderApiKeys(keys),
+                provider_api_key_hints: buildProviderApiKeyHints(keys),
             })
             .returning('*');
 
@@ -172,6 +199,7 @@ export class AiOrganizationSettingsModel {
                 | 'mcp_content_writes_enabled'
                 | 'default_ai_agent_model_config'
                 | 'encrypted_provider_api_keys'
+                | 'provider_api_key_hints'
             >
         > = {};
         if (data.aiAgentsVisible !== undefined) {
@@ -212,13 +240,14 @@ export class AiOrganizationSettingsModel {
                 const existingKeys = this.decryptProviderApiKeys(
                     currentRow.encrypted_provider_api_keys,
                 );
+                const mergedKeys = applyProviderApiKeyUpdates(
+                    existingKeys,
+                    providerApiKeyUpdates,
+                );
                 updateData.encrypted_provider_api_keys =
-                    this.encryptProviderApiKeys(
-                        applyProviderApiKeyUpdates(
-                            existingKeys,
-                            providerApiKeyUpdates,
-                        ),
-                    );
+                    this.encryptProviderApiKeys(mergedKeys);
+                updateData.provider_api_key_hints =
+                    buildProviderApiKeyHints(mergedKeys);
 
                 const [row] = await trx<AiOrganizationSettingsTable>(
                     AiOrganizationSettingsTableName,

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -341,6 +341,7 @@ describe('AiAgentReviewClassifierService', () => {
             aiAgentReviewsEnabled: true,
             mcpContentWritesEnabled: true,
             defaultAiAgentModelConfig: null,
+            providerApiKeysSet: { anthropic: false, openai: false },
         });
         model.createRun.mockResolvedValue(makeRun());
         model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
@@ -406,6 +407,7 @@ describe('AiAgentReviewClassifierService', () => {
                 aiAgentReviewsEnabled: false,
                 mcpContentWritesEnabled: true,
                 defaultAiAgentModelConfig: null,
+                providerApiKeysSet: { anthropic: false, openai: false },
             },
         );
 

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -342,6 +342,7 @@ describe('AiAgentReviewClassifierService', () => {
             mcpContentWritesEnabled: true,
             defaultAiAgentModelConfig: null,
             providerApiKeysSet: { anthropic: false, openai: false },
+            providerApiKeyHints: { anthropic: null, openai: null },
         });
         model.createRun.mockResolvedValue(makeRun());
         model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
@@ -408,6 +409,7 @@ describe('AiAgentReviewClassifierService', () => {
                 mcpContentWritesEnabled: true,
                 defaultAiAgentModelConfig: null,
                 providerApiKeysSet: { anthropic: false, openai: false },
+                providerApiKeyHints: { anthropic: null, openai: null },
             },
         );
 

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -151,6 +151,7 @@ export class AiOrganizationSettingsService extends BaseService {
                 mcpContentWritesEnabled: true,
                 defaultAiAgentModelConfig: null,
                 providerApiKeysSet: { anthropic: false, openai: false },
+                providerApiKeyHints: { anthropic: null, openai: null },
                 defaultAiAgentModelOptions: this.getDefaultModelOptions(),
                 isTrial: isTrialEligible,
             };

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -150,6 +150,7 @@ export class AiOrganizationSettingsService extends BaseService {
                 aiAgentReviewsEnabled: false,
                 mcpContentWritesEnabled: true,
                 defaultAiAgentModelConfig: null,
+                providerApiKeysSet: { anthropic: false, openai: false },
                 defaultAiAgentModelOptions: this.getDefaultModelOptions(),
                 isTrial: isTrialEligible,
             };

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -107,9 +107,11 @@ export type CreateAiOrganizationSettings = Omit<
     providerApiKeys?: UpdateAiProviderApiKeys;
 };
 
-export type UpdateAiOrganizationSettings = Partial<
-    Omit<AiOrganizationSettings, 'organizationUuid' | 'providerApiKeysSet'>
-> & {
+export type UpdateAiOrganizationSettings = {
+    aiAgentsVisible?: boolean;
+    aiAgentReviewsEnabled?: boolean;
+    mcpContentWritesEnabled?: boolean;
+    defaultAiAgentModelConfig?: AiAgentModelConfig | null;
     providerApiKeys?: UpdateAiProviderApiKeys;
 };
 

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -86,6 +86,11 @@ export type AiProviderApiKeysSet = {
     openai: boolean;
 };
 
+export type AiProviderApiKeyHints = {
+    anthropic: string | null;
+    openai: string | null;
+};
+
 export type UpdateAiProviderApiKeys = {
     anthropic?: string | null;
     openai?: string | null;
@@ -98,11 +103,12 @@ export type AiOrganizationSettings = {
     mcpContentWritesEnabled: boolean;
     defaultAiAgentModelConfig: AiAgentModelConfig | null;
     providerApiKeysSet: AiProviderApiKeysSet;
+    providerApiKeyHints: AiProviderApiKeyHints;
 };
 
 export type CreateAiOrganizationSettings = Omit<
     AiOrganizationSettings,
-    'providerApiKeysSet'
+    'providerApiKeysSet' | 'providerApiKeyHints'
 > & {
     providerApiKeys?: UpdateAiProviderApiKeys;
 };

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -78,19 +78,40 @@ export type ComputedAiOrganizationSettings = {
 };
 
 // AI Organization Settings Types
+export const BYO_AI_PROVIDERS = ['anthropic', 'openai'] as const;
+export type ByoAiProvider = (typeof BYO_AI_PROVIDERS)[number];
+
+export type AiProviderApiKeysSet = {
+    anthropic: boolean;
+    openai: boolean;
+};
+
+export type UpdateAiProviderApiKeys = {
+    anthropic?: string | null;
+    openai?: string | null;
+};
+
 export type AiOrganizationSettings = {
     organizationUuid: string;
     aiAgentsVisible: boolean;
     aiAgentReviewsEnabled: boolean;
     mcpContentWritesEnabled: boolean;
     defaultAiAgentModelConfig: AiAgentModelConfig | null;
+    providerApiKeysSet: AiProviderApiKeysSet;
 };
 
-export type CreateAiOrganizationSettings = AiOrganizationSettings;
+export type CreateAiOrganizationSettings = Omit<
+    AiOrganizationSettings,
+    'providerApiKeysSet'
+> & {
+    providerApiKeys?: UpdateAiProviderApiKeys;
+};
 
 export type UpdateAiOrganizationSettings = Partial<
-    Omit<AiOrganizationSettings, 'organizationUuid'>
->;
+    Omit<AiOrganizationSettings, 'organizationUuid' | 'providerApiKeysSet'>
+> & {
+    providerApiKeys?: UpdateAiProviderApiKeys;
+};
 
 export type ApiAiOrganizationSettingsResponse = ApiSuccess<
     AiOrganizationSettings & ComputedAiOrganizationSettings

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -309,6 +309,11 @@ export enum FeatureFlags {
      * is presence-of-feature, not permission.
      */
     CodingAgent = 'ai-coding-agent',
+
+    /**
+     * Let org admins set their own Anthropic/OpenAI API keys for AI agents.
+     */
+    OrgAiProviderApiKeys = 'org-ai-provider-api-keys',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
## Summary

Part 1/5 of the **BYO org AI provider API keys** stack: org admins will be able to store their organization's own Anthropic/OpenAI API key for Ask AI, encrypted at rest, gated behind the `org-ai-provider-api-keys` feature flag.

This PR adds the storage layer:

- **Common types**: `providerApiKeysSet: { anthropic, openai }` (read side, booleans only) and `providerApiKeys: { anthropic?: string | null; openai?: string | null }` (write side: string = set, `null` = remove) on the AI organization settings types, plus the `FeatureFlags.OrgAiProviderApiKeys` enum entry.
- **Migration**: nullable `encrypted_provider_api_keys bytea` on `ai_organization_settings`. Additive and reversible; no data mutation.
- **Model**: `AiOrganizationSettingsModel` now takes `EncryptionUtil` (AES-256-GCM keyed off `LIGHTDASH_SECRET`, same pattern as warehouse credentials) and stores the keys as an encrypted JSON blob. Raw keys never leave the model — reads only expose `providerApiKeysSet` booleans; `findDecryptedProviderApiKeys` is backend-internal. Key updates run in a transaction with a `SELECT … FOR UPDATE` row lock to prevent lost updates on concurrent PATCHes. Decrypt failures (e.g. rotated `LIGHTDASH_SECRET`) degrade to "no keys" with a warning log instead of throwing.

## Regression analysis

- **No behavior change until the flag is enabled** — and even then, nothing changes until an org stores a key (later PRs in the stack wire the read/write paths).
- The new column is nullable; old code running against the migrated schema during a rolling deploy is unaffected.
- `AiOrganizationSettings` gains a required `providerApiKeysSet` field — all existing constructors/mocks in the repo were updated in this PR.
- System roles / custom roles / service accounts: no permission surface changes here.

### Key hints (added after review feedback)

Org admins see a partially-redacted hint of each stored key, matching provider practice ([Anthropic `partial_key_hint`](https://platform.claude.com/docs/en/api/admin-api/apikeys/get-api-key): `sk-ant-api03-R2D...igAA`; OpenAI dashboard: `sk-...j3kl`). Hints live in a new `provider_api_key_hints` jsonb column (same single migration), are computed from the plaintext at write time via `buildProviderApiKeyHint` (prefix + 3 chars + `...` + last 4; short keys degrade to `<first 2>...`), and are written in the same statement/transaction as the encrypted blob so they cannot diverge. Hints are the only key-derived material ever exposed.

## Tests

- TDD'd pure merge helper `applyProviderApiKeyUpdates` (set/trim, merge, null-removal, empty-key `ParameterError`).
- Migration verified against a live DB (`\d ai_organization_settings`).

Follow-up planned: encrypt/decrypt round-trip test at the model layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A86u7EfarsqNDPMwh9m3cv