### PR TITLE
fix(echarts): normalize 100% stacking per value-axis

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -26,6 +26,7 @@ import {
     relocateMarkLinesToVisibleSeries,
     resolveCartesianGranularityLabels,
     selectContinuousDateRange,
+    transformStack100ByValueAxis,
 } from './useEchartsCartesianConfig';
 
 dayjs.extend(utcPlugin);
@@ -1434,6 +1435,110 @@ describe('getStackTotalSeries', () => {
             baseArgs.isStack100,
         );
         expect(result).toHaveLength(0);
+    });
+});
+
+describe('transformStack100ByValueAxis', () => {
+    const barOnAxis = (y: string, yAxisIndex: number): EChartsSeries => ({
+        type: CartesianSeriesType.BAR,
+        stack: 'stack',
+        yAxisIndex,
+        encode: { x: 'x', y, tooltip: [y], seriesName: y },
+    });
+
+    // Series on the secondary axis were previously skipped, leaving raw values
+    // the tooltip then rendered with a "%" suffix.
+    test('normalizes stacked series on the secondary axis', () => {
+        const rows = [
+            { x: 'A', chA: 30, chB: 10 },
+            { x: 'B', chA: 20, chB: 20 },
+        ];
+        const { transformedResults, originalValues } =
+            transformStack100ByValueAxis(
+                rows,
+                'x',
+                [barOnAxis('chA', 1), barOnAxis('chB', 1)],
+                false,
+            );
+
+        expect(transformedResults[0].chA).toBe(75);
+        expect(transformedResults[0].chB).toBe(25);
+        expect(transformedResults[1].chA).toBe(50);
+        expect(transformedResults[1].chB).toBe(50);
+        // Original absolute values are preserved for tooltip counts.
+        expect(originalValues.get('A')?.get('chA')).toBe(30);
+        expect(originalValues.get('B')?.get('chB')).toBe(20);
+    });
+
+    test('normalizes each value axis against its own total, not across axes', () => {
+        const rows = [{ x: 'A', p0: 25, p1: 75, s0: 10, s1: 90 }];
+        const { transformedResults } = transformStack100ByValueAxis(
+            rows,
+            'x',
+            [
+                barOnAxis('p0', 0),
+                barOnAxis('p1', 0),
+                barOnAxis('s0', 1),
+                barOnAxis('s1', 1),
+            ],
+            false,
+        );
+
+        // Primary axis normalizes against 100 (25 + 75); secondary against
+        // 100 (10 + 90). A single cross-axis total would give 12.5 / 37.5 / …
+        expect(transformedResults[0].p0).toBe(25);
+        expect(transformedResults[0].p1).toBe(75);
+        expect(transformedResults[0].s0).toBe(10);
+        expect(transformedResults[0].s1).toBe(90);
+    });
+
+    test('reads the X-encoded hash and xAxisIndex when axes are flipped', () => {
+        const rows = [{ y: 'A', chA: 30, chB: 10 }];
+        const flippedBar = (x: string): EChartsSeries => ({
+            type: CartesianSeriesType.BAR,
+            stack: 'stack',
+            xAxisIndex: 1,
+            encode: { x, y: 'y', tooltip: [x], seriesName: x },
+        });
+
+        const { transformedResults } = transformStack100ByValueAxis(
+            rows,
+            'y',
+            [flippedBar('chA'), flippedBar('chB')],
+            true,
+        );
+
+        expect(transformedResults[0].chA).toBe(75);
+        expect(transformedResults[0].chB).toBe(25);
+    });
+
+    test('ignores series without a stack (e.g. line/scatter) so their values stay raw', () => {
+        const rows = [{ x: 'A', bar: 30, line: 10 }];
+        const lineSeries: EChartsSeries = {
+            type: CartesianSeriesType.LINE,
+            stack: undefined,
+            yAxisIndex: 0,
+            encode: {
+                x: 'x',
+                y: 'line',
+                tooltip: ['line'],
+                seriesName: 'line',
+            },
+        };
+
+        const { transformedResults, originalValues } =
+            transformStack100ByValueAxis(
+                rows,
+                'x',
+                [barOnAxis('bar', 0), lineSeries],
+                false,
+            );
+
+        // The single stacked bar is 100% of its own stack.
+        expect(transformedResults[0].bar).toBe(100);
+        // The un-stacked line keeps its raw value and no percentage entry.
+        expect(transformedResults[0].line).toBe(10);
+        expect(originalValues.get('A')?.has('line')).toBe(false);
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -946,9 +946,11 @@ const getMetricFromParam = (
     return v;
 };
 
-const isPrimaryYAxis = (series: Series) => {
-    return (series.yAxisIndex ?? 0) === 0;
-};
+// Stacked bar/area series (on any axis) whose values become percentages under
+// 100% stacking. Line/scatter never stack, so they are excluded.
+const isStack100Normalized = (series: Series) =>
+    !!series.stack &&
+    (series.type === CartesianSeriesType.BAR || !!series.areaStyle);
 
 /**
  * Create a labelLayout configuration for stacked bar charts.
@@ -1097,10 +1099,10 @@ const getPivotSeries = ({
                                 !!flipAxes,
                             );
 
-                            // For 100% stacked bar charts on the primary axis, values are already percentages (0-100)
-                            // Only apply stack100 formatting if this series is on yAxisIndex 0
+                            // For 100% stacked bar/area series, values are already percentages (0-100).
+                            // Applies on whichever axis the stacked series renders on.
                             const formattedValue =
-                                isStack100 && isPrimaryYAxis(series)
+                                isStack100 && isStack100Normalized(series)
                                     ? formatStack100Value(raw)
                                     : String(
                                           seriesValueFormatter(
@@ -1287,10 +1289,10 @@ const getSimpleSeries = ({
                             !!flipAxes,
                         );
 
-                        // For 100% stacked charts on the primary axis, values are already percentages (0-100)
-                        // Only apply stack100 formatting if this series is on yAxisIndex 0
+                        // For 100% stacked bar/area series, values are already percentages (0-100).
+                        // Applies on whichever axis the stacked series renders on.
                         const formattedValue =
-                            isStack100 && (series.yAxisIndex ?? 0) === 0
+                            isStack100 && isStack100Normalized(series)
                                 ? formatStack100Value(rawValue)
                                 : String(
                                       seriesValueFormatter(
@@ -2173,23 +2175,45 @@ const getEchartAxes = ({
     const stackValue = validCartesianConfig.layout?.stack;
     const shouldStack100 = stackValue === StackType.PERCENT;
 
+    // Value-axis positions (0 = primary, 1 = secondary) carrying stacked series.
+    // yAxisIndex holds the value-axis position for both orientations.
+    const stack100ValueAxes = shouldStack100
+        ? (validCartesianConfig.eChartsConfig.series ?? []).reduce<Set<number>>(
+              (acc, serie) => {
+                  if (
+                      serie.stack &&
+                      (serie.type === CartesianSeriesType.BAR ||
+                          !!serie.areaStyle)
+                  ) {
+                      acc.add(serie.yAxisIndex ?? 0);
+                  }
+                  return acc;
+              },
+              new Set<number>(),
+          )
+        : new Set<number>();
+    const primaryValueAxisStack100 = stack100ValueAxes.has(0);
+    const secondaryValueAxisStack100 = stack100ValueAxes.has(1);
+
     const bottomAxisBounds = getMinAndMaxFromBottomAxisBounds(
         bottomAxisType,
         bottomAxisMinValue,
         bottomAxisMaxValue,
     );
 
+    // Clamp/format the primary value axis as % only when it carries stacked series.
+    const clampPrimaryAxisTo100 = shouldStack100 && primaryValueAxisStack100;
     // For 100% stacking with flipped axes, set X-axis max to 100
     const maxXAxisValue =
         bottomAxisType === 'value'
-            ? shouldStack100 && validCartesianConfig.layout.flipAxes
+            ? clampPrimaryAxisTo100 && validCartesianConfig.layout.flipAxes
                 ? 100 // For 100% stacking with flipped axes, max is always 100
                 : bottomAxisBounds.max
             : undefined;
 
     const maxYAxisValue =
         leftAxisType === 'value'
-            ? shouldStack100 && !validCartesianConfig.layout.flipAxes
+            ? clampPrimaryAxisTo100 && !validCartesianConfig.layout.flipAxes
                 ? 100 // For 100% stacking without flipped axes, max is always 100
                 : yAxisConfiguration?.[0]?.max ||
                   referenceLineMaxBound(referenceLineMaxLeftY) ||
@@ -2213,7 +2237,7 @@ const getEchartAxes = ({
     const bottomAxisLabelConfig = bottomAxisConfigWithStyle.axisLabel
         ? {
               ...bottomAxisConfigWithStyle.axisLabel,
-              ...(shouldStack100 && validCartesianConfig.layout.flipAxes
+              ...(clampPrimaryAxisTo100 && validCartesianConfig.layout.flipAxes
                   ? { formatter: '{value}%' }
                   : {}),
               ...(!validCartesianConfig.layout.flipAxes &&
@@ -2231,7 +2255,7 @@ const getEchartAxes = ({
     const leftAxisLabelConfig = leftAxisConfigWithStyle.axisLabel
         ? {
               ...leftAxisConfigWithStyle.axisLabel,
-              ...(shouldStack100 && !validCartesianConfig.layout.flipAxes
+              ...(clampPrimaryAxisTo100 && !validCartesianConfig.layout.flipAxes
                   ? { formatter: '{value}%' }
                   : {}),
               ...(validCartesianConfig.layout.flipAxes &&
@@ -2245,6 +2269,31 @@ const getEchartAxes = ({
                   : {}),
           }
         : undefined;
+
+    // Secondary value axis (right Y / top X) formats as % when it carries the
+    // stacked series. Built directly since it only has an axisLabel with a custom format.
+    const clampSecondaryAxisTo100 =
+        shouldStack100 && secondaryValueAxisStack100;
+    const rightAxisLabelConfig =
+        clampSecondaryAxisTo100 && !validCartesianConfig.layout.flipAxes
+            ? {
+                  ...getAxisLabelStyle(axisLabelFontSize),
+                  ...((rightAxisConfigWithStyle.axisLabel as
+                      | Record<string, unknown>
+                      | undefined) ?? {}),
+                  formatter: '{value}%',
+              }
+            : undefined;
+    const topAxisLabelConfig =
+        clampSecondaryAxisTo100 && validCartesianConfig.layout.flipAxes
+            ? {
+                  ...getAxisLabelStyle(axisLabelFontSize),
+                  ...((topAxisConfigWithStyle.axisLabel as
+                      | Record<string, unknown>
+                      | undefined) ?? {}),
+                  formatter: '{value}%',
+              }
+            : undefined;
 
     return {
         xAxis: [
@@ -2329,17 +2378,24 @@ const getEchartAxes = ({
                           )
                         : undefined,
                 max:
+                    // eslint-disable-next-line no-nested-ternary
                     topAxisType === 'value'
-                        ? xAxisConfiguration?.[1]?.max ||
-                          maybeGetAxisDefaultMaxValue(
-                              allowSecondAxisDefaultRange,
-                          )
+                        ? clampSecondaryAxisTo100 &&
+                          validCartesianConfig.layout.flipAxes
+                            ? 100 // secondary value axis normalized to 100%
+                            : xAxisConfiguration?.[1]?.max ||
+                              maybeGetAxisDefaultMaxValue(
+                                  allowSecondAxisDefaultRange,
+                              )
                         : undefined,
                 ...(topAxisType === 'value' &&
                 xAxisConfiguration?.[1]?.minInterval !== undefined
                     ? { minInterval: xAxisConfiguration[1].minInterval }
                     : {}),
                 ...topAxisConfigWithStyle,
+                ...(topAxisLabelConfig
+                    ? { axisLabel: topAxisLabelConfig }
+                    : {}),
                 splitLine: isAxisTheSameForAllSeries
                     ? gridStyle
                     : { show: false },
@@ -2441,18 +2497,25 @@ const getEchartAxes = ({
                           )
                         : undefined,
                 max:
+                    // eslint-disable-next-line no-nested-ternary
                     rightAxisType === 'value'
-                        ? yAxisConfiguration?.[1]?.max ||
-                          referenceLineMaxBound(referenceLineMaxRightY) ||
-                          maybeGetAxisDefaultMaxValue(
-                              allowSecondAxisDefaultRange,
-                          )
+                        ? clampSecondaryAxisTo100 &&
+                          !validCartesianConfig.layout.flipAxes
+                            ? 100 // secondary value axis normalized to 100%
+                            : yAxisConfiguration?.[1]?.max ||
+                              referenceLineMaxBound(referenceLineMaxRightY) ||
+                              maybeGetAxisDefaultMaxValue(
+                                  allowSecondAxisDefaultRange,
+                              )
                         : undefined,
                 ...(rightAxisType === 'value' &&
                 yAxisConfiguration?.[1]?.minInterval !== undefined
                     ? { minInterval: yAxisConfiguration[1].minInterval }
                     : {}),
                 ...rightAxisConfigWithStyle,
+                ...(rightAxisLabelConfig
+                    ? { axisLabel: rightAxisLabelConfig }
+                    : {}),
                 splitLine: isAxisTheSameForAllSeries
                     ? gridStyle
                     : { show: false },
@@ -2546,6 +2609,54 @@ const getStackTotalRows = (
         acc.push(flipAxis ? [0, row[hash], total] : [row[hash], 0, total]);
         return acc;
     }, []);
+};
+
+/**
+ * Convert stacked series values to per-x percentages for 100% stacking,
+ * normalizing each value-axis against its own per-x total so charts with
+ * stacked series on the secondary axis are normalized too.
+ */
+export const transformStack100ByValueAxis = <T extends Record<string, unknown>>(
+    rows: T[],
+    xFieldId: string,
+    stackedSeries: EChartsSeries[],
+    flipAxes: boolean | undefined,
+): {
+    transformedResults: T[];
+    originalValues: Map<string, Map<string, number>>;
+} => {
+    const refsByValueAxis = new Map<number, string[]>();
+    stackedSeries.forEach((serie) => {
+        if (!serie.stack || !serie.encode) return;
+        const hash = flipAxes ? serie.encode.x : serie.encode.y;
+        if (typeof hash !== 'string') return;
+        // When flipped, the value axis is the X axis, so the axis position lives
+        // on xAxisIndex; otherwise it's yAxisIndex.
+        const valueAxisIndex = flipAxes
+            ? (serie.xAxisIndex ?? 0)
+            : (serie.yAxisIndex ?? 0);
+        const refs = refsByValueAxis.get(valueAxisIndex) ?? [];
+        refs.push(hash);
+        refsByValueAxis.set(valueAxisIndex, refs);
+    });
+
+    let transformedResults = rows;
+    const originalValues = new Map<string, Map<string, number>>();
+    refsByValueAxis.forEach((yFieldRefs) => {
+        const result = transformToPercentageStacking(
+            transformedResults,
+            xFieldId,
+            yFieldRefs,
+        );
+        transformedResults = result.transformedResults;
+        result.originalValues.forEach((fieldMap, xValue) => {
+            const merged = originalValues.get(xValue) ?? new Map();
+            fieldMap.forEach((value, field) => merged.set(field, value));
+            originalValues.set(xValue, merged);
+        });
+    });
+
+    return { transformedResults, originalValues };
 };
 
 // To hack the stack totals in echarts we need to create a fake series with the value 0 and display the total in the label
@@ -3339,27 +3450,12 @@ const useEchartsCartesianConfig = (
             };
         }
 
-        // Collect all y-field hashes from stacked series ON THE PRIMARY AXIS ONLY
-        // 100% stacking should only affect series on yAxisIndex 0 (the left/primary Y-axis)
-        const yFieldRefs = stackedSeriesWithColorAssignments
-            .filter((serie) => {
-                return (
-                    serie.stack && serie.encode && (serie.yAxisIndex ?? 0) === 0 // Only primary axis
-                );
-            })
-            .map((serie) =>
-                validCartesianConfig?.layout.flipAxes
-                    ? serie.encode!.x
-                    : serie.encode!.y,
-            )
-            .filter((hash): hash is string => !!hash);
-
-        // Use shared transformation utility
         const { transformedResults, originalValues: originalValuesMap } =
-            transformToPercentageStacking(
+            transformStack100ByValueAxis(
                 paddedSortedResults,
                 xFieldId,
-                yFieldRefs,
+                stackedSeriesWithColorAssignments,
+                validCartesianConfig?.layout.flipAxes,
             );
 
         return {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8697/100percent-stacking-displays-the-absolute-value-with-a-percent-suffix

### Description:
100% stacking only converted series on the primary Y-axis to percentages, yet the stack100 tooltip, value labels, and axis formatting were applied regardless of axis. A chart whose stacked series sit on the secondary (right) axis therefore rendered raw absolute values with a "%" suffix (e.g. "15792938.0% (0)") instead of each segment's share of the total.

Before:
<img width="2581" height="1443" alt="Screenshot 2026-07-07 at 11 16 53" src="https://github.com/user-attachments/assets/a788619f-1d5e-4ffb-9b55-ae2d13d0363f" />


After:
<img width="2581" height="1443" alt="Screenshot 2026-07-07 at 11 17 15" src="https://github.com/user-attachments/assets/a3c9de99-ce51-4d6b-a1ac-67716013a5f0" />
