### PR TITLE
refactor(frontend): migrate Button to mantine-8

### DIFF
--- a/packages/frontend/src/components/DataOps/index.tsx
+++ b/packages/frontend/src/components/DataOps/index.tsx
@@ -1,5 +1,6 @@
 import { ProjectType } from '@lightdash/common';
-import { Button, Flex, Select, Title, Text } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { Flex, Select, Title, Text } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useProject } from '../../hooks/useProject';
 import { useProjects } from '../../hooks/useProjects';

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
-import { ActionIcon, Button, Group, Tooltip, Text } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { ActionIcon, Group, Tooltip, Text } from '@mantine/core';
 import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import {
@@ -163,10 +164,9 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
                         position="left"
                     >
                         <Button
-                            size="xs"
+                            size="compact-xs"
                             variant="subtle"
-                            compact
-                            leftIcon={<MantineIcon icon={IconPlus} />}
+                            leftSection={<MantineIcon icon={IconPlus} />}
                             onClick={handleAddCustomDimension}
                             data-testid="VirtualSectionHeader/AddCustomDimensionButton"
                         >

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -12,7 +12,8 @@ import {
     type EChartsSeries,
     type FieldId,
 } from '@lightdash/common';
-import { Button, useMantineColorScheme } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,
@@ -397,7 +398,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                                 ? closeVisualizationConfig
                                                 : openVisualizationConfig
                                         }
-                                        rightIcon={
+                                        rightSection={
                                             <MantineIcon
                                                 icon={
                                                     isVisualizationConfigOpen

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -4,7 +4,7 @@ import {
     WarehouseTypes,
     type CreateWarehouseCredentials,
 } from '@lightdash/common';
-import { Button } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { useCreateMutation } from '../../hooks/useProject';
@@ -124,7 +124,7 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                         />
 
                         <Button
-                            sx={{ alignSelf: 'end' }}
+                            style={{ alignSelf: 'end' }}
                             type="submit"
                             loading={isSavingProject}
                         >

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.module.css
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.module.css
@@ -6,3 +6,12 @@
 .repositoryHint:hover {
     background-color: var(--mantine-color-ldGray-1);
 }
+
+.githubSignInButton {
+    background-color: black;
+    color: white;
+}
+
+.githubSignInButton:hover {
+    background-color: var(--mantine-color-ldGray-8);
+}

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -1,10 +1,9 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     Avatar,
-    Button,
     Group,
     PasswordInput,
     ScrollArea,
@@ -161,20 +160,14 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
         <>
             {' '}
             <Button
-                leftIcon={
+                leftSection={
                     <Avatar
                         src={githubIcon}
                         size="sm"
                         styles={{ image: { filter: 'invert(1)' } }}
                     />
                 }
-                sx={() => ({
-                    backgroundColor: 'black',
-                    color: 'white',
-                    '&:hover': {
-                        backgroundColor: 'ldGray.8',
-                    },
-                })}
+                className={styles.githubSignInButton}
                 onClick={() => {
                     window.open(
                         GITHUB_INSTALL_URL,

--- a/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import { ActionIcon, Button, Flex, Input, TextInput } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { ActionIcon, Flex, Input, TextInput } from '@mantine/core';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import get from 'lodash/get';
 import { useState, type ReactNode } from 'react';
@@ -103,7 +103,7 @@ export const MultiKeyValuePairsInput = ({
                 <Button
                     size="sm"
                     onClick={addValue}
-                    leftIcon={<MantineIcon icon={IconPlus} />}
+                    leftSection={<MantineIcon icon={IconPlus} />}
                     disabled={disabled}
                 >
                     Add variable

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep1.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep1.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import { Button, Tooltip, Text } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Tooltip, Text } from '@mantine/core';
 import { Prism } from '@mantine/prism';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -38,7 +38,7 @@ const ConnectManuallyStep1: FC<ConnectManuallyStep1Props> = ({
                 variant="subtle"
                 size="sm"
                 top={-50}
-                leftIcon={<MantineIcon icon={IconChevronLeft} />}
+                leftSection={<MantineIcon icon={IconChevronLeft} />}
                 onClick={onBack}
             >
                 Back
@@ -72,7 +72,7 @@ const ConnectManuallyStep1: FC<ConnectManuallyStep1Props> = ({
                                 href="https://docs.lightdash.com/guides/how-to-create-dimensions"
                                 target="_blank"
                                 rel="noreferrer noopener"
-                                rightIcon={
+                                rightSection={
                                     <MantineIcon icon={IconChevronRight} />
                                 }
                                 onClick={() => {

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
@@ -1,5 +1,5 @@
-import { Box, Stack } from '@mantine-8/core';
-import { Button, createStyles, keyframes } from '@mantine/core';
+import { Box, Button, Stack } from '@mantine-8/core';
+import { createStyles, keyframes } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
 import confetti from 'canvas-confetti';
 import { type FC } from 'react';

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
@@ -3,8 +3,8 @@ import {
     TimeFrames,
     type OrganizationProject,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Avatar, Button, LoadingOverlay, Tabs, Text } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Avatar, LoadingOverlay, Tabs, Text } from '@mantine/core';
 import { useOs } from '@mantine/hooks';
 import { Prism } from '@mantine/prism';
 import { IconChevronLeft, IconClock } from '@tabler/icons-react';
@@ -115,7 +115,7 @@ const ConnectUsingCLI: FC<ConnectUsingCliProps> = ({
                 variant="subtle"
                 size="sm"
                 top={-50}
-                leftIcon={<MantineIcon icon={IconChevronLeft} />}
+                leftSection={<MantineIcon icon={IconChevronLeft} />}
                 onClick={onBack}
             >
                 Back

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import { Avatar, Button, Text } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Avatar, Text } from '@mantine/core';
 import {
     IconChecklist,
     IconChevronLeft,
@@ -36,7 +36,7 @@ const SelectConnectMethod: FC<SelectConnectMethodProps> = ({
                 variant="subtle"
                 size="sm"
                 top={-50}
-                leftIcon={<MantineIcon icon={IconChevronLeft} />}
+                leftSection={<MantineIcon icon={IconChevronLeft} />}
                 onClick={onBack}
             >
                 Back

--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -6,8 +6,8 @@ import {
     type CreateWarehouseCredentials,
     type Project,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { Alert, Anchor, Button, Card, Flex } from '@mantine/core';
+import { Box, Button } from '@mantine-8/core';
+import { Alert, Anchor, Card, Flex } from '@mantine/core';
 import { IconExclamationCircle, IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
@@ -183,7 +183,7 @@ const UpdateProjectConnection: FC<{
                                     variant="subtle"
                                     color="gray"
                                     size="xs"
-                                    rightIcon={
+                                    rightSection={
                                         <MantineIcon icon={IconExternalLink} />
                                     }
                                     component="a"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,10 +1,9 @@
 import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import type { SelectItem } from '@mantine/core';
 import {
     Anchor,
     Autocomplete,
-    Button,
     FileInput,
     Group,
     Image,
@@ -88,7 +87,7 @@ export const BigQuerySSOInput: FC<{
                 variant="default"
                 color="gray"
                 disabled={disabled}
-                leftIcon={
+                leftSection={
                     <Image
                         width={16}
                         src={

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.module.css
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.module.css
@@ -1,0 +1,3 @@
+.signInButton:hover {
+    text-decoration: underline;
+}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -2,11 +2,10 @@ import {
     DatabricksAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     Group,
     PasswordInput,
     Select,
@@ -30,6 +29,7 @@ import FormSection from '../Inputs/FormSection';
 import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { getWarehouseIcon } from '../ProjectConnectFlow/utils';
 import { useProjectFormContext } from '../useProjectFormContext';
+import classes from './DatabricksForm.module.css';
 import DataTimezoneField from './DataTimezoneField';
 import { DatabricksDefaultValues } from './defaultValues';
 import { getSsoLabel, PERSONAL_ACCESS_TOKEN_LABEL } from './util';
@@ -80,8 +80,8 @@ export const DatabricksSSOInput: FC<{
             variant="default"
             color="gray"
             disabled={disabled}
-            leftIcon={getWarehouseIcon(WarehouseTypes.DATABRICKS, 'sm')}
-            sx={{ ':hover': { textDecoration: 'underline' } }}
+            leftSection={getWarehouseIcon(WarehouseTypes.DATABRICKS, 'sm')}
+            className={classes.signInButton}
             fullWidth
         >
             Sign in with Databricks
@@ -443,11 +443,12 @@ const DatabricksForm: FC<{
                                     <Button
                                         variant="default"
                                         size="xs"
-                                        sx={(theme) => ({
+                                        style={{
                                             alignSelf: 'flex-end',
-                                            boxShadow: theme.shadows.subtle,
-                                        })}
-                                        leftIcon={
+                                            boxShadow:
+                                                'var(--mantine-shadow-subtle)',
+                                        }}
+                                        leftSection={
                                             <MantineIcon icon={IconPlus} />
                                         }
                                         onClick={addCompute}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -1,9 +1,8 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     CopyButton,
     NumberInput,
     PasswordInput,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -3,11 +3,10 @@ import {
     RedshiftAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     CopyButton,
     NumberInput,
     PasswordInput,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.module.css
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.module.css
@@ -1,0 +1,3 @@
+.signInButton:hover {
+    text-decoration: underline;
+}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -1,8 +1,7 @@
 import { SnowflakeAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
     Anchor,
-    Button,
     FileInput,
     Group,
     NumberInput,
@@ -33,6 +32,7 @@ import { getWarehouseIcon } from '../ProjectConnectFlow/utils';
 import { useProjectFormContext } from '../useProjectFormContext';
 import DataTimezoneField from './DataTimezoneField';
 import { SnowflakeDefaultValues } from './defaultValues';
+import classes from './SnowflakeForm.module.css';
 import {
     EXTERNAL_BROWSER_LABEL,
     getSsoLabel,
@@ -72,8 +72,8 @@ export const SnowflakeSSOInput: FC<{
             variant="default"
             color="gray"
             disabled={disabled}
-            leftIcon={getWarehouseIcon(WarehouseTypes.SNOWFLAKE, 'sm')}
-            sx={{ ':hover': { textDecoration: 'underline' } }}
+            leftSection={getWarehouseIcon(WarehouseTypes.SNOWFLAKE, 'sm')}
+            className={classes.signInButton}
         >
             Sign in with Snowflake
         </Button>

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -1,9 +1,8 @@
 import { subject } from '@casl/ability';
 import { hasIntersection, TableSelectionType } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
     Anchor,
-    Button,
     Collapse,
     Flex,
     Highlight,

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,5 +1,5 @@
-import { Box } from '@mantine-8/core';
-import { Button, Flex, Text } from '@mantine/core';
+import { Box, Button } from '@mantine-8/core';
+import { Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
@@ -264,7 +264,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                         <Button
                             variant="default"
                             size={'xs'}
-                            leftIcon={<IconRefresh size={16} />}
+                            leftSection={<IconRefresh size={16} />}
                             onClick={triggerChunkErrorReload}
                         >
                             Refresh page

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/AllowedDomainsPanel.module.css
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/AllowedDomainsPanel.module.css
@@ -1,0 +1,3 @@
+.addProjectButton[data-disabled='true'] {
+    pointer-events: all;
+}

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -6,10 +6,9 @@ import {
     validateOrganizationEmailDomains,
     type AllowedEmailDomains,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Button,
     Flex,
     MultiSelect,
     Select,
@@ -33,6 +32,7 @@ import {
 } from '../../../hooks/organization/useAllowedDomains';
 import { useProjects } from '../../../hooks/useProjects';
 import MantineIcon from '../../common/MantineIcon';
+import styles from './AllowedDomainsPanel.module.css';
 
 const roleOptions: Array<{
     value: AllowedEmailDomains['role'];
@@ -417,15 +417,11 @@ const AllowedDomainsPanel: FC = () => {
                                             {...(!canAddMoreProjects && {
                                                 'data-disabled': true,
                                             })}
-                                            sx={{
-                                                '&[data-disabled="true"]': {
-                                                    pointerEvents: 'all',
-                                                },
-                                            }}
+                                            className={styles.addProjectButton}
                                             onClick={handleAddProject}
                                             variant="outline"
                                             size="xs"
-                                            leftIcon={
+                                            leftSection={
                                                 <MantineIcon icon={IconPlus} />
                                             }
                                         >

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,8 +1,8 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
+import { Button } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
-    Button,
     ColorSwatch,
     Flex,
     Group,
@@ -152,12 +152,12 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                                     onSetActive(palette.colorPaletteUuid)
                                 }
                                 h={32}
-                                sx={() => ({
+                                style={{
                                     visibility:
                                         isHovered && !isActive
                                             ? 'visible'
                                             : 'hidden',
-                                })}
+                                }}
                             >
                                 Use This Theme
                             </Button>

--- a/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
@@ -1,6 +1,6 @@
 import { ProjectType } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Button, Flex, Select } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Flex, Select } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useEffect, type FC } from 'react';
 import { z } from 'zod';

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -1,8 +1,7 @@
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
     Alert,
     Avatar,
-    Button,
     Flex,
     Group,
     Loader,
@@ -120,7 +119,7 @@ const GithubSettingsPanel: FC = () => {
                                 target="_blank"
                                 variant="default"
                                 href={GITHUB_INSTALL_URL}
-                                leftIcon={<MantineIcon icon={IconRefresh} />}
+                                leftSection={<MantineIcon icon={IconRefresh} />}
                                 onClick={() => {
                                     deleteGithubInstallationMutation.mutate(
                                         undefined,
@@ -145,7 +144,7 @@ const GithubSettingsPanel: FC = () => {
                                 onClick={() =>
                                     deleteGithubInstallationMutation.mutate()
                                 }
-                                leftIcon={<MantineIcon icon={IconTrash} />}
+                                leftSection={<MantineIcon icon={IconTrash} />}
                             >
                                 Delete
                             </Button>
@@ -168,7 +167,9 @@ const GithubSettingsPanel: FC = () => {
                                     color="yellow"
                                     variant="outline"
                                     href={GITHUB_INSTALL_URL}
-                                    leftIcon={<MantineIcon icon={IconClock} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconClock} />
+                                    }
                                 >
                                     Pending approval
                                 </Button>

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -1,14 +1,5 @@
-import { Box, Stack } from '@mantine-8/core';
-import {
-    Alert,
-    Avatar,
-    Button,
-    Flex,
-    Group,
-    Loader,
-    Title,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Stack } from '@mantine-8/core';
+import { Alert, Avatar, Flex, Group, Loader, Title, Text } from '@mantine/core';
 import { IconAlertCircle, IconRefresh, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import gitlabIcon from '../../../svgs/gitlab-icon.svg';
@@ -78,7 +69,7 @@ const GitlabSettingsPanel: FC = () => {
                                 target="_blank"
                                 variant="default"
                                 href={GITLAB_INSTALL_URL}
-                                leftIcon={<MantineIcon icon={IconRefresh} />}
+                                leftSection={<MantineIcon icon={IconRefresh} />}
                                 onClick={() => {
                                     deleteGitlabInstallationMutation.mutate(
                                         undefined,
@@ -103,7 +94,7 @@ const GitlabSettingsPanel: FC = () => {
                                 onClick={() =>
                                     deleteGitlabInstallationMutation.mutate()
                                 }
-                                leftIcon={<MantineIcon icon={IconTrash} />}
+                                leftSection={<MantineIcon icon={IconTrash} />}
                             >
                                 Delete
                             </Button>

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Button, Group, LoadingOverlay, Title, Text } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Group, LoadingOverlay, Title, Text } from '@mantine/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
@@ -42,7 +42,7 @@ export const OrganizationWarehouseCredentialsPanel = () => {
                             </Stack>
                             <Button
                                 size="xs"
-                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                leftSection={<MantineIcon icon={IconPlus} />}
                                 onClick={() => setIsCreatingCredentials(true)}
                             >
                                 Add new credentials

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -9,9 +9,8 @@ import {
     XAxisSort,
     type ItemsMap,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
-    Button,
     Checkbox,
     Group,
     NumberInput,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -1,12 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
-import {
-    Button,
-    Flex,
-    Group,
-    Loader,
-    useMantineTheme,
-    Text,
-} from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { Flex, Group, Loader, useMantineTheme, Text } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
@@ -1,5 +1,6 @@
 import { type ItemsMap } from '@lightdash/common';
-import { Button, Popover, Textarea } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { Popover, Textarea } from '@mantine/core';
 import { IconSparkles } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
@@ -59,10 +60,10 @@ export const GenerateVizWithAi = ({
         >
             <Popover.Target>
                 <Button
-                    compact
+                    size="compact-sm"
                     variant="default"
                     fz="xs"
-                    leftIcon={<MantineIcon icon={IconSparkles} />}
+                    leftSection={<MantineIcon icon={IconSparkles} />}
                 >
                     AI
                 </Button>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisTemplate.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisTemplate.tsx
@@ -3,8 +3,7 @@ import {
     sortedItemsForYAxis,
     type ItemsMap,
 } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import { Button, Menu } from '@mantine-8/core';
 import {
     IconChartBar,
     IconChartBubble,
@@ -96,11 +95,10 @@ export const SelectTemplate = ({
             </Menu.Dropdown>
             <Menu.Target>
                 <Button
-                    size="sm"
+                    size="compact-sm"
                     variant="default"
-                    compact
                     fz="xs"
-                    leftIcon={<MantineIcon icon={IconPlus} />}
+                    leftSection={<MantineIcon icon={IconPlus} />}
                 >
                     Insert template
                 </Button>

--- a/packages/frontend/src/components/common/CollapsableCard/constants.ts
+++ b/packages/frontend/src/components/common/CollapsableCard/constants.ts
@@ -1,8 +1,5 @@
-import {
-    type ActionIconProps,
-    type ButtonProps,
-    type PopoverProps,
-} from '@mantine/core';
+import { type ButtonProps } from '@mantine-8/core';
+import { type ActionIconProps, type PopoverProps } from '@mantine/core';
 
 export const COLLAPSABLE_CARD_BUTTON_PROPS: Omit<ButtonProps, 'children'> = {
     variant: 'default',

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -27,8 +27,8 @@ import {
     type ResultValue,
     type SortField,
 } from '@lightdash/common';
-import { Box, Menu, type BoxProps } from '@mantine-8/core';
-import { Button, Group, useMantineColorScheme, Text } from '@mantine/core';
+import { Box, Button, Menu, type BoxProps } from '@mantine-8/core';
+import { Group, useMantineColorScheme, Text } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import {
     flexRender,
@@ -1967,8 +1967,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                             ) : (
                                                 <Group spacing="two" noWrap>
                                                     <Button
-                                                        compact
-                                                        size="xs"
+                                                        size="compact-xs"
                                                         variant="subtle"
                                                         styles={(theme) => ({
                                                             root: {
@@ -1984,7 +1983,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                                 fontFeatureSettings:
                                                                     "'tnum'",
                                                             },
-                                                            leftIcon: {
+                                                            section: {
                                                                 marginRight: 0,
                                                             },
                                                         })}
@@ -1995,7 +1994,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                             e.preventDefault();
                                                             toggleExpander();
                                                         }}
-                                                        leftIcon={
+                                                        leftSection={
                                                             <MantineIcon
                                                                 size={14}
                                                                 icon={

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,12 +13,11 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
+import { Box, Button } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
 import {
     ActionIcon,
     Anchor,
-    Button,
     Divider,
     Group,
     TextInput,
@@ -736,7 +735,7 @@ const InfiniteResourceTable = ({
                                 variant="filled"
                                 size="xs"
                                 color="blue"
-                                leftIcon={
+                                leftSection={
                                     <MantineIcon icon={IconFolderSymlink} />
                                 }
                                 onClick={openTransferItemsModal}

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -3,8 +3,8 @@ import {
     getErrorMessage,
     type Space,
 } from '@lightdash/common';
+import { Button } from '@mantine-8/core';
 import {
-    Button,
     Group,
     MantineProvider,
     useMantineColorScheme,

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,8 +14,8 @@ import {
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
+import { Button } from '@mantine-8/core';
 import {
-    Button,
     Center,
     Group,
     Loader,
@@ -287,8 +287,7 @@ const TableRow: FC<TableRowProps> = ({
                         {cell.getIsGrouped() ? (
                             <Group spacing="xxs">
                                 <Button
-                                    compact
-                                    size="xs"
+                                    size="compact-xs"
                                     variant="subtle"
                                     styles={(theme) => ({
                                         root: {
@@ -296,7 +295,7 @@ const TableRow: FC<TableRowProps> = ({
                                             paddingLeft: theme.spacing.two,
                                             paddingRight: theme.spacing.xxs,
                                         },
-                                        leftIcon: {
+                                        section: {
                                             marginRight: 0,
                                         },
                                     })}
@@ -307,7 +306,7 @@ const TableRow: FC<TableRowProps> = ({
                                         e.preventDefault();
                                         toggleExpander();
                                     }}
-                                    leftIcon={
+                                    leftSection={
                                         <MantineIcon
                                             size={14}
                                             icon={

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import { Anchor, Button, Group, TextInput, Title, Text } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Anchor, Group, TextInput, Title, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -58,7 +58,7 @@ const ScimAccessTokensPanel: FC = () => {
                         <Button
                             variant="subtle"
                             onClick={handleCopyToClipboard}
-                            compact
+                            size="compact-sm"
                         >
                             <IconCopy size={16} />
                         </Button>

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
@@ -1,4 +1,5 @@
-import { Button, Card, List, Tooltip } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { Card, List, Tooltip } from '@mantine/core';
 import { type SuggestionProps } from '@tiptap/suggestion';
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { type SuggestionsItem } from '../../types';
@@ -89,7 +90,7 @@ export const SuggestionList = forwardRef<
                             position="right"
                         >
                             <Button
-                                compact
+                                size="compact-sm"
                                 onClick={() => {
                                     if (item.disabled) return;
                                     selectItem(index);

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -7,10 +7,9 @@ import {
     type DashboardFilterRule,
     type FilterRule,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Button,
     Checkbox,
     Group,
     Select,
@@ -162,10 +161,9 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         supportsSingleValue(filterType, filterRule.operator) &&
                         isEditMode && (
                             <Button
-                                compact
-                                size="xs"
+                                size="compact-xs"
                                 variant={'light'}
-                                rightIcon={
+                                rightSection={
                                     <Tooltip
                                         variant="xs"
                                         label={

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -19,9 +19,8 @@ import {
     type DashboardTile,
     type ResultColumn,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
-    Button,
     Flex,
     Group,
     Select,

--- a/packages/frontend/src/features/errorBoundary/ErrorFallbacks.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorFallbacks.tsx
@@ -1,5 +1,5 @@
-import { Box, Stack } from '@mantine-8/core';
-import { Button, Text } from '@mantine/core';
+import { Box, Button, Stack } from '@mantine-8/core';
+import { Text } from '@mantine/core';
 import { Prism } from '@mantine/prism';
 import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
 import { type FC } from 'react';

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
@@ -1,6 +1,6 @@
 import type { CatalogMetricsTreeEdge } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { Button, Group, useMantineTheme, Text } from '@mantine/core';
+import { Box, Button } from '@mantine-8/core';
+import { Group, useMantineTheme, Text } from '@mantine/core';
 import { IconLayoutGridRemove } from '@tabler/icons-react';
 import {
     Background,
@@ -165,10 +165,10 @@ const SavedTreeCanvasFlow: FC<Props> = ({
                                             })
                                         }
                                         size="xs"
-                                        sx={{
+                                        style={{
                                             boxShadow: theme.shadows.subtle,
                                         }}
-                                        leftIcon={
+                                        leftSection={
                                             <MantineIcon
                                                 color="ldGray.5"
                                                 icon={IconLayoutGridRemove}

--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,5 +1,6 @@
 import { type CatalogField } from '@lightdash/common';
-import { Button, Tooltip } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { type ContentTableRow } from '../../../components/common/ContentTable';
@@ -48,7 +49,7 @@ export const ExploreMetricButton = ({ row }: Props) => {
             fz="xs"
         >
             <Button
-                compact
+                size="compact-sm"
                 variant="darkPrimary"
                 onClick={handleExploreClick}
                 py="xxs"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -1,8 +1,7 @@
 import { getErrorMessage, type CatalogItem } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Button,
     Divider,
     Group,
     Popover,
@@ -169,8 +168,7 @@ const EditPopover: FC<EditPopoverProps> = ({
 
                         <Button
                             variant="darkPrimary"
-                            size="xs"
-                            compact
+                            size="compact-xs"
                             onClick={handleSave}
                         >
                             Save

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -1,7 +1,6 @@
 import { type CatalogField, type Tag } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
-    Button,
     Group,
     Popover,
     UnstyledButton,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -1,8 +1,7 @@
 import { isEmojiIcon, type CatalogField } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
+import { Box, Button } from '@mantine-8/core';
 import {
     ActionIcon,
-    Button,
     getDefaultZIndex,
     Group,
     Highlight,
@@ -72,11 +71,12 @@ const SharedEmojiPicker = forwardRef(
                             <Group position="right">
                                 <Button
                                     variant="light"
-                                    size="xs"
-                                    compact
+                                    size="compact-xs"
                                     color="gray"
                                     onClick={() => onClick(null)}
-                                    leftIcon={<MantineIcon icon={IconTrash} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconTrash} />
+                                    }
                                 >
                                     Remove
                                 </Button>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.module.css
@@ -1,0 +1,4 @@
+.tableButton[data-disabled] {
+    background-color: transparent;
+    font-weight: 400;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,6 +1,6 @@
 import { SpotlightTableColumns, type CatalogField } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { Button, Flex, Group, Text } from '@mantine/core';
+import { Box, Button } from '@mantine-8/core';
+import { Flex, Group, Text } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus, IconUser } from '@tabler/icons-react';
 import { useMemo } from 'react';
@@ -28,6 +28,7 @@ import { MetricsCatalogCategoryForm } from './MetricsCatalogCategoryForm';
 import { MetricsCatalogColumnDescription } from './MetricsCatalogColumnDescription';
 import { MetricsCatalogColumnName } from './MetricsCatalogColumnName';
 import { MetricsCatalogColumnOwner } from './MetricsCatalogColumnOwner';
+import styles from './MetricsCatalogColumns.module.css';
 
 export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
     {
@@ -107,31 +108,19 @@ export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
                     component="a"
                     href={url.toString()}
                     target="_blank"
-                    size="xs"
-                    compact
+                    size="compact-xs"
                     color="ldGray.6"
                     variant="subtle"
-                    leftIcon={<TableFilled />}
+                    leftSection={<TableFilled />}
                     fz="sm"
                     c="ldDark.7"
                     fw={500}
-                    sx={{
-                        '&[data-disabled]': {
-                            backgroundColor: 'transparent',
-                            fontWeight: 400,
-                        },
-                    }}
+                    className={styles.tableButton}
                     styles={(theme) => ({
-                        leftIcon: {
+                        section: {
                             marginRight: theme.spacing.xxs,
-                            color:
-                                theme.colorScheme === 'dark'
-                                    ? theme.colors.ldDark[7]
-                                    : theme.colors.ldGray[4],
-                            '--table-icon-stroke':
-                                theme.colorScheme === 'dark'
-                                    ? theme.colors.ldDark[4]
-                                    : 'white',
+                            color: `light-dark(var(--mantine-color-ldGray-4), var(--mantine-color-ldDark-7))`,
+                            '--table-icon-stroke': `light-dark(white, var(--mantine-color-ldDark-4))`,
                         },
                     })}
                 >

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.module.css
@@ -1,0 +1,9 @@
+.viewDemoButton {
+    display: none;
+    border: none;
+    flex-grow: 1;
+}
+
+.viewDemoButton:hover {
+    background-color: var(--mantine-color-ldDark-5);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,13 +1,11 @@
 import { subject } from '@casl/ability';
 import { CatalogCategoryFilterMode, isCompileJob } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack, type ButtonProps } from '@mantine-8/core';
 import {
     ActionIcon,
-    Button,
     Group,
     Popover,
     useMantineTheme,
-    type ButtonProps,
     Text,
 } from '@mantine/core';
 import { useClickOutside, useDisclosure } from '@mantine/hooks';
@@ -40,6 +38,7 @@ import {
 } from '../store/metricsCatalogSlice';
 import { type MetricCatalogView } from '../types';
 import { MetricChartUsageModal } from './MetricChartUsageModal';
+import classes from './MetricsCatalogPanel.module.css';
 import { MetricsTable } from './MetricsTable';
 
 const LOCAL_STORAGE_KEY = 'metrics-catalog-learn-more-popover-closed';
@@ -87,7 +86,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                     ref={buttonRef}
                     size="xs"
                     variant="default"
-                    leftIcon={<MantineIcon icon={IconSparkles} />}
+                    leftSection={<MantineIcon icon={IconSparkles} />}
                     style={buttonStyles}
                     onClick={opened ? handleClose : open}
                 >
@@ -136,14 +135,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                             c="ldGray.0"
                             hidden={true}
                             disabled={true}
-                            sx={(theme) => ({
-                                display: 'none', // ! Disabled for now
-                                border: 'none',
-                                flexGrow: 1,
-                                '&:hover': {
-                                    backgroundColor: theme.colors.ldDark[5],
-                                },
-                            })}
+                            className={classes.viewDemoButton}
                         >
                             View Demo
                         </Button>
@@ -152,7 +144,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                             href="https://docs.lightdash.com/guides/metrics-catalog/"
                             target="_blank"
                             radius="md"
-                            sx={{ border: 'none', flexGrow: 1 }}
+                            style={{ border: 'none', flexGrow: 1 }}
                         >
                             Learn more
                         </Button>
@@ -465,7 +457,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
                         <Button
                             size="xs"
                             variant="default"
-                            leftIcon={
+                            leftSection={
                                 <MantineIcon
                                     size="sm"
                                     color="ldGray.7"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/MetricsTableTopToolbar.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/MetricsTableTopToolbar.module.css
@@ -1,0 +1,4 @@
+.toolbarButton {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    box-shadow: var(--mantine-shadow-subtle);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -20,11 +20,10 @@ import {
     type CatalogCategoryFilterMode,
     type CatalogField,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
-    Button,
     Center,
     Divider,
     Group,
@@ -68,6 +67,7 @@ import {
 } from '../../store/metricsCatalogSlice';
 import { MetricCatalogView } from '../../types';
 import CategoriesFilter from './CategoriesFilter';
+import styles from './MetricsTableTopToolbar.module.css';
 import OwnersFilter from './OwnersFilter';
 import TableFilter from './TableFilter';
 type MetricsTableTopToolbarProps = GroupProps & {
@@ -510,12 +510,9 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                                     radius="md"
                                                     h={28}
                                                     onClick={handleReset}
-                                                    sx={(theme) => ({
-                                                        border: `1px solid ${theme.colors.ldGray[2]}`,
-                                                        boxShadow:
-                                                            theme.shadows
-                                                                .subtle,
-                                                    })}
+                                                    className={
+                                                        styles.toolbarButton
+                                                    }
                                                     disabled={
                                                         isDefaultConfig &&
                                                         !hasConfigChanges
@@ -554,11 +551,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                                 variant="default"
                                                 onClick={handleReset}
                                                 disabled={!hasConfigChanges}
-                                                sx={(theme) => ({
-                                                    border: `1px solid ${theme.colors.ldGray[2]}`,
-                                                    boxShadow:
-                                                        theme.shadows.subtle,
-                                                })}
+                                                className={styles.toolbarButton}
                                             >
                                                 Discard
                                             </Button>

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -4,9 +4,8 @@ import {
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
-    Button,
     Divider,
     Group,
     Popover,
@@ -346,10 +345,11 @@ export const MetricExploreDatePicker: FC<Props> = ({
                                         radius="md"
                                         variant="default"
                                         onClick={() => handleOpen(false)}
-                                        sx={(theme) => ({
-                                            boxShadow: theme.shadows.subtle,
-                                            border: `1px solid ${theme.colors.ldGray[2]}`,
-                                        })}
+                                        style={{
+                                            boxShadow:
+                                                'var(--mantine-shadow-subtle)',
+                                            border: '1px solid var(--mantine-color-ldGray-2)',
+                                        }}
                                     >
                                         Cancel
                                     </Button>
@@ -362,9 +362,10 @@ export const MetricExploreDatePicker: FC<Props> = ({
 
                                             handleTrackDateFilterApplied();
                                         }}
-                                        sx={(theme) => ({
-                                            boxShadow: theme.shadows.subtle,
-                                        })}
+                                        style={{
+                                            boxShadow:
+                                                'var(--mantine-shadow-subtle)',
+                                        }}
                                     >
                                         Apply
                                     </Button>

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.module.css
@@ -1,0 +1,3 @@
+.clearButton:hover {
+    background-color: var(--mantine-color-ldGray-1);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -4,8 +4,8 @@ import {
     type CompiledDimension,
     type FilterRule,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Button, Group, Select, Text } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Group, Select, Text } from '@mantine/core';
 import { IconFilter, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -19,6 +19,7 @@ import {
     getOperatorOptions,
 } from '../../utils/metricExploreFilter';
 import SelectItem from '../SelectItem';
+import classes from './MetricExploreFilter.module.css';
 import { MetricExploreFilterAutoComplete } from './MetricExploreFilterAutoComplete';
 
 type Props = {
@@ -199,25 +200,20 @@ export const MetricExploreFilter: FC<Props> = ({
                 <Group spacing="xs">
                     <Button
                         variant="subtle"
-                        compact
                         color="dark"
-                        size="xs"
+                        size="compact-xs"
                         radius="md"
-                        rightIcon={
+                        rightSection={
                             <MantineIcon
                                 icon={IconX}
                                 color="ldGray.5"
                                 size={12}
                             />
                         }
-                        sx={{
-                            '&:hover': {
-                                backgroundColor: theme.colors.ldGray[1],
-                            },
-                            visibility: showClearButton,
-                        }}
+                        className={classes.clearButton}
+                        style={{ visibility: showClearButton }}
                         styles={{
-                            rightIcon: {
+                            section: {
                                 marginLeft: 4,
                             },
                         }}
@@ -294,11 +290,10 @@ export const MetricExploreFilter: FC<Props> = ({
             {filterState.fieldId && dimensionMetadata?.requiresValues && (
                 <Button
                     color={theme.colorScheme === 'dark' ? 'ldGray.2' : 'dark'}
-                    compact
-                    size="xs"
+                    size="compact-xs"
                     disabled={!canApplyFilter}
-                    sx={{
-                        boxShadow: theme.shadows.subtle,
+                    style={{
+                        boxShadow: 'var(--mantine-shadow-subtle)',
                         alignSelf: 'flex-end',
                     }}
                     onClick={handleApplyFilter}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.module.css
@@ -1,0 +1,3 @@
+.clearButton:hover {
+    background-color: var(--mantine-color-ldGray-1);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -5,16 +5,8 @@ import {
     type CompiledDimension,
     type MetricExplorerQuery,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import {
-    Alert,
-    Button,
-    Group,
-    Loader,
-    Select,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Stack } from '@mantine-8/core';
+import { Alert, Group, Loader, Select, Tooltip, Text } from '@mantine/core';
 import { IconInfoCircle, IconX } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useMemo, type FC } from 'react';
@@ -22,6 +14,7 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import { Blocks } from '../../../../svgs/metricsCatalog';
 import { useSelectStyles } from '../../styles/useSelectStyles';
 import SelectItem from '../SelectItem';
+import buttonClasses from './MetricExploreSegmentationPicker.module.css';
 
 type Props = {
     query: MetricExplorerQuery;
@@ -59,25 +52,22 @@ export const MetricExploreSegmentationPicker: FC<Props> = ({
 
                 <Button
                     variant="subtle"
-                    compact
                     color="dark"
-                    size="xs"
+                    size="compact-xs"
                     radius="md"
-                    rightIcon={
+                    rightSection={
                         <MantineIcon icon={IconX} color="ldGray.5" size={12} />
                     }
-                    sx={(theme) => ({
+                    className={buttonClasses.clearButton}
+                    style={{
                         visibility:
                             !('segmentDimension' in query) ||
                             !query.segmentDimension
                                 ? 'hidden'
                                 : 'visible',
-                        '&:hover': {
-                            backgroundColor: theme.colors.ldGray[1],
-                        },
-                    })}
+                    }}
                     styles={{
-                        rightIcon: {
+                        section: {
                             marginLeft: 4,
                         },
                     }}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,15 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Button,
-    Group,
-    Menu,
-    Paper,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { ActionIcon, Group, Menu, Paper, Tooltip, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,
@@ -298,7 +290,7 @@ export const HeaderCreate: FC = () => {
                                 <Button
                                     variant="default"
                                     size="xs"
-                                    leftIcon={getCtaIcon(ctaAction)}
+                                    leftSection={getCtaIcon(ctaAction)}
                                     disabled={isCtaDisabled}
                                     onClick={handleCtaClick}
                                 >

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,8 +1,7 @@
 import { type SqlChart } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Button,
     Group,
     HoverCard,
     Menu,

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,15 +1,7 @@
 import { subject } from '@casl/ability';
 import { DashboardTileTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Button,
-    Group,
-    Menu,
-    Paper,
-    Title,
-    Tooltip,
-} from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { ActionIcon, Group, Menu, Paper, Title, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -8,11 +8,10 @@ import {
     SEED_ORG_1_ADMIN_PASSWORD,
     type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     Card,
     Divider,
     PasswordInput,

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,9 +1,8 @@
 import { LightdashMode, type ApiErrorDetail } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     CopyButton,
     Group,
     Modal,
@@ -173,11 +172,10 @@ const ApiErrorDisplayWithHealth = ({
                     </Text>
                     <Group spacing="xs">
                         <Button
-                            size="xs"
-                            compact
+                            size="compact-xs"
                             variant="outline"
                             color="red.6"
-                            leftIcon={
+                            leftSection={
                                 <MantineIcon
                                     color="red.6"
                                     icon={IconSpeakerphone}

--- a/packages/frontend/src/hooks/toaster/types.ts
+++ b/packages/frontend/src/hooks/toaster/types.ts
@@ -1,5 +1,5 @@
 import { type ApiErrorDetail } from '@lightdash/common';
-import { type ButtonProps } from '@mantine/core';
+import { type ButtonProps } from '@mantine-8/core';
 import { type notifications } from '@mantine/notifications';
 import { type PolymorphicComponentProps } from '@mantine/utils';
 import { type Icon } from '@tabler/icons-react';

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -1,6 +1,6 @@
 import type { ApiErrorDetail } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { Button, useMantineColorScheme, useMantineTheme } from '@mantine/core';
+import { Box, Button, Stack } from '@mantine-8/core';
+import { useMantineColorScheme, useMantineTheme } from '@mantine/core';
 import { notifications, type NotificationProps } from '@mantine/notifications';
 import {
     IconAlertCircleFilled,
@@ -126,7 +126,7 @@ const useToaster = () => {
                                     radius="md"
                                     variant="light"
                                     color={color}
-                                    leftIcon={
+                                    leftSection={
                                         action.icon ? (
                                             <MantineIcon icon={action.icon} />
                                         ) : undefined

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -40,7 +40,7 @@ declare module '@mantine-8/core' {
 
 declare module '@mantine-8/core' {
     export interface ButtonProps {
-        variant?: ButtonVariant | 'compact-outline' | 'dark';
+        variant?: ButtonVariant | 'compact-outline' | 'dark' | 'darkPrimary';
     }
 
     export interface PaperProps {
@@ -203,12 +203,33 @@ export const getMantine8ThemeOverride = (
                             },
                         };
                     }
+                    if (props.variant === 'darkPrimary') {
+                        return {
+                            root: {
+                                '--button-bg': `var(--mantine-color-foreground-0)`,
+                                '--button-hover': `color-mix(in srgb, var(--mantine-color-foreground-0) 80%, transparent)`,
+                                '--button-color': `var(--mantine-color-ldGray-0)`,
+                                '--button-bd': `none`,
+                            },
+                        };
+                    }
                     return { root: {} };
                 },
-                styles: (theme) => ({
+                styles: (theme, props) => ({
                     root: {
                         fontFamily: theme.fontFamily,
                         fontWeight: 500,
+                        ...(props.variant === 'darkPrimary'
+                            ? {
+                                  '&[data-loading]': {
+                                      boxShadow: theme.shadows.subtle,
+                                  },
+                                  '&[data-disabled]': {
+                                      boxShadow: theme.shadows.subtle,
+                                      color: `color-mix(in srgb, var(--mantine-color-foreground-0) 50%, transparent)`,
+                                  },
+                              }
+                            : {}),
                     },
                 }),
                 defaultProps: {

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -1,14 +1,6 @@
 import { getEmailSchema } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    Button,
-    Center,
-    List,
-    TextInput,
-    Title,
-    Text,
-} from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Anchor, Center, List, TextInput, Title, Text } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -1,7 +1,6 @@
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
     Anchor,
-    Button,
     Card,
     Center,
     PasswordInput,

--- a/packages/frontend/src/pages/SavedApps.tsx
+++ b/packages/frontend/src/pages/SavedApps.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { ContentType, FeatureFlags } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Button, Group } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Group } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { Link, Navigate, useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
@@ -57,7 +57,7 @@ const SavedApps = () => {
                             <Button
                                 component={Link}
                                 to={`/projects/${projectUuid}/apps/generate`}
-                                leftIcon={<IconPlus size={18} />}
+                                leftSection={<IconPlus size={18} />}
                             >
                                 Create data app
                             </Button>

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -1,6 +1,6 @@
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Button, Group } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Group } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -64,7 +64,7 @@ const SavedDashboards = () => {
                             userCanCreateDashboards &&
                             !isDemo && (
                                 <Button
-                                    leftIcon={<IconPlus size={18} />}
+                                    leftSection={<IconPlus size={18} />}
                                     onClick={handleCreateDashboard}
                                 >
                                     Create dashboard

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -1,6 +1,6 @@
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Button, Group } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Group } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -45,7 +45,7 @@ const SavedQueries: FC = () => {
                         />
                         {!isDemo && userCanCreateCharts ? (
                             <Button
-                                leftIcon={<IconPlus size={18} />}
+                                leftSection={<IconPlus size={18} />}
                                 onClick={handleCreateChart}
                             >
                                 Create chart

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -6,8 +6,8 @@ import {
     ResourceViewItemType,
     type ResourceViewSpaceItem,
 } from '@lightdash/common';
-import { Box, Menu, Stack } from '@mantine-8/core';
-import { ActionIcon, Button, Group } from '@mantine/core';
+import { Box, Button, Menu, Stack } from '@mantine-8/core';
+import { ActionIcon, Group } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconDots,
@@ -262,7 +262,7 @@ const Space: FC = () => {
                                             <Box>
                                                 <Button
                                                     data-testid="Space/AddButton"
-                                                    leftIcon={
+                                                    leftSection={
                                                         <MantineIcon
                                                             icon={IconPlus}
                                                         />

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Button, Group } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Group } from '@mantine/core';
 import { IconFolderPlus, IconPlus } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useParams } from 'react-router';
@@ -79,7 +79,7 @@ const Spaces: FC = () => {
                         <Group spacing="xs">
                             {!isDemo && userCanManageSpace && (
                                 <Button
-                                    leftIcon={<IconPlus size={18} />}
+                                    leftSection={<IconPlus size={18} />}
                                     onClick={handleCreateSpace}
                                 >
                                     Add

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -3,10 +3,9 @@ import {
     type UserActivity as UserActivityResponse,
     type UserWithCount,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Button, Stack } from '@mantine-8/core';
 import {
     Anchor,
-    Button,
     Card,
     Group,
     Table,

--- a/packages/frontend/src/stories/Button.stories.tsx
+++ b/packages/frontend/src/stories/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Button> = {

--- a/packages/frontend/src/stories/FormCard.stories.tsx
+++ b/packages/frontend/src/stories/FormCard.stories.tsx
@@ -1,6 +1,5 @@
-import { Stack } from '@mantine-8/core';
+import { Button, Stack } from '@mantine-8/core';
 import {
-    Button,
     Card,
     SegmentedControl,
     Select,
@@ -59,7 +58,7 @@ export function FormCard({ hasError = false }: FormCardProps) {
                         type="submit"
                         radius="md"
                         variant="darkPrimary"
-                        sx={{
+                        style={{
                             alignSelf: 'flex-end',
                         }}
                     >

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import { Button, Group, Title } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
+import { Group, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import MultipleToastBody from '../hooks/toaster/MultipleToastBody';


### PR DESCRIPTION
## What & why

Part 2 of the Mantine v6 → v8 migration. Migrates **`Button`** (and `ButtonProps`) from `@mantine/core` to `@mantine-8/core` across 67 files. **Stacked on #25233** (Stack/Box/Text) — review/merge that first.

`Group` (PR3) follows separately. Mixed imports are split; every other component stays on v6.

## Changes

- **67 files**: import splits + v8 Button prop renames on `<Button>` tags only:
  - `leftIcon` → `leftSection`, `rightIcon` → `rightSection`
  - `compact` → folded into `size` (`size="compact-xs"`, defaulting to `compact-sm` when no size was set — v6's default size)
  - `styles={{ leftIcon/rightIcon }}` icon selector → `styles={{ section }}`
  - removed no-op `uppercase` / `loaderPosition`
- **`sx` (removed in v8)** → CSS modules where a selector is involved (`:hover`, `[data-disabled]`, `[data-resize-handle-state]`), or inline `style` for dynamic-only values (e.g. `visibility` toggles). New modules: `MetricsCatalogPanel`, `MetricsTableTopToolbar`, `MetricExploreFilter`, `MetricExploreSegmentationPicker`, `AllowedDomainsPanel`, `DatabricksForm`, `SnowflakeForm`, `MetricsCatalogColumns`, + `GithubForm` extended.

### Theme changes (`mantine8Theme.ts`)

- **Registered the `darkPrimary` Button variant** in the v8 theme. It was the v6 *default* variant (foreground-colored, differs from the existing v8 `dark` variant in dark mode), and ~4 call sites set it explicitly. Ported its `vars` (bg/hover/color) plus the `[data-loading]`/`[data-disabled]` box-shadow so those buttons render identically.
- Replaced `theme.colorScheme` (removed in v8) in `MetricsCatalogColumns` with the CSS `light-dark()` function.

## Scope / regression analysis

- **Only** `Button` changes alias — no other component touched. `UnstyledButton`, `CloseButton`, `CopyButton`, `FileButton`, and custom wrappers (`OnboardingButton`, `RefreshDbtButton`) are deliberately left as-is; their `leftIcon`/`compact`/`sx` props are unchanged.
- v8's Button type rejects the old props (`leftIcon`, `compact`, `sx`, `styles.leftIcon`, `darkPrimary` before registration), so `typecheck` is a hard safety net — a missed rename cannot ship silently.
- The one behavior-sensitive case (`darkPrimary` in dark mode) is preserved by registering the variant rather than remapping to `dark`.

## Verification

- `pnpm -F frontend typecheck:fast` — 0 errors
- `oxlint` on all 68 changed source files — 0 warnings / 0 errors
- `oxfmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UJY1ihpNm7LBPLqnMd8j3
