### PR TITLE
feat(ai): bridge AI artifact verification to content_verification

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2152,6 +2152,7 @@ export type ContentVerificationEvent = BaseTrack & {
         projectId: string;
         contentType: ContentType;
         contentId: string;
+        source?: 'ai_artifact';
     };
 };
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -4602,6 +4602,14 @@ export class AiAgentModel {
             });
     }
 
+    async findPromptSavedQueryUuid(promptUuid: string): Promise<string | null> {
+        const row = await this.database(AiPromptTableName)
+            .select('saved_query_uuid')
+            .where({ ai_prompt_uuid: promptUuid })
+            .first<{ saved_query_uuid: string | null }>();
+        return row?.saved_query_uuid ?? null;
+    }
+
     async updateMessageSavedQuery(data: {
         messageUuid: string;
         savedQueryUuid: string | null;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -149,6 +149,7 @@ import {
     AiAgentSuggestionSubmitEvent,
     AiAgentToolCallEvent,
     AiAgentUpdatedEvent,
+    ContentVerificationEvent,
     LightdashAnalytics,
 } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
@@ -5319,6 +5320,65 @@ export class AiAgentService extends BaseService {
         });
     }
 
+    // Bridges AI artifact verification to the content_verification table
+    private async syncSavedContentVerification(
+        user: SessionUser,
+        organizationUuid: string,
+        projectUuid: string,
+        {
+            savedQueryUuid,
+            savedDashboardUuid,
+            verified,
+        }: {
+            savedQueryUuid: string | null;
+            savedDashboardUuid: string | null;
+            verified: boolean;
+        },
+    ): Promise<void> {
+        let savedContent: { contentType: ContentType; contentUuid: string };
+        if (savedQueryUuid) {
+            savedContent = {
+                contentType: ContentType.CHART,
+                contentUuid: savedQueryUuid,
+            };
+        } else if (savedDashboardUuid) {
+            savedContent = {
+                contentType: ContentType.DASHBOARD,
+                contentUuid: savedDashboardUuid,
+            };
+        } else {
+            return;
+        }
+
+        if (verified) {
+            await this.contentVerificationModel.verify(
+                savedContent.contentType,
+                savedContent.contentUuid,
+                projectUuid,
+                user.userUuid,
+            );
+        } else {
+            await this.contentVerificationModel.unverify(
+                savedContent.contentType,
+                savedContent.contentUuid,
+            );
+        }
+
+        this.analytics.track<ContentVerificationEvent>({
+            event: verified
+                ? 'content_verification.created'
+                : 'content_verification.deleted',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                contentType: savedContent.contentType,
+                contentId: savedContent.contentUuid,
+                source: 'ai_artifact',
+            },
+        });
+    }
+
     async setArtifactVersionVerified(
         user: SessionUser,
         {
@@ -5390,6 +5450,26 @@ export class AiAgentService extends BaseService {
             versionUuid,
             verified,
             user.userUuid,
+        );
+
+        // Charts saved from the web app link to the prompt, not the artifact version
+        const savedQueryUuid =
+            artifact.savedQueryUuid ??
+            (artifact.promptUuid
+                ? await this.aiAgentModel.findPromptSavedQueryUuid(
+                      artifact.promptUuid,
+                  )
+                : null);
+
+        await this.syncSavedContentVerification(
+            user,
+            organizationUuid,
+            agent.projectUuid,
+            {
+                savedQueryUuid,
+                savedDashboardUuid: artifact.savedDashboardUuid,
+                verified,
+            },
         );
 
         this.analytics.track<AiAgentArtifactVersionVerifiedEvent>({

--- a/packages/backend/src/ee/services/AiAgentService/contentVerificationBridge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/contentVerificationBridge.test.ts
@@ -1,0 +1,209 @@
+import { ContentType, type SessionUser } from '@lightdash/common';
+import { AiAgentService } from './AiAgentService';
+
+vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+const ORGANIZATION_UUID = 'org-uuid';
+const PROJECT_UUID = 'project-uuid';
+const USER_UUID = 'user-uuid';
+const AGENT_UUID = 'agent-uuid';
+const ARTIFACT_UUID = 'artifact-uuid';
+const VERSION_UUID = 'version-uuid';
+const PROMPT_UUID = 'prompt-uuid';
+
+const user = {
+    userUuid: USER_UUID,
+    organizationUuid: ORGANIZATION_UUID,
+    ability: {
+        can: vi.fn(() => true),
+        cannot: vi.fn(() => false),
+        relevantRuleFor: vi.fn(() => undefined),
+        rules: [],
+    },
+} as unknown as SessionUser;
+
+const makeArtifact = (overrides: {
+    savedQueryUuid?: string | null;
+    savedDashboardUuid?: string | null;
+}) => ({
+    artifactUuid: ARTIFACT_UUID,
+    versionUuid: VERSION_UUID,
+    promptUuid: PROMPT_UUID,
+    title: 'Artifact title',
+    description: null,
+    savedQueryUuid: overrides.savedQueryUuid ?? null,
+    savedDashboardUuid: overrides.savedDashboardUuid ?? null,
+});
+
+const buildService = ({
+    artifact,
+    promptSavedQueryUuid = null,
+}: {
+    artifact: ReturnType<typeof makeArtifact>;
+    promptSavedQueryUuid?: string | null;
+}) => {
+    const contentVerificationModel = {
+        verify: vi.fn().mockResolvedValue(undefined),
+        unverify: vi.fn().mockResolvedValue(undefined),
+    };
+    const analytics = { track: vi.fn() };
+    const aiAgentModel = {
+        getAgent: vi.fn().mockResolvedValue({
+            name: 'Agent',
+            projectUuid: PROJECT_UUID,
+        }),
+        getArtifact: vi.fn().mockResolvedValue(artifact),
+        setArtifactVersionVerified: vi.fn().mockResolvedValue(undefined),
+        findPromptSavedQueryUuid: vi
+            .fn()
+            .mockResolvedValue(promptSavedQueryUuid),
+        getArtifactEmbedding: vi.fn().mockResolvedValue({
+            embedding: [],
+            provider: 'test',
+            model: 'test',
+        }),
+        getArtifactQuestion: vi.fn().mockResolvedValue('Existing question'),
+    };
+    const featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: true }),
+    };
+    const service = new AiAgentService({
+        aiAgentModel,
+        contentVerificationModel,
+        analytics,
+        featureFlagService,
+        lightdashConfig: {
+            siteUrl: 'https://app.example.com',
+            ai: { copilot: { embeddingEnabled: true } },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    return { service, contentVerificationModel, analytics, aiAgentModel };
+};
+
+const setVerified = (service: AiAgentService, verified: boolean) =>
+    service.setArtifactVersionVerified(user, {
+        agentUuid: AGENT_UUID,
+        artifactUuid: ARTIFACT_UUID,
+        versionUuid: VERSION_UUID,
+        verified,
+    });
+
+describe('AiAgentService content verification bridge', () => {
+    it('verifying an artifact saved as a chart (via prompt) writes a chart verification and tracks source ai_artifact', async () => {
+        const { service, contentVerificationModel, analytics } = buildService({
+            artifact: makeArtifact({}),
+            promptSavedQueryUuid: 'chart-uuid',
+        });
+
+        await setVerified(service, true);
+
+        expect(contentVerificationModel.verify).toHaveBeenCalledWith(
+            ContentType.CHART,
+            'chart-uuid',
+            PROJECT_UUID,
+            USER_UUID,
+        );
+        expect(analytics.track).toHaveBeenCalledWith({
+            event: 'content_verification.created',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                contentType: ContentType.CHART,
+                contentId: 'chart-uuid',
+                source: 'ai_artifact',
+            },
+        });
+    });
+
+    it('prefers the artifact version chart link over the prompt link', async () => {
+        const { service, contentVerificationModel, aiAgentModel } =
+            buildService({
+                artifact: makeArtifact({ savedQueryUuid: 'version-chart' }),
+                promptSavedQueryUuid: 'prompt-chart',
+            });
+
+        await setVerified(service, true);
+
+        expect(aiAgentModel.findPromptSavedQueryUuid).not.toHaveBeenCalled();
+        expect(contentVerificationModel.verify).toHaveBeenCalledWith(
+            ContentType.CHART,
+            'version-chart',
+            PROJECT_UUID,
+            USER_UUID,
+        );
+    });
+
+    it('verifying an artifact saved as a dashboard writes a dashboard verification', async () => {
+        const { service, contentVerificationModel, analytics } = buildService({
+            artifact: makeArtifact({ savedDashboardUuid: 'dashboard-uuid' }),
+        });
+
+        await setVerified(service, true);
+
+        expect(contentVerificationModel.verify).toHaveBeenCalledWith(
+            ContentType.DASHBOARD,
+            'dashboard-uuid',
+            PROJECT_UUID,
+            USER_UUID,
+        );
+        expect(analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'content_verification.created',
+                properties: expect.objectContaining({
+                    contentType: ContentType.DASHBOARD,
+                    contentId: 'dashboard-uuid',
+                    source: 'ai_artifact',
+                }),
+            }),
+        );
+    });
+
+    it('unverifying removes the verification and tracks the deletion', async () => {
+        const { service, contentVerificationModel, analytics } = buildService({
+            artifact: makeArtifact({}),
+            promptSavedQueryUuid: 'chart-uuid',
+        });
+
+        await setVerified(service, false);
+
+        expect(contentVerificationModel.unverify).toHaveBeenCalledWith(
+            ContentType.CHART,
+            'chart-uuid',
+        );
+        expect(contentVerificationModel.verify).not.toHaveBeenCalled();
+        expect(analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'content_verification.deleted',
+                properties: expect.objectContaining({
+                    source: 'ai_artifact',
+                }),
+            }),
+        );
+    });
+
+    it('does nothing for artifacts not persisted as saved content', async () => {
+        const { service, contentVerificationModel, analytics } = buildService({
+            artifact: makeArtifact({}),
+            promptSavedQueryUuid: null,
+        });
+
+        await setVerified(service, true);
+
+        expect(contentVerificationModel.verify).not.toHaveBeenCalled();
+        expect(contentVerificationModel.unverify).not.toHaveBeenCalled();
+        expect(analytics.track).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'content_verification.created',
+            }),
+        );
+    });
+});


### PR DESCRIPTION
Closes: PROD-7127.

## What changed

When `AiAgentService.setArtifactVersionVerified` runs and the artifact version is already persisted as a saved chart (`saved_query_uuid`) or dashboard (`saved_dashboard_uuid`), the verification now also writes to (`verified=true`) or removes from (`verified=false`) the `content_verification` table.

Both analytics events fire, as scoped in the ticket: `ai_agent.artifact_version_verified` plus `content_verification.created`/`.deleted`. The `ContentVerificationEvent` gains an optional `source?: 'ai_artifact'` property, sent only by the bridge, so bridge-created verifications are attributable in analytics. Existing manual and content-as-code call sites are untouched (events without `source` = non-bridge).

## Why

Admin verification and AI artifact verification were fully decoupled — verifying an AI-generated chart was invisible to the verified badge, content-as-code YAML, the MCP `list_verified_content` tool, and search. This is the minimum-viable convergence.

## Out of scope (per ticket)

- Reverse direction (admin-verifying a chart does not backlink to the artifact).
- Full table-level merge of `ai_artifact_versions.verified_*` into `content_verification`.
- Artifacts saved as charts/dashboards _after_ being verified don't retroactively bridge.

## Regression analysis

- Unverifying an AI artifact now deletes the `content_verification` row for its saved content — this can remove a verification an admin created manually on the same chart. Accepted per ticket scope (unverify should be symmetric); the alternative (leaving stale verified badges) is worse.
- Analytics: `source` is a new property on an existing event; downstream dashboards keyed on event name are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXYVLs8UWL1BLhHY6gM2o

## Local verification (ran live against dev stack)

- `PATCH .../versions/{uuid}/verified {verified: true}` on an artifact linked to a saved **chart** → `content_verification` row created, attributed to the verifying user; the verified badge renders on the chart. `{verified: false}` deletes the row.
- Same flow with a **dashboard**\-type artifact → `dashboard` row created; the green verified badge renders on the dashboard page (screenshot taken from the live UI).

## Known edge case (out of scope, documented)

If two versions of the same artifact are verified and the newer one is unverified, the bridge deletes the `content_verification` row while the older version remains verified in `ai_artifact_versions`. Confirmed live. Follow-up candidate alongside the verify-then-save gap (verifying an artifact _before_ saving it as content doesn't bridge retroactively).

## Fix after end-to-end UI testing

Driving the real web flow (Ask AI prompt → save chart → "Add to verified answers") surfaced that `ai_artifact_versions.saved_query_uuid` is **never written by any code path** — charts saved from the web app link via `ai_prompt.saved_query_uuid` instead (only dashboards populate the artifact-version column). The bridge now falls back to the prompt link for charts. Verified end-to-end in the running app: AI-generated chart saved via the UI gets the verified badge the moment its artifact is added to verified answers.