### PR TITLE
feat(mcp): include AI-verified saved artifacts in list_verified_content

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -51,6 +51,7 @@ import {
     ApiUpdateEvaluationRequest,
     assertUnreachable,
     ChartKind,
+    ContentType,
     CreateLlmAssessment,
     CreateSlackPrompt,
     CreateSlackThread,
@@ -77,6 +78,7 @@ import {
     UpdateWebAppResponse,
     type AiAgent,
     type AiAgentIntegration,
+    type VerifiedContentListItem,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import moment from 'moment';
@@ -92,6 +94,7 @@ import {
     SavedChartsTableName,
     SavedChartVersionsTableName,
 } from '../../database/entities/savedCharts';
+import { SpaceTableName } from '../../database/entities/spaces';
 import { DbUser, UserTableName } from '../../database/entities/users';
 import { isUniqueConstraintViolation } from '../../database/errors';
 import KnexPaginate from '../../database/pagination';
@@ -4651,6 +4654,190 @@ export class AiAgentModel {
             .where({
                 ai_artifact_version_uuid: artifactVersionUuid,
             });
+    }
+
+    async getVerifiedSavedArtifactContent(
+        projectUuid: string,
+    ): Promise<VerifiedContentListItem[]> {
+        const chartRows = await this.database(AiArtifactVersionsTableName)
+            .leftJoin(
+                AiPromptTableName,
+                `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+                `${AiPromptTableName}.ai_prompt_uuid`,
+            )
+            // Charts saved from the web app link to the prompt, not the artifact version
+            .innerJoin(
+                SavedChartsTableName,
+                `${SavedChartsTableName}.saved_query_uuid`,
+                this.database.raw(
+                    `coalesce(${AiArtifactVersionsTableName}.saved_query_uuid, ${AiPromptTableName}.saved_query_uuid)`,
+                ),
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SavedChartsTableName}.space_id`,
+                `${SpaceTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${SpaceTableName}.project_id`,
+                `${ProjectTableName}.project_id`,
+            )
+            .leftJoin(
+                UserTableName,
+                `${AiArtifactVersionsTableName}.verified_by_user_uuid`,
+                `${UserTableName}.user_uuid`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNotNull(`${AiArtifactVersionsTableName}.verified_at`)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .distinctOn(`${SavedChartsTableName}.saved_query_uuid`)
+            .orderBy([
+                { column: `${SavedChartsTableName}.saved_query_uuid` },
+                {
+                    column: `${AiArtifactVersionsTableName}.verified_at`,
+                    order: 'desc',
+                },
+            ])
+            .select(
+                this.database
+                    .ref(
+                        `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                    )
+                    .as('verification_uuid'),
+                this.database
+                    .ref(`${SavedChartsTableName}.saved_query_uuid`)
+                    .as('content_uuid'),
+                `${SavedChartsTableName}.name`,
+                `${SavedChartsTableName}.description`,
+                `${SavedChartsTableName}.views_count`,
+                `${SavedChartsTableName}.last_version_chart_kind`,
+                this.database
+                    .ref(`${SavedChartsTableName}.last_version_updated_at`)
+                    .as('last_updated_at'),
+                this.database(SavedChartVersionsTableName)
+                    .select('explore_name')
+                    .whereRaw(
+                        `${SavedChartVersionsTableName}.saved_query_id = ${SavedChartsTableName}.saved_query_id`,
+                    )
+                    .orderBy('created_at', 'desc')
+                    .limit(1)
+                    .as('explore_name'),
+                `${SpaceTableName}.space_uuid`,
+                this.database.ref(`${SpaceTableName}.name`).as('space_name'),
+                `${UserTableName}.user_uuid`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
+                `${AiArtifactVersionsTableName}.verified_at`,
+            );
+
+        const dashboardRows = await this.database(AiArtifactVersionsTableName)
+            .innerJoin(
+                DashboardsTableName,
+                `${AiArtifactVersionsTableName}.saved_dashboard_uuid`,
+                `${DashboardsTableName}.dashboard_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${DashboardsTableName}.space_id`,
+                `${SpaceTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${SpaceTableName}.project_id`,
+                `${ProjectTableName}.project_id`,
+            )
+            .leftJoin(
+                UserTableName,
+                `${AiArtifactVersionsTableName}.verified_by_user_uuid`,
+                `${UserTableName}.user_uuid`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNotNull(`${AiArtifactVersionsTableName}.verified_at`)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .distinctOn(`${DashboardsTableName}.dashboard_uuid`)
+            .orderBy([
+                { column: `${DashboardsTableName}.dashboard_uuid` },
+                {
+                    column: `${AiArtifactVersionsTableName}.verified_at`,
+                    order: 'desc',
+                },
+            ])
+            .select(
+                this.database
+                    .ref(
+                        `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                    )
+                    .as('verification_uuid'),
+                this.database
+                    .ref(`${DashboardsTableName}.dashboard_uuid`)
+                    .as('content_uuid'),
+                `${DashboardsTableName}.name`,
+                `${DashboardsTableName}.description`,
+                `${DashboardsTableName}.views_count`,
+                this.database(DashboardVersionsTableName)
+                    .select('created_at')
+                    .whereRaw(
+                        `${DashboardVersionsTableName}.dashboard_id = ${DashboardsTableName}.dashboard_id`,
+                    )
+                    .orderBy('created_at', 'desc')
+                    .limit(1)
+                    .as('last_updated_at'),
+                `${SpaceTableName}.space_uuid`,
+                this.database.ref(`${SpaceTableName}.name`).as('space_name'),
+                `${UserTableName}.user_uuid`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
+                `${AiArtifactVersionsTableName}.verified_at`,
+            );
+
+        const toBaseItem = (row: {
+            verification_uuid: string;
+            content_uuid: string;
+            name: string;
+            description: string | null;
+            views_count: number;
+            last_updated_at: Date | null;
+            space_uuid: string;
+            space_name: string;
+            user_uuid: string;
+            first_name: string;
+            last_name: string;
+            verified_at: Date;
+        }) => ({
+            uuid: row.verification_uuid,
+            contentUuid: row.content_uuid,
+            name: row.name,
+            description: row.description ?? null,
+            spaceUuid: row.space_uuid,
+            spaceName: row.space_name,
+            views: row.views_count,
+            lastUpdatedAt: row.last_updated_at,
+            verifiedBy: {
+                userUuid: row.user_uuid,
+                firstName: row.first_name,
+                lastName: row.last_name,
+            },
+            verifiedAt: row.verified_at,
+        });
+
+        const charts: VerifiedContentListItem[] = chartRows.map((row) => ({
+            ...toBaseItem(row),
+            contentType: ContentType.CHART,
+            chartKind: row.last_version_chart_kind,
+            exploreName: row.explore_name ?? null,
+        }));
+
+        const dashboards: VerifiedContentListItem[] = dashboardRows.map(
+            (row) => ({
+                ...toBaseItem(row),
+                contentType: ContentType.DASHBOARD,
+            }),
+        );
+
+        return [...charts, ...dashboards];
     }
 
     async updateArtifactEmbedding(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -101,6 +101,7 @@ import {
     type AiWebAppThreadCreatedFrom,
     type SessionUser,
     type SuggestionValidationCatalog,
+    type VerifiedContentListItem,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -5318,6 +5319,31 @@ export class AiAgentService extends BaseService {
         await this.aiAgentModel.updateArtifactVersion(versionUuid, {
             savedDashboardUuid,
         });
+    }
+
+    async getVerifiedSavedArtifactContent(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<VerifiedContentListItem[]> {
+        const project = await this.projectModel.getSummary(projectUuid);
+
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('ContentVerification', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                    metadata: { projectUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to view verified content',
+            );
+        }
+
+        return this.aiAgentModel.getVerifiedSavedArtifactContent(projectUuid);
     }
 
     // Bridges AI artifact verification to the content_verification table

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -205,6 +205,7 @@ const makeMcpService = ({
     dashboardSearchResults = [],
     chartSearchResults = [],
     verifiedContent = [],
+    artifactVerifiedContent = [],
     runtimeErrors = {},
 }: {
     context?: {
@@ -226,6 +227,7 @@ const makeMcpService = ({
     })[];
     chartSearchResults?: ReturnType<typeof makeChartSearchResult>[];
     verifiedContent?: Record<string, unknown>[];
+    artifactVerifiedContent?: Record<string, unknown>[];
     runtimeErrors?: {
         findExplores?: string;
         findFields?: string;
@@ -318,6 +320,9 @@ const makeMcpService = ({
         getRelevantVerifiedAnswerContextForAgent: vi.fn().mockResolvedValue({
             relevantVerifiedAnswers: [],
         }),
+        getVerifiedSavedArtifactContent: vi
+            .fn()
+            .mockResolvedValue(artifactVerifiedContent),
     };
 
     const contentVerificationService = {
@@ -925,6 +930,51 @@ describe('MCP async query polling', () => {
         const verifiedContentResult = JSON.parse(getTextResult(verifiedResult));
 
         expect(verifiedContentResult).toEqual([allowedVerifiedContent]);
+    });
+
+    it('merges AI-verified saved artifacts into list_verified_content without duplicates', async () => {
+        const spaceUuid = 'space-uuid';
+        const verifiedChart = {
+            contentType: 'chart',
+            contentUuid: 'chart-uuid',
+            name: 'Verified Chart',
+            spaceUuid,
+        };
+        const artifactOnlyChart = {
+            contentType: 'chart',
+            contentUuid: 'artifact-chart-uuid',
+            name: 'AI Verified Chart',
+            spaceUuid,
+        };
+        const artifactDuplicateOfVerifiedChart = {
+            ...verifiedChart,
+            name: 'AI duplicate of Verified Chart',
+        };
+
+        makeMcpService({
+            context: {
+                projectUuid,
+                projectName: 'Project',
+                agentUuid: null,
+                agentName: null,
+                tags: null,
+            },
+            verifiedContent: [verifiedChart],
+            artifactVerifiedContent: [
+                artifactOnlyChart,
+                artifactDuplicateOfVerifiedChart,
+            ],
+        });
+
+        const verifiedResult = await getToolCallback(
+            McpToolName.LIST_VERIFIED_CONTENT,
+        )({}, extra);
+        const verifiedContentResult = JSON.parse(getTextResult(verifiedResult));
+
+        expect(verifiedContentResult).toEqual([
+            verifiedChart,
+            artifactOnlyChart,
+        ]);
     });
 
     it('uses active agent tags for run_metric_query', async () => {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -2660,7 +2660,27 @@ export class McpService extends BaseService {
                         user,
                         projectUuid,
                     );
-                const scopedVerifiedContent = verifiedContent.filter(
+                // Pre-bridge AI-verified artifacts only exist in ai_artifact_versions
+                const artifactVerifiedContent =
+                    await this.aiAgentService.getVerifiedSavedArtifactContent(
+                        user,
+                        projectUuid,
+                    );
+                const verifiedContentKeys = new Set(
+                    verifiedContent.map(
+                        (item) => `${item.contentType}:${item.contentUuid}`,
+                    ),
+                );
+                const mergedVerifiedContent = [
+                    ...verifiedContent,
+                    ...artifactVerifiedContent.filter(
+                        (item) =>
+                            !verifiedContentKeys.has(
+                                `${item.contentType}:${item.contentUuid}`,
+                            ),
+                    ),
+                ];
+                const scopedVerifiedContent = mergedVerifiedContent.filter(
                     ({ spaceUuid }) =>
                         McpService.hasAgentSpaceAccess(
                             effectiveScope.spaceAccess,


### PR DESCRIPTION
Closes: PROD-7131 (part 1 — include AI-verified artifacts).

Stacked on #25210 (verification bridge) and #25209 (payload enrichment).

## What changed

`list_verified_content` now also returns AI-verified artifacts that are persisted as saved charts/dashboards but have no `content_verification` row (i.e. verified before the bridge in #25210 landed):

- New `AiAgentModel.getVerifiedSavedArtifactContent(projectUuid)` — queries `ai_artifact_versions` joined to saved content, same `VerifiedContentListItem` shape (verifier from `verified_by_user_uuid`, one row per saved item via latest verified version).
- Exposed through `AiAgentService.getVerifiedSavedArtifactContent` with the same `manage ContentVerification` CASL check as the existing list.
- The MCP handler merges both sources, deduping by `contentType:contentUuid` with `content_verification` rows winning. Agent space-access scoping applies to the merged list.

## Decisions

- **Unsaved AI-verified artifacts are excluded.** They only exist inside agent threads — an external agent can't open them as charts/dashboards, so they aren't discoverable content. No `source` field added; provenance is already visible via `verifiedBy`.
- No backfill migration: the merge covers pre-bridge rows at read time, so historical data needs no mutation.

## Regression analysis

MCP-only change: the REST `listVerifiedContent` endpoint and frontend listing are untouched. Consumers of the MCP tool may see more rows than before (the pre-bridge AI-verified ones), which is the point of the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXYVLs8UWL1BLhHY6gM2o

## Local verification (ran live against dev stack)

- Simulated a pre-bridge state (artifact verified, no `content_verification` row): MCP `list_verified_content` returned the chart, fully enriched, verifier resolved from `verified_by_user_uuid`.
- Dedup probe: with both a `content_verification` row and a verified artifact for the same chart, the item appears once and the canonical row wins (its `uuid` is the verification record, not the artifact version).
- Ranking probe on `find_content`: a verified chart with a weak description match (searchRank 0.44) sorted above an exact-name unverified match (0.67) — verification is an absolute trump over relevance, with relevance order preserved within each group.

## Known edge case

Unverifying the latest artifact version while an older version of the same artifact is still verified leaves the item in this MCP list (sourced from the old version) even though the badge row was deleted by the bridge. Confirmed live; rare flow, accepted for now.

## Fix after end-to-end UI testing

Charts saved from the web app link via `ai_prompt.saved_query_uuid`, not `ai_artifact_versions.saved_query_uuid` (which no code path writes). The chart query now resolves the saved chart via `coalesce(artifact_version.saved_query_uuid, prompt.saved_query_uuid)`. Verified live: an AI-generated chart saved through the UI and verified in the thread appears in `list_verified_content` alongside manually verified content, deduped.