### PR TITLE
fix(ai-writeback): support monorepo dbt projects with local packages

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -3441,6 +3441,19 @@ export class AiWritebackService extends BaseService {
                     `${CWD}/${turn.gitConnection.projectSubPath}`,
                 )}`,
             );
+            // `dbt deps` rewrites `<projectSubPath>/package-lock.yml` — and the
+            // sandbox dbt version usually differs from the one that generated the
+            // committed lockfile, so it reformats it / bumps its sha1_hash even
+            // when nothing actually changed. That's pure noise in a
+            // metadata-writeback PR, so restore the committed lockfile — or drop
+            // it entirely when deps created one the repo didn't track. Either way
+            // `dbt_packages/` stays installed, so compile is unaffected.
+            const lockfile = `${turn.gitConnection.projectSubPath}/package-lock.yml`;
+            await sandbox.commands.run(
+                `git -C ${CWD} checkout -- ${JSON.stringify(
+                    lockfile,
+                )} 2>/dev/null || rm -f ${JSON.stringify(`${CWD}/${lockfile}`)}`,
+            );
         } catch (error) {
             this.logger.warn(
                 `AiWriteback: 'dbt deps' failed (continuing; compile will surface any unresolved packages): ${getErrorMessage(

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -3386,7 +3386,7 @@ export class AiWritebackService extends BaseService {
      * the compile-timings log — the in-sandbox prerequisites for a dbt-writeback
      * turn. Extracted as the `beforeAgentRun` hook of {@link dbtWritebackConfig}.
      */
-    private static async prepareDbtAgentRun(
+    private async prepareDbtAgentRun(
         sandbox: SandboxHandle,
         turn: TurnContext,
     ): Promise<void> {
@@ -3422,6 +3422,32 @@ export class AiWritebackService extends BaseService {
         // Reset the timings log each turn — the sandbox filesystem persists across
         // pause/resume, so a resumed turn would otherwise double-count prior runs.
         await sandbox.files.write(COMPILE_TIMINGS_PATH, '');
+
+        // Install dbt package dependencies (`dbt deps`) once per turn, before the
+        // agent's first compile. A fresh clone has no `dbt_packages/`, so any
+        // project with a non-empty `packages.yml` — a `local:` monorepo package or
+        // an ordinary dbt-hub package — fails `lightdash compile`/`dbt ls` with
+        // "Run dbt deps to install package dependencies". Run it here (not in the
+        // compile wrapper, which is re-invoked on every compile within a turn — a
+        // per-compile `deps` would be wasteful). Reuse the wrapper's `dbtBin` PATH
+        // and secret-stripped env so a malicious dbt_project.yml can't read secrets
+        // via Jinja `env_var(...)` during parse. Best-effort: `commands.run` throws
+        // on a non-zero exit, so tolerate a deps failure (e.g. transient hub
+        // fetch) — the agent's compile surfaces the same error if it truly can't
+        // resolve, and we're no worse off than before this ran.
+        try {
+            await sandbox.commands.run(
+                `env ${unsetFlags} PATH="${dbtBin}:$PATH" dbt deps --project-dir ${JSON.stringify(
+                    `${CWD}/${turn.gitConnection.projectSubPath}`,
+                )}`,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `AiWriteback: 'dbt deps' failed (continuing; compile will surface any unresolved packages): ${getErrorMessage(
+                    error,
+                )} (sandboxId=${sandbox.sandboxId})`,
+            );
+        }
 
         // Push the warehouse skill files alongside the prompts. `shared.md`
         // always; the dialect file only when one exists for this warehouse.
@@ -3483,7 +3509,7 @@ export class AiWritebackService extends BaseService {
                 };
             },
             beforeAgentRun: (sandbox, turn) =>
-                AiWritebackService.prepareDbtAgentRun(sandbox, turn),
+                this.prepareDbtAgentRun(sandbox, turn),
             afterAgentRun: (sandbox) => this.reportCompileTimings(sandbox),
         };
     }

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
@@ -64,6 +64,7 @@ import {
     collectDiffStat,
     collectFileChanges,
     commitLocal,
+    resolveDbtProjectPaths,
     stageChanges,
 } from './sandboxGit';
 
@@ -470,7 +471,12 @@ export class GithubProvider implements GitProvider {
         denyCiPaths: boolean;
     }): Promise<LandedCommit> {
         setStage('commit');
-        await stageChanges(sandbox, connection.projectSubPath, this.logger);
+        const projectPaths = await resolveDbtProjectPaths(
+            sandbox,
+            connection.projectSubPath,
+            this.logger,
+        );
+        await stageChanges(sandbox, projectPaths, this.logger);
         const fileChanges = await collectFileChanges(sandbox, { denyCiPaths });
         // Read the line stat while the change is still staged — the local commit
         // below clears the index.

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.ts
@@ -56,6 +56,7 @@ import {
     assertStagedPathsAllowed,
     collectDiffStat,
     commitLocal,
+    resolveDbtProjectPaths,
     stageChanges,
 } from './sandboxGit';
 
@@ -434,7 +435,12 @@ export class GitlabProvider implements GitProvider {
         denyCiPaths: boolean;
     }): Promise<LandedCommit> {
         setStage('commit');
-        await stageChanges(sandbox, connection.projectSubPath, this.logger);
+        const projectPaths = await resolveDbtProjectPaths(
+            sandbox,
+            connection.projectSubPath,
+            this.logger,
+        );
+        await stageChanges(sandbox, projectPaths, this.logger);
         // Host-side denied-path gate (GitLab pushes via git, so check the staged
         // paths here rather than in collectFileChanges). Reject the whole commit
         // — secrets always, CI/workflow for the general agent.

--- a/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.test.ts
@@ -1,5 +1,13 @@
+import type { Logger } from 'winston';
 import { DeniedPathError } from '../deniedPaths';
-import { assertStagedPathsAllowed, collectFileChanges } from './sandboxGit';
+import {
+    assertStagedPathsAllowed,
+    collectFileChanges,
+    resolveDbtProjectPaths,
+    stageChanges,
+} from './sandboxGit';
+
+const logger = { info: vi.fn(), warn: vi.fn() } as unknown as Logger;
 
 // Minimal sandbox stub exposing only what the denied-path gate touches:
 // `commands.run` returns the `git diff --cached --name-status -z` buffer, and
@@ -88,5 +96,177 @@ describe('assertStagedPathsAllowed — GitLab push gate', () => {
                 denyCiPaths: true,
             }),
         ).resolves.toBeUndefined();
+    });
+});
+
+// Sandbox stub for resolveDbtProjectPaths: `files.read` dispatches by suffix
+// (manifest.json vs dbt_project.yml), and `commands.run` returns the resolver
+// script's stdout (the newline-separated repo-relative paths the sandbox would
+// print after resolving each local package's dbt_packages symlink).
+const resolverSandbox = ({
+    manifest,
+    dbtProjectYml = '',
+    resolverStdout = '',
+}: {
+    manifest: object | null;
+    dbtProjectYml?: string | null;
+    resolverStdout?: string;
+}) => {
+    const run = vi.fn().mockResolvedValue({ stdout: resolverStdout });
+    return {
+        sandbox: {
+            sandboxId: 'sbx',
+            files: {
+                read: vi.fn(async (path: string) => {
+                    if (path.endsWith('/target/manifest.json')) {
+                        if (manifest === null) throw new Error('not found');
+                        return JSON.stringify(manifest);
+                    }
+                    if (path.endsWith('/dbt_project.yml')) {
+                        if (dbtProjectYml === null)
+                            throw new Error('not found');
+                        return dbtProjectYml;
+                    }
+                    throw new Error(`unexpected read: ${path}`);
+                }),
+            },
+            commands: { run },
+        } as never,
+        run,
+    };
+};
+
+describe('resolveDbtProjectPaths', () => {
+    it('returns ["."] for a repo-root project without touching the manifest', async () => {
+        const { sandbox, run } = resolverSandbox({ manifest: null });
+        await expect(
+            resolveDbtProjectPaths(sandbox, '.', logger),
+        ).resolves.toEqual(['.']);
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('stages the connected project PLUS resolved local package trees, skipping root + vendored hub packages', async () => {
+        const sub = 'fabrics/acme-data-prod/projects/analytics/core';
+        const pkgPath =
+            'packages/domains/companies/acme/consumer-aligned/analytics';
+        const { sandbox, run } = resolverSandbox({
+            manifest: {
+                metadata: { project_name: 'acme_core' },
+                nodes: {
+                    'model.acme_core.fct': { package_name: 'acme_core' },
+                    'model.acme_consumer_aligned.dim_widget': {
+                        package_name: 'acme_consumer_aligned',
+                    },
+                },
+                // A hub package present only via macros; its dbt_packages entry
+                // is a real dir, so the sandbox resolver never emits it.
+                macros: { 'macro.dbt_utils.x': { package_name: 'dbt_utils' } },
+            },
+            resolverStdout: `${pkgPath}\n`,
+        });
+
+        await expect(
+            resolveDbtProjectPaths(sandbox, sub, logger),
+        ).resolves.toEqual([sub, pkgPath]);
+
+        // Both non-root packages are probed in the sandbox; the vendored one is
+        // filtered by the symlink test at runtime (stubbed out of stdout here).
+        const script = run.mock.calls[0][0] as string;
+        expect(script).toContain('acme_consumer_aligned');
+        expect(script).toContain('dbt_utils');
+        expect(script).not.toContain('acme_core');
+        expect(script).toContain(`${sub}/dbt_packages/`);
+    });
+
+    it('honors a packages-install-path override from dbt_project.yml', async () => {
+        const sub = 'core';
+        const { sandbox, run } = resolverSandbox({
+            manifest: {
+                metadata: { project_name: 'root' },
+                nodes: {
+                    'model.pkg.m': { package_name: 'pkg' },
+                },
+            },
+            dbtProjectYml: 'packages-install-path: dbt_modules\n',
+            resolverStdout: 'shared/pkg\n',
+        });
+        await expect(
+            resolveDbtProjectPaths(sandbox, sub, logger),
+        ).resolves.toEqual([sub, 'shared/pkg']);
+        expect(run.mock.calls[0][0]).toContain(`${sub}/dbt_modules/`);
+    });
+
+    it('drops package names outside the safe dbt charset (no shell injection via a crafted manifest)', async () => {
+        const sub = 'core';
+        const { sandbox, run } = resolverSandbox({
+            manifest: {
+                metadata: { project_name: 'root' },
+                nodes: {
+                    'model.evil.m': { package_name: 'evil; rm -rf /' },
+                    'model.good.m': { package_name: 'good_pkg' },
+                },
+            },
+            resolverStdout: '',
+        });
+        await resolveDbtProjectPaths(sandbox, sub, logger);
+        const script = run.mock.calls[0][0] as string;
+        expect(script).toContain('good_pkg');
+        expect(script).not.toContain('rm -rf');
+    });
+
+    it('falls back to [projectSubPath] when the manifest is unreadable', async () => {
+        const sub = 'core';
+        const { sandbox, run } = resolverSandbox({ manifest: null });
+        await expect(
+            resolveDbtProjectPaths(sandbox, sub, logger),
+        ).resolves.toEqual([sub]);
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('falls back to [projectSubPath] when only the root package compiled (no packages to resolve)', async () => {
+        const sub = 'core';
+        const { sandbox, run } = resolverSandbox({
+            manifest: {
+                metadata: { project_name: 'root' },
+                nodes: { 'model.root.m': { package_name: 'root' } },
+            },
+        });
+        await expect(
+            resolveDbtProjectPaths(sandbox, sub, logger),
+        ).resolves.toEqual([sub]);
+        expect(run).not.toHaveBeenCalled();
+    });
+});
+
+describe('stageChanges', () => {
+    const stagingSandbox = () => {
+        const add = vi.fn().mockResolvedValue(undefined);
+        const run = vi.fn().mockResolvedValue({ stdout: '' });
+        return {
+            sandbox: {
+                sandboxId: 'sbx',
+                git: { add },
+                commands: { run },
+            } as never,
+            add,
+            run,
+        };
+    };
+
+    it('stages the given paths as files and also the repo-root workflows dir', async () => {
+        const { sandbox, add, run } = stagingSandbox();
+        const paths = ['fabrics/.../core', 'packages/.../analytics'];
+        await stageChanges(sandbox, paths, logger);
+        expect(add).toHaveBeenCalledWith(expect.any(String), { files: paths });
+        expect(run).toHaveBeenCalledWith(
+            expect.stringContaining('add .github/workflows'),
+        );
+    });
+
+    it('falls back to --all (and skips workflows) when the project is the repo root', async () => {
+        const { sandbox, add, run } = stagingSandbox();
+        await stageChanges(sandbox, ['.'], logger);
+        expect(add).toHaveBeenCalledWith(expect.any(String), { all: true });
+        expect(run).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.ts
@@ -1,3 +1,4 @@
+import * as yaml from 'js-yaml';
 import type { Logger } from 'winston';
 import type { GithubFileChanges } from '../../../../clients/github/Github';
 import type { SandboxHandle } from '../../SandboxRuntime';
@@ -6,31 +7,195 @@ import { DeniedPathError, findDeniedCommitPaths } from '../deniedPaths';
 import type { GitCommitAuthor } from '../types';
 import { parseGitNameStatus } from '../utils';
 
+// Default dbt package install directory, relative to the project dir. Overridable
+// in dbt_project.yml via `packages-install-path`; see resolveDbtProjectPaths.
+const DEFAULT_PACKAGES_INSTALL_PATH = 'dbt_packages';
+
+// dbt project/package names are `[A-Za-z0-9_]` (a leading letter/underscore then
+// word chars). We read them out of the repo's own manifest.json — untrusted
+// content — and interpolate them into a shell command below, so anything outside
+// this charset is dropped rather than escaped: it can't be a real dbt package and
+// keeps the command injection-free.
+const SAFE_DBT_NAME = /^[A-Za-z0-9_]+$/;
+// `packages-install-path` is likewise repo-controlled and interpolated into the
+// same command. Allow only a plain relative path (dir names, `.`/`..`, slashes) —
+// enough for real overrides, nothing that can break out of the single-quoted
+// shell word — and fall back to the default otherwise.
+const SAFE_INSTALL_PATH = /^[A-Za-z0-9_./-]+$/;
+
+/**
+ * Read the dbt `packages-install-path` from the project's dbt_project.yml,
+ * falling back to the default (`dbt_packages`) when unset, unreadable, or not a
+ * plain relative path. This is where `dbt deps` installs each package (and, for
+ * `local:` packages, where it symlinks the real source from).
+ */
+const readPackagesInstallPath = async (
+    sandbox: SandboxHandle,
+    projectSubPath: string,
+): Promise<string> => {
+    try {
+        const raw = await sandbox.files.read(
+            `${CWD}/${projectSubPath}/dbt_project.yml`,
+        );
+        const parsed = yaml.load(raw);
+        const value =
+            parsed !== null && typeof parsed === 'object'
+                ? (parsed as Record<string, unknown>)['packages-install-path']
+                : undefined;
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (SAFE_INSTALL_PATH.test(trimmed)) {
+                return trimmed;
+            }
+        }
+    } catch {
+        // Missing/unparseable dbt_project.yml — fall through to the default.
+    }
+    return DEFAULT_PACKAGES_INSTALL_PATH;
+};
+
+/**
+ * Resolve the set of repo-root-relative paths that constitute the dbt project
+ * being written back to: the connected project subtree PLUS every `local:`
+ * package it actually compiled. This is what {@link stageChanges} must stage so
+ * that an edit to a model whose real source lives in an imported package tree
+ * (e.g. a monorepo `packages/...` dir, outside `projectSubPath`) is committed —
+ * without resorting to `git add --all`, which would also sweep in agent scratch.
+ *
+ * Source of truth is dbt's own package resolution, not a guess:
+ *  - `target/manifest.json` lists every compiled node's `package_name` (dbt
+ *    deletes the old `root_path` field from the manifest, so package_name +
+ *    install path is the canonical mapping).
+ *  - `dbt deps` installs each non-root package at
+ *    `<projectSubPath>/<packages-install-path>/<package_name>`. For a `local:`
+ *    package that install entry is a SYMLINK back to the real source in the repo;
+ *    for a dbt-hub package it's a vendored real dir (git-ignored). Resolving the
+ *    symlink yields the real repo path; the `-L` test excludes the vendored dirs.
+ *
+ * This generalises to arbitrarily nested local packages — `dbt deps` flattens the
+ * whole dependency tree into the install dir — and to a `packages-install-path`
+ * override. Best-effort: any failure to read/parse the manifest falls back to
+ * just `[projectSubPath]` (the pre-existing scope), so staging never regresses
+ * to worse than before. When the project IS the repo root (`projectSubPath` is
+ * `.`) there is nothing to narrow, so we return `['.']` and let stageChanges do
+ * its `--all` fallback.
+ */
+export const resolveDbtProjectPaths = async (
+    sandbox: SandboxHandle,
+    projectSubPath: string,
+    logger: Logger,
+): Promise<string[]> => {
+    if (projectSubPath === '.') {
+        return ['.'];
+    }
+    const paths = new Set<string>([projectSubPath]);
+
+    let manifest: unknown;
+    try {
+        manifest = JSON.parse(
+            await sandbox.files.read(
+                `${CWD}/${projectSubPath}/target/manifest.json`,
+            ),
+        );
+    } catch (error) {
+        logger.warn(
+            `AiWriteback: could not read target/manifest.json to resolve local package paths; staging only '${projectSubPath}' (sandboxId=${sandbox.sandboxId})`,
+        );
+        return [...paths];
+    }
+
+    const rootPackage = (manifest as { metadata?: { project_name?: string } })
+        .metadata?.project_name;
+    // Collect the package name of every compiled resource across all node-like
+    // collections. Anything with a `package_name` counts — models, sources,
+    // macros, exposures, metrics, semantic models, docs.
+    const packageNames = new Set<string>();
+    for (const collection of Object.values(
+        manifest as Record<string, unknown>,
+    )) {
+        if (collection !== null && typeof collection === 'object') {
+            for (const resource of Object.values(
+                collection as Record<string, unknown>,
+            )) {
+                const packageName = (resource as { package_name?: unknown })
+                    ?.package_name;
+                if (
+                    typeof packageName === 'string' &&
+                    packageName !== rootPackage &&
+                    SAFE_DBT_NAME.test(packageName)
+                ) {
+                    packageNames.add(packageName);
+                }
+            }
+        }
+    }
+    if (packageNames.size === 0) {
+        return [...paths];
+    }
+
+    const installPath = await readPackagesInstallPath(sandbox, projectSubPath);
+    // Resolve each candidate package's install entry inside the sandbox: emit a
+    // repo-relative path only for symlinks (local packages) whose target lands
+    // inside the repo. Vendored hub packages are real dirs (`-L` fails) and are
+    // skipped. All interpolated values are charset-validated above.
+    const packageList = [...packageNames].join(' ');
+    const script = [
+        `cwd_real=$(readlink -f ${JSON.stringify(CWD)})`,
+        `for p in ${packageList}; do`,
+        `  link="${CWD}/${projectSubPath}/${installPath}/$p"`,
+        `  [ -L "$link" ] || continue`,
+        `  real=$(readlink -f "$link" 2>/dev/null) || continue`,
+        `  [ -n "$real" ] || continue`,
+        `  case "$real/" in`,
+        `    "$cwd_real/"*) rel="\${real#"$cwd_real/"}"; [ -n "$rel" ] && printf '%s\\n' "$rel" ;;`,
+        `  esac`,
+        `done`,
+    ].join('\n');
+
+    try {
+        const { stdout } = await sandbox.commands.run(script);
+        stdout
+            .split('\n')
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0 && line !== projectSubPath)
+            .forEach((line) => paths.add(line));
+    } catch (error) {
+        logger.warn(
+            `AiWriteback: failed to resolve local package paths; staging only '${projectSubPath}' (sandboxId=${sandbox.sandboxId})`,
+        );
+    }
+
+    return [...paths];
+};
+
 /**
  * Stage the agent's changes for commit. We deliberately avoid `git add --all`:
  * the agent can leave scratch files (e.g. PR metadata) in the working tree, and
  * staging everything is how those leaked into PRs. Instead we stage only the dbt
- * project subtree the writeback is scoped to, so anything outside it can never
- * be committed. When the dbt project IS the repo root we cannot narrow the path,
- * so we fall back to staging all and rely on the caller having scrubbed the
- * known scratch files before this runs.
+ * project paths the writeback is scoped to (the connected project subtree plus
+ * any imported `local:` package trees it compiled — see
+ * {@link resolveDbtProjectPaths}), so anything outside them can never be
+ * committed. When the dbt project IS the repo root we cannot narrow the path, so
+ * we fall back to staging all and rely on the caller having scrubbed the known
+ * scratch files before this runs — {@link resolveDbtProjectPaths} signals that
+ * case by returning exactly `['.']`.
  */
 export const stageChanges = async (
     sandbox: SandboxHandle,
-    projectSubPath: string,
+    paths: string[],
     logger: Logger,
 ): Promise<void> => {
-    const scopedToProject = projectSubPath !== '.';
+    const scopedToProject = !(paths.length === 1 && paths[0] === '.');
     logger.info(
         `AiWriteback: staging ${
             scopedToProject
-                ? `'${projectSubPath}'`
+                ? paths.map((path) => `'${path}'`).join(', ')
                 : 'all (dbt project is the repo root)'
         } (sandboxId=${sandbox.sandboxId})`,
     );
     await sandbox.git.add(
         CWD,
-        scopedToProject ? { files: [projectSubPath] } : { all: true },
+        scopedToProject ? { files: paths } : { all: true },
     );
     if (scopedToProject) {
         // Also stage Lightdash CI workflow files the agent may have added when

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -104,12 +104,20 @@ ${
         ? `
 ## Repo context (pre-computed)
 
-The block below is the full sorted listing of every \`.sql\`/\`.yml\`/\`.yaml\`
-file under the dbt project. Treat it as the authoritative inventory.
+The block below is the sorted listing of every \`.sql\`/\`.yml\`/\`.yaml\` file
+under the connected dbt project directory (\`${dbtProjectDir}\`) ONLY — it does
+not cover the rest of the repository.
 
-- Consult this block FIRST when you need to find a model or schema file.
+- Consult this block FIRST when you need to find a model or schema file, and
+  \`Read\` files directly when you need their contents.
 - Do NOT run \`find\`, \`ls\`, or \`Glob\` to re-discover paths that already
-  appear here. \`Read\` files directly when you need their contents.
+  appear here.
+- BUT this listing is NOT exhaustive for the whole repo. In a monorepo the
+  project can import models from \`local:\` packages (declared in
+  \`packages.yml\`) whose real source files live ELSEWHERE in the repository,
+  outside \`${dbtProjectDir}\`, and so do NOT appear above. If a model the
+  request refers to is missing here, use \`Glob\`/\`Grep\` from the repo root to
+  find its real file and edit THAT file — not any copy under \`dbt_packages/\`.
 
 <repo_context>
 ${context.repoContext}


### PR DESCRIPTION
Closes PROD-8712

## Problem

AI writeback failed for dbt projects that import models from `local:` packages living **outside** the connected project directory — a monorepo shape where reusable dbt packages sit in one tree (e.g. `packages/…`) and the runnable project Lightdash connects to (`projectSubPath`) sits in another. Two independent failures:

1. **Compile failed.** The sandbox never ran `dbt deps`, so packages declared in `packages.yml` (both `local:` and dbt-hub) were never installed into `dbt_packages/` before `lightdash compile` / `dbt ls`, which then errored:
   > Compilation Error — dbt found N package(s) specified in packages.yml, but only 0 package(s) installed in dbt_packages. Run "dbt deps" to install package dependencies.

   This affects **any** writeback project with a non-empty `packages.yml` (a fresh sandbox clone never has `dbt_packages/`), not only monorepos.

2. **Commit failed.** `stageChanges` staged only `projectSubPath`, so an edit to a model whose real source lives in an imported package tree (outside the subpath) was never staged. `git commit` then exited 1 with "no changes added to commit".

## Fix

- **`dbt deps` in the sandbox.** Run it once per turn in `prepareDbtAgentRun`, before the agent's first compile, reusing the compile wrapper's dbt-version `PATH` and secret-stripped env (so a malicious `dbt_project.yml` can't read secrets via Jinja `env_var(...)` during parse). Best-effort: a `deps` failure is logged, not fatal.

- **Keep `package-lock.yml` out of the PR.** `dbt deps` rewrites the lockfile, and the sandbox dbt version usually differs from the one that generated the committed lockfile — so it reformats the file / bumps its `sha1_hash` even when nothing changed. After deps we restore the committed lockfile (or drop it when deps created one the repo didn't track); `dbt_packages/` stays installed, so compile is unaffected.

- **`resolveDbtProjectPaths`.** Read `target/manifest.json` and, for every compiled non-root package, resolve `<projectSubPath>/<packages-install-path>/<package_name>`. dbt symlinks `local:` packages to their real repo source, so resolving that symlink yields the real path to stage; vendored dbt-hub packages are real dirs and are skipped. Package names are charset-validated before touching a shell (the manifest is untrusted repo content). `stageChanges` now takes a path list and stages all of them, **preserving the no-`git add --all` security property** (agent scratch files outside these paths still can't be committed). Both the GitHub and GitLab provider call sites are updated.

  > Note: the manifest's `root_path` field (the obvious candidate) is `None` in modern dbt (manifest v11+), so `package_name` + install-path + dbt's own local-package symlink is the canonical mapping instead. This also generalises to arbitrarily nested local packages — `dbt deps` flattens the whole tree into the install dir.

- **System-prompt guidance.** `<repo_context>` now states it is scoped to the connected project dir only; for monorepos with `local:` package imports, a referenced model's real file may live elsewhere — use `Glob`/`Grep` rather than assuming the listing is exhaustive.

## Testing

**Unit** — 23 tests in `sandboxGit.test.ts` cover `resolveDbtProjectPaths` (multi-package staging, root-package/vendored-package exclusion, `packages-install-path` override, shell-injection charset guard, manifest-unreadable fallback) and `stageChanges` (path-list staging vs the `--all` repo-root fallback).

**End-to-end** — driven through the real writeback flow (Docker sandbox → agent → PR) against throwaway DuckDB fixtures. A pre-fix run (old code) reproduced both failures — compile failures, `staging '<subpath>'`, `git commit` → "no changes added to commit", HTTP 500 — confirming the negative control. Post-fix matrix:

| Scenario | `packages.yml` | Edit lands in | Result |
|----------|----------------|---------------|--------|
| Single local package (monorepo) | local + hub | imported package tree | ✅ staged `subpath` + package; PR has the package edit |
| Nested local packages (A→B) | nested local | **deepest** package | ✅ staged `core` + `pkg-a` + `pkg-b` (flattened symlinks); PR edit in deepest package |
| Hub package only | hub only | connected project | ✅ deps installs hub pkg, compile ok; staged only `subpath` (vendored pkg not staged) |
| No packages | none | connected project | ✅ deps no-op; staged only `subpath`; PR has only the model edit |
| Repo-root project (`projectSubPath = .`) | — | connected project | unit test (`--all` fallback) |
| `packages-install-path` override | local | package | unit test |
| GitLab provider | local | package | unit test + identical resolver code path |

Every end-to-end run compiled `exit 0`, staged exactly the right paths, and opened a PR containing only the intended metadata edit (no `package-lock.yml` churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXSj7xuZ9yMnDntkQ4NePJ
