### PR TITLE
feat(analytics): non-expiring dedicated usage-events bucket in local dev

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -95,7 +95,9 @@ INTERNAL_LIGHTDASH_HOST=http://lightdash-dev:3000
 # MinIO
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
-MINIO_DEFAULT_BUCKETS=default,results,lightdash-apps
+MINIO_DEFAULT_BUCKETS=default,results,lightdash-apps,lightdash-usage-events
+# Buckets excluded from the auto-expiry lifecycle rule (long-lived data)
+MINIO_NO_EXPIRY_BUCKETS=lightdash-usage-events
 MINIO_BROWSER=on
 
 # S3 Configuration
@@ -119,6 +121,12 @@ S3_FORCE_PATH_STYLE=true # needed when using MinIO since it only supports path s
 
 # Apps Storage Config (inherits endpoint/credentials from S3_* above)
 APPS_S3_BUCKET=lightdash-apps
+
+# Usage Events Storage Config (inherits endpoint/credentials from S3_* above).
+# Uses a dedicated non-expiring bucket: falling back to S3_BUCKET would put the
+# long-lived event history under that bucket's auto-expiry lifecycle rule.
+USAGE_EVENTS_S3_BUCKET=lightdash-usage-events
+USAGE_EVENTS_S3_REGION=us-east-1
 
 DEV_SSH_PUBLIC_KEY=
 

--- a/docker/init-minio.sh
+++ b/docker/init-minio.sh
@@ -12,16 +12,26 @@ done
 
 echo "MinIO is ready. Creating buckets..."
 
+# Returns success if $1 is listed in MINIO_NO_EXPIRY_BUCKETS (comma-separated)
+is_no_expiry_bucket() {
+  case ",$MINIO_NO_EXPIRY_BUCKETS," in
+    *",$1,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 IFS=','
 for bucket in $MINIO_DEFAULT_BUCKETS; do
   if [ -n "$bucket" ]; then
     if ! mc mb -p local/"$bucket" 2>/dev/null; then
       echo "Bucket '$bucket' already exists or could not be created"
     fi
-    
+
     # Configure lifecycle policy to auto-delete files after MINIO_EXPIRATION_DAYS days (default: 1 day)
     EXPIRATION_DAYS="${MINIO_EXPIRATION_DAYS:-1}"
-    if [ "$EXPIRATION_DAYS" -gt 0 ] 2>/dev/null; then
+    if is_no_expiry_bucket "$bucket"; then
+      echo "Skipping lifecycle policy for bucket '$bucket' (long-lived data)"
+    elif [ "$EXPIRATION_DAYS" -gt 0 ] 2>/dev/null; then
       echo "Setting lifecycle policy for bucket '$bucket': expire after $EXPIRATION_DAYS day(s)"
       mc ilm rule add --expire-days "$EXPIRATION_DAYS" local/"$bucket" 2>/dev/null || \
         echo "Could not set lifecycle policy for bucket '$bucket' (may already exist)"

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -126,6 +126,57 @@ test('Should use explicit pre-aggregate S3 credentials when set', () => {
     });
 });
 
+test('Should default usage events S3 config to base S3 config', () => {
+    process.env.S3_ACCESS_KEY = 'base_access_key';
+    process.env.S3_SECRET_KEY = 'base_secret_key';
+
+    const config = parseConfig();
+    expect(config.usageEvents.s3).toEqual({
+        endpoint: 'mock_endpoint',
+        bucket: 'mock_bucket',
+        region: 'mock_region',
+        accessKey: 'base_access_key',
+        secretKey: 'base_secret_key',
+        forcePathStyle: false,
+    });
+});
+
+test('Should use dedicated usage events bucket with base S3 credential fallback', () => {
+    process.env.S3_ACCESS_KEY = 'base_access_key';
+    process.env.S3_SECRET_KEY = 'base_secret_key';
+    process.env.USAGE_EVENTS_S3_BUCKET = 'usage_events_bucket';
+    process.env.USAGE_EVENTS_S3_REGION = 'usage_events_region';
+
+    const config = parseConfig();
+    expect(config.usageEvents.s3).toEqual({
+        endpoint: 'mock_endpoint',
+        bucket: 'usage_events_bucket',
+        region: 'usage_events_region',
+        accessKey: 'base_access_key',
+        secretKey: 'base_secret_key',
+        forcePathStyle: false,
+    });
+});
+
+test('Should use explicit usage events S3 credentials when set', () => {
+    process.env.S3_ACCESS_KEY = 'base_access_key';
+    process.env.S3_SECRET_KEY = 'base_secret_key';
+    process.env.USAGE_EVENTS_S3_BUCKET = 'usage_events_bucket';
+    process.env.USAGE_EVENTS_S3_REGION = 'usage_events_region';
+    process.env.USAGE_EVENTS_S3_ACCESS_KEY = 'usage_events_access_key';
+    process.env.USAGE_EVENTS_S3_SECRET_KEY = 'usage_events_secret_key';
+
+    const config = parseConfig();
+    expect(config.usageEvents.s3).toEqual({
+        endpoint: 'mock_endpoint',
+        bucket: 'usage_events_bucket',
+        region: 'usage_events_region',
+        accessKey: 'usage_events_access_key',
+        secretKey: 'usage_events_secret_key',
+        forcePathStyle: false,
+    });
+});
+
 test('Should default apps S3 config to base S3 config', () => {
     process.env.S3_ACCESS_KEY = 'mock_access_key';
     process.env.S3_SECRET_KEY = 'mock_secret_key';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -940,6 +940,10 @@ export const parsePreAggregateResultsS3Config = ():
     };
 };
 
+/**
+ * Prefer a dedicated USAGE_EVENTS_S3_BUCKET: the base bucket's object-expiry
+ * lifecycle rules would delete the long-lived event history.
+ */
 export const parseUsageEventsS3Config = (): Omit<
     S3Config,
     'expirationTime'


### PR DESCRIPTION
## Summary

Local MinIO (`docker/init-minio.sh`) applies a **1-day auto-expiry** lifecycle rule to every bucket in `MINIO_DEFAULT_BUCKETS`. Usage events fall back to the shared `S3_BUCKET` (`default`) when no dedicated bucket is configured, so in local dev the long-lived event history (raw zone + compacted parquet) was silently deleted daily.

- Adds a dedicated `lightdash-usage-events` bucket to `MINIO_DEFAULT_BUCKETS`.
- Introduces `MINIO_NO_EXPIRY_BUCKETS` (comma-separated), honoured by `init-minio.sh`, so long-lived buckets skip the expiry rule.
- Points dev config at it via `USAGE_EVENTS_S3_BUCKET`/`USAGE_EVENTS_S3_REGION` in `.env.development`.
- Adds parseConfig tests covering the usage-events S3 fallback and override semantics (previously untested).

**No behaviour change to the backend config parsing** — the `USAGE_EVENTS_S3_*` → base `S3_*` fallback is unchanged. Cloud environments should set the dedicated bucket vars (provisioning handled in the cloud repo).

Relates: PROD-8604

https://claude.ai/code/session_01WA3dULsFGJBhDckDEKg2ju
