### PR TITLE
feat: default ai chat sql mode on

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -244,17 +244,6 @@
     }
 }
 
-/* ------------------------------------------------------------------ *
- *  SQL mode active state — slow, smooth indigo border + halo. No      *
- *  animation; relies on a long CSS transition so toggling on/off      *
- *  reads as a calm fade rather than a snap.                            *
- * ------------------------------------------------------------------ */
-.sqlModeActive {
-    border-color: var(--mantine-color-indigo-4) !important;
-    box-shadow: 0 0 0 2px
-        color-mix(in srgb, var(--mantine-color-indigo-5) 12%, transparent);
-}
-
 /* Long, gentle ease applies both when toggling on *and* off. */
 .minimalInputWrapper,
 .inputCard {
@@ -474,19 +463,6 @@
 
 .sqlModeControl {
     flex-shrink: 0;
-}
-
-.sqlModeLabel {
-    line-height: 1;
-    white-space: nowrap;
-
-    @mixin light {
-        color: var(--mantine-color-indigo-6);
-    }
-
-    @mixin dark {
-        color: var(--mantine-color-indigo-3);
-    }
 }
 
 @media (max-width: 48em) {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -535,18 +535,11 @@ export const AgentChatInput = ({
     const renderSqlModeControl = ({
         actionSize,
         iconSize,
-        labelPosition = 'after',
     }: {
         actionSize: number | 'sm' | 'md';
         iconSize: number;
-        labelPosition?: 'before' | 'after';
     }) => {
         if (!onSqlModeChange || disabled) return null;
-        const label = sqlMode ? (
-            <Text size="xs" fw={600} className={styles.sqlModeLabel}>
-                SQL mode on
-            </Text>
-        ) : null;
 
         return (
             <Tooltip
@@ -557,14 +550,13 @@ export const AgentChatInput = ({
                 label="Let the agent reach for raw SQL when the question can't be answered from the semantic layer alone. Each query still asks for your approval before running."
             >
                 <Group gap={6} wrap="nowrap" className={styles.sqlModeControl}>
-                    {labelPosition === 'before' && label}
                     <ActionIcon
                         variant={sqlMode ? 'light' : 'subtle'}
                         color={sqlMode ? 'indigo' : 'gray'}
                         size={actionSize}
                         className={styles.sqlModeButton}
                         onClick={() => onSqlModeChange(!sqlMode)}
-                        aria-label="Toggle SQL mode"
+                        aria-label="Toggle SQL Runner"
                         aria-pressed={sqlMode}
                     >
                         <MantineIcon
@@ -573,7 +565,6 @@ export const AgentChatInput = ({
                             color={sqlMode ? 'indigo.5' : 'ldGray.6'}
                         />
                     </ActionIcon>
-                    {labelPosition === 'after' && label}
                 </Group>
             </Tooltip>
         );
@@ -590,12 +581,7 @@ export const AgentChatInput = ({
                 {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
                 <Box className={styles.threadInputStack}>
-                    <Box
-                        className={`${styles.minimalInputWrapper} ${
-                            sqlMode ? styles.sqlModeActive : ''
-                        }`}
-                        pos="relative"
-                    >
+                    <Box className={styles.minimalInputWrapper} pos="relative">
                         <RichTextEditor
                             editor={editor}
                             classNames={{
@@ -681,7 +667,6 @@ export const AgentChatInput = ({
                         {renderSqlModeControl({
                             actionSize: 'sm',
                             iconSize: 14,
-                            labelPosition: 'before',
                         })}
                     </Box>
                 )}
@@ -710,11 +695,7 @@ export const AgentChatInput = ({
         >
             {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
-            <Box
-                className={`${styles.inputCard} ${
-                    sqlMode ? styles.sqlModeActive : ''
-                }`}
-            >
+            <Box className={styles.inputCard}>
                 <RichTextEditor
                     editor={editor}
                     classNames={{
@@ -829,7 +810,6 @@ export const AgentChatInput = ({
                           {renderSqlModeControl({
                               actionSize: 'sm',
                               iconSize: 14,
-                              labelPosition: 'before',
                           })}
                       </Box>
                   )

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -145,7 +145,7 @@ const NewThreadPanel: FC<{
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     // New threads have no uuid yet — keep the toggle in local state and seed
     // the per-thread slice entry once the thread is created.
-    const [sqlMode, setSqlMode] = useState(false);
+    const [sqlMode, setSqlMode] = useState(true);
     const [composerSeed, setComposerSeed] = useState<string | null>(null);
     const dispatchToStore = useAiAgentStoreDispatch();
     const handleToolResult = useCallback(

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.test.ts
@@ -13,17 +13,14 @@ const wrap = (aiAgentThreadMode: ReturnType<typeof reducer>) => ({
 });
 
 describe('aiAgentThreadModeSlice', () => {
-    it('selectThreadSqlMode defaults to false for an unknown thread', () => {
+    it('selectThreadSqlMode defaults to true for an unknown thread', () => {
         const state = wrap(reducer(undefined, { type: '@@init' }));
-        expect(selectThreadSqlMode('t1')(state)).toBe(false);
+        expect(selectThreadSqlMode('t1')(state)).toBe(true);
     });
 
     it('selectThreadSqlModeRaw is undefined until the thread is toggled', () => {
-        // undefined lets callers (e.g. workspace build threads) pick their own
-        // default — `raw ?? true` — without changing the global default.
         const state = wrap(reducer(undefined, { type: '@@init' }));
         expect(selectThreadSqlModeRaw('t1')(state)).toBeUndefined();
-        expect(selectThreadSqlModeRaw('t1')(state) ?? true).toBe(true);
     });
 
     it('reflects the stored value once set', () => {
@@ -33,6 +30,6 @@ describe('aiAgentThreadModeSlice', () => {
         );
         const state = wrap(next);
         expect(selectThreadSqlModeRaw('t1')(state)).toBe(false);
-        expect(selectThreadSqlModeRaw('t1')(state) ?? true).toBe(false);
+        expect(selectThreadSqlMode('t1')(state)).toBe(false);
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.ts
@@ -17,7 +17,7 @@ type State = Record<string, ThreadMode>;
 
 const initialState: State = {};
 
-const DEFAULT_SQL_MODE = false;
+const DEFAULT_SQL_MODE = true;
 
 export const aiAgentThreadModeSlice = createSlice({
     name: 'aiAgentThreadMode',
@@ -41,8 +41,7 @@ export const selectThreadSqlMode =
         state.aiAgentThreadMode[threadUuid]?.sqlMode ?? DEFAULT_SQL_MODE;
 
 // Returns undefined when the thread has no stored toggle yet, so a caller can
-// apply its own default (workspace build threads default SQL mode on) while
-// everywhere else keeps DEFAULT_SQL_MODE.
+// apply its own default while everywhere else keeps DEFAULT_SQL_MODE.
 export const selectThreadSqlModeRaw =
     (threadUuid: string) =>
     (state: { aiAgentThreadMode: State }): boolean | undefined =>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -75,7 +75,7 @@ const AgentsRouterPage = () => {
 
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
-    const [sqlMode, setSqlMode] = useState(false);
+    const [sqlMode, setSqlMode] = useState(true);
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const chartUuid = searchParams.get('chartUuid');
     const dashboardUuid = searchParams.get('dashboardUuid');

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -62,7 +62,7 @@ const AiAgentNewThreadPage: FC = () => {
     });
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
-    const [sqlMode, setSqlMode] = useState(false);
+    const [sqlMode, setSqlMode] = useState(true);
     const dispatch = useAiAgentStoreDispatch();
     const { agent, agents, navigateFromAgentChat } =
         useOutletContext<AgentContext>();


### PR DESCRIPTION
### Summary
- Default AI agent SQL Runner access on for permissioned users in new and existing chat surfaces
- Keep submit payloads guarded by SQL Runner permission availability
- Update thread mode selector coverage
- Keep SQL Runner composer control icon-only; active state keeps the blue icon background

### Validation
- direnv exec . pnpm -F frontend test src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.test.ts
- direnv exec . pnpm -F frontend typecheck:fast
- Browser: signed in locally as seeded admin and verified composer defaults SQL Runner access on
- Review agent: no findings

Closes: https://linear.app/lightdash/issue/ZAP-585/auto-prompt-users-to-enter-sql-mode-from-chat