### PR TITLE
feat: add pinned "Selected" section to field tree in Explorer

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
@@ -80,6 +80,15 @@
     background-color: var(--ld-field-default-bg-hover);
 }
 
+/* Inner flex so the field and table labels align on their text baselines
+   despite different font sizes */
+.labels {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+}
+
 .label {
     min-width: 0;
     overflow: hidden;

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
@@ -87,6 +87,15 @@
     align-items: baseline;
     gap: 8px;
     min-width: 0;
+    flex: 1 1 auto;
+}
+
+.actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    margin-left: auto;
 }
 
 .label {

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
@@ -1,0 +1,138 @@
+.section {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex-shrink: 0;
+    animation: fade-in 180ms ease;
+}
+
+.divider {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 4px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-6);
+    user-select: none;
+}
+
+.divider::before,
+.divider::after {
+    content: '';
+    flex: 1;
+    border-top: 1px solid var(--mantine-color-ldGray-3);
+}
+
+/* Cap the pinned area so a long selection can't crowd out the tree */
+.list {
+    display: flex;
+    flex-direction: column;
+    max-height: 224px;
+    overflow-y: auto;
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    height: 32px;
+    padding: 0 12px;
+    flex-shrink: 0;
+    overflow: hidden;
+    cursor: pointer;
+    animation: row-enter 180ms ease;
+}
+
+.rowExiting {
+    animation: row-exit 180ms ease forwards;
+    pointer-events: none;
+}
+
+.row svg {
+    flex-shrink: 0;
+}
+
+.row[data-field-kind='dimension'] {
+    background-color: var(--ld-field-dimension-bg);
+}
+
+.row[data-field-kind='dimension']:hover {
+    background-color: var(--ld-field-dimension-bg-hover);
+}
+
+.row[data-field-kind='metric'] {
+    background-color: var(--ld-field-metric-bg);
+}
+
+.row[data-field-kind='metric']:hover {
+    background-color: var(--ld-field-metric-bg-hover);
+}
+
+.row[data-field-kind='default'] {
+    background-color: var(--ld-field-default-bg);
+}
+
+.row[data-field-kind='default']:hover {
+    background-color: var(--ld-field-default-bg-hover);
+}
+
+.label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 14px;
+}
+
+.tableLabel {
+    flex-shrink: 0;
+    font-size: 12px;
+    white-space: nowrap;
+}
+
+.row[data-field-kind='dimension'] .tableLabel {
+    color: var(--ld-field-dimension-color);
+}
+
+.row[data-field-kind='metric'] .tableLabel {
+    color: var(--ld-field-metric-color);
+}
+
+.row[data-field-kind='default'] .tableLabel {
+    color: var(--ld-field-default-color);
+}
+
+@keyframes row-enter {
+    from {
+        height: 0;
+        opacity: 0;
+    }
+    to {
+        height: 32px;
+        opacity: 1;
+    }
+}
+
+@keyframes row-exit {
+    from {
+        height: 32px;
+        opacity: 1;
+    }
+    to {
+        height: 0;
+        opacity: 0;
+    }
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -7,8 +7,8 @@ import {
     isMetric,
     type FilterableField,
 } from '@lightdash/common';
-import { ActionIcon, Tooltip } from '@mantine/core';
 import { UnstyledButton } from '@mantine-8/core';
+import { ActionIcon, Tooltip } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
 import {
     memo,
@@ -139,9 +139,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
         <UnstyledButton
             component="div"
             className={
-                isExiting
-                    ? `${classes.row} ${classes.rowExiting}`
-                    : classes.row
+                isExiting ? `${classes.row} ${classes.rowExiting}` : classes.row
             }
             data-field-kind={getFieldKind(item)}
             onClick={handleClick}
@@ -194,18 +192,25 @@ type Props = {
     onDeselect: (fieldId: string, isDimension: boolean) => void;
 };
 
+type ExitingField = { field: SelectedField; index: number };
+
 /**
  * Pinned "Selected" section shown above the field tree. Deselected rows are
- * kept mounted briefly so they can animate out instead of snapping away.
+ * kept mounted briefly (in exitingFields) so they can animate out instead of
+ * snapping away; the rendered list is derived from props + exitingFields.
  */
 const SelectedFieldsSectionComponent: FC<Props> = ({ fields, onDeselect }) => {
-    const [rows, setRows] = useState<RenderedRow[]>(() =>
-        fields.map((field) => ({ ...field, isExiting: false })),
-    );
+    const [exitingFields, setExitingFields] = useState<
+        Map<string, ExitingField>
+    >(new Map());
+    const prevFieldsRef = useRef<SelectedField[]>(fields);
     const exitTimeouts = useRef(new Map<string, number>());
 
+    // Single external-system sync: manage exit timers when the selection changes
     useEffect(() => {
         const currentIds = new Set(fields.map((field) => field.fieldId));
+        const prevFields = prevFieldsRef.current;
+        prevFieldsRef.current = fields;
 
         // Cancel pending removals for fields that were re-selected mid-exit
         exitTimeouts.current.forEach((timeout, fieldId) => {
@@ -215,38 +220,44 @@ const SelectedFieldsSectionComponent: FC<Props> = ({ fields, onDeselect }) => {
             }
         });
 
-        setRows((prev) => {
-            const next: RenderedRow[] = fields.map((field) => ({
-                ...field,
-                isExiting: false,
-            }));
-            prev.forEach((row, index) => {
-                if (!currentIds.has(row.fieldId)) {
-                    next.splice(Math.min(index, next.length), 0, {
-                        ...row,
-                        isExiting: true,
-                    });
+        const removed = prevFields.filter(
+            (field) =>
+                !currentIds.has(field.fieldId) &&
+                !exitTimeouts.current.has(field.fieldId),
+        );
+
+        setExitingFields((prev) => {
+            let changed = false;
+            const next = new Map(prev);
+            prev.forEach((_, fieldId) => {
+                if (currentIds.has(fieldId)) {
+                    next.delete(fieldId);
+                    changed = true;
                 }
             });
-            return next;
+            removed.forEach((field) => {
+                next.set(field.fieldId, {
+                    field,
+                    index: prevFields.indexOf(field),
+                });
+                changed = true;
+            });
+            return changed ? next : prev;
+        });
+
+        removed.forEach((field) => {
+            const timeout = window.setTimeout(() => {
+                exitTimeouts.current.delete(field.fieldId);
+                setExitingFields((prev) => {
+                    if (!prev.has(field.fieldId)) return prev;
+                    const next = new Map(prev);
+                    next.delete(field.fieldId);
+                    return next;
+                });
+            }, EXIT_ANIMATION_MS);
+            exitTimeouts.current.set(field.fieldId, timeout);
         });
     }, [fields]);
-
-    useEffect(() => {
-        rows.forEach((row) => {
-            if (row.isExiting && !exitTimeouts.current.has(row.fieldId)) {
-                const timeout = window.setTimeout(() => {
-                    exitTimeouts.current.delete(row.fieldId);
-                    setRows((current) =>
-                        current.filter(
-                            (r) => !(r.fieldId === row.fieldId && r.isExiting),
-                        ),
-                    );
-                }, EXIT_ANIMATION_MS);
-                exitTimeouts.current.set(row.fieldId, timeout);
-            }
-        });
-    }, [rows]);
 
     useEffect(() => {
         const timeouts = exitTimeouts.current;
@@ -254,6 +265,25 @@ const SelectedFieldsSectionComponent: FC<Props> = ({ fields, onDeselect }) => {
             timeouts.forEach((timeout) => window.clearTimeout(timeout));
         };
     }, []);
+
+    const rows: RenderedRow[] = useMemo(() => {
+        const currentIds = new Set(fields.map((field) => field.fieldId));
+        const result: RenderedRow[] = fields.map((field) => ({
+            ...field,
+            isExiting: false,
+        }));
+        // Splice exiting rows back in at their previous position
+        [...exitingFields.values()]
+            .filter(({ field }) => !currentIds.has(field.fieldId))
+            .sort((a, b) => a.index - b.index)
+            .forEach(({ field, index }) => {
+                result.splice(Math.min(index, result.length), 0, {
+                    ...field,
+                    isExiting: true,
+                });
+            });
+        return result;
+    }, [fields, exitingFields]);
 
     if (rows.length === 0) return null;
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -1,0 +1,162 @@
+import {
+    isAdditionalMetric,
+    isCustomDimension,
+    isDimension,
+    isField,
+    isMetric,
+} from '@lightdash/common';
+import { UnstyledButton } from '@mantine-8/core';
+import { memo, useCallback, useEffect, useRef, useState, type FC } from 'react';
+import FieldIcon from '../../common/Filters/FieldIcon';
+import classes from './SelectedFieldsSection.module.css';
+import { type NodeItem } from './TableTree/Tree/types';
+
+export type SelectedField = {
+    fieldId: string;
+    item: NodeItem;
+    tableLabel: string | null;
+    isDimension: boolean;
+};
+
+type RenderedRow = SelectedField & { isExiting: boolean };
+
+const EXIT_ANIMATION_MS = 180;
+
+const getFieldKind = (item: NodeItem): 'dimension' | 'metric' | 'default' => {
+    if (isCustomDimension(item) || isDimension(item)) return 'dimension';
+    if (isAdditionalMetric(item) || isMetric(item)) return 'metric';
+    return 'default';
+};
+
+const getFieldLabel = (item: NodeItem): string =>
+    isField(item) || isAdditionalMetric(item)
+        ? item.label || item.name
+        : item.name;
+
+type RowProps = {
+    row: RenderedRow;
+    onDeselect: (fieldId: string, isDimension: boolean) => void;
+};
+
+const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
+    const { fieldId, item, tableLabel, isDimension: isDim, isExiting } = row;
+
+    const handleClick = useCallback(() => {
+        if (!isExiting) onDeselect(fieldId, isDim);
+    }, [isExiting, onDeselect, fieldId, isDim]);
+
+    const label = getFieldLabel(item);
+
+    return (
+        <UnstyledButton
+            className={
+                isExiting
+                    ? `${classes.row} ${classes.rowExiting}`
+                    : classes.row
+            }
+            data-field-kind={getFieldKind(item)}
+            onClick={handleClick}
+            data-testid={`selected-field-${fieldId}`}
+        >
+            <FieldIcon item={item} size="md" />
+            <span className={classes.label} title={label}>
+                {label}
+            </span>
+            {tableLabel && (
+                <span className={classes.tableLabel}>{tableLabel}</span>
+            )}
+        </UnstyledButton>
+    );
+});
+
+SelectedFieldRow.displayName = 'SelectedFieldRow';
+
+type Props = {
+    fields: SelectedField[];
+    onDeselect: (fieldId: string, isDimension: boolean) => void;
+};
+
+/**
+ * Pinned "Selected" section shown above the field tree. Deselected rows are
+ * kept mounted briefly so they can animate out instead of snapping away.
+ */
+const SelectedFieldsSectionComponent: FC<Props> = ({ fields, onDeselect }) => {
+    const [rows, setRows] = useState<RenderedRow[]>(() =>
+        fields.map((field) => ({ ...field, isExiting: false })),
+    );
+    const exitTimeouts = useRef(new Map<string, number>());
+
+    useEffect(() => {
+        const currentIds = new Set(fields.map((field) => field.fieldId));
+
+        // Cancel pending removals for fields that were re-selected mid-exit
+        exitTimeouts.current.forEach((timeout, fieldId) => {
+            if (currentIds.has(fieldId)) {
+                window.clearTimeout(timeout);
+                exitTimeouts.current.delete(fieldId);
+            }
+        });
+
+        setRows((prev) => {
+            const next: RenderedRow[] = fields.map((field) => ({
+                ...field,
+                isExiting: false,
+            }));
+            prev.forEach((row, index) => {
+                if (!currentIds.has(row.fieldId)) {
+                    next.splice(Math.min(index, next.length), 0, {
+                        ...row,
+                        isExiting: true,
+                    });
+                }
+            });
+            return next;
+        });
+    }, [fields]);
+
+    useEffect(() => {
+        rows.forEach((row) => {
+            if (row.isExiting && !exitTimeouts.current.has(row.fieldId)) {
+                const timeout = window.setTimeout(() => {
+                    exitTimeouts.current.delete(row.fieldId);
+                    setRows((current) =>
+                        current.filter(
+                            (r) => !(r.fieldId === row.fieldId && r.isExiting),
+                        ),
+                    );
+                }, EXIT_ANIMATION_MS);
+                exitTimeouts.current.set(row.fieldId, timeout);
+            }
+        });
+    }, [rows]);
+
+    useEffect(() => {
+        const timeouts = exitTimeouts.current;
+        return () => {
+            timeouts.forEach((timeout) => window.clearTimeout(timeout));
+        };
+    }, []);
+
+    if (rows.length === 0) return null;
+
+    return (
+        <div className={classes.section}>
+            <div className={classes.divider}>Selected</div>
+            <div className={classes.list} data-testid="SelectedFieldsSection">
+                {rows.map((row) => (
+                    <SelectedFieldRow
+                        key={row.fieldId}
+                        row={row}
+                        onDeselect={onDeselect}
+                    />
+                ))}
+            </div>
+            <div className={classes.divider}>All fields</div>
+        </div>
+    );
+};
+
+const SelectedFieldsSection = memo(SelectedFieldsSectionComponent);
+SelectedFieldsSection.displayName = 'SelectedFieldsSection';
+
+export default SelectedFieldsSection;

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -59,12 +59,14 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
             data-testid={`selected-field-${fieldId}`}
         >
             <FieldIcon item={item} size="md" />
-            <span className={classes.label} title={label}>
-                {label}
+            <span className={classes.labels}>
+                <span className={classes.label} title={label}>
+                    {label}
+                </span>
+                {tableLabel && (
+                    <span className={classes.tableLabel}>{tableLabel}</span>
+                )}
             </span>
-            {tableLabel && (
-                <span className={classes.tableLabel}>{tableLabel}</span>
-            )}
         </UnstyledButton>
     );
 });

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -3,12 +3,37 @@ import {
     isCustomDimension,
     isDimension,
     isField,
+    isFilterableField,
     isMetric,
+    type FilterableField,
 } from '@lightdash/common';
+import { ActionIcon, Tooltip } from '@mantine/core';
 import { UnstyledButton } from '@mantine-8/core';
-import { memo, useCallback, useEffect, useRef, useState, type FC } from 'react';
+import { IconFilter } from '@tabler/icons-react';
+import {
+    memo,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import { useToggle } from 'react-use';
+import {
+    explorerActions,
+    selectIsFieldFiltered,
+    useExplorerDispatch,
+    useExplorerSelector,
+    type ExplorerStoreState,
+} from '../../../features/explorer/store';
+import { useAddFilter } from '../../../hooks/useFilters';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import FieldIcon from '../../common/Filters/FieldIcon';
+import MantineIcon from '../../common/MantineIcon';
 import classes from './SelectedFieldsSection.module.css';
+import TreeSingleNodeActions from './TableTree/Tree/TreeSingleNodeActions';
 import { type NodeItem } from './TableTree/Tree/types';
 
 export type SelectedField = {
@@ -41,14 +66,78 @@ type RowProps = {
 const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
     const { fieldId, item, tableLabel, isDimension: isDim, isExiting } = row;
 
+    const dispatch = useExplorerDispatch();
+    const addFilter = useAddFilter();
+    const { track } = useTracking();
+
+    const [isHover, toggleHover] = useToggle(false);
+    const [isMenuOpen, toggleMenu] = useToggle(false);
+
+    const selectIsFiltered = useMemo(
+        () => (state: ExplorerStoreState) =>
+            selectIsFieldFiltered(state, fieldId),
+        [fieldId],
+    );
+    const isFieldFiltered = useExplorerSelector(
+        selectIsFiltered,
+        (a, b) => a === b,
+    );
+
+    const isFiltered = isField(item) && isFieldFiltered;
+    const showFilterAction =
+        (isFiltered || isHover) &&
+        !isAdditionalMetric(item) &&
+        isFilterableField(item);
+
+    const description =
+        isField(item) || isAdditionalMetric(item)
+            ? item.description
+            : undefined;
+
+    const label = getFieldLabel(item);
+
     const handleClick = useCallback(() => {
         if (!isExiting) onDeselect(fieldId, isDim);
     }, [isExiting, onDeselect, fieldId, isDim]);
 
-    const label = getFieldLabel(item);
+    const handleMouseEnter = useCallback(
+        () => toggleHover(true),
+        [toggleHover],
+    );
+    const handleMouseLeave = useCallback(
+        () => toggleHover(false),
+        [toggleHover],
+    );
+
+    const handleFilterClick = useCallback(
+        (e: React.MouseEvent<HTMLButtonElement>) => {
+            track({ name: EventName.ADD_FILTER_CLICKED });
+            if (!isFiltered) addFilter(item as FilterableField, undefined);
+            e.stopPropagation();
+        },
+        [isFiltered, addFilter, item, track],
+    );
+
+    const onOpenDescriptionView = useCallback(() => {
+        toggleHover(false);
+        dispatch(
+            explorerActions.openItemDetail({
+                itemType: 'field',
+                label,
+                description,
+                fieldItem: item,
+            }),
+        );
+    }, [toggleHover, dispatch, item, label, description]);
+
+    const onToggleMenu = useCallback(() => {
+        toggleHover(false);
+        toggleMenu();
+    }, [toggleHover, toggleMenu]);
 
     return (
         <UnstyledButton
+            component="div"
             className={
                 isExiting
                     ? `${classes.row} ${classes.rowExiting}`
@@ -56,6 +145,8 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
             }
             data-field-kind={getFieldKind(item)}
             onClick={handleClick}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
             data-testid={`selected-field-${fieldId}`}
         >
             <FieldIcon item={item} size="md" />
@@ -66,6 +157,31 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                 {tableLabel && (
                     <span className={classes.tableLabel}>{tableLabel}</span>
                 )}
+            </span>
+            <span className={classes.actions}>
+                {showFilterAction && (
+                    <Tooltip
+                        withinPortal
+                        label={
+                            isFiltered
+                                ? 'This field is filtered'
+                                : 'Click here to add filter'
+                        }
+                    >
+                        <ActionIcon onClick={handleFilterClick}>
+                            <MantineIcon icon={IconFilter} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+                <TreeSingleNodeActions
+                    item={item}
+                    isHovered={isHover}
+                    isSelected
+                    isOpened={isMenuOpen}
+                    hasDescription={!!description}
+                    onViewDescription={onOpenDescriptionView}
+                    onMenuChange={onToggleMenu}
+                />
             </span>
         </UnstyledButton>
     );

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Text, useMantineTheme } from '@mantine/core';
+import { Group, NavLink, Text, useMantineTheme } from '@mantine/core';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { TableItemDetailPreview } from '../ItemDetailPreview';
@@ -19,6 +19,14 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
     const theme = useMantineTheme();
     const { table, isExpanded } = item.data;
     const [isHover, toggleHover] = useToggle(false);
+
+    // Matches what the tree renders: hidden fields are excluded
+    const fieldCount = useMemo(
+        () =>
+            Object.values(table.dimensions).filter((d) => !d.hidden).length +
+            Object.values(table.metrics).filter((m) => !m.hidden).length,
+        [table.dimensions, table.metrics],
+    );
 
     const tableMetadata = useMemo(
         () => ({
@@ -60,9 +68,16 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
             closePreview={handleMouseLeave}
             tableMetadata={tableMetadata}
         >
-            <Text truncate fw={600}>
-                {table.label}
-            </Text>
+            <Group spacing="xs" noWrap>
+                <Text truncate fw={600}>
+                    {table.label}
+                </Text>
+                {!isExpanded && (
+                    <Text size="xs" color="ldGray.6" fw={400}>
+                        {fieldCount} {fieldCount === 1 ? 'field' : 'fields'}
+                    </Text>
+                )}
+            </Group>
         </TableItemDetailPreview>
     );
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
@@ -1,13 +1,6 @@
-import { ActionIcon, Group, Tooltip } from '@mantine-8/core';
 import { NavLink, Text, useMantineTheme } from '@mantine/core';
-import { IconInfoCircle, IconTable } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useToggle } from 'react-use';
-import {
-    explorerActions,
-    useExplorerDispatch,
-} from '../../../../../features/explorer/store';
-import MantineIcon from '../../../../common/MantineIcon';
 import { TableItemDetailPreview } from '../ItemDetailPreview';
 import type { TableHeaderItem } from './types';
 
@@ -24,12 +17,8 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
     onToggle,
 }) => {
     const theme = useMantineTheme();
-    const dispatch = useExplorerDispatch();
     const { table, isExpanded } = item.data;
     const [isHover, toggleHover] = useToggle(false);
-    const showMetadataIcon = Boolean(
-        table.dbtPackageName || table.ymlPath || table.sqlPath,
-    );
 
     const tableMetadata = useMemo(
         () => ({
@@ -49,18 +38,6 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
         () => toggleHover(false),
         [toggleHover],
     );
-
-    const openMetadataModal = useCallback(() => {
-        toggleHover(false);
-        dispatch(
-            explorerActions.openItemDetail({
-                itemType: 'table',
-                label: table.label,
-                description: table.description,
-                tableMetadata,
-            }),
-        );
-    }, [toggleHover, dispatch, table.label, table.description, tableMetadata]);
 
     const stickyStyle = useMemo(
         () => ({
@@ -83,27 +60,9 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
             closePreview={handleMouseLeave}
             tableMetadata={tableMetadata}
         >
-            <Group gap="xs" wrap="nowrap">
-                <Text truncate fw={600}>
-                    {table.label}
-                </Text>
-                {showMetadataIcon && (
-                    <Tooltip label="View dbt model details" withinPortal>
-                        <ActionIcon
-                            variant="subtle"
-                            size="sm"
-                            color="gray"
-                            aria-label="View dbt model details"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                openMetadataModal();
-                            }}
-                        >
-                            <MantineIcon icon={IconInfoCircle} />
-                        </ActionIcon>
-                    </Tooltip>
-                )}
-            </Group>
+            <Text truncate fw={600}>
+                {table.label}
+            </Text>
         </TableItemDetailPreview>
     );
 
@@ -113,7 +72,6 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
             onClick={onToggle}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
-            icon={<MantineIcon icon={IconTable} size="lg" color="ldGray.7" />}
             label={label}
             style={stickyStyle}
         >

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.test.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.test.ts
@@ -457,11 +457,13 @@ describe('flattenTreeForVirtualization', () => {
         const { items: result, sectionContexts } =
             flattenTreeForVirtualization(options);
 
-        const dimensionItems = result.filter((item) => {
-            if (item.type !== 'tree-node') return false;
-            const context = sectionContexts.get(item.data.sectionKey);
-            return context?.sectionType === 'dimensions';
-        });
+        const dimensionItems = result.filter(
+            (item): item is Extract<typeof item, { type: 'tree-node' }> => {
+                if (item.type !== 'tree-node') return false;
+                const context = sectionContexts.get(item.data.sectionKey);
+                return context?.sectionType === 'dimensions';
+            },
+        );
 
         // Only the "Attributes" group remains; "Identifiers" is hidden because
         // its only child is selected

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.test.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.test.ts
@@ -430,6 +430,66 @@ describe('flattenTreeForVirtualization', () => {
         expect(customMetricNodes.length).toBeGreaterThan(0);
     });
 
+    it('should exclude active fields from the tree', () => {
+        const options: FlattenTreeOptions = {
+            ...baseOptions,
+            activeFields: new Set(['orders_status', 'orders_total']),
+        };
+
+        const { items: result } = flattenTreeForVirtualization(options);
+
+        const treeNodeKeys = result
+            .filter((item) => item.type === 'tree-node')
+            .map((item) => item.data.node.key);
+
+        expect(treeNodeKeys).toEqual(['orders_id']);
+    });
+
+    it('should hide a group when all its children are active fields', () => {
+        const options: FlattenTreeOptions = {
+            ...baseOptions,
+            tables: [mockTableWithGroups],
+            expandedGroups: new Set(['orders-dimensions-group-Identifiers']),
+            activeFields: new Set(['orders_id']),
+            sectionNodeMaps: createSectionNodeMaps([mockTableWithGroups]),
+        };
+
+        const { items: result, sectionContexts } =
+            flattenTreeForVirtualization(options);
+
+        const dimensionItems = result.filter((item) => {
+            if (item.type !== 'tree-node') return false;
+            const context = sectionContexts.get(item.data.sectionKey);
+            return context?.sectionType === 'dimensions';
+        });
+
+        // Only the "Attributes" group remains; "Identifiers" is hidden because
+        // its only child is selected
+        expect(dimensionItems.length).toBe(1);
+        expect(dimensionItems[0].data.isGroup).toBe(true);
+        expect(dimensionItems[0].data.node.key).toBe('Attributes');
+    });
+
+    it('should exclude active fields from search results too', () => {
+        const options: FlattenTreeOptions = {
+            ...baseOptions,
+            searchQuery: 'o',
+            isSearching: true,
+            searchResultsMap: {
+                orders: ['orders_status', 'orders_total'],
+            },
+            activeFields: new Set(['orders_total']),
+        };
+
+        const { items: result } = flattenTreeForVirtualization(options);
+
+        const treeNodeKeys = result
+            .filter((item) => item.type === 'tree-node')
+            .map((item) => item.data.node.key);
+
+        expect(treeNodeKeys).toEqual(['orders_status']);
+    });
+
     it('should auto-expand tables when searching', () => {
         const options: FlattenTreeOptions = {
             ...baseOptions,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
@@ -34,7 +34,9 @@ import {
 } from './types';
 
 /**
- * Recursively flatten a node and its children
+ * Recursively flatten a node and its children.
+ * Active (selected) fields are excluded — they render in the pinned
+ * "Selected" section instead of the tree.
  */
 function flattenNodeRecursive(
     node: TreeNode,
@@ -44,6 +46,7 @@ function flattenNodeRecursive(
     expandedGroups: Set<string>,
     searchResults: string[],
     isSearching: boolean,
+    activeFields: Set<string>,
     depth: number = 0,
     parentPath: string = '',
 ): TreeNodeItem[] {
@@ -54,21 +57,26 @@ function flattenNodeRecursive(
 
     const isGroup = isGroupNode(node);
 
-    if (!isVisible && !isGroup) return items;
+    if (!isGroup && (!isVisible || activeFields.has(node.key))) return items;
 
     // If it's a group, check if any children are visible
     if (isGroup) {
         const groupNode = node;
-        const hasMatchInDescendants = (treeNode: TreeNode): boolean =>
-            searchResults.includes(treeNode.key) ||
-            (isGroupNode(treeNode) &&
-                Object.values(treeNode.children).some(hasMatchInDescendants));
+        const hasVisibleDescendant = (treeNode: TreeNode): boolean => {
+            if (isGroupNode(treeNode)) {
+                return Object.values(treeNode.children).some(
+                    hasVisibleDescendant,
+                );
+            }
+            if (activeFields.has(treeNode.key)) return false;
+            return !isSearching || searchResults.includes(treeNode.key);
+        };
 
-        const hasVisibleChildren =
-            !isSearching ||
-            Object.values(groupNode.children).some(hasMatchInDescendants);
+        const isGroupVisible =
+            (isSearching && searchResults.includes(node.key)) ||
+            Object.values(groupNode.children).some(hasVisibleDescendant);
 
-        if (!hasVisibleChildren && isSearching) {
+        if (!isGroupVisible) {
             return items;
         }
 
@@ -111,6 +119,7 @@ function flattenNodeRecursive(
                         expandedGroups,
                         searchResults,
                         isSearching,
+                        activeFields,
                         depth + 1,
                         childParentPath,
                     ),
@@ -202,6 +211,7 @@ function flattenSection(
                 expandedGroups,
                 searchResults,
                 isSearching,
+                options.activeFields,
                 baseDepth,
             ),
         );

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/types.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/types.ts
@@ -182,7 +182,7 @@ export interface FlattenTreeOptions {
     // Selected fields (for determining if missing field is dimension or metric)
     selectedDimensions: string[];
 
-    // Active fields (for pinning selected items to top)
+    // Active fields are excluded from the tree — they render in the pinned "Selected" section
     activeFields: Set<string>;
 
     // Git integration

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -1,5 +1,7 @@
 import {
     getItemId,
+    isCustomDimension,
+    isDimension,
     type AdditionalMetric,
     type CompiledTable,
     type Dimension,
@@ -29,6 +31,10 @@ import {
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import MantineIcon from '../../common/MantineIcon';
+import SelectedFieldsSection, {
+    type SelectedField,
+} from './SelectedFieldsSection';
+import { type NodeItem } from './TableTree/Tree/types';
 import { getSearchResults } from './TableTree/Tree/utils';
 import {
     flattenTreeForVirtualization,
@@ -178,6 +184,41 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
         });
     }, []);
 
+    // Resolve active field ids to their items for the pinned "Selected" section
+    const selectedFields = useMemo<SelectedField[]>(() => {
+        if (activeFields.size === 0) return [];
+
+        const itemsById = new Map<string, NodeItem>();
+        Object.values(explore.tables).forEach((table) => {
+            Object.values(table.dimensions).forEach((dimension) =>
+                itemsById.set(getItemId(dimension), dimension),
+            );
+            Object.values(table.metrics).forEach((metric) =>
+                itemsById.set(getItemId(metric), metric),
+            );
+        });
+        additionalMetrics.forEach((metric) =>
+            itemsById.set(getItemId(metric), metric),
+        );
+        (customDimensions ?? []).forEach((dimension) =>
+            itemsById.set(getItemId(dimension), dimension),
+        );
+
+        return [...activeFields].flatMap((fieldId) => {
+            const item = itemsById.get(fieldId);
+            // Table calculations and missing fields aren't in the tree
+            if (!item) return [];
+            return [
+                {
+                    fieldId,
+                    item,
+                    tableLabel: explore.tables[item.table]?.label ?? null,
+                    isDimension: isDimension(item) || isCustomDimension(item),
+                },
+            ];
+        });
+    }, [activeFields, explore, additionalMetrics, customDimensions]);
+
     const virtualizedTreeData = useMemo(() => {
         return flattenTreeForVirtualization({
             tables: tableTrees,
@@ -233,6 +274,11 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
                 value={search}
                 onChange={handleSearchChange}
                 data-testid="ExploreTree/SearchInput"
+            />
+
+            <SelectedFieldsSection
+                fields={selectedFields}
+                onDeselect={onSelectedFieldChange}
             />
 
             <VirtualizedTreeList

--- a/packages/frontend/src/mantine8CssVariablesResolver.ts
+++ b/packages/frontend/src/mantine8CssVariablesResolver.ts
@@ -16,6 +16,7 @@ import {
     SIDEBAR_RESIZE_HANDLE_WIDTH,
     SIDEBAR_TOGGLE_RESERVE,
 } from './components/common/Page/constants';
+import { LD_FIELD_COLORS } from './mantineTheme';
 
 // Bridges JS layout constants to global CSS variables so CSS modules can
 // reference them without re-declaring the literal values.
@@ -34,6 +35,15 @@ export const cssVariablesResolver: CSSVariablesResolver = () => ({
         '--dashboard-header-zindex': `${DASHBOARD_HEADER_ZINDEX}`,
         '--dashboard-tab-height': `${DASHBOARD_TAB_HEIGHT}px`,
         '--dashboard-tabs-zindex': `${DASHBOARD_TABS_ZINDEX}`,
+        '--ld-field-dimension-bg': LD_FIELD_COLORS.dimension.bg,
+        '--ld-field-dimension-bg-hover': LD_FIELD_COLORS.dimension.bgHover,
+        '--ld-field-dimension-color': LD_FIELD_COLORS.dimension.color,
+        '--ld-field-metric-bg': LD_FIELD_COLORS.metric.bg,
+        '--ld-field-metric-bg-hover': LD_FIELD_COLORS.metric.bgHover,
+        '--ld-field-metric-color': LD_FIELD_COLORS.metric.color,
+        '--ld-field-default-bg': LD_FIELD_COLORS.DEFAULT.bg,
+        '--ld-field-default-bg-hover': LD_FIELD_COLORS.DEFAULT.bgHover,
+        '--ld-field-default-color': LD_FIELD_COLORS.DEFAULT.color,
     },
     light: {},
     dark: {},


### PR DESCRIPTION
### Description:

This PR adds a new pinned "Selected" section at the top of the field tree in the Explorer that displays all currently selected fields. Selected fields are removed from the main tree to avoid duplication and reduce clutter.

**Key changes:**

1. **New `SelectedFieldsSection` component** - Displays selected fields in a pinned section above the tree with smooth enter/exit animations. Deselected rows remain mounted briefly to animate out instead of snapping away.

2. **Updated tree flattening logic** - Modified `flattenTreeForVirtualization` to exclude active (selected) fields from the tree and hide groups when all their children are selected. This prevents duplication and keeps the tree focused on unselected fields.

3. **Theme variables** - Added CSS variables for field type styling (dimension/metric/default backgrounds and colors) to `mantine8CssVariablesResolver.ts` for consistent theming across the selected section.

4. **Integration in ExploreTree** - The selected fields section is rendered above the virtualized tree list, with proper resolution of field items and table labels.

**Behavior:**
- Selected fields appear in the pinned section with their field icon, label, and table name
- Clicking a selected field deselects it
- Fields animate smoothly when selected/deselected
- Groups are hidden when all their children are selected
- Search results also exclude selected fields
- The pinned section has a max-height to prevent crowding out the tree

**Tests:**
- Added unit tests in `flattenTree.test.ts` covering:
  - Exclusion of active fields from the tree
  - Group hiding when all children are selected
  - Exclusion of active fields from search results

https://claude.ai/code/session_01PL73vnGdT1irv4Z28ufteG