### PR TITLE
feat(backend): resolve org AI provider keys in AiAgentService model calls

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -204,6 +204,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getExternalConnectionModel(),
                     sandboxRegistryModel:
                         models.getSandboxRegistryModel<SandboxRegistryModel>(),
+                    orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
+                        lightdashConfig: context.lightdashConfig,
+                        aiOrganizationSettingsModel:
+                            models.getAiOrganizationSettingsModel(),
+                        featureFlagService: repository.getFeatureFlagService(),
+                    }),
                 }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({
@@ -240,6 +246,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     openAi: new OpenAi(
                         context.lightdashConfig.ai.copilot.providers.openai,
                     ), // TODO This should go in client repository as soon as it is available
+                    orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
+                        lightdashConfig: context.lightdashConfig,
+                        aiOrganizationSettingsModel:
+                            models.getAiOrganizationSettingsModel(),
+                        featureFlagService: repository.getFeatureFlagService(),
+                    }),
                 }),
             aiAgentToolsService: ({ models, repository, context }) =>
                 new AiAgentToolsService({
@@ -401,6 +413,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiRouterModel: models.getAiRouterModel<AiRouterModel>(),
                     aiAgentService:
                         repository.getAiAgentService<AiAgentService>(),
+                    orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
+                        lightdashConfig: context.lightdashConfig,
+                        aiOrganizationSettingsModel:
+                            models.getAiOrganizationSettingsModel(),
+                        featureFlagService: repository.getFeatureFlagService(),
+                    }),
                 }),
             aiAgentDocumentService: ({ models, repository, context }) =>
                 new AiAgentDocumentService({
@@ -412,6 +430,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentService:
                         repository.getAiAgentService<AiAgentService>(),
                     lightdashConfig: context.lightdashConfig,
+                    orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
+                        lightdashConfig: context.lightdashConfig,
+                        aiOrganizationSettingsModel:
+                            models.getAiOrganizationSettingsModel(),
+                        featureFlagService: repository.getFeatureFlagService(),
+                    }),
                 }),
             aiAgentReviewClassifierService: ({ models, repository, context }) =>
                 new AiAgentReviewClassifierService({

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -317,6 +317,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     contentService: repository.getContentService(),
                     aiOrganizationSettingsService:
                         repository.getAiOrganizationSettingsService(),
+                    orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
+                        lightdashConfig: context.lightdashConfig,
+                        aiOrganizationSettingsModel:
+                            models.getAiOrganizationSettingsModel(),
+                        featureFlagService: repository.getFeatureFlagService(),
+                    }),
                     shareService: repository.getShareService(),
                     fileStorageClient: clients.getFileStorageClient(),
                     downloadFileModel: models.getDownloadFileModel(),

--- a/packages/backend/src/ee/services/AiAgentDocumentService.ts
+++ b/packages/backend/src/ee/services/AiAgentDocumentService.ts
@@ -27,6 +27,7 @@ import {
     generateDocumentSummary,
 } from './ai/agents/documentSummaryGenerator';
 import { getModel } from './ai/models';
+import { OrgAiCopilotConfigResolver } from './ai/OrgAiCopilotConfigResolver';
 import type { AiAgentService } from './AiAgentService/AiAgentService';
 
 const ALLOWED_MIME_TYPES = new Set([
@@ -67,6 +68,7 @@ type AiAgentDocumentServiceDependencies = {
     commercialFeatureFlagModel: CommercialFeatureFlagModel;
     aiAgentService: AiAgentService;
     lightdashConfig: LightdashConfig;
+    orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
 
 export class AiAgentDocumentService extends BaseService {
@@ -80,6 +82,8 @@ export class AiAgentDocumentService extends BaseService {
 
     private readonly lightdashConfig: LightdashConfig;
 
+    private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
+
     constructor(dependencies: AiAgentDocumentServiceDependencies) {
         super();
         this.analytics = dependencies.analytics;
@@ -88,6 +92,8 @@ export class AiAgentDocumentService extends BaseService {
             dependencies.commercialFeatureFlagModel;
         this.aiAgentService = dependencies.aiAgentService;
         this.lightdashConfig = dependencies.lightdashConfig;
+        this.orgAiCopilotConfigResolver =
+            dependencies.orgAiCopilotConfigResolver;
     }
 
     /**
@@ -261,8 +267,12 @@ export class AiAgentDocumentService extends BaseService {
             user,
             body,
         );
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                organizationUuid,
+            );
         const modelOptions = {
-            ...getModel(this.lightdashConfig.ai.copilot, {
+            ...getModel(copilotConfig, {
                 enableReasoning: false,
                 useFastModel: true,
             }),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -240,6 +240,7 @@ import {
     getModel,
 } from '../ai/models';
 import { matchesPreset } from '../ai/models/presets';
+import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
 import {
     requestingUserRoleFromCustomRole,
     requestingUserRoleFromSystemRole,
@@ -392,6 +393,7 @@ type AiAgentServiceDependencies = {
     savedChartService: SavedChartService;
     contentService: ContentService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
+    orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
     shareService: ShareService;
     fileStorageClient: FileStorageClient;
     downloadFileModel: DownloadFileModel;
@@ -641,6 +643,8 @@ export class AiAgentService extends BaseService {
     private readonly prometheusMetrics?: PrometheusMetrics;
 
     private readonly aiOrganizationSettingsService: AiOrganizationSettingsService;
+
+    private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 
     private readonly shareService: ShareService;
 
@@ -943,6 +947,8 @@ export class AiAgentService extends BaseService {
         this.prometheusMetrics = dependencies.prometheusMetrics;
         this.aiOrganizationSettingsService =
             dependencies.aiOrganizationSettingsService;
+        this.orgAiCopilotConfigResolver =
+            dependencies.orgAiCopilotConfigResolver;
         this.shareService = dependencies.shareService;
         this.fileStorageClient = dependencies.fileStorageClient;
         this.downloadFileModel = dependencies.downloadFileModel;
@@ -1682,7 +1688,11 @@ export class AiAgentService extends BaseService {
         let modelId = 'fallback';
 
         try {
-            const modelOptions = getModel(this.lightdashConfig.ai.copilot, {
+            const copilotConfig =
+                await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                    organizationUuid,
+                );
+            const modelOptions = getModel(copilotConfig, {
                 enableReasoning: false,
                 useFastModel: true,
             });
@@ -2113,25 +2123,27 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        const defaultModel = getDefaultModel(this.lightdashConfig.ai.copilot);
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                organizationUuid,
+            );
+        const defaultModel = getDefaultModel(copilotConfig);
 
-        return getAvailableModels(this.lightdashConfig.ai.copilot).map(
-            (preset) => {
-                const isDefault =
-                    defaultModel !== null &&
-                    preset.provider === defaultModel.provider &&
-                    matchesPreset(preset, defaultModel.name);
+        return getAvailableModels(copilotConfig).map((preset) => {
+            const isDefault =
+                defaultModel !== null &&
+                preset.provider === defaultModel.provider &&
+                matchesPreset(preset, defaultModel.name);
 
-                return {
-                    name: preset.name,
-                    displayName: preset.displayName,
-                    description: preset.description,
-                    provider: preset.provider,
-                    default: isDefault,
-                    supportsReasoning: preset.supportsReasoning,
-                };
-            },
-        );
+            return {
+                name: preset.name,
+                displayName: preset.displayName,
+                description: preset.description,
+                provider: preset.provider,
+                default: isDefault,
+                supportsReasoning: preset.supportsReasoning,
+            };
+        });
     }
 
     async listAgentThreads(
@@ -3996,6 +4008,10 @@ export class AiAgentService extends BaseService {
         // Web-app only for now. Slack still needs compaction UX + thread replay
         // semantics before we can safely reuse this flow there.
         const compactionLogContext = `[AiAgent][Compaction] thread=${threadUuid} prompt=${prompt.promptUuid}`;
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                user.organizationUuid ?? null,
+            );
         const latestCompaction =
             await this.aiAgentModel.findLatestThreadCompaction(threadUuid);
 
@@ -4019,7 +4035,7 @@ export class AiAgentService extends BaseService {
         }
 
         const { supportsCompaction, contextWindowTokens } =
-            getCompactionModelMetadata(this.lightdashConfig.ai.copilot, {
+            getCompactionModelMetadata(copilotConfig, {
                 provider: prompt.modelConfig?.modelProvider as AnyType,
                 modelName: prompt.modelConfig?.modelName,
             });
@@ -4094,7 +4110,7 @@ export class AiAgentService extends BaseService {
         }
 
         const compactionModel = {
-            ...getModel(this.lightdashConfig.ai.copilot, {
+            ...getModel(copilotConfig, {
                 provider: prompt.modelConfig?.modelProvider as AnyType,
                 modelName: prompt.modelConfig?.modelName,
                 useFastModel: true,
@@ -4787,8 +4803,12 @@ export class AiAgentService extends BaseService {
                 });
 
             // Use fast model for title generation (lightweight task)
+            const copilotConfig =
+                await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                    user.organizationUuid ?? null,
+                );
             const modelOptions = {
-                ...getModel(this.lightdashConfig.ai.copilot, {
+                ...getModel(copilotConfig, {
                     enableReasoning: false,
                     useFastModel: true,
                 }),
@@ -4847,7 +4867,11 @@ export class AiAgentService extends BaseService {
             agent.tags,
         );
 
-        const { model } = getModel(this.lightdashConfig.ai.copilot, {
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                user.organizationUuid ?? null,
+            );
+        const { model } = getModel(copilotConfig, {
             enableReasoning: false,
         });
 
@@ -7756,7 +7780,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const availableSkills = canUseContentTools
             ? await this.aiAgentToolsService.listAgentSkills()
             : [];
-        const modelProperties = getModel(this.lightdashConfig.ai.copilot, {
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                promptProject.organizationUuid,
+            );
+        const modelProperties = getModel(copilotConfig, {
             enableReasoning: prompt.modelConfig?.reasoning,
             modelName: prompt.modelConfig?.modelName,
             provider: prompt.modelConfig?.modelProvider as AnyType,
@@ -10581,7 +10609,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         // sets the project for this thread and all subsequent messages.
         if (promptText.trim().length > 0) {
             try {
-                const { model } = getModel(this.lightdashConfig.ai.copilot);
+                const copilotConfig =
+                    await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                        organizationUuid,
+                    );
+                const { model } = getModel(copilotConfig);
                 const routedProjectUuid = await routeProjectForSlack(
                     model,
                     candidateProjects.map((project) => ({
@@ -10694,7 +10726,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             };
         }
 
-        const { model } = getModel(this.lightdashConfig.ai.copilot);
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                organizationUuid,
+            );
+        const { model } = getModel(copilotConfig);
 
         const decision = await selectAgent({
             model,

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -120,14 +120,25 @@ const makeService = ({
         getAvailableAgents: vi.fn().mockResolvedValue(candidates),
     };
 
+    const orgAiCopilotConfigResolver = {
+        getCopilotConfig: vi.fn().mockResolvedValue({}),
+    };
+
     const service = new AiRouterService({
         analytics: analytics as never,
         lightdashConfig: { ai: { copilot: {} } } as never,
         aiRouterModel: aiRouterModel as never,
         aiAgentService: aiAgentService as never,
+        orgAiCopilotConfigResolver: orgAiCopilotConfigResolver as never,
     });
 
-    return { service, analytics, aiRouterModel, aiAgentService };
+    return {
+        service,
+        analytics,
+        aiRouterModel,
+        aiAgentService,
+        orgAiCopilotConfigResolver,
+    };
 };
 
 describe('AiRouterService', () => {

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -25,6 +25,7 @@ import { BaseService } from '../../../services/BaseService';
 import { type AiRouterModel } from '../../models/AiRouterModel';
 import { selectAgent } from '../ai/agents/agentSelector';
 import { getModel } from '../ai/models';
+import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
 import { type AiAgentService } from '../AiAgentService/AiAgentService';
 
 type Deps = {
@@ -32,6 +33,7 @@ type Deps = {
     lightdashConfig: LightdashConfig;
     aiRouterModel: AiRouterModel;
     aiAgentService: AiAgentService;
+    orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
 
 type RoutePromptMode = 'web' | 'mcp';
@@ -55,17 +57,21 @@ export class AiRouterService extends BaseService {
 
     private readonly aiAgentService: AiAgentService;
 
+    private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
+
     constructor({
         analytics,
         lightdashConfig,
         aiRouterModel,
         aiAgentService,
+        orgAiCopilotConfigResolver,
     }: Deps) {
         super({ serviceName: 'AiRouterService' });
         this.analytics = analytics;
         this.lightdashConfig = lightdashConfig;
         this.aiRouterModel = aiRouterModel;
         this.aiAgentService = aiAgentService;
+        this.orgAiCopilotConfigResolver = orgAiCopilotConfigResolver;
     }
 
     private static organizationUuidOf(account: RegisteredAccount): string {
@@ -172,7 +178,11 @@ export class AiRouterService extends BaseService {
             projectUuid,
         });
 
-        const { model } = getModel(this.lightdashConfig.ai.copilot);
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                organizationUuid,
+            );
+        const { model } = getModel(copilotConfig);
         const brain = await selectAgent({
             model,
             candidates,

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -57,6 +57,7 @@ import { generateTooltip as generateTooltipFromContext } from '../ai/agents/tool
 import { getModel } from '../ai/models';
 import { getAnthropicModel } from '../ai/models/anthropic-claude';
 import { getModelPreset } from '../ai/models/presets';
+import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
 import { AiCallAttribution } from '../ai/utils/aiCallTelemetry';
 import { convertQueryResultsToCsv } from '../ai/utils/convertQueryResultsToCsv';
 import { fieldDesc, formatSummaryArray } from './utils/prepareData';
@@ -85,6 +86,7 @@ type Dependencies = {
     openAi: OpenAi;
     lightdashConfig: LightdashConfig;
     featureFlagService: FeatureFlagService;
+    orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
 
 export class AiService {
@@ -106,6 +108,8 @@ export class AiService {
 
     private readonly featureFlagService: FeatureFlagService;
 
+    private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
+
     constructor(dependencies: Dependencies) {
         this.analytics = dependencies.analytics;
         this.dashboardModel = dependencies.dashboardModel;
@@ -116,6 +120,8 @@ export class AiService {
         this.openAi = dependencies.openAi;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.featureFlagService = dependencies.featureFlagService;
+        this.orgAiCopilotConfigResolver =
+            dependencies.orgAiCopilotConfigResolver;
     }
 
     /**
@@ -136,8 +142,12 @@ export class AiService {
             projectUuid: telemetry?.projectUuid ?? null,
         };
 
-        const anthropicConfig =
-            this.lightdashConfig.ai.copilot.providers.anthropic;
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                user.organizationUuid ?? null,
+            );
+
+        const anthropicConfig = copilotConfig.providers.anthropic;
 
         if (anthropicConfig?.apiKey) {
             const preset = getModelPreset('anthropic', 'claude-haiku-4-5');
@@ -164,7 +174,7 @@ export class AiService {
         }
 
         return {
-            ...getModel(this.lightdashConfig.ai.copilot, {
+            ...getModel(copilotConfig, {
                 enableReasoning: false,
                 useFastModel: true,
             }),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -107,6 +107,7 @@ function buildService() {
         promoteService: {} as never,
         externalConnectionModel: {} as never,
         sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
     });
 
     // Stub ability checks to allow everything

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
@@ -80,6 +80,7 @@ function buildService() {
         promoteService: {} as never,
         externalConnectionModel: {} as never,
         sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
     });
 
     const service = raw as unknown as ServiceWithPrivates;

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -57,6 +57,7 @@ function buildService(
         promoteService: {} as never,
         externalConnectionModel: {} as never,
         sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
     });
     // Bypass real CASL — the mapping/flow is what these tests cover.
     (

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -78,6 +78,7 @@ function buildService(appModel: unknown) {
         promoteService: {} as never,
         externalConnectionModel: {} as never,
         sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
     });
     // Bypass real CASL — the mapping/flow is what these tests cover.
     (

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -76,6 +76,7 @@ function buildService() {
             promoteService: {} as never,
             externalConnectionModel: {} as never,
             sandboxRegistryModel: {} as never,
+            orgAiCopilotConfigResolver: {} as never,
         }) as unknown as PrivateWithSamples,
         featureFlagModel,
     };

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -212,6 +212,7 @@ function buildService(overrides: {
         promoteService: {} as never,
         externalConnectionModel: {} as never,
         sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
     });
 
     if (s3ClientOverride) {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -104,6 +104,7 @@ import { type ExternalConnectionModel } from '../../models/ExternalConnectionMod
 import type { SandboxRegistryModel } from '../../models/SandboxRegistryModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
+import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
 import { getAiCallTelemetry } from '../ai/utils/aiCallTelemetry';
 import {
     createSandboxManager,
@@ -199,6 +200,7 @@ type AppGenerateServiceDeps = {
     promoteService: PromoteService;
     externalConnectionModel: ExternalConnectionModel;
     sandboxRegistryModel: SandboxRegistryModel;
+    orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
 
 type GenerateAppOptions = {
@@ -275,6 +277,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly sandboxRegistryModel: SandboxRegistryModel;
 
+    private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
+
     // Lazily built from config on first use; memoized for the service lifetime.
     private sandboxManager: SandboxManager | undefined;
 
@@ -298,6 +302,7 @@ export class AppGenerateService extends BaseService {
         promoteService,
         externalConnectionModel,
         sandboxRegistryModel,
+        orgAiCopilotConfigResolver,
     }: AppGenerateServiceDeps) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -319,6 +324,7 @@ export class AppGenerateService extends BaseService {
         this.promoteService = promoteService;
         this.externalConnectionModel = externalConnectionModel;
         this.sandboxRegistryModel = sandboxRegistryModel;
+        this.orgAiCopilotConfigResolver = orgAiCopilotConfigResolver;
     }
 
     /**
@@ -3652,7 +3658,10 @@ export class AppGenerateService extends BaseService {
             throw new ParameterError('Prompt is required');
         }
 
-        const { copilot } = this.lightdashConfig.ai;
+        const copilot =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                organizationUuid,
+            );
         const llmProvider: 'anthropic' | 'bedrock' =
             copilot.defaultProvider === 'bedrock' ? 'bedrock' : 'anthropic';
 


### PR DESCRIPTION
## Summary

Part 4/5 of the **BYO org AI provider API keys** stack.

Threads the org-resolved copilot config through every org-contextable model-factory call:

- **`AiAgentService`** (8 sites): agent suggestions, model listing, thread compaction (metadata + model, resolved once per method), thread-title generation, agent readiness, main chat streaming (org of the prompt's project), and both Slack routing paths.
- **Satellite services**: `AiAgentDocumentService` (doc summarization), `AiRouterService`, `AiService` (ambient AI, including its direct anthropic-config read), `AppGenerateService` (data-app clarification).

Deliberately **left on the instance key** (v1 non-goals): embeddings, the review-classifier LLM judge, the eval judge (`assessResult`), and `generateArtifactQuestion` (scheduler payload has no org uuid). Instance-level reads (`maxQueryLimit`, `debugLoggingEnabled`, etc.) stay global. The `AppGenerateService` Claude-Code sandbox env also stays on the instance key (CLI-style billing; noted as a consistency follow-up).

## Regression analysis

- **Flag off (default) or no org keys stored: byte-for-byte identical model config** — the resolver returns the instance config, so all orgs today see zero change.
- With flag on + org key set, that org's chat/utility AI calls use the org key; all other orgs unaffected (config resolved per organization per call; no shared client state — `getModel` already builds a fresh client per call).
- New failure/latency surface: model resolution now does a flag lookup + settings read per call in these paths. Failure behaves like any other DB error in the same methods. If it shows in traces, a short-TTL memo on `getCopilotConfig` is the planned mitigation.
- Service accounts / system roles / custom roles: unaffected — no permission changes.

## Verified

Residual grep confirms the only remaining `lightdashConfig.ai.copilot` model-factory reads are the two excluded methods; org-uuid origin of every threaded site verified from source (including `promptProject.organizationUuid` = the prompt's project org). E2E (top of stack): an invalid org key produces a real Anthropic 401 in the agent thread; removing the key falls back to the instance key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A86u7EfarsqNDPMwh9m3cv