### PR TITLE
feat: add browser AWS SSO for Redshift IAM credentials

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -58,6 +58,8 @@
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-lambda-microvms": "3.1075.0",
         "@aws-sdk/client-s3": "3.992.0",
+        "@aws-sdk/client-sso": "3.1079.0",
+        "@aws-sdk/client-sso-oidc": "3.1079.0",
         "@aws-sdk/credential-providers": "3.995.0",
         "@aws-sdk/lib-storage": "3.995.0",
         "@aws-sdk/s3-request-presigner": "3.995.0",

--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -12,6 +12,14 @@ declare module 'express-session' {
             databricks?: {
                 projectUuid?: string | undefined;
             };
+            redshiftAwsSso?: {
+                clientId: string;
+                clientSecret: string;
+                deviceCode: string;
+                region: string;
+                startUrl: string;
+                expiresAt: number;
+            };
             azureAdStrategyName?: string | undefined;
             oktaOrganizationUuid?: string | undefined;
             oidcStrategyName?: string | undefined;

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -15,10 +15,15 @@ import {
     ParameterError,
     PersonalAccessToken,
     PersonalAccessTokenWithToken,
+    RedshiftAwsSsoCompleteRequest,
+    RedshiftAwsSsoCompleteResponse,
+    RedshiftAwsSsoStartRequest,
+    RedshiftAwsSsoStartResponse,
     RegisterOrActivateUser,
     UpsertUserWarehouseCredentials,
     UserWarehouseCredentials,
     validatePassword,
+    WarehouseTypes,
 } from '@lightdash/common';
 import {
     Body,
@@ -349,6 +354,131 @@ export class UserController extends BaseController {
             results: await this.services
                 .getUserService()
                 .createWarehouseCredentials(toSessionUser(req.account), body),
+        };
+    }
+
+    /**
+     * Start Redshift AWS SSO login
+     * @summary Start Redshift AWS SSO login
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Post('/warehouseCredentials/redshift/aws-sso/start')
+    @OperationId('startRedshiftAwsSsoWarehouseCredentials')
+    async startRedshiftAwsSsoWarehouseCredentials(
+        @Request() req: express.Request,
+        @Body() body: RedshiftAwsSsoStartRequest,
+    ): Promise<RedshiftAwsSsoStartResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        let startRequest = body;
+        if (body.projectUuid) {
+            const project = await this.services
+                .getProjectService()
+                .getProject(body.projectUuid, req.account);
+            if (project.warehouseConnection?.type !== WarehouseTypes.REDSHIFT) {
+                throw new ParameterError(
+                    'Redshift AWS SSO credentials can only be created for Redshift projects.',
+                );
+            }
+            if (
+                !project.warehouseConnection.awsSsoStartUrl ||
+                !project.warehouseConnection.awsSsoRegion
+            ) {
+                throw new ParameterError(
+                    'Redshift AWS SSO credentials require AWS IAM Identity Center to be configured on the project.',
+                );
+            }
+            startRequest = {
+                ...body,
+                startUrl:
+                    body.startUrl ?? project.warehouseConnection.awsSsoStartUrl,
+                region: body.region ?? project.warehouseConnection.awsSsoRegion,
+            };
+        }
+        const { session, results } = await this.services
+            .getUserService()
+            .startRedshiftAwsSsoDeviceAuthorization(startRequest);
+        req.session.oauth = {
+            ...(req.session.oauth ?? {}),
+            redshiftAwsSso: session,
+        };
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Complete Redshift AWS SSO login
+     * @summary Complete Redshift AWS SSO login
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Post('/warehouseCredentials/redshift/aws-sso/complete')
+    @OperationId('completeRedshiftAwsSsoWarehouseCredentials')
+    async completeRedshiftAwsSsoWarehouseCredentials(
+        @Request() req: express.Request,
+        @Body() body: RedshiftAwsSsoCompleteRequest,
+    ): Promise<RedshiftAwsSsoCompleteResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        let completeRequest = body;
+        if (body.projectUuid) {
+            const project = await this.services
+                .getProjectService()
+                .getProject(body.projectUuid, req.account);
+            if (project.warehouseConnection?.type !== WarehouseTypes.REDSHIFT) {
+                throw new ParameterError(
+                    'Redshift AWS SSO credentials can only be created for Redshift projects.',
+                );
+            }
+            if (
+                !project.warehouseConnection.awsSsoAccountId ||
+                !project.warehouseConnection.awsSsoRoleName
+            ) {
+                throw new ParameterError(
+                    'Redshift AWS SSO credentials require AWS IAM Identity Center to be configured on the project.',
+                );
+            }
+            completeRequest = {
+                ...body,
+                accountId:
+                    body.accountId ??
+                    project.warehouseConnection.awsSsoAccountId,
+                roleName:
+                    body.roleName ?? project.warehouseConnection.awsSsoRoleName,
+            };
+        }
+        const results = await this.services
+            .getUserService()
+            .completeRedshiftAwsSsoDeviceAuthorization(
+                toSessionUser(req.account),
+                req.session.oauth?.redshiftAwsSso,
+                completeRequest,
+            );
+
+        if (results.status === 'authenticated') {
+            if (body.projectUuid) {
+                try {
+                    await this.services
+                        .getProjectService()
+                        .upsertProjectCredentialsPreference(
+                            toSessionUser(req.account),
+                            body.projectUuid,
+                            results.credentials.uuid,
+                        );
+                } catch (e) {
+                    Logger.warn(
+                        `Failed to set Redshift AWS SSO credentials preference for project ${body.projectUuid}`,
+                        e,
+                    );
+                }
+            }
+            delete req.session.oauth?.redshiftAwsSso;
+        }
+
+        return {
+            status: 'ok',
+            results,
         };
     }
 

--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -105,7 +105,9 @@ const credentialsTarget = (
 
             if (
                 credentials.authenticationType ===
-                RedshiftAuthenticationType.IAM
+                    RedshiftAuthenticationType.IAM ||
+                credentials.authenticationType ===
+                    RedshiftAuthenticationType.IAM_BROWSER
             ) {
                 if (!credentials.region) {
                     throw new ParameterError(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15221,7 +15221,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15232,7 +15232,7 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                tableName:
+                                                                                                fieldType:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15619,7 +15619,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -15630,7 +15630,7 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    tableName:
+                                                                                                    fieldType:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -15962,27 +15962,10 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
+                                                                                fieldId:
                                                                                     {
                                                                                         dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
+                                                                                            'string',
                                                                                         required: true,
                                                                                     },
                                                                                 description:
@@ -16010,18 +15993,35 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                fieldId:
+                                                                                fieldType:
                                                                                     {
                                                                                         dataType:
-                                                                                            'string',
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
                                                                                         required: true,
                                                                                     },
-                                                                                name: {
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                table: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -16746,7 +16746,7 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                fieldType:
+                                                                                tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -16757,7 +16757,7 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                tableName:
+                                                                                fieldType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -19609,7 +19609,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     RedshiftAuthenticationType: {
         dataType: 'refEnum',
-        enums: ['password', 'iam'],
+        enums: ['password', 'iam', 'iam_browser'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__':
@@ -19775,6 +19775,34 @@ const models: TsoaRoute.Models = {
                         ],
                     },
                     assumeRoleExternalId: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    awsSsoStartUrl: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    awsSsoRegion: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    awsSsoAccountId: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    awsSsoRoleName: {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'string' },
@@ -21046,6 +21074,10 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        awsSsoRoleName: { dataType: 'string' },
+                        awsSsoAccountId: { dataType: 'string' },
+                        awsSsoRegion: { dataType: 'string' },
+                        awsSsoStartUrl: { dataType: 'string' },
                         assumeRoleExternalId: { dataType: 'string' },
                         assumeRoleArn: { dataType: 'string' },
                         sessionToken: { dataType: 'string' },
@@ -26510,6 +26542,111 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RedshiftAwsSsoStartResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                interval: { dataType: 'double', required: true },
+                expiresIn: { dataType: 'double', required: true },
+                userCode: { dataType: 'string', required: true },
+                verificationUriComplete: { dataType: 'string', required: true },
+                verificationUri: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RedshiftAwsSsoStartResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'RedshiftAwsSsoStartResults', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RedshiftAwsSsoStartRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                region: { dataType: 'string' },
+                startUrl: { dataType: 'string' },
+                projectUuid: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RedshiftAwsSsoCompleteResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        status: {
+                            dataType: 'enum',
+                            enums: ['pending'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        credentials: {
+                            ref: 'UserWarehouseCredentials',
+                            required: true,
+                        },
+                        status: {
+                            dataType: 'enum',
+                            enums: ['authenticated'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RedshiftAwsSsoCompleteResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'RedshiftAwsSsoCompleteResults',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RedshiftAwsSsoCompleteRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                databaseUser: { dataType: 'string' },
+                credentialsName: { dataType: 'string' },
+                projectName: { dataType: 'string' },
+                projectUuid: { dataType: 'string' },
+                roleName: { dataType: 'string' },
+                accountId: { dataType: 'string' },
             },
             validators: {},
         },
@@ -32966,7 +33103,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32976,7 +33113,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32986,7 +33123,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -32999,7 +33136,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -33661,7 +33798,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33671,7 +33808,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33681,7 +33818,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -33694,7 +33831,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -60461,6 +60598,124 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'createWarehouseCredentials',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsUserController_startRedshiftAwsSsoWarehouseCredentials: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'RedshiftAwsSsoStartRequest',
+        },
+    };
+    app.post(
+        '/api/v1/user/warehouseCredentials/redshift/aws-sso/start',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.startRedshiftAwsSsoWarehouseCredentials,
+        ),
+
+        async function UserController_startRedshiftAwsSsoWarehouseCredentials(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsUserController_startRedshiftAwsSsoWarehouseCredentials,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<UserController>(UserController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'startRedshiftAwsSsoWarehouseCredentials',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsUserController_completeRedshiftAwsSsoWarehouseCredentials: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'RedshiftAwsSsoCompleteRequest',
+        },
+    };
+    app.post(
+        '/api/v1/user/warehouseCredentials/redshift/aws-sso/complete',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.completeRedshiftAwsSsoWarehouseCredentials,
+        ),
+
+        async function UserController_completeRedshiftAwsSsoWarehouseCredentials(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsUserController_completeRedshiftAwsSsoWarehouseCredentials,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<UserController>(UserController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'completeRedshiftAwsSsoWarehouseCredentials',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16688,13 +16688,13 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -16702,9 +16702,9 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -16858,13 +16858,13 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "fieldType": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -16872,9 +16872,9 @@
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -17046,12 +17046,8 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
+                                                                                "fieldId": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "description": {
                                                                                     "type": "string",
@@ -17060,13 +17056,17 @@
                                                                                 "label": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
@@ -17075,12 +17075,12 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "isFromJoinedTable",
                                                                                 "fieldFilterType",
-                                                                                "fieldType",
+                                                                                "fieldId",
                                                                                 "description",
                                                                                 "label",
-                                                                                "fieldId",
-                                                                                "name",
-                                                                                "table"
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -17401,13 +17401,13 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17415,9 +17415,9 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -20016,7 +20016,7 @@
                 "type": "string"
             },
             "RedshiftAuthenticationType": {
-                "enum": ["password", "iam"],
+                "enum": ["password", "iam", "iam_browser"],
                 "type": "string"
             },
             "Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
@@ -20113,6 +20113,18 @@
                         "type": "string"
                     },
                     "assumeRoleExternalId": {
+                        "type": "string"
+                    },
+                    "awsSsoStartUrl": {
+                        "type": "string"
+                    },
+                    "awsSsoRegion": {
+                        "type": "string"
+                    },
+                    "awsSsoAccountId": {
+                        "type": "string"
+                    },
+                    "awsSsoRoleName": {
                         "type": "string"
                     }
                 },
@@ -21071,6 +21083,18 @@
                     },
                     {
                         "properties": {
+                            "awsSsoRoleName": {
+                                "type": "string"
+                            },
+                            "awsSsoAccountId": {
+                                "type": "string"
+                            },
+                            "awsSsoRegion": {
+                                "type": "string"
+                            },
+                            "awsSsoStartUrl": {
+                                "type": "string"
+                            },
                             "assumeRoleExternalId": {
                                 "type": "string"
                             },
@@ -26644,6 +26668,129 @@
                     }
                 },
                 "required": ["credentials", "name"],
+                "type": "object"
+            },
+            "RedshiftAwsSsoStartResults": {
+                "properties": {
+                    "interval": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "expiresIn": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "userCode": {
+                        "type": "string"
+                    },
+                    "verificationUriComplete": {
+                        "type": "string"
+                    },
+                    "verificationUri": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "interval",
+                    "expiresIn",
+                    "userCode",
+                    "verificationUriComplete",
+                    "verificationUri"
+                ],
+                "type": "object"
+            },
+            "RedshiftAwsSsoStartResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/RedshiftAwsSsoStartResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "RedshiftAwsSsoStartRequest": {
+                "properties": {
+                    "region": {
+                        "type": "string"
+                    },
+                    "startUrl": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "RedshiftAwsSsoCompleteResults": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "enum": ["pending"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["status"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "credentials": {
+                                "$ref": "#/components/schemas/UserWarehouseCredentials"
+                            },
+                            "status": {
+                                "type": "string",
+                                "enum": ["authenticated"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["credentials", "status"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "RedshiftAwsSsoCompleteResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/RedshiftAwsSsoCompleteResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "RedshiftAwsSsoCompleteRequest": {
+                "properties": {
+                    "databaseUser": {
+                        "type": "string"
+                    },
+                    "credentialsName": {
+                        "type": "string"
+                    },
+                    "projectName": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "roleName": {
+                        "type": "string"
+                    },
+                    "accountId": {
+                        "type": "string"
+                    }
+                },
                 "type": "object"
             },
             "OpenIdIdentityIssuerType": {
@@ -33471,22 +33618,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -34050,22 +34197,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -43633,7 +43780,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3323.0",
+        "version": "0.3326.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -52285,6 +52432,90 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/UpsertUserWarehouseCredentials"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/user/warehouseCredentials/redshift/aws-sso/start": {
+            "post": {
+                "operationId": "startRedshiftAwsSsoWarehouseCredentials",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RedshiftAwsSsoStartResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Start Redshift AWS SSO login",
+                "summary": "Start Redshift AWS SSO login",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RedshiftAwsSsoStartRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/user/warehouseCredentials/redshift/aws-sso/complete": {
+            "post": {
+                "operationId": "completeRedshiftAwsSsoWarehouseCredentials",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RedshiftAwsSsoCompleteResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Complete Redshift AWS SSO login",
+                "summary": "Complete Redshift AWS SSO login",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RedshiftAwsSsoCompleteRequest"
                             }
                         }
                     }

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -463,8 +463,10 @@ export class UserWarehouseCredentialsModel {
         if (
             data.credentials.type === WarehouseTypes.REDSHIFT &&
             'authenticationType' in data.credentials &&
-            data.credentials.authenticationType ===
-                RedshiftAuthenticationType.IAM
+            (data.credentials.authenticationType ===
+                RedshiftAuthenticationType.IAM ||
+                data.credentials.authenticationType ===
+                    RedshiftAuthenticationType.IAM_BROWSER)
         ) {
             const result = redshiftIamUserCredentialsSchema.safeParse(
                 data.credentials,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1,3 +1,10 @@
+import { GetRoleCredentialsCommand, SSOClient } from '@aws-sdk/client-sso';
+import {
+    CreateTokenCommand,
+    RegisterClientCommand,
+    SSOOIDCClient,
+    StartDeviceAuthorizationCommand,
+} from '@aws-sdk/client-sso-oidc';
 import { subject } from '@casl/ability';
 import {
     ActivateUser,
@@ -42,6 +49,11 @@ import {
     ParameterError,
     PasswordReset,
     ProjectMemberRole,
+    RedshiftAuthenticationType,
+    RedshiftAwsSsoCompleteRequest,
+    RedshiftAwsSsoCompleteResults,
+    RedshiftAwsSsoStartRequest,
+    RedshiftAwsSsoStartResults,
     RegisterOrActivateUser,
     resolveEffectiveOrganizationSettings,
     ServiceAccount,
@@ -100,6 +112,18 @@ import { wrapSentryTransaction } from '../utils';
 import { processAvatarImage } from '../utils/processAvatarImage';
 import { BaseService } from './BaseService';
 import { getOrganizationSettingsInstanceDefaults } from './OrganizationSettingsService/getInstanceDefaults';
+
+const AWS_SSO_DEVICE_GRANT_TYPE =
+    'urn:ietf:params:oauth:grant-type:device_code';
+
+type RedshiftAwsSsoSession = {
+    clientId: string;
+    clientSecret: string;
+    deviceCode: string;
+    region: string;
+    startUrl: string;
+    expiresAt: number;
+};
 
 type UserServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -2655,6 +2679,224 @@ export class UserService extends BaseService {
         }
 
         return this.createWarehouseCredentials(user, databricksCredentials);
+    }
+
+    static isAwsSsoAuthorizationPending(error: unknown): boolean {
+        const errorName = (error as { name?: string })?.name;
+        return (
+            errorName === 'AuthorizationPendingException' ||
+            errorName === 'SlowDownException'
+        );
+    }
+
+    private static validateRedshiftAwsSsoStartRequest(
+        data: RedshiftAwsSsoStartRequest,
+    ) {
+        try {
+            if (!data.startUrl) {
+                throw new Error('Missing start URL');
+            }
+            const startUrl = new URL(data.startUrl);
+            if (startUrl.protocol !== 'https:') {
+                throw new Error('Invalid protocol');
+            }
+        } catch {
+            throw new ParameterError('AWS access portal URL must be valid.');
+        }
+
+        if (!data.region?.trim()) {
+            throw new ParameterError(
+                'AWS IAM Identity Center region is required.',
+            );
+        }
+    }
+
+    private static validateRedshiftAwsSsoCompleteRequest(
+        data: RedshiftAwsSsoCompleteRequest,
+    ) {
+        if (!data.accountId || !/^\d{12}$/.test(data.accountId.trim())) {
+            throw new ParameterError(
+                'AWS account ID must be a 12 digit number.',
+            );
+        }
+
+        if (!data.roleName?.trim()) {
+            throw new ParameterError('AWS role name is required.');
+        }
+    }
+
+    async startRedshiftAwsSsoDeviceAuthorization(
+        data: RedshiftAwsSsoStartRequest,
+    ): Promise<{
+        session: RedshiftAwsSsoSession;
+        results: RedshiftAwsSsoStartResults;
+    }> {
+        UserService.validateRedshiftAwsSsoStartRequest(data);
+
+        const region = data.region!.trim();
+        const startUrl = data.startUrl!.trim();
+        this.logger.info('Starting Redshift AWS SSO device authorization', {
+            region,
+        });
+        const client = new SSOOIDCClient({ region });
+        const registeredClient = await client.send(
+            new RegisterClientCommand({
+                clientName: 'Lightdash Redshift AWS SSO',
+                clientType: 'public',
+            }),
+        );
+
+        if (!registeredClient.clientId || !registeredClient.clientSecret) {
+            throw new ParameterError(
+                'AWS IAM Identity Center did not return client registration details.',
+            );
+        }
+
+        const authorization = await client.send(
+            new StartDeviceAuthorizationCommand({
+                clientId: registeredClient.clientId,
+                clientSecret: registeredClient.clientSecret,
+                startUrl,
+            }),
+        );
+
+        if (
+            !authorization.deviceCode ||
+            !authorization.verificationUri ||
+            !authorization.verificationUriComplete ||
+            !authorization.userCode ||
+            authorization.expiresIn === undefined ||
+            authorization.interval === undefined
+        ) {
+            throw new ParameterError(
+                'AWS IAM Identity Center did not return device authorization details.',
+            );
+        }
+
+        return {
+            session: {
+                clientId: registeredClient.clientId,
+                clientSecret: registeredClient.clientSecret,
+                deviceCode: authorization.deviceCode,
+                region,
+                startUrl,
+                expiresAt: Date.now() + authorization.expiresIn * 1000,
+            },
+            results: {
+                verificationUri: authorization.verificationUri,
+                verificationUriComplete: authorization.verificationUriComplete,
+                userCode: authorization.userCode,
+                expiresIn: authorization.expiresIn,
+                interval: authorization.interval,
+            },
+        };
+    }
+
+    async completeRedshiftAwsSsoDeviceAuthorization(
+        user: SessionUser,
+        session: RedshiftAwsSsoSession | undefined,
+        data: RedshiftAwsSsoCompleteRequest,
+    ): Promise<RedshiftAwsSsoCompleteResults> {
+        if (!session) {
+            throw new ParameterError('AWS SSO login has not been started.');
+        }
+
+        if (session.expiresAt < Date.now()) {
+            throw new ParameterError('AWS SSO login has expired. Try again.');
+        }
+
+        UserService.validateRedshiftAwsSsoCompleteRequest(data);
+
+        const oidcClient = new SSOOIDCClient({ region: session.region });
+        let accessToken: string | undefined;
+
+        try {
+            const token = await oidcClient.send(
+                new CreateTokenCommand({
+                    clientId: session.clientId,
+                    clientSecret: session.clientSecret,
+                    deviceCode: session.deviceCode,
+                    grantType: AWS_SSO_DEVICE_GRANT_TYPE,
+                }),
+            );
+            accessToken = token.accessToken;
+        } catch (e) {
+            if (UserService.isAwsSsoAuthorizationPending(e)) {
+                return { status: 'pending' };
+            }
+            throw e;
+        }
+
+        if (!accessToken) {
+            throw new ParameterError(
+                'AWS IAM Identity Center did not return an access token.',
+            );
+        }
+
+        const ssoClient = new SSOClient({ region: session.region });
+        const roleCredentials = await ssoClient.send(
+            new GetRoleCredentialsCommand({
+                accessToken,
+                accountId: data.accountId!.trim(),
+                roleName: data.roleName!.trim(),
+            }),
+        );
+
+        const awsCredentials = roleCredentials.roleCredentials;
+        if (
+            !awsCredentials?.accessKeyId ||
+            !awsCredentials.secretAccessKey ||
+            !awsCredentials.sessionToken
+        ) {
+            throw new ParameterError(
+                'AWS IAM Identity Center did not return role credentials.',
+            );
+        }
+
+        const roleName = data.roleName!.trim();
+        const credentialsName =
+            data.credentialsName?.trim() || `Redshift AWS SSO (${roleName})`;
+        const projectName = data.projectName?.trim();
+        const redshiftCredentials: UpsertUserWarehouseCredentials = {
+            name: credentialsName,
+            credentials: {
+                type: WarehouseTypes.REDSHIFT,
+                authenticationType: RedshiftAuthenticationType.IAM_BROWSER,
+                user: data.databaseUser?.trim() ?? '',
+                accessKeyId: awsCredentials.accessKeyId,
+                secretAccessKey: awsCredentials.secretAccessKey,
+                sessionToken: awsCredentials.sessionToken,
+            },
+        };
+
+        const existingCredentials = data.projectUuid
+            ? await this.userWarehouseCredentialsModel.findForProject(
+                  data.projectUuid,
+                  user.userUuid,
+                  WarehouseTypes.REDSHIFT,
+              )
+            : undefined;
+        const credentials = existingCredentials
+            ? await this.updateWarehouseCredentials(
+                  user,
+                  existingCredentials.uuid,
+                  redshiftCredentials,
+              )
+            : await this.createWarehouseCredentials(
+                  user,
+                  {
+                      ...redshiftCredentials,
+                      name: projectName
+                          ? `Redshift AWS SSO (${projectName})`
+                          : redshiftCredentials.name,
+                  },
+                  data.projectUuid,
+              );
+
+        return {
+            status: 'authenticated',
+            credentials,
+        };
     }
 
     async createWarehouseCredentials(

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -277,7 +277,11 @@ import {
     type UserAllowedOrganization,
 } from './user';
 import { type UserAvatarColorValue } from './userAvatars';
-import { type UserWarehouseCredentials } from './userWarehouseCredentials';
+import {
+    type RedshiftAwsSsoCompleteResults,
+    type RedshiftAwsSsoStartResults,
+    type UserWarehouseCredentials,
+} from './userWarehouseCredentials';
 import {
     type ApiChartValidationResponse,
     type ApiDashboardValidationResponse,
@@ -1050,6 +1054,8 @@ type ApiResults =
     | { sha: string; path: string }
     | { filePath: string }
     | UserWarehouseCredentials
+    | RedshiftAwsSsoStartResults
+    | RedshiftAwsSsoCompleteResults
     | ApiJobStatusResponse['results']
     | ApiJobScheduledResponse['results']
     | ApiSshKeyPairResponse['results']

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -260,13 +260,6 @@ export enum FeatureFlags {
     ProLimits = 'pro-limits',
 
     /**
-     * Show the AWS IAM authentication option on the Redshift connection form.
-     * When off, only username/password auth is offered. Lets IAM auth be
-     * rolled out / disabled per-org at runtime without a deploy.
-     */
-    RedshiftIamAuth = 'redshift-iam-auth',
-
-    /**
      * Replace the discoverFields sub-agent with a deterministic grep over an
      * in-memory, annotated view of the project's cached explores (explore =
      * directory, field = file). Connection-agnostic (reads compiled explores,

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -449,6 +449,7 @@ export const stripDucklakeNestedSensitive = (
 export enum RedshiftAuthenticationType {
     PASSWORD = 'password',
     IAM = 'iam',
+    IAM_BROWSER = 'iam_browser',
 }
 
 export type CreateRedshiftCredentials = SshTunnelConfiguration & {
@@ -486,6 +487,10 @@ export type CreateRedshiftCredentials = SshTunnelConfiguration & {
     sessionToken?: string;
     assumeRoleArn?: string;
     assumeRoleExternalId?: string;
+    awsSsoStartUrl?: string;
+    awsSsoRegion?: string;
+    awsSsoAccountId?: string;
+    awsSsoRoleName?: string;
 };
 export type RedshiftCredentials = Omit<
     CreateRedshiftCredentials,

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -108,6 +108,48 @@ export type UpsertUserWarehouseCredentials = {
     credentials: UserWarehouseCredentialsWithSecrets['credentials'];
 };
 
+export type RedshiftAwsSsoStartRequest = {
+    projectUuid?: string;
+    startUrl?: string;
+    region?: string;
+};
+
+export type RedshiftAwsSsoStartResults = {
+    verificationUri: string;
+    verificationUriComplete: string;
+    userCode: string;
+    expiresIn: number;
+    interval: number;
+};
+
+export type RedshiftAwsSsoStartResponse = {
+    status: 'ok';
+    results: RedshiftAwsSsoStartResults;
+};
+
+export type RedshiftAwsSsoCompleteRequest = {
+    accountId?: string;
+    roleName?: string;
+    projectUuid?: string;
+    projectName?: string;
+    credentialsName?: string;
+    databaseUser?: string;
+};
+
+export type RedshiftAwsSsoCompleteResults =
+    | {
+          status: 'pending';
+      }
+    | {
+          status: 'authenticated';
+          credentials: UserWarehouseCredentials;
+      };
+
+export type RedshiftAwsSsoCompleteResponse = {
+    status: 'ok';
+    results: RedshiftAwsSsoCompleteResults;
+};
+
 // Zod schema for validating Snowflake SSO user warehouse credentials
 // Requires refreshToken and disallows token field
 export const snowflakeSsoUserCredentialsSchema = z
@@ -152,7 +194,10 @@ export const bigquerySsoUserCredentialsSchema = z
 export const redshiftIamUserCredentialsSchema = z
     .object({
         type: z.literal(WarehouseTypes.REDSHIFT),
-        authenticationType: z.literal(RedshiftAuthenticationType.IAM),
+        authenticationType: z.union([
+            z.literal(RedshiftAuthenticationType.IAM),
+            z.literal(RedshiftAuthenticationType.IAM_BROWSER),
+        ]),
         user: z.string().optional(),
         password: z.string().optional(),
         accessKeyId: z.string().optional(),

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -71,7 +71,7 @@ export const BigQuerySchemaInput: FC<{
     );
 };
 
-export const BigQuerySSOInput: FC<{
+const BigQuerySSOInput: FC<{
     isAuthenticated: boolean;
     disabled: boolean;
     openLoginPopup: () => void;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -64,7 +64,7 @@ export const DatabricksSchemaInput: FC<{
     );
 };
 
-export const DatabricksSSOInput: FC<{
+const DatabricksSSOInput: FC<{
     isAuthenticated: boolean;
     disabled: boolean;
     disabledTooltip?: string;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -1,8 +1,4 @@
-import {
-    FeatureFlags,
-    RedshiftAuthenticationType,
-    WarehouseTypes,
-} from '@lightdash/common';
+import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
 import { Stack } from '@mantine-8/core';
 import {
     ActionIcon,
@@ -18,7 +14,6 @@ import {
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import { useToggle } from 'react-use';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
@@ -46,15 +41,60 @@ export const RedshiftSchemaInput: FC<{
     );
 };
 
+const RedshiftAwsSsoFields: FC<{
+    disabled: boolean;
+    required?: boolean;
+}> = ({ disabled, required = false }) => {
+    const form = useFormContext();
+
+    return (
+        <>
+            <TextInput
+                name="warehouse.awsSsoStartUrl"
+                label="AWS access portal URL"
+                description="The IAM Identity Center access portal URL users will open to sign in."
+                placeholder="https://your-start-url.awsapps.com/start"
+                required={required}
+                {...form.getInputProps('warehouse.awsSsoStartUrl')}
+                disabled={disabled}
+            />
+            <TextInput
+                name="warehouse.awsSsoRegion"
+                label="IAM Identity Center region"
+                description="The AWS region where IAM Identity Center is configured."
+                placeholder="us-east-1"
+                required={required}
+                {...form.getInputProps('warehouse.awsSsoRegion')}
+                disabled={disabled}
+            />
+            <TextInput
+                name="warehouse.awsSsoAccountId"
+                label="AWS account ID"
+                description="The AWS account users should access through IAM Identity Center."
+                placeholder="123456789012"
+                required={required}
+                {...form.getInputProps('warehouse.awsSsoAccountId')}
+                disabled={disabled}
+            />
+            <TextInput
+                name="warehouse.awsSsoRoleName"
+                label="AWS role name"
+                description="The IAM Identity Center role or permission-set role assigned to users."
+                placeholder="AWSReservedSSO_Redshift"
+                required={required}
+                {...form.getInputProps('warehouse.awsSsoRoleName')}
+                disabled={disabled}
+            />
+        </>
+    );
+};
+
 const RedshiftForm: FC<{
     disabled: boolean;
 }> = ({ disabled }) => {
     const [isOpen, toggleOpen] = useToggle(false);
     const { savedProject } = useProjectFormContext();
     const form = useFormContext();
-    const redshiftIamAuthFlag = useServerFeatureFlag(
-        FeatureFlags.RedshiftIamAuth,
-    );
 
     const requireSecrets: boolean =
         savedProject?.warehouseConnection?.type !== WarehouseTypes.REDSHIFT;
@@ -67,53 +107,21 @@ const RedshiftForm: FC<{
 
     const warehouse = form.values.warehouse;
 
-    // The flag resolves asynchronously; until it does, don't touch the
-    // authentication type or we'd clobber a saved IAM connection back to
-    // password before the flag loads.
-    const isIamAuthFlagResolved = redshiftIamAuthFlag.isFetched;
-    const isIamAuthEnabled = redshiftIamAuthFlag.data?.enabled === true;
-
-    const savedAuthenticationType =
-        savedProject?.warehouseConnection?.type === WarehouseTypes.REDSHIFT
-            ? savedProject.warehouseConnection.authenticationType
-            : undefined;
-
-    const defaultAuthenticationType =
-        savedAuthenticationType ?? RedshiftAuthenticationType.PASSWORD;
+    const defaultAuthenticationType = RedshiftAuthenticationType.PASSWORD;
 
     useEffect(() => {
-        if (!isIamAuthFlagResolved) {
-            return;
-        }
         const currentType = warehouse.authenticationType;
-        const nextType = isIamAuthEnabled
-            ? defaultAuthenticationType
-            : RedshiftAuthenticationType.PASSWORD;
 
-        if (
-            currentType === undefined ||
-            (!isIamAuthEnabled &&
-                currentType !== RedshiftAuthenticationType.PASSWORD)
-        ) {
-            form.setFieldValue('warehouse.authenticationType', nextType);
+        if (currentType !== defaultAuthenticationType) {
+            form.setFieldValue(
+                'warehouse.authenticationType',
+                defaultAuthenticationType,
+            );
         }
-    }, [
-        defaultAuthenticationType,
-        form,
-        warehouse.authenticationType,
-        isIamAuthEnabled,
-        isIamAuthFlagResolved,
-    ]);
+    }, [defaultAuthenticationType, form, warehouse.authenticationType]);
 
-    const authenticationType = isIamAuthEnabled
-        ? (warehouse.authenticationType ?? defaultAuthenticationType)
-        : RedshiftAuthenticationType.PASSWORD;
-
-    const isPasswordAuthentication =
-        authenticationType === RedshiftAuthenticationType.PASSWORD;
-    const isIamAuthentication =
-        authenticationType === RedshiftAuthenticationType.IAM;
-    const isServerless = warehouse.isServerless ?? false;
+    const requireUserCredentials =
+        form.values.warehouse.requireUserCredentials ?? false;
 
     const showSshTunnelConfiguration: boolean =
         form.values.warehouse.useSshTunnel ??
@@ -145,127 +153,32 @@ const RedshiftForm: FC<{
                     disabled={disabled}
                     labelProps={{ style: { marginTop: '8px' } }}
                 />
-                {isIamAuthEnabled && (
-                    <Select
-                        name="warehouse.authenticationType"
-                        label="Authentication type"
-                        description="Choose whether to authenticate with a database username and password, or with AWS IAM (temporary credentials)."
-                        data={[
-                            {
-                                value: RedshiftAuthenticationType.PASSWORD,
-                                label: 'Username & password',
-                            },
-                            {
-                                value: RedshiftAuthenticationType.IAM,
-                                label: 'AWS IAM',
-                            },
-                        ]}
-                        defaultValue={defaultAuthenticationType}
-                        {...form.getInputProps('warehouse.authenticationType')}
-                        required
-                        disabled={disabled}
-                    />
-                )}
-                {isPasswordAuthentication && (
-                    <>
-                        <TextInput
-                            name="warehouse.user"
-                            label="User"
-                            description="This is the database user name."
-                            required={requireSecrets}
-                            {...form.getInputProps('warehouse.user')}
-                            placeholder={
-                                disabled || !requireSecrets
-                                    ? '**************'
-                                    : undefined
-                            }
-                            disabled={disabled}
-                        />
-                        <PasswordInput
-                            name="warehouse.password"
-                            label="Password"
-                            description="This is the database user password."
-                            required={requireSecrets}
-                            placeholder={
-                                disabled || !requireSecrets
-                                    ? '**************'
-                                    : undefined
-                            }
-                            {...form.getInputProps('warehouse.password')}
-                            disabled={disabled}
-                        />
-                    </>
-                )}
-                {isIamAuthentication && (
-                    <>
-                        <TextInput
-                            name="warehouse.region"
-                            label="AWS region"
-                            description="The AWS region where your Redshift cluster or serverless workgroup is located."
-                            required
-                            placeholder="us-east-1"
-                            {...form.getInputProps('warehouse.region')}
-                            disabled={disabled}
-                        />
-                        <BooleanSwitch
-                            name="warehouse.isServerless"
-                            label="Redshift Serverless"
-                            description="Enable if connecting to a Redshift Serverless workgroup rather than a provisioned cluster."
-                            {...form.getInputProps('warehouse.isServerless', {
-                                type: 'checkbox',
-                            })}
-                            disabled={disabled}
-                        />
-                        {isServerless ? (
-                            <TextInput
-                                name="warehouse.workgroupName"
-                                label="Workgroup name"
-                                description="The name of your Redshift Serverless workgroup."
-                                required
-                                {...form.getInputProps(
-                                    'warehouse.workgroupName',
-                                )}
-                                disabled={disabled}
-                            />
-                        ) : (
-                            <TextInput
-                                name="warehouse.clusterIdentifier"
-                                label="Cluster identifier"
-                                description="The identifier of your provisioned Redshift cluster."
-                                required
-                                {...form.getInputProps(
-                                    'warehouse.clusterIdentifier',
-                                )}
-                                disabled={disabled}
-                            />
-                        )}
-                        <TextInput
-                            name="warehouse.user"
-                            label="Database user"
-                            description="The Redshift database user to request temporary credentials for."
-                            required={!isServerless}
-                            {...form.getInputProps('warehouse.user')}
-                            disabled={disabled}
-                        />
-                        <TextInput
-                            name="warehouse.assumeRoleArn"
-                            label="Assume role ARN"
-                            description="Recommended: an IAM role Lightdash assumes to mint Redshift credentials. Leave blank to use the host's IAM role (self-hosted), or provide AWS access keys under Advanced."
-                            placeholder="arn:aws:iam::123456789012:role/my-redshift-role"
-                            {...form.getInputProps('warehouse.assumeRoleArn')}
-                            disabled={disabled}
-                        />
-                        <TextInput
-                            name="warehouse.assumeRoleExternalId"
-                            label="Assume role external ID"
-                            description="External ID required by the assume-role trust policy, if configured."
-                            {...form.getInputProps(
-                                'warehouse.assumeRoleExternalId',
-                            )}
-                            disabled={disabled}
-                        />
-                    </>
-                )}
+                <TextInput
+                    name="warehouse.user"
+                    label="User"
+                    description="This is the database user name."
+                    required={requireSecrets}
+                    {...form.getInputProps('warehouse.user')}
+                    placeholder={
+                        disabled || !requireSecrets
+                            ? '**************'
+                            : undefined
+                    }
+                    disabled={disabled}
+                />
+                <PasswordInput
+                    name="warehouse.password"
+                    label="Password"
+                    description="This is the database user password."
+                    required={requireSecrets}
+                    placeholder={
+                        disabled || !requireSecrets
+                            ? '**************'
+                            : undefined
+                    }
+                    {...form.getInputProps('warehouse.password')}
+                    disabled={disabled}
+                />
                 <TextInput
                     name="warehouse.dbname"
                     label="DB name"
@@ -289,49 +202,8 @@ const RedshiftForm: FC<{
                             disabled={disabled}
                         />
 
-                        {isIamAuthentication && (
-                            <>
-                                <TextInput
-                                    name="warehouse.accessKeyId"
-                                    label="AWS access key ID"
-                                    description="Advanced: static IAM user access key, only if you are not using an assume-role ARN or the host's IAM role. Long-lived secret — prefer assume-role where possible."
-                                    placeholder={
-                                        disabled || !requireSecrets
-                                            ? '**************'
-                                            : undefined
-                                    }
-                                    {...form.getInputProps(
-                                        'warehouse.accessKeyId',
-                                    )}
-                                    disabled={disabled}
-                                />
-                                <PasswordInput
-                                    name="warehouse.secretAccessKey"
-                                    label="AWS secret access key"
-                                    description="Secret access key paired with the access key ID above."
-                                    placeholder={
-                                        disabled || !requireSecrets
-                                            ? '**************'
-                                            : undefined
-                                    }
-                                    {...form.getInputProps(
-                                        'warehouse.secretAccessKey',
-                                    )}
-                                    disabled={disabled}
-                                />
-                                {!isServerless && (
-                                    <BooleanSwitch
-                                        name="warehouse.autoCreate"
-                                        label="Auto-create database user"
-                                        description="Create the database user automatically if it does not already exist (GetClusterCredentials AutoCreate)."
-                                        {...form.getInputProps(
-                                            'warehouse.autoCreate',
-                                            { type: 'checkbox' },
-                                        )}
-                                        disabled={disabled}
-                                    />
-                                )}
-                            </>
+                        {requireUserCredentials && (
+                            <RedshiftAwsSsoFields disabled={disabled} />
                         )}
 
                         <NumberInput

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -57,7 +57,7 @@ export const SnowflakeSchemaInput: FC<{
     );
 };
 
-export const SnowflakeSSOInput: FC<{
+const SnowflakeSSOInput: FC<{
     isAuthenticated: boolean;
     disabled: boolean;
     openLoginPopup: () => void;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
@@ -116,6 +116,10 @@ export const RedshiftDefaultValues: CreateRedshiftCredentials = {
     secretAccessKey: '',
     assumeRoleArn: '',
     assumeRoleExternalId: '',
+    awsSsoStartUrl: '',
+    awsSsoRegion: '',
+    awsSsoAccountId: '',
+    awsSsoRoleName: '',
     autoCreate: false,
 };
 

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
@@ -1,7 +1,7 @@
 import { capitalize, type WarehouseTypes } from '@lightdash/common';
 
-export const getSsoLabel = (warehouse: WarehouseTypes) =>
-    `User Account (Sign in with ${capitalize(warehouse)})`;
+export const getSsoLabel = (warehouse: WarehouseTypes, provider?: string) =>
+    `User Account (Sign in with ${provider ?? capitalize(warehouse)})`;
 export const PRIVATE_KEY_LABEL = `Service Account (JSON key file)`;
 export const PASSWORD_LABEL = `Password`;
 export const EXTERNAL_BROWSER_LABEL = `External Browser`;

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -102,11 +102,18 @@ export const CreateCredentialsModal: FC<Props> = ({
         },
     });
 
-    const showSaveButton = ![
-        WarehouseTypes.BIGQUERY,
-        WarehouseTypes.SNOWFLAKE,
-        WarehouseTypes.DATABRICKS,
-    ].includes(warehouseType ?? form.values.credentials.type);
+    const isRedshiftBrowserSso =
+        form.values.credentials.type === WarehouseTypes.REDSHIFT &&
+        'authenticationType' in form.values.credentials &&
+        form.values.credentials.authenticationType ===
+            RedshiftAuthenticationType.IAM_BROWSER;
+    const showSaveButton =
+        !isRedshiftBrowserSso &&
+        ![
+            WarehouseTypes.BIGQUERY,
+            WarehouseTypes.SNOWFLAKE,
+            WarehouseTypes.DATABRICKS,
+        ].includes(warehouseType ?? form.values.credentials.type);
 
     return (
         <MantineModal
@@ -175,6 +182,7 @@ export const CreateCredentialsModal: FC<Props> = ({
                         form={form}
                         disabled={isSaving}
                         onClose={onClose}
+                        onSuccess={onSuccess}
                         projectUuid={projectUuid}
                         projectName={projectName}
                         databricksCredentialsName={

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -2,6 +2,7 @@ import {
     RedshiftAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
+    type UserWarehouseCredentials,
 } from '@lightdash/common';
 import {
     Alert,
@@ -20,14 +21,15 @@ import {
     IconChevronRight,
     IconInfoCircle,
 } from '@tabler/icons-react';
-import { type FC, useState } from 'react';
+import { type FC, useEffect, useState } from 'react';
 import { useGoogleLoginPopup } from '../../../hooks/gdrive/useGdrive';
 import { useDatabricksLoginPopup } from '../../../hooks/useDatabricks';
+import { useProject } from '../../../hooks/useProject';
+import { useRedshiftAwsSsoLoginPopup } from '../../../hooks/useRedshiftAwsSso';
 import { useSnowflakeLoginPopup } from '../../../hooks/useSnowflake';
 import MantineIcon from '../../common/MantineIcon';
-import { BigQuerySSOInput } from '../../ProjectConnection/WarehouseForms/BigQueryForm';
-import { DatabricksSSOInput } from '../../ProjectConnection/WarehouseForms/DatabricksForm';
-import { SnowflakeSSOInput } from '../../ProjectConnection/WarehouseForms/SnowflakeForm';
+import { getSsoLabel } from '../../ProjectConnection/WarehouseForms/util';
+import { WarehouseSsoButton } from './WarehouseSsoButton';
 
 const BigQueryFormInput: FC<{ onClose: () => void }> = ({ onClose }) => {
     const { mutate: openLoginPopup } = useGoogleLoginPopup('bigquery', onClose);
@@ -35,8 +37,9 @@ const BigQueryFormInput: FC<{ onClose: () => void }> = ({ onClose }) => {
     // If this popup happens, it means we don't have warehouse credentials,
     // (aka isAuthenticated is false), so we need to authenticate
     return (
-        <BigQuerySSOInput
-            isAuthenticated={false}
+        <WarehouseSsoButton
+            warehouseType={WarehouseTypes.BIGQUERY}
+            providerName="Google"
             disabled={false}
             openLoginPopup={openLoginPopup}
         />
@@ -55,8 +58,9 @@ export const SnowflakeFormInput: FC<{ onClose: () => void }> = ({
     // If this popup happens, it means we don't have warehouse credentials,
     // (aka isAuthenticated is false), so we need to authenticate
     return (
-        <SnowflakeSSOInput
-            isAuthenticated={false}
+        <WarehouseSsoButton
+            warehouseType={WarehouseTypes.SNOWFLAKE}
+            providerName="Snowflake"
             disabled={false}
             openLoginPopup={openLoginPopup}
         />
@@ -81,8 +85,9 @@ const DatabricksFormInput: FC<{
     // If this popup happens, it means we don't have warehouse credentials,
     // (aka isAuthenticated is false), so we need to authenticate
     return (
-        <DatabricksSSOInput
-            isAuthenticated={false}
+        <WarehouseSsoButton
+            warehouseType={WarehouseTypes.DATABRICKS}
+            providerName="Databricks"
             disabled={false}
             openLoginPopup={openLoginPopup}
         />
@@ -92,7 +97,20 @@ const DatabricksFormInput: FC<{
 const RedshiftIamFormInputs: FC<{
     disabled: boolean;
     form: UseFormReturnType<UpsertUserWarehouseCredentials>;
-}> = ({ disabled, form }) => {
+    onClose: () => void;
+    onSuccess?: (data: UserWarehouseCredentials) => void;
+    projectUuid?: string;
+    projectName?: string;
+    isAwsSsoConfigured?: boolean;
+}> = ({
+    disabled,
+    form,
+    onClose,
+    onSuccess,
+    projectUuid,
+    projectName,
+    isAwsSsoConfigured,
+}) => {
     const redshiftCredentials =
         form.values.credentials.type === WarehouseTypes.REDSHIFT
             ? form.values.credentials
@@ -105,6 +123,68 @@ const RedshiftIamFormInputs: FC<{
     const [isAdvancedOpen, setIsAdvancedOpen] = useState(
         !!redshiftCredentials?.user || hasAdvancedIamOptions,
     );
+    const isBrowserIamAuthentication =
+        redshiftCredentials !== undefined &&
+        'authenticationType' in redshiftCredentials &&
+        redshiftCredentials.authenticationType ===
+            RedshiftAuthenticationType.IAM_BROWSER;
+    const { mutate: openAwsSsoLogin, isLoading: isAwsSsoLoading } =
+        useRedshiftAwsSsoLoginPopup({
+            onLogin: async (credentials) => {
+                onSuccess?.(credentials);
+                onClose();
+            },
+        });
+    const isAwsSsoDisabled =
+        disabled || isAwsSsoLoading || !projectUuid || !isAwsSsoConfigured;
+
+    if (isBrowserIamAuthentication) {
+        return (
+            <Stack gap="xs">
+                <WarehouseSsoButton
+                    warehouseType={WarehouseTypes.REDSHIFT}
+                    providerName="AWS"
+                    disabled={isAwsSsoDisabled}
+                    disabledTooltip={
+                        !projectUuid
+                            ? 'Open this from a Redshift project to sign in with AWS'
+                            : !isAwsSsoConfigured
+                              ? 'Ask an admin to configure AWS IAM Identity Center on the Redshift project connection'
+                              : undefined
+                    }
+                    loading={isAwsSsoLoading}
+                    openLoginPopup={() => {
+                        openAwsSsoLogin({
+                            projectUuid,
+                            projectName,
+                            databaseUser: redshiftCredentials?.user,
+                        });
+                    }}
+                />
+
+                {!projectUuid && (
+                    <Text fz="xs" c="dimmed">
+                        Browser sign-in is available from a project that has AWS
+                        IAM Identity Center configured.
+                    </Text>
+                )}
+                {projectUuid && !isAwsSsoConfigured && (
+                    <Text fz="xs" c="dimmed">
+                        Ask an admin to configure AWS IAM Identity Center on the
+                        Redshift project connection.
+                    </Text>
+                )}
+
+                <TextInput
+                    size="xs"
+                    label="Database user"
+                    description="Optional. Leave blank to use the IAM identity as the Redshift database user."
+                    disabled={disabled}
+                    {...form.getInputProps('credentials.user')}
+                />
+            </Stack>
+        );
+    }
 
     return (
         <Stack gap="xs">
@@ -157,6 +237,7 @@ const RedshiftIamFormInputs: FC<{
             />
 
             <Button
+                type="button"
                 size="compact-xs"
                 variant="subtle"
                 color="gray"
@@ -207,6 +288,7 @@ export const WarehouseFormInputs: FC<{
     disabled: boolean;
     form: UseFormReturnType<UpsertUserWarehouseCredentials>;
     onClose: () => void;
+    onSuccess?: (data: UserWarehouseCredentials) => void;
     projectUuid?: string;
     projectName?: string;
     databricksCredentialsName?: string;
@@ -214,17 +296,51 @@ export const WarehouseFormInputs: FC<{
     form,
     disabled,
     onClose,
+    onSuccess,
     projectUuid,
     projectName,
     databricksCredentialsName,
 }) => {
-    const redshiftAuthenticationType =
-        form.values.credentials.type === WarehouseTypes.REDSHIFT
-            ? 'authenticationType' in form.values.credentials
-                ? (form.values.credentials.authenticationType ??
-                  RedshiftAuthenticationType.PASSWORD)
-                : RedshiftAuthenticationType.PASSWORD
+    const { data: project } = useProject(projectUuid, {
+        enabled:
+            form.values.credentials.type === WarehouseTypes.REDSHIFT &&
+            !!projectUuid,
+    });
+    const redshiftProjectCredentials =
+        project?.warehouseConnection?.type === WarehouseTypes.REDSHIFT
+            ? project.warehouseConnection
             : undefined;
+    const isProjectBrowserIamAuthentication =
+        redshiftProjectCredentials?.authenticationType ===
+        RedshiftAuthenticationType.IAM_BROWSER;
+    const isAwsSsoConfigured =
+        !!redshiftProjectCredentials?.awsSsoStartUrl &&
+        !!redshiftProjectCredentials.awsSsoRegion &&
+        !!redshiftProjectCredentials.awsSsoAccountId &&
+        !!redshiftProjectCredentials.awsSsoRoleName;
+    const redshiftAuthenticationType = isProjectBrowserIamAuthentication
+        ? RedshiftAuthenticationType.IAM_BROWSER
+        : form.values.credentials.type === WarehouseTypes.REDSHIFT
+          ? 'authenticationType' in form.values.credentials
+              ? (form.values.credentials.authenticationType ??
+                RedshiftAuthenticationType.PASSWORD)
+              : RedshiftAuthenticationType.PASSWORD
+          : undefined;
+
+    useEffect(() => {
+        if (
+            isProjectBrowserIamAuthentication &&
+            form.values.credentials.type === WarehouseTypes.REDSHIFT &&
+            'authenticationType' in form.values.credentials &&
+            form.values.credentials.authenticationType !==
+                RedshiftAuthenticationType.IAM_BROWSER
+        ) {
+            form.setFieldValue(
+                'credentials.authenticationType',
+                RedshiftAuthenticationType.IAM_BROWSER,
+            );
+        }
+    }, [form, isProjectBrowserIamAuthentication]);
 
     switch (form.values.credentials.type) {
         case WarehouseTypes.SNOWFLAKE:
@@ -253,31 +369,47 @@ export const WarehouseFormInputs: FC<{
         case WarehouseTypes.REDSHIFT:
             return (
                 <>
-                    <Select
-                        required
-                        size="xs"
-                        label="Authentication type"
-                        data={[
-                            {
-                                value: RedshiftAuthenticationType.PASSWORD,
-                                label: 'Username & password',
-                            },
-                            {
-                                value: RedshiftAuthenticationType.IAM,
-                                label: 'AWS IAM',
-                            },
-                        ]}
-                        disabled={disabled}
-                        {...form.getInputProps(
-                            'credentials.authenticationType',
-                        )}
-                    />
+                    {!isProjectBrowserIamAuthentication && (
+                        <Select
+                            required
+                            size="xs"
+                            label="Authentication type"
+                            data={[
+                                {
+                                    value: RedshiftAuthenticationType.PASSWORD,
+                                    label: 'Username & password',
+                                },
+                                {
+                                    value: RedshiftAuthenticationType.IAM,
+                                    label: 'AWS IAM (CLI credentials)',
+                                },
+                                {
+                                    value: RedshiftAuthenticationType.IAM_BROWSER,
+                                    label: getSsoLabel(
+                                        WarehouseTypes.REDSHIFT,
+                                        'AWS',
+                                    ),
+                                },
+                            ]}
+                            disabled={disabled}
+                            {...form.getInputProps(
+                                'credentials.authenticationType',
+                            )}
+                        />
+                    )}
 
                     {redshiftAuthenticationType ===
-                    RedshiftAuthenticationType.IAM ? (
+                        RedshiftAuthenticationType.IAM ||
+                    redshiftAuthenticationType ===
+                        RedshiftAuthenticationType.IAM_BROWSER ? (
                         <RedshiftIamFormInputs
                             disabled={disabled}
                             form={form}
+                            onClose={onClose}
+                            onSuccess={onSuccess}
+                            projectUuid={projectUuid}
+                            projectName={projectName}
+                            isAwsSsoConfigured={isAwsSsoConfigured}
                         />
                     ) : (
                         <>

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseSsoButton.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseSsoButton.tsx
@@ -1,0 +1,57 @@
+import { WarehouseTypes } from '@lightdash/common';
+import { Button, Tooltip } from '@mantine-8/core';
+import { type FC, type ReactNode } from 'react';
+import { getWarehouseIcon } from '../../ProjectConnection/ProjectConnectFlow/utils';
+
+const GOOGLE_LOGO_SRC =
+    'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZyI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj48cGF0aCBkPSJNMTcuNiA5LjJsLS4xLTEuOEg5djMuNGg0LjhDMTMuNiAxMiAxMyAxMyAxMiAxMy42djIuMmgzYTguOCA4LjggMCAwIDAgMi42LTYuNnoiIGZpbGw9IiM0Mjg1RjQiIGZpbGwtcnVsZT0ibm9uemVybyIvPjxwYXRoIGQ9Ik05IDE4YzIuNCAwIDQuNS0uOCA2LTIuMmwtMy0yLjJhNS40IDUuNCAwIDAgMS04LTIuOUgxVjEzYTkgOSAwIDAgMCA4IDV6IiBmaWxsPSIjMzRBODUzIiBmaWxsLXJ1bGU9Im5vbnplcm8iLz48cGF0aCBkPSJNNCAxMC43YTUuNCA1LjQgMCAwIDEgMC0zLjRWNUgxYTkgOSAwIDAgMCAwIDhsMy0yLjN6IiBmaWxsPSIjRkJCQzA1IiBmaWxsLXJ1bGU9Im5vbnplcm8iLz48cGF0aCBkPSJNOSAzLjZjMS4zIDAgMi41LjQgMy40IDEuM0wxNSAyLjNBOSA5IDAgMCAwIDEgNWwzIDIuNGE1LjQgNS40IDAgMCAxIDUtMy43eiIgZmlsbD0iI0VBNDMzNSIgZmlsbC1ydWxlPSJub256ZXJvIi8+PHBhdGggZD0iTTAgMGgxOHYxOEgweiIvPjwvZz48L3N2Zz4=';
+
+const getSsoButtonIcon = (warehouseType: WarehouseTypes): ReactNode =>
+    warehouseType === WarehouseTypes.BIGQUERY ? (
+        <img width={16} height={16} src={GOOGLE_LOGO_SRC} alt="Google logo" />
+    ) : (
+        getWarehouseIcon(warehouseType, 'sm')
+    );
+
+export const WarehouseSsoButton: FC<{
+    warehouseType: WarehouseTypes;
+    providerName: string;
+    disabled: boolean;
+    disabledTooltip?: string;
+    loading?: boolean;
+    openLoginPopup: () => void;
+}> = ({
+    warehouseType,
+    providerName,
+    disabled,
+    disabledTooltip,
+    loading,
+    openLoginPopup,
+}) => {
+    const button = (
+        <Button
+            type="button"
+            variant="default"
+            color="gray"
+            fullWidth
+            disabled={disabled}
+            loading={loading}
+            leftSection={getSsoButtonIcon(warehouseType)}
+            onClick={() => {
+                openLoginPopup();
+            }}
+        >
+            Sign in with {providerName}
+        </Button>
+    );
+
+    if (disabled && disabledTooltip) {
+        return (
+            <Tooltip label={disabledTooltip} withArrow>
+                <div>{button}</div>
+            </Tooltip>
+        );
+    }
+
+    return button;
+};

--- a/packages/frontend/src/hooks/useRedshiftAwsSso.test.tsx
+++ b/packages/frontend/src/hooks/useRedshiftAwsSso.test.tsx
@@ -1,0 +1,149 @@
+import {
+    RedshiftAuthenticationType,
+    WarehouseTypes,
+    type UserWarehouseCredentials,
+} from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type Mock,
+} from 'vitest';
+import { useRedshiftAwsSsoLoginPopup } from './useRedshiftAwsSso';
+
+vi.mock('../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+vi.mock('./toaster/useToaster', () => ({
+    default: () => ({
+        showToastError: vi.fn(),
+    }),
+}));
+
+import { lightdashApi } from '../api';
+
+const mockApi = lightdashApi as unknown as Mock;
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+}
+
+describe('useRedshiftAwsSsoLoginPopup', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('opens AWS SSO, polls until authenticated, and returns the created credentials', async () => {
+        const popupWindow = {
+            close: vi.fn(),
+        } as unknown as Window;
+        vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+
+        const credentials: UserWarehouseCredentials = {
+            uuid: 'credential-uuid',
+            name: 'Redshift AWS SSO',
+            userUuid: 'user-uuid',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            credentials: {
+                type: WarehouseTypes.REDSHIFT,
+                authenticationType: RedshiftAuthenticationType.IAM_BROWSER,
+                user: 'javier',
+            },
+            project: null,
+        };
+        mockApi
+            .mockResolvedValueOnce({
+                verificationUri: 'https://device.sso.aws.amazon.com',
+                verificationUriComplete:
+                    'https://device.sso.aws.amazon.com/?user_code=ABCD-EFGH',
+                userCode: 'ABCD-EFGH',
+                expiresIn: 60,
+                interval: 1,
+            })
+            .mockResolvedValueOnce({ status: 'pending' })
+            .mockResolvedValueOnce({
+                status: 'authenticated',
+                credentials,
+            });
+        const onLogin = vi.fn();
+
+        const { result } = renderHook(
+            () =>
+                useRedshiftAwsSsoLoginPopup({
+                    onLogin,
+                }),
+            { wrapper: createWrapper() },
+        );
+
+        let login: Promise<UserWarehouseCredentials>;
+        act(() => {
+            login = result.current.mutateAsync({
+                projectUuid: 'project-uuid',
+                projectName: 'Project',
+                databaseUser: 'javier',
+            });
+        });
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0);
+        });
+
+        expect(window.open).toHaveBeenCalledWith(
+            'https://device.sso.aws.amazon.com/?user_code=ABCD-EFGH',
+            'aws-sso-login-popup',
+            'width=600,height=700',
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1000);
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1000);
+        });
+
+        await expect(login!).resolves.toEqual(credentials);
+        expect(onLogin).toHaveBeenCalledWith(credentials);
+        expect(popupWindow.close).toHaveBeenCalledTimes(1);
+        expect(mockApi).toHaveBeenNthCalledWith(1, {
+            url: '/user/warehouseCredentials/redshift/aws-sso/start',
+            method: 'POST',
+            body: JSON.stringify({
+                projectUuid: 'project-uuid',
+            }),
+        });
+        expect(mockApi).toHaveBeenNthCalledWith(2, {
+            url: '/user/warehouseCredentials/redshift/aws-sso/complete',
+            method: 'POST',
+            body: JSON.stringify({
+                projectUuid: 'project-uuid',
+                projectName: 'Project',
+                credentialsName: undefined,
+                databaseUser: 'javier',
+            }),
+        });
+    });
+});

--- a/packages/frontend/src/hooks/useRedshiftAwsSso.ts
+++ b/packages/frontend/src/hooks/useRedshiftAwsSso.ts
@@ -1,0 +1,117 @@
+import {
+    type ApiError,
+    type RedshiftAwsSsoCompleteRequest,
+    type RedshiftAwsSsoCompleteResults,
+    type RedshiftAwsSsoStartRequest,
+    type RedshiftAwsSsoStartResults,
+    type UserWarehouseCredentials,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { lightdashApi } from '../api';
+import useToaster from './toaster/useToaster';
+
+type RedshiftAwsSsoLoginRequest = RedshiftAwsSsoStartRequest &
+    RedshiftAwsSsoCompleteRequest;
+
+const sleep = (ms: number) =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+const startRedshiftAwsSsoLogin = async (data: RedshiftAwsSsoStartRequest) =>
+    lightdashApi<RedshiftAwsSsoStartResults>({
+        url: `/user/warehouseCredentials/redshift/aws-sso/start`,
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+const completeRedshiftAwsSsoLogin = async (
+    data: RedshiftAwsSsoCompleteRequest,
+) =>
+    lightdashApi<RedshiftAwsSsoCompleteResults>({
+        url: `/user/warehouseCredentials/redshift/aws-sso/complete`,
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+const triggerRedshiftAwsSsoLogin = async (
+    data: RedshiftAwsSsoLoginRequest,
+): Promise<UserWarehouseCredentials> => {
+    const start = await startRedshiftAwsSsoLogin({
+        projectUuid: data.projectUuid,
+        startUrl: data.startUrl,
+        region: data.region,
+    });
+
+    const popupWindow = window.open(
+        start.verificationUriComplete,
+        'aws-sso-login-popup',
+        'width=600,height=700',
+    );
+
+    if (!popupWindow) {
+        throw new Error('Failed to open AWS sign-in window');
+    }
+
+    const intervalMs = Math.max(start.interval, 1) * 1000;
+    const expiresAt = Date.now() + start.expiresIn * 1000;
+
+    while (Date.now() < expiresAt) {
+        await sleep(intervalMs);
+        const result = await completeRedshiftAwsSsoLogin({
+            accountId: data.accountId,
+            roleName: data.roleName,
+            projectUuid: data.projectUuid,
+            projectName: data.projectName,
+            credentialsName: data.credentialsName,
+            databaseUser: data.databaseUser,
+        });
+
+        if (result.status === 'authenticated') {
+            popupWindow.close();
+            return result.credentials;
+        }
+    }
+
+    popupWindow.close();
+    throw new Error('AWS sign-in expired. Please try again.');
+};
+
+export function useRedshiftAwsSsoLoginPopup({
+    onLogin: _onLogin,
+}: {
+    onLogin: (credentials: UserWarehouseCredentials) => Promise<void>;
+}) {
+    const { showToastError } = useToaster();
+    const queryClient = useQueryClient();
+    const ssoMutation = useMutation<
+        UserWarehouseCredentials,
+        ApiError | Error,
+        RedshiftAwsSsoLoginRequest
+    >({
+        mutationFn: triggerRedshiftAwsSsoLogin,
+        onSuccess: async (credentials) => {
+            await queryClient.invalidateQueries(['user_warehouse_credentials']);
+            await queryClient.invalidateQueries([
+                'project_user_warehouse_credentials',
+            ]);
+            await _onLogin(credentials);
+        },
+        onError: (error) => {
+            showToastError({
+                title: 'AWS sign-in failed',
+                subtitle:
+                    error instanceof Error
+                        ? error.message
+                        : error.error.message || 'Please try again',
+            });
+        },
+    });
+
+    return useMemo(() => {
+        return {
+            ...ssoMutation,
+        };
+    }, [ssoMutation]);
+}

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
@@ -67,7 +67,9 @@ export class RedshiftWarehouseClient extends PostgresClient<CreateRedshiftCreden
         const ssl = getSSLConfigFromMode(sslmode);
 
         const isIam =
-            credentials.authenticationType === RedshiftAuthenticationType.IAM;
+            credentials.authenticationType === RedshiftAuthenticationType.IAM ||
+            credentials.authenticationType ===
+                RedshiftAuthenticationType.IAM_BROWSER;
 
         // For password auth the connection string is fixed at construction.
         // For IAM auth credentials are minted lazily before each query (the
@@ -119,7 +121,9 @@ export class RedshiftWarehouseClient extends PostgresClient<CreateRedshiftCreden
     ): Promise<void> {
         if (
             this.credentials.authenticationType ===
-            RedshiftAuthenticationType.IAM
+                RedshiftAuthenticationType.IAM ||
+            this.credentials.authenticationType ===
+                RedshiftAuthenticationType.IAM_BROWSER
         ) {
             this.config = await this.resolveIamPoolConfig();
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,12 @@ importers:
       '@aws-sdk/client-s3':
         specifier: 3.992.0
         version: 3.992.0
+      '@aws-sdk/client-sso':
+        specifier: 3.1079.0
+        version: 3.1079.0
+      '@aws-sdk/client-sso-oidc':
+        specifier: 3.1079.0
+        version: 3.1079.0
       '@aws-sdk/credential-providers':
         specifier: 3.995.0
         version: 3.995.0
@@ -2007,6 +2013,14 @@ packages:
     resolution: {integrity: sha512-6xfXGCvnWGgy5zZAse64Ru2G2qLKnPY7h8tchlsmGWVcJOWgz7iM3jmsWsQiJ79zH9A8HAPHU+ZD8TYYkwC+0Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sso-oidc@3.1079.0':
+    resolution: {integrity: sha512-sOrS3MOrnv1h4C4NpXmfDX0LpUdZey3uPyTi94bu7P2ILeXe0GJilP7aTnbrft7GxES9srNyJcrBXetsOxE2zA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sso@3.1079.0':
+    resolution: {integrity: sha512-n6RkW02jDM0lrLKK6VnwZFObNBT3XSWd6pZ96/VPouGHff9LTV8fWjMsX+llgMDBM8B+YJgk3B+PfBKBkXEAgw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-sts@3.992.0':
     resolution: {integrity: sha512-qE7kp/CtRzErguocNIYJQYrlEBXzAtNQ2vhGMyQ3AQNkdl/vM0CeP6QpCXfnsERyIKJMYiP/3Uc4QFUIV9PfWw==}
     engines: {node: '>=20.0.0'}
@@ -2017,6 +2031,10 @@ packages:
 
   '@aws-sdk/core@3.974.23':
     resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.27':
+    resolution: {integrity: sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.0':
@@ -2035,12 +2053,20 @@ packages:
     resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.53':
+    resolution: {integrity: sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.15':
     resolution: {integrity: sha512-dJuSTreu/T8f24SHDNTjd7eQ4rabr0TzPh2UTCwYexQtzG3nTDKm1e5eIdhiroTMDkPEJeY+WPkA6F9wod/20A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.51':
     resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.55':
+    resolution: {integrity: sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.13':
@@ -2051,12 +2077,20 @@ packages:
     resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.60':
+    resolution: {integrity: sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.13':
     resolution: {integrity: sha512-RtYcrxdnJHKY8MFQGLltCURcjuMjnaQpAxPE6+/QEdDHHItMKZgabRe/KScX737F9vJMQsmJy9EmMOkCnoC1JQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.55':
     resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.59':
+    resolution: {integrity: sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.14':
@@ -2067,12 +2101,20 @@ packages:
     resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.62':
+    resolution: {integrity: sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.13':
     resolution: {integrity: sha512-rsRG0LQA4VR+jnDyuqtXi2CePYSmfm5GNL9KxiW8DSe25YwJSr06W8TdUfONAC+rjsTI+aIH2rBGG5FjMeANrw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.49':
     resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.53':
+    resolution: {integrity: sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.13':
@@ -2083,12 +2125,20 @@ packages:
     resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.59':
+    resolution: {integrity: sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.13':
     resolution: {integrity: sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.55':
     resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.59':
+    resolution: {integrity: sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-providers@3.995.0':
@@ -2157,6 +2207,10 @@ packages:
     resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.27':
+    resolution: {integrity: sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.6':
     resolution: {integrity: sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==}
     engines: {node: '>=20.0.0'}
@@ -2177,8 +2231,16 @@ packages:
     resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1074.0':
     resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1079.0':
+    resolution: {integrity: sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.999.0':
@@ -2187,6 +2249,10 @@ packages:
 
   '@aws-sdk/types@3.973.13':
     resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.15':
+    resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.4':
@@ -2237,12 +2303,20 @@ packages:
     resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/xml-builder@3.972.33':
+    resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/xml-builder@3.972.8':
     resolution: {integrity: sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@azure/abort-controller@2.1.2':
@@ -6417,12 +6491,20 @@ packages:
     resolution: {integrity: sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.29.1':
+    resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.10':
     resolution: {integrity: sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.4.2':
     resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.6':
+    resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.8':
@@ -6451,6 +6533,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.5.2':
     resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.3':
+    resolution: {integrity: sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.9':
@@ -6513,6 +6599,10 @@ packages:
     resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.3':
+    resolution: {integrity: sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.10':
     resolution: {integrity: sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==}
     engines: {node: '>=18.0.0'}
@@ -6545,6 +6635,10 @@ packages:
     resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.6.2':
+    resolution: {integrity: sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.0':
     resolution: {integrity: sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==}
     engines: {node: '>=18.0.0'}
@@ -6555,6 +6649,10 @@ packages:
 
   '@smithy/types@4.15.0':
     resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.1':
+    resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.10':
@@ -17588,7 +17686,7 @@ snapshots:
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
@@ -17674,20 +17772,20 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/credential-provider-node': 3.972.14
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
       '@aws-sdk/middleware-host-header': 3.972.6
       '@aws-sdk/middleware-logger': 3.972.6
       '@aws-sdk/middleware-recursion-detection': 3.972.6
       '@aws-sdk/middleware-user-agent': 3.972.15
       '@aws-sdk/region-config-resolver': 3.972.6
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-endpoints': 3.980.0
       '@aws-sdk/util-user-agent-browser': 3.972.6
       '@aws-sdk/util-user-agent-node': 3.973.0
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.25.1
-      '@smithy/fetch-http-handler': 5.3.11
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
       '@smithy/middleware-content-length': 4.2.10
@@ -17696,7 +17794,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.11
       '@smithy/middleware-stack': 4.2.10
       '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.4.12
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
       '@smithy/types': 4.15.0
@@ -17920,24 +18018,45 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-sso-oidc@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-node': 3.972.62
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-sso@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-sts@3.992.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/core': 3.974.23
       '@aws-sdk/credential-provider-node': 3.972.14
       '@aws-sdk/middleware-host-header': 3.972.6
       '@aws-sdk/middleware-logger': 3.972.6
       '@aws-sdk/middleware-recursion-detection': 3.972.6
       '@aws-sdk/middleware-user-agent': 3.972.15
       '@aws-sdk/region-config-resolver': 3.972.6
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-endpoints': 3.992.0
       '@aws-sdk/util-user-agent-browser': 3.972.6
       '@aws-sdk/util-user-agent-node': 3.973.0
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.25.1
-      '@smithy/fetch-http-handler': 5.3.11
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
       '@smithy/middleware-content-length': 4.2.10
@@ -17946,7 +18065,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.11
       '@smithy/middleware-stack': 4.2.10
       '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.4.12
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
       '@smithy/types': 4.15.0
@@ -17991,6 +18110,17 @@ snapshots:
       bowser: 2.11.0
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.1
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      bowser: 2.11.0
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.0':
     dependencies:
       '@smithy/types': 4.15.0
@@ -18018,8 +18148,16 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.23
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.15':
@@ -18039,10 +18177,20 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.23
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/fetch-http-handler': 5.5.2
       '@smithy/node-http-handler': 4.8.2
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.13':
@@ -18075,9 +18223,25 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.972.55
       '@aws-sdk/nested-clients': 3.997.23
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/credential-provider-imds': 4.4.2
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-env': 3.972.53
+      '@aws-sdk/credential-provider-http': 3.972.55
+      '@aws-sdk/credential-provider-login': 3.972.59
+      '@aws-sdk/credential-provider-process': 3.972.53
+      '@aws-sdk/credential-provider-sso': 3.972.59
+      '@aws-sdk/credential-provider-web-identity': 3.972.59
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.13':
@@ -18098,8 +18262,17 @@ snapshots:
       '@aws-sdk/core': 3.974.23
       '@aws-sdk/nested-clients': 3.997.23
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.14':
@@ -18133,6 +18306,20 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.62':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.53
+      '@aws-sdk/credential-provider-http': 3.972.55
+      '@aws-sdk/credential-provider-ini': 3.972.60
+      '@aws-sdk/credential-provider-process': 3.972.53
+      '@aws-sdk/credential-provider-sso': 3.972.59
+      '@aws-sdk/credential-provider-web-identity': 3.972.59
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.13':
     dependencies:
       '@aws-sdk/core': 3.973.15
@@ -18146,8 +18333,16 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.23
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.13':
@@ -18169,8 +18364,18 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.23
       '@aws-sdk/token-providers': 3.1074.0
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/token-providers': 3.1079.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.13':
@@ -18190,8 +18395,17 @@ snapshots:
       '@aws-sdk/core': 3.974.23
       '@aws-sdk/nested-clients': 3.997.23
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-providers@3.995.0':
@@ -18221,9 +18435,9 @@ snapshots:
 
   '@aws-sdk/ec2-metadata-service@3.992.0':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.4.12
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.15.0
       '@smithy/util-stream': 4.5.15
@@ -18381,19 +18595,19 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/core': 3.974.23
       '@aws-sdk/middleware-host-header': 3.972.6
       '@aws-sdk/middleware-logger': 3.972.6
       '@aws-sdk/middleware-recursion-detection': 3.972.6
       '@aws-sdk/middleware-user-agent': 3.972.15
       '@aws-sdk/region-config-resolver': 3.972.6
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-endpoints': 3.996.3
       '@aws-sdk/util-user-agent-browser': 3.972.6
       '@aws-sdk/util-user-agent-node': 3.973.0
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.25.1
-      '@smithy/fetch-http-handler': 5.3.11
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
       '@smithy/middleware-content-length': 4.2.10
@@ -18402,7 +18616,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.11
       '@smithy/middleware-stack': 4.2.10
       '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.4.12
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
       '@smithy/types': 4.15.0
@@ -18427,10 +18641,21 @@ snapshots:
       '@aws-sdk/core': 3.974.23
       '@aws-sdk/signature-v4-multi-region': 3.996.35
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/fetch-http-handler': 5.5.2
       '@smithy/node-http-handler': 4.8.2
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.27':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.972.6':
@@ -18477,20 +18702,36 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1074.0':
     dependencies:
       '@aws-sdk/core': 3.974.23
       '@aws-sdk/nested-clients': 3.997.23
       '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.999.0':
     dependencies:
-      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/core': 3.974.23
       '@aws-sdk/nested-clients': 3.996.3
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.15.0
@@ -18501,6 +18742,11 @@ snapshots:
   '@aws-sdk/types@3.973.13':
     dependencies:
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.15':
+    dependencies:
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.4':
@@ -18514,7 +18760,7 @@ snapshots:
 
   '@aws-sdk/util-endpoints@3.980.0':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-endpoints': 3.3.1
@@ -18530,7 +18776,7 @@ snapshots:
 
   '@aws-sdk/util-endpoints@3.995.0':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-endpoints': 3.3.1
@@ -18538,7 +18784,7 @@ snapshots:
 
   '@aws-sdk/util-endpoints@3.996.3':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-endpoints': 3.3.1
@@ -18575,6 +18821,11 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/xml-builder@3.972.33':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.8':
     dependencies:
       '@smithy/types': 4.15.0
@@ -18582,6 +18833,8 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -23408,6 +23661,11 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/core@3.29.1':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.10':
     dependencies:
       '@smithy/node-config-provider': 4.3.10
@@ -23420,6 +23678,12 @@ snapshots:
     dependencies:
       '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.6':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.8':
@@ -23464,6 +23728,12 @@ snapshots:
     dependencies:
       '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.9':
@@ -23566,6 +23836,12 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -23613,6 +23889,12 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.6.2':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.0':
     dependencies:
       '@smithy/core': 3.23.6
@@ -23628,6 +23910,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.1':
     dependencies:
       tslib: 2.8.1
 
@@ -23736,7 +24022,7 @@ snapshots:
 
   '@smithy/util-waiter@4.5.1':
     dependencies:
-      '@smithy/core': 3.25.1
+      '@smithy/core': 3.26.0
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.1':


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-552/support-browser-based-aws-sso-login-for-per-user-redshift-iam

![CleanShot 2026-07-07 at 17.03.50@2x.png](https://app.graphite.com/user-attachments/assets/88292cb5-b74a-48a8-86af-356d0ae84962.png)

### Description

- Adds browser-based AWS IAM Identity Center device login for Redshift IAM user warehouse credentials.
- Stores the resulting AWS role credentials through the existing per-user Redshift IAM credential path, including project-scoped credential preference updates.
- Keeps the manual AWS credential form as the fallback path and adds focused frontend polling coverage.

### Testing

- pnpm generate-api
- pnpm -F common typecheck
- pnpm -F common lint
- pnpm -F backend typecheck
- pnpm -F backend lint
- pnpm -F backend format
- pnpm -F backend test src/ee/services/AppGenerateService/readDesignForDownload.test.ts
- pnpm -F @lightdash/frontend typecheck
- pnpm -F @lightdash/frontend lint
- pnpm -F @lightdash/frontend format
- pnpm -F @lightdash/frontend test src/hooks/useRedshiftAwsSso.test.tsx
- git diff --check

Note: `pnpm -F backend test:dev:nowatch` passed 3,646 tests and hit one timeout in `src/ee/services/AppGenerateService/readDesignForDownload.test.ts`; rerunning that exact test passed.

Closes: SPK-552
Relates: #24848