### PR TITLE
feat(mcp): persist MCP tool call activity for admin observability

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -460,6 +460,12 @@ import {
     ManagedAgentSettingsTableName,
 } from '../ee/database/entities/managedAgent';
 import {
+    McpClientInfoTable,
+    McpClientInfoTableName,
+    McpToolCallTable,
+    McpToolCallTableName,
+} from '../ee/database/entities/mcpToolCall';
+import {
     PreAggregateDailyStatsTable,
     PreAggregateDailyStatsTableName,
 } from '../ee/database/entities/preAggregateDailyStats';
@@ -608,6 +614,8 @@ declare module 'knex/types/tables' {
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;
         [AiAgentToolResultTableName]: AiAgentToolResultTable;
+        [McpToolCallTableName]: McpToolCallTable;
+        [McpClientInfoTableName]: McpClientInfoTable;
         [AiSqlApprovalTableName]: AiSqlApprovalTable;
         [DashboardTabsTableName]: DashboardTabsTable;
         [NotificationsTableName]: NotificationsTable;

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2126,7 +2126,15 @@ export type McpToolCallEvent = BaseTrack & {
     properties: {
         organizationId: string;
         projectId?: string;
+        agentId?: string;
         toolName: string;
+        status: 'success' | 'error';
+        durationMs: number;
+        authType: string;
+        clientName?: string;
+        clientVersion?: string;
+        userAgent?: string;
+        protocolVersion?: string;
     };
 };
 

--- a/packages/backend/src/ee/database/entities/mcpToolCall.ts
+++ b/packages/backend/src/ee/database/entities/mcpToolCall.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+export const McpToolCallTableName = 'mcp_tool_call';
+
+export type DbMcpToolCall = {
+    mcp_tool_call_uuid: string;
+    organization_uuid: string;
+    user_uuid: string;
+    project_uuid: string | null;
+    agent_uuid: string | null;
+    tool_name: string;
+    tool_args: object;
+    status: 'success' | 'error';
+    error_message: string | null;
+    duration_ms: number;
+    result_metadata: object | null;
+    client_name: string | null;
+    client_version: string | null;
+    user_agent: string | null;
+    auth_type: string;
+    protocol_version: string | null;
+    created_at: Date;
+};
+
+export type McpToolCallTable = Knex.CompositeTableType<
+    DbMcpToolCall,
+    Omit<DbMcpToolCall, 'mcp_tool_call_uuid' | 'created_at'>,
+    never
+>;
+
+export const McpClientInfoTableName = 'mcp_client_info';
+
+export type DbMcpClientInfo = {
+    user_uuid: string;
+    organization_uuid: string;
+    user_agent: string;
+    client_name: string;
+    client_version: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type McpClientInfoTable = Knex.CompositeTableType<
+    DbMcpClientInfo,
+    Omit<DbMcpClientInfo, 'created_at' | 'updated_at'>,
+    Pick<DbMcpClientInfo, 'client_name' | 'client_version' | 'updated_at'>
+>;

--- a/packages/backend/src/ee/database/migrations/20260707120000_create_mcp_tool_call_table.ts
+++ b/packages/backend/src/ee/database/migrations/20260707120000_create_mcp_tool_call_table.ts
@@ -1,0 +1,91 @@
+import { Knex } from 'knex';
+
+const McpToolCallTableName = 'mcp_tool_call';
+const McpClientInfoTableName = 'mcp_client_info';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(McpToolCallTableName, (table) => {
+        table
+            .uuid('mcp_tool_call_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table.uuid('organization_uuid').notNullable();
+        table.uuid('user_uuid').notNullable();
+        table.uuid('project_uuid').nullable();
+        table.uuid('agent_uuid').nullable();
+        table.text('tool_name').notNullable();
+        table.jsonb('tool_args').notNullable();
+        table.text('status').notNullable();
+        table.text('error_message').nullable();
+        table.integer('duration_ms').notNullable();
+        table.jsonb('result_metadata').nullable();
+        table.text('client_name').nullable();
+        table.text('client_version').nullable();
+        table.text('user_agent').nullable();
+        table.text('auth_type').notNullable();
+        table.text('protocol_version').nullable();
+        table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+
+        table
+            .foreign('organization_uuid')
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        table
+            .foreign('user_uuid')
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE');
+        // Rows outlive their project/agent so org-level usage history is
+        // preserved; the 90-day retention job is the real bound on growth.
+        table
+            .foreign('project_uuid')
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('SET NULL');
+        table
+            .foreign('agent_uuid')
+            .references('ai_agent_uuid')
+            .inTable('ai_agent')
+            .onDelete('SET NULL');
+
+        table.index(['organization_uuid', 'created_at']);
+        table.index(['project_uuid', 'created_at']);
+        // Retention cleanup deletes purely by age
+        table.index('created_at');
+    });
+
+    // Client identity from the MCP initialize handshake. The transport is
+    // stateless (one server per POST), so tool-call requests never carry
+    // clientInfo — it only appears on initialize requests. This table keeps
+    // the latest handshake per (user, org, user_agent); tool calls attach it
+    // by matching their request's user-agent, so concurrent clients of the
+    // same user don't overwrite each other.
+    await knex.schema.createTable(McpClientInfoTableName, (table) => {
+        table.uuid('user_uuid').notNullable();
+        table.uuid('organization_uuid').notNullable();
+        table.text('user_agent').notNullable();
+        table.text('client_name').notNullable();
+        table.text('client_version').nullable();
+        table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+        table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable();
+
+        table.primary(['user_uuid', 'organization_uuid', 'user_agent']);
+
+        table
+            .foreign('user_uuid')
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE');
+        table
+            .foreign('organization_uuid')
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(McpClientInfoTableName);
+    await knex.schema.dropTableIfExists(McpToolCallTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -39,6 +39,7 @@ import { DashboardSummaryModel } from './models/DashboardSummaryModel';
 import { EmbedModel } from './models/EmbedModel';
 import { ExternalConnectionModel } from './models/ExternalConnectionModel';
 import { ManagedAgentModel } from './models/ManagedAgentModel';
+import { McpToolCallModel } from './models/McpToolCallModel';
 import { ProjectCiStatusModel } from './models/ProjectCiStatusModel';
 import { ProjectContextModel } from './models/ProjectContextModel';
 import { SandboxRegistryModel } from './models/SandboxRegistryModel';
@@ -763,6 +764,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     searchModel: models.getSearchModel(),
                     spaceService: repository.getSpaceService(),
                     mcpContextModel: models.getMcpContextModel(),
+                    mcpToolCallModel:
+                        models.getMcpToolCallModel<McpToolCallModel>(),
                     projectModel: models.getProjectModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     aiOrganizationSettingsService:
@@ -841,6 +844,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
             schedulerAiAugmentationModel: ({ database }) =>
                 new SchedulerAiAugmentationModel({ database }),
             aiRouterModel: ({ database }) => new AiRouterModel({ database }),
+            mcpToolCallModel: ({ database }) =>
+                new McpToolCallModel({ database }),
             aiOrganizationSettingsModel: ({ database, utils }) =>
                 new AiOrganizationSettingsModel({
                     database,
@@ -936,6 +941,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.serviceRepository.getProjectContextService<ProjectContextService>(),
                 projectModel: context.models.getProjectModel(),
                 openIdIdentityModel: context.models.getOpenIdIdentityModel(),
+                mcpToolCallModel:
+                    context.models.getMcpToolCallModel<McpToolCallModel>(),
                 prometheusMetrics: context.prometheusMetrics,
             }),
         clientProviders: {

--- a/packages/backend/src/ee/models/McpToolCallModel.ts
+++ b/packages/backend/src/ee/models/McpToolCallModel.ts
@@ -1,0 +1,99 @@
+import { Knex } from 'knex';
+import {
+    DbMcpClientInfo,
+    DbMcpToolCall,
+    McpClientInfoTableName,
+    McpToolCallTableName,
+} from '../database/entities/mcpToolCall';
+
+export type CreateMcpToolCall = Omit<
+    DbMcpToolCall,
+    'mcp_tool_call_uuid' | 'created_at' | 'tool_args' | 'result_metadata'
+> & {
+    tool_args: object;
+    result_metadata: object | null;
+};
+
+export type UpsertMcpClientInfo = {
+    userUuid: string;
+    organizationUuid: string;
+    userAgent: string;
+    clientName: string;
+    clientVersion: string | null;
+};
+
+// Oversized args are replaced (not truncated mid-JSON) so tool_args stays
+// valid jsonb; the original size is kept for the admin UI to explain the gap.
+const MAX_TOOL_ARGS_BYTES = 64 * 1024;
+
+const capToolArgs = (args: object): object => {
+    const serialized = JSON.stringify(args);
+    if (serialized.length <= MAX_TOOL_ARGS_BYTES) {
+        return args;
+    }
+    return {
+        truncated: true,
+        originalSizeBytes: serialized.length,
+    };
+};
+
+export class McpToolCallModel {
+    private database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async createToolCall(data: CreateMcpToolCall): Promise<void> {
+        await this.database(McpToolCallTableName).insert({
+            ...data,
+            tool_args: capToolArgs(data.tool_args),
+        });
+    }
+
+    async upsertClientInfo(data: UpsertMcpClientInfo): Promise<void> {
+        await this.database(McpClientInfoTableName)
+            .insert({
+                user_uuid: data.userUuid,
+                organization_uuid: data.organizationUuid,
+                user_agent: data.userAgent,
+                client_name: data.clientName,
+                client_version: data.clientVersion,
+            })
+            .onConflict(['user_uuid', 'organization_uuid', 'user_agent'])
+            .merge({
+                client_name: data.clientName,
+                client_version: data.clientVersion,
+                updated_at: this.database.fn.now(),
+            });
+    }
+
+    async findClientInfo(
+        userUuid: string,
+        organizationUuid: string,
+        userAgent: string,
+    ): Promise<DbMcpClientInfo | undefined> {
+        return this.database(McpClientInfoTableName)
+            .where({
+                user_uuid: userUuid,
+                organization_uuid: organizationUuid,
+                user_agent: userAgent,
+            })
+            .first();
+    }
+
+    async deleteToolCallsOlderThan(days: number): Promise<number> {
+        // A non-positive retention would compute a future cutoff and delete
+        // everything
+        if (!Number.isInteger(days) || days <= 0) {
+            throw new Error(`Invalid retention days: ${days}`);
+        }
+        return this.database(McpToolCallTableName)
+            .where(
+                'created_at',
+                '<',
+                this.database.raw('now() - make_interval(days => ?)', [days]),
+            )
+            .delete();
+    }
+}

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -18,6 +18,7 @@ import {
 import { TypedEETaskList } from '../../scheduler/types';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type AiAgentReviewNotificationModel } from '../models/AiAgentReviewNotificationModel';
+import { type McpToolCallModel } from '../models/McpToolCallModel';
 import { AiAgentAdminService } from '../services/AiAgentAdminService';
 import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
 import { type AiAgentReviewNotificationService } from '../services/AiAgentReviewNotificationService';
@@ -28,6 +29,7 @@ import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgen
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 import { sendReviewNotification } from './tasks/sendReviewNotification';
 
+const MCP_TOOL_CALL_RETENTION_DAYS = 90;
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
@@ -47,6 +49,7 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     projectContextService: ProjectContextService;
     projectModel: ProjectModel;
     openIdIdentityModel: OpenIdIdentityModel;
+    mcpToolCallModel: McpToolCallModel;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
@@ -74,6 +77,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly openIdIdentityModel: OpenIdIdentityModel;
 
+    protected readonly mcpToolCallModel: McpToolCallModel;
+
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
         this.aiAgentService = args.aiAgentService;
@@ -91,6 +96,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.projectContextService = args.projectContextService;
         this.projectModel = args.projectModel;
         this.openIdIdentityModel = args.openIdIdentityModel;
+        this.mcpToolCallModel = args.mcpToolCallModel;
     }
 
     protected getCronItems() {
@@ -102,6 +108,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 options: {
                     backfillPeriod: 5 * 60 * 1000, // 5 min
                     maxAttempts: 1,
+                },
+            },
+            {
+                task: EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS,
+                pattern: '45 0 * * *', // 00:45 UTC daily
+                options: {
+                    backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
+                    maxAttempts: 3,
                 },
             },
         ];
@@ -123,6 +137,16 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             [EE_SCHEDULER_TASKS.SLACK_AI_PROMPT]: async (payload, _helpers) => {
                 await this.aiAgentService.replyToSlackPrompt(
                     payload.slackPromptUuid,
+                );
+            },
+            [EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: async () => {
+                Logger.info('Starting MCP tool call cleanup job');
+                const deleted =
+                    await this.mcpToolCallModel.deleteToolCallsOlderThan(
+                        MCP_TOOL_CALL_RETENTION_DAYS,
+                    );
+                Logger.info(
+                    `MCP tool call cleanup completed. Records deleted: ${deleted}`,
                 );
             },
             [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: async (

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -3,6 +3,7 @@ import {
     Account,
     AiAgentWithContext,
     AiResultType,
+    AnyType,
     ApiKeyAccount,
     assertUnreachable,
     buildRunSqlDescription,
@@ -108,6 +109,8 @@ import {
 } from '../../../services/UserAttributesService/UserAttributeUtils';
 import { wrapSentryTransaction } from '../../../utils';
 import { VERSION } from '../../../version';
+import { DbMcpClientInfo } from '../../database/entities/mcpToolCall';
+import { McpToolCallModel } from '../../models/McpToolCallModel';
 import {
     getMcpAnalystPromptWithContext,
     MCP_ANALYST_PROMPT,
@@ -218,6 +221,7 @@ type McpServiceArguments = {
     searchModel: SearchModel;
     spaceService: SpaceService;
     mcpContextModel: McpContextModel;
+    mcpToolCallModel: McpToolCallModel;
     featureFlagService: FeatureFlagService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
     aiAgentService: AiAgentService;
@@ -233,6 +237,10 @@ export type ExtraContext = {
     headerUserAttributes?: UserAttributeValueMap;
     /** Project UUID passed via X-Lightdash-Project header; overrides stored context */
     headerProjectUuid?: string;
+    /** User-Agent of the MCP client request, used to attach client identity to tool calls */
+    userAgent?: string;
+    /** Negotiated protocol version from the MCP-Protocol-Version header */
+    protocolVersion?: string;
 };
 
 type McpEffectiveScope = {
@@ -253,6 +261,8 @@ const extraContextSchema = z.object({
     account: z.custom<OauthAccount | ApiKeyAccount | ServiceAcctAccount>(),
     headerUserAttributes: z.custom<UserAttributeValueMap>().optional(),
     headerProjectUuid: z.string().optional(),
+    userAgent: z.string().optional(),
+    protocolVersion: z.string().optional(),
 });
 
 const mcpProtocolContextSchema = z.object({
@@ -293,6 +303,8 @@ export class McpService extends BaseService {
 
     private mcpContextModel: McpContextModel;
 
+    private mcpToolCallModel: McpToolCallModel;
+
     private shareService: ShareService;
 
     private featureFlagService: FeatureFlagService;
@@ -322,6 +334,7 @@ export class McpService extends BaseService {
         spaceService,
         projectModel,
         mcpContextModel,
+        mcpToolCallModel,
         featureFlagService,
         aiOrganizationSettingsService,
         aiAgentService,
@@ -342,6 +355,7 @@ export class McpService extends BaseService {
         this.projectModel = projectModel;
         this.spaceService = spaceService;
         this.mcpContextModel = mcpContextModel;
+        this.mcpToolCallModel = mcpToolCallModel;
         this.featureFlagService = featureFlagService;
         this.aiOrganizationSettingsService = aiOrganizationSettingsService;
         this.aiAgentService = aiAgentService;
@@ -1087,7 +1101,7 @@ export class McpService extends BaseService {
      * AiWriteback gate in setupHandlers).
      */
     private registerRunAiWritebackTool(): void {
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpRunAiWritebackTool.name,
             {
                 title: mcpRunAiWritebackTool.title,
@@ -1101,12 +1115,6 @@ export class McpService extends BaseService {
 
                 const { user } = McpService.getAccount(ctx);
                 const projectUuid = await this.resolveProjectUuid(ctx);
-
-                this.trackToolCall(
-                    ctx,
-                    McpToolName.RUN_AI_WRITEBACK,
-                    projectUuid,
-                );
 
                 try {
                     const result = await this.aiWritebackService.run({
@@ -1170,7 +1178,7 @@ export class McpService extends BaseService {
     }
 
     private registerContentWriteTools(): void {
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpCreateContentTool.name,
             {
                 title: mcpCreateContentTool.title,
@@ -1182,12 +1190,6 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
                 const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
-
-                this.trackToolCall(
-                    ctx,
-                    McpToolName.CREATE_CONTENT,
-                    projectUuid,
-                );
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
@@ -1214,7 +1216,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpEditContentTool.name,
             {
                 title: mcpEditContentTool.title,
@@ -1226,8 +1228,6 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
                 const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
-
-                this.trackToolCall(ctx, McpToolName.EDIT_CONTENT, projectUuid);
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
@@ -1263,7 +1263,7 @@ export class McpService extends BaseService {
             mcpContentWritesEnabled: true,
         },
     ): void {
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpGetLightdashVersionTool.name,
             {
                 title: mcpGetLightdashVersionTool.title,
@@ -1274,7 +1274,6 @@ export class McpService extends BaseService {
             async (_args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                this.trackToolCall(ctx, McpToolName.GET_LIGHTDASH_VERSION);
                 return {
                     content: [
                         {
@@ -1286,7 +1285,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpListExploresTool.name,
             {
                 title: mcpListExploresTool.title,
@@ -1299,12 +1298,6 @@ export class McpService extends BaseService {
                     const ctx = getMcpContext(extra);
 
                     const projectUuid = await this.resolveProjectUuid(ctx);
-
-                    this.trackToolCall(
-                        ctx,
-                        McpToolName.LIST_EXPLORES,
-                        projectUuid,
-                    );
 
                     const toolsRuntime = await this.getToolsRuntime(
                         ctx,
@@ -1339,7 +1332,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpFindExploresTool.name,
             {
                 title: mcpFindExploresTool.title,
@@ -1353,8 +1346,6 @@ export class McpService extends BaseService {
                 const { user } = McpService.getAccount(ctx);
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
-
-                this.trackToolCall(ctx, McpToolName.FIND_EXPLORES, projectUuid);
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
@@ -1415,7 +1406,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpFindFieldsTool.name,
             {
                 title: mcpFindFieldsTool.title,
@@ -1428,8 +1419,6 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
-
-                this.trackToolCall(ctx, McpToolName.FIND_FIELDS, projectUuid);
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
@@ -1475,7 +1464,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpFindContentTool.name,
             {
                 title: mcpFindContentTool.title,
@@ -1488,8 +1477,6 @@ export class McpService extends BaseService {
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
-
-                this.trackToolCall(ctx, McpToolName.FIND_CONTENT, projectUuid);
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
@@ -1517,7 +1504,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpListContentTool.name,
             {
                 title: mcpListContentTool.title,
@@ -1530,8 +1517,6 @@ export class McpService extends BaseService {
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
-
-                this.trackToolCall(ctx, McpToolName.LIST_CONTENT, projectUuid);
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
@@ -1555,7 +1540,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpReadContentTool.name,
             {
                 title: mcpReadContentTool.title,
@@ -1567,8 +1552,6 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
                 const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
-
-                this.trackToolCall(ctx, McpToolName.READ_CONTENT, projectUuid);
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
@@ -1601,7 +1584,7 @@ export class McpService extends BaseService {
         // When the project is pinned via header, hide the project-selection
         // tools so clients can't change context for a request-scoped pin.
         if (!options.projectPinned) {
-            this.mcpServer.registerTool(
+            this.registerTrackedTool(
                 mcpListProjectsTool.name,
                 {
                     title: mcpListProjectsTool.title,
@@ -1619,8 +1602,6 @@ export class McpService extends BaseService {
                     const ctx = getMcpContext(extra);
                     const { user, organizationUuid } =
                         McpService.getAccount(ctx);
-
-                    this.trackToolCall(ctx, McpToolName.LIST_PROJECTS);
 
                     const allProjects = await wrapSentryTransaction(
                         'McpService.listProjects.getAllByOrganizationUuid',
@@ -1658,7 +1639,7 @@ export class McpService extends BaseService {
                 },
             );
 
-            this.mcpServer.registerTool(
+            this.registerTrackedTool(
                 mcpSetProjectTool.name,
                 {
                     title: mcpSetProjectTool.title,
@@ -1676,12 +1657,6 @@ export class McpService extends BaseService {
                     const ctx = getMcpContext(extra);
                     const { user, organizationUuid, account } =
                         McpService.getAccount(ctx);
-
-                    this.trackToolCall(
-                        ctx,
-                        McpToolName.SET_PROJECT,
-                        args.projectUuid,
-                    );
 
                     if (!args.projectUuid) {
                         throw new ParameterError('Project UUID is required');
@@ -1745,7 +1720,7 @@ export class McpService extends BaseService {
             );
         }
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpGetCurrentProjectTool.name,
             {
                 title: mcpGetCurrentProjectTool.title,
@@ -1757,8 +1732,6 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
 
                 const { user, organizationUuid } = McpService.getAccount(ctx);
-
-                this.trackToolCall(ctx, McpToolName.GET_CURRENT_PROJECT);
 
                 const contextRow = await this.mcpContextModel.getContext(
                     user.userUuid,
@@ -1803,7 +1776,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpListAgentsTool.name,
             {
                 title: mcpListAgentsTool.title,
@@ -1817,8 +1790,6 @@ export class McpService extends BaseService {
                 const { user } = McpService.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
-
-                this.trackToolCall(ctx, McpToolName.LIST_AGENTS);
 
                 const projectUuid =
                     args.projectUuid ??
@@ -1848,7 +1819,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpRouteAgentTool.name,
             {
                 title: mcpRouteAgentTool.title,
@@ -1866,8 +1837,6 @@ export class McpService extends BaseService {
 
                 const projectUuid =
                     args.projectUuid ?? (await this.resolveProjectUuid(ctx));
-
-                this.trackToolCall(ctx, McpToolName.ROUTE_AGENT, projectUuid);
 
                 let selection;
                 try {
@@ -1925,7 +1894,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpSetAgentTool.name,
             {
                 title: mcpSetAgentTool.title,
@@ -1940,8 +1909,6 @@ export class McpService extends BaseService {
                     McpService.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
-
-                this.trackToolCall(ctx, McpToolName.SET_AGENT, args.agentUuid);
 
                 if (!args.agentUuid) {
                     throw new ParameterError('Agent UUID is required');
@@ -1983,7 +1950,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpClearAgentTool.name,
             {
                 title: mcpClearAgentTool.title,
@@ -1995,8 +1962,6 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
 
                 const { user, organizationUuid } = McpService.getAccount(ctx);
-
-                this.trackToolCall(ctx, McpToolName.CLEAR_AGENT);
 
                 const existingContext = await this.mcpContextModel.getContext(
                     user.userUuid,
@@ -2033,7 +1998,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpGetCurrentAgentTool.name,
             {
                 title: mcpGetCurrentAgentTool.title,
@@ -2047,8 +2012,6 @@ export class McpService extends BaseService {
                 const { user, organizationUuid } = McpService.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
-
-                this.trackToolCall(ctx, McpToolName.GET_CURRENT_AGENT);
 
                 const contextRow = await this.mcpContextModel.getContext(
                     user.userUuid,
@@ -2121,7 +2084,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpRunMetricQueryTool.name,
             {
                 title: mcpRunMetricQueryTool.title,
@@ -2135,12 +2098,6 @@ export class McpService extends BaseService {
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ..._args, projectUuid };
-
-                this.trackToolCall(
-                    ctx,
-                    McpToolName.RUN_METRIC_QUERY,
-                    projectUuid,
-                );
 
                 try {
                     const deadlineMs =
@@ -2242,92 +2199,95 @@ export class McpService extends BaseService {
                 annotations: mcpRenderChartTool.annotations,
                 _meta: { ui: { resourceUri: chartResourceUri } },
             },
-            async (_args, extra) => {
-                const ctx = getMcpContext(extra);
+            this.wrapToolCallback(
+                mcpRenderChartTool.name,
+                async (_args, extra) => {
+                    const ctx = getMcpContext(extra);
 
-                const projectUuid = await this.resolveProjectUuid(ctx);
-                const argsWithProject = { ..._args, projectUuid };
+                    const projectUuid = await this.resolveProjectUuid(ctx);
+                    const argsWithProject = { ..._args, projectUuid };
 
-                this.trackToolCall(ctx, McpToolName.RENDER_CHART, projectUuid);
+                    try {
+                        const { user, account } = McpService.getAccount(ctx);
+                        const renderTool =
+                            toolRenderChartArgsSchemaTransformed.parse(
+                                argsWithProject,
+                            );
 
-                try {
-                    const { user, account } = McpService.getAccount(ctx);
-                    const renderTool =
-                        toolRenderChartArgsSchemaTransformed.parse(
-                            argsWithProject,
-                        );
+                        const queryHistory =
+                            await this.asyncQueryService.getAsyncQueryHistory({
+                                account,
+                                projectUuid,
+                                queryUuid: renderTool.queryUuid,
+                            });
 
-                    const queryHistory =
-                        await this.asyncQueryService.getAsyncQueryHistory({
-                            account,
+                        if (
+                            queryHistory.context !==
+                            QueryExecutionContext.MCP_RUN_METRIC_QUERY
+                        ) {
+                            throw new ParameterError(
+                                'render_chart currently supports queries started by run_metric_query',
+                            );
+                        }
+
+                        if (queryHistory.status !== QueryHistoryStatus.READY) {
+                            throw new UnexpectedServerError(
+                                queryHistory.error ??
+                                    `Query is not ready to render; current status is ${queryHistory.status}`,
+                            );
+                        }
+
+                        await this.assertMetricQueryInEffectiveScope({
+                            ctx,
+                            user,
                             projectUuid,
-                            queryUuid: renderTool.queryUuid,
+                            metricQuery: queryHistory.metricQuery,
                         });
 
-                    if (
-                        queryHistory.context !==
-                        QueryExecutionContext.MCP_RUN_METRIC_QUERY
-                    ) {
-                        throw new ParameterError(
-                            'render_chart currently supports queries started by run_metric_query',
-                        );
-                    }
-
-                    if (queryHistory.status !== QueryHistoryStatus.READY) {
-                        throw new UnexpectedServerError(
-                            queryHistory.error ??
-                                `Query is not ready to render; current status is ${queryHistory.status}`,
-                        );
-                    }
-
-                    await this.assertMetricQueryInEffectiveScope({
-                        ctx,
-                        user,
-                        projectUuid,
-                        metricQuery: queryHistory.metricQuery,
-                    });
-
-                    const queryTool = McpService.buildRenderChartQueryTool({
-                        renderTool,
-                        metricQuery: queryHistory.metricQuery,
-                    });
-
-                    const results =
-                        await this.asyncQueryService.getRawAsyncQueryResults({
-                            account,
-                            projectUuid,
-                            queryUuid: renderTool.queryUuid,
+                        const queryTool = McpService.buildRenderChartQueryTool({
+                            renderTool,
+                            metricQuery: queryHistory.metricQuery,
                         });
 
-                    return await this.buildRenderChartResponse({
-                        ctx,
-                        queryUuid: renderTool.queryUuid,
-                        projectUuid,
-                        queryTool,
-                        query: queryHistory.metricQuery,
-                        rows: results.rows,
-                        fields: results.fields,
-                    });
-                } catch (e) {
-                    const errorMessage =
-                        e instanceof Error ? e.message : String(e);
-                    this.logger.error(
-                        `[McpService] Error in render_chart tool: ${errorMessage}`,
-                    );
-                    return {
-                        content: [
-                            {
-                                type: 'text' as const,
-                                text: `Error rendering chart: ${errorMessage}`,
-                            },
-                        ],
-                        isError: true,
-                    };
-                }
-            },
+                        const results =
+                            await this.asyncQueryService.getRawAsyncQueryResults(
+                                {
+                                    account,
+                                    projectUuid,
+                                    queryUuid: renderTool.queryUuid,
+                                },
+                            );
+
+                        return await this.buildRenderChartResponse({
+                            ctx,
+                            queryUuid: renderTool.queryUuid,
+                            projectUuid,
+                            queryTool,
+                            query: queryHistory.metricQuery,
+                            rows: results.rows,
+                            fields: results.fields,
+                        });
+                    } catch (e) {
+                        const errorMessage =
+                            e instanceof Error ? e.message : String(e);
+                        this.logger.error(
+                            `[McpService] Error in render_chart tool: ${errorMessage}`,
+                        );
+                        return {
+                            content: [
+                                {
+                                    type: 'text' as const,
+                                    text: `Error rendering chart: ${errorMessage}`,
+                                },
+                            ],
+                            isError: true,
+                        };
+                    }
+                },
+            ),
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpSearchFieldValuesTool.name,
             {
                 title: mcpSearchFieldValuesTool.title,
@@ -2340,12 +2300,6 @@ export class McpService extends BaseService {
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
-
-                this.trackToolCall(
-                    ctx,
-                    McpToolName.SEARCH_FIELD_VALUES,
-                    projectUuid,
-                );
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
@@ -2378,7 +2332,7 @@ export class McpService extends BaseService {
         const runSqlArgsSchema = createToolRunSqlArgsSchema({
             maxLimit: this.lightdashConfig.mcp.runSqlMaxLimit,
         });
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpRunSqlTool.name,
             {
                 title: mcpRunSqlTool.title,
@@ -2395,8 +2349,6 @@ export class McpService extends BaseService {
 
                 const { account } = McpService.getAccount(ctx);
                 const projectUuid = await this.resolveProjectUuid(ctx);
-
-                this.trackToolCall(ctx, McpToolName.RUN_SQL, projectUuid);
 
                 try {
                     const deadlineMs =
@@ -2467,7 +2419,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpGetQueryResultTool.name,
             {
                 title: mcpGetQueryResultTool.title,
@@ -2481,12 +2433,6 @@ export class McpService extends BaseService {
 
                 const { user, account } = McpService.getAccount(ctx);
                 const projectUuid = await this.resolveProjectUuid(ctx);
-
-                this.trackToolCall(
-                    ctx,
-                    McpToolName.GET_QUERY_RESULT,
-                    projectUuid,
-                );
 
                 try {
                     let queryHistory =
@@ -2631,7 +2577,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpListVerifiedContentTool.name,
             {
                 title: mcpListVerifiedContentTool.title,
@@ -2644,12 +2590,6 @@ export class McpService extends BaseService {
 
                 const { user } = McpService.getAccount(ctx);
                 const projectUuid = await this.resolveProjectUuid(ctx);
-
-                this.trackToolCall(
-                    ctx,
-                    McpToolName.LIST_VERIFIED_CONTENT,
-                    projectUuid,
-                );
 
                 const effectiveScope = await this.getEffectiveScopeFromContext(
                     ctx,
@@ -3080,7 +3020,7 @@ export class McpService extends BaseService {
     }
 
     private registerSkillToolHandlers(): void {
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpListSkillsTool.name,
             {
                 title: mcpListSkillsTool.title,
@@ -3089,10 +3029,7 @@ export class McpService extends BaseService {
                 outputSchema: mcpListSkillsTool.outputSchema.shape,
                 annotations: mcpListSkillsTool.annotations,
             },
-            async (_args, extra) => {
-                const ctx = getMcpContext(extra);
-                this.trackToolCall(ctx, McpToolName.LIST_SKILLS);
-
+            async () => {
                 const skills = await this.aiAgentToolsService.listMcpSkills();
                 return mcpListSkillsTool.result.structured(
                     JSON.stringify({ skills }, null, 2),
@@ -3101,7 +3038,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpReadSkillTool.name,
             {
                 title: mcpReadSkillTool.title,
@@ -3110,10 +3047,7 @@ export class McpService extends BaseService {
                 outputSchema: mcpReadSkillTool.outputSchema.shape,
                 annotations: mcpReadSkillTool.annotations,
             },
-            async (args, extra) => {
-                const ctx = getMcpContext(extra);
-                this.trackToolCall(ctx, McpToolName.READ_SKILL);
-
+            async (args) => {
                 const result = await this.aiAgentToolsService.loadMcpSkill(
                     args.name,
                 );
@@ -3131,7 +3065,7 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
+        this.registerTrackedTool(
             mcpReadSkillResourceTool.name,
             {
                 title: mcpReadSkillResourceTool.title,
@@ -3140,10 +3074,7 @@ export class McpService extends BaseService {
                 outputSchema: mcpReadSkillResourceTool.outputSchema.shape,
                 annotations: mcpReadSkillResourceTool.annotations,
             },
-            async (args, extra) => {
-                const ctx = getMcpContext(extra);
-                this.trackToolCall(ctx, McpToolName.READ_SKILL_RESOURCE);
-
+            async (args) => {
                 const result =
                     await this.aiAgentToolsService.loadMcpSkillResource(args);
                 if (!result) {
@@ -3336,24 +3267,211 @@ export class McpService extends BaseService {
         }
     }
 
-    private trackToolCall(
-        context: McpProtocolContext,
-        toolName: string,
-        projectUuid?: string,
-    ): void {
-        try {
-            const { user, organizationUuid } = McpService.getAccount(context);
-            this.analytics.track<McpToolCallEvent>({
-                event: 'mcp_tool_call',
-                userId: user.userUuid,
-                properties: {
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
+    /**
+     * Registers a tool with its handler wrapped in activity tracking
+     * (mcp_tool_call row + analytics per invocation). New tools must go
+     * through this — a direct mcpServer.registerTool call still works but
+     * silently skips recording.
+     */
+    private registerTrackedTool: McpServer['registerTool'] = (
+        name,
+        config,
+        handler,
+    ) =>
+        this.mcpServer.registerTool(
+            name,
+            config,
+            this.wrapToolCallback(name, handler),
+        );
+
+    private wrapToolCallback<
+        Callback extends (...cbArgs: AnyType[]) => AnyType,
+    >(toolName: string, handler: Callback): Callback {
+        const wrapped = async (...cbArgs: AnyType[]) => {
+            // ToolCallback is (extra) for tools without an input schema and
+            // (args, extra) otherwise
+            const [toolArgs, extra] =
+                cbArgs.length > 1 ? [cbArgs[0], cbArgs[1]] : [{}, cbArgs[0]];
+            const startedAt = Date.now();
+            try {
+                const result = await handler(...cbArgs);
+                this.recordToolCall({
                     toolName,
-                },
+                    toolArgs,
+                    extra,
+                    durationMs: Date.now() - startedAt,
+                    status: result?.isError === true ? 'error' : 'success',
+                    errorMessage:
+                        result?.isError === true
+                            ? McpService.getResultErrorText(result)
+                            : null,
+                });
+                return result;
+            } catch (error) {
+                this.recordToolCall({
+                    toolName,
+                    toolArgs,
+                    extra,
+                    durationMs: Date.now() - startedAt,
+                    status: 'error',
+                    errorMessage: getErrorMessage(error),
+                });
+                throw error;
+            }
+        };
+        return wrapped as Callback;
+    }
+
+    private static getResultErrorText(result: AnyType): string | null {
+        const text = Array.isArray(result?.content)
+            ? result.content.find((item: AnyType) => item?.type === 'text')
+                  ?.text
+            : undefined;
+        return typeof text === 'string' ? text.slice(0, 500) : null;
+    }
+
+    // Fire-and-forget: observability must never fail or slow down a tool call
+    private recordToolCall(params: {
+        toolName: string;
+        toolArgs: object;
+        extra: RequestHandlerExtra<ServerRequest, ServerNotification>;
+        durationMs: number;
+        status: 'success' | 'error';
+        errorMessage: string | null;
+    }): void {
+        void this.persistToolCall(params).catch((error) => {
+            this.logger.warn(
+                `Failed to record MCP tool call: ${getErrorMessage(error)}`,
+            );
+        });
+    }
+
+    private async persistToolCall({
+        toolName,
+        toolArgs,
+        extra,
+        durationMs,
+        status,
+        errorMessage,
+    }: {
+        toolName: string;
+        toolArgs: object;
+        extra: RequestHandlerExtra<ServerRequest, ServerNotification>;
+        durationMs: number;
+        status: 'success' | 'error';
+        errorMessage: string | null;
+    }): Promise<void> {
+        const context = getMcpContext(extra);
+        const { user, account, organizationUuid } =
+            McpService.getAccount(context);
+        const { userAgent, protocolVersion, headerProjectUuid } =
+            context.authInfo?.extra ?? {};
+
+        // Project/agent scope and client identity come from DB lookups, but
+        // they are enrichment only — a lookup failure must not cost the
+        // analytics event or the activity row
+        let projectUuid: string | null = headerProjectUuid ?? null;
+        let agentUuid: string | null = null;
+        let clientInfo: DbMcpClientInfo | undefined;
+        try {
+            const contextRow = await this.mcpContextModel.getContext(
+                user.userUuid,
+                organizationUuid,
+            );
+            const contextProjectUuid = contextRow?.context.projectUuid;
+            projectUuid = headerProjectUuid ?? contextProjectUuid ?? null;
+            // Mirrors getEffectiveScopeFromContext: the stored agent only
+            // applies when the effective project is the one it was selected in
+            agentUuid =
+                headerProjectUuid && contextProjectUuid !== headerProjectUuid
+                    ? null
+                    : (contextRow?.context.agentUuid ?? null);
+
+            clientInfo = userAgent
+                ? await this.mcpToolCallModel.findClientInfo(
+                      user.userUuid,
+                      organizationUuid,
+                      userAgent,
+                  )
+                : undefined;
+        } catch (error) {
+            this.logger.warn(
+                `Failed to enrich MCP tool call record: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+        }
+
+        const authType = account.authentication.type;
+
+        this.analytics.track<McpToolCallEvent>({
+            event: 'mcp_tool_call',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid ?? undefined,
+                agentId: agentUuid ?? undefined,
+                toolName,
+                status,
+                durationMs,
+                authType,
+                clientName: clientInfo?.client_name,
+                clientVersion: clientInfo?.client_version ?? undefined,
+                userAgent,
+                protocolVersion,
+            },
+        });
+
+        await this.mcpToolCallModel.createToolCall({
+            organization_uuid: organizationUuid,
+            user_uuid: user.userUuid,
+            project_uuid: projectUuid,
+            agent_uuid: agentUuid,
+            tool_name: toolName,
+            tool_args: toolArgs,
+            status,
+            error_message: errorMessage,
+            duration_ms: durationMs,
+            result_metadata: null,
+            client_name: clientInfo?.client_name ?? null,
+            client_version: clientInfo?.client_version ?? null,
+            user_agent: userAgent ?? null,
+            auth_type: authType,
+            protocol_version: protocolVersion ?? null,
+        });
+    }
+
+    /**
+     * Stores the client identity from an MCP initialize handshake. The
+     * transport is stateless, so this is the only request that carries
+     * clientInfo — tool calls attach it later by matching user agent.
+     */
+    public async captureClientInfo({
+        user,
+        clientName,
+        clientVersion,
+        userAgent,
+    }: {
+        user: SessionUser;
+        clientName: string;
+        clientVersion: string | null;
+        userAgent: string;
+    }): Promise<void> {
+        try {
+            if (!user.organizationUuid) {
+                return;
+            }
+            await this.mcpToolCallModel.upsertClientInfo({
+                userUuid: user.userUuid,
+                organizationUuid: user.organizationUuid,
+                userAgent,
+                clientName,
+                clientVersion,
             });
         } catch (error) {
-            this.logger.debug('Failed to track MCP tool call', error);
+            this.logger.warn(
+                `Failed to capture MCP client info: ${getErrorMessage(error)}`,
+            );
         }
     }
 }

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -153,6 +153,7 @@ export type ModelManifest = {
     aiAgentReviewNotificationModel: unknown;
     projectContextModel: unknown;
     aiRouterModel: unknown;
+    mcpToolCallModel: unknown;
     managedAgentModel: unknown;
     aiOrganizationSettingsModel: unknown;
     embedModel: unknown;
@@ -779,6 +780,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getMcpToolCallModel<ModelImplT>(): ModelImplT {
+        return this.getModel('mcpToolCallModel');
     }
 
     public getAiAgentDocumentModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -88,6 +88,55 @@ function extractUserAttributesFromHeader(
     }
 }
 
+const MCP_PROTOCOL_VERSION_HEADER = 'MCP-Protocol-Version';
+
+function extractProtocolVersionFromHeader(
+    req: express.Request,
+): string | undefined {
+    const headerValue = req.headers[MCP_PROTOCOL_VERSION_HEADER.toLowerCase()];
+    return typeof headerValue === 'string' ? headerValue : undefined;
+}
+
+/**
+ * Reads the client identity from an MCP initialize request body
+ * ({ method: 'initialize', params: { clientInfo: { name, version } } }).
+ * Only single-message bodies are inspected: an initialize inside a JSON-RPC
+ * batch array is missed (batching was removed in protocol 2025-06-18, so this
+ * only affects older clients, which then fall back to user-agent identity).
+ */
+function extractClientInfoFromInitialize(
+    req: express.Request,
+): { name: string; version: string | null } | undefined {
+    const { body }: { body: unknown } = req;
+    if (
+        typeof body !== 'object' ||
+        body === null ||
+        !('method' in body) ||
+        body.method !== 'initialize'
+    ) {
+        return undefined;
+    }
+    const params =
+        'params' in body && typeof body.params === 'object'
+            ? (body.params as { clientInfo?: unknown })
+            : undefined;
+    const clientInfo = params?.clientInfo;
+    if (
+        typeof clientInfo !== 'object' ||
+        clientInfo === null ||
+        !('name' in clientInfo) ||
+        typeof clientInfo.name !== 'string' ||
+        clientInfo.name.length === 0
+    ) {
+        return undefined;
+    }
+    const version =
+        'version' in clientInfo && typeof clientInfo.version === 'string'
+            ? clientInfo.version
+            : null;
+    return { name: clientInfo.name, version };
+}
+
 /*
 MCP servers MUST use the HTTP header WWW-Authenticate when returning a 401 Unauthorized to indicate
 the location of the resource server metadata URL as described in RFC9728 Section 5.1 "WWW-Authenticate Response".
@@ -170,6 +219,21 @@ mcpRouter.all(
                 // to prevent cross-client response data leaks (CVE-2026-25536)
                 // See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
                 const headerProjectUuid = extractProjectUuidFromHeader(req);
+                const userAgent = req.account?.requestContext?.userAgent;
+                const protocolVersion = extractProtocolVersionFromHeader(req);
+
+                // The transport is stateless, so clientInfo only ever appears
+                // on initialize requests; store it so later tool calls can
+                // attach the client identity by matching user agent.
+                const clientInfo = extractClientInfoFromInitialize(req);
+                if (clientInfo && userAgent && req.user) {
+                    await mcpService.captureClientInfo({
+                        user: req.user,
+                        clientName: clientInfo.name,
+                        clientVersion: clientInfo.version,
+                        userAgent,
+                    });
+                }
                 // Dark launch: the run_ai_writeback tool is only registered
                 // (and thus only listed/invocable) when the AiWriteback flag is
                 // enabled for this caller. Resolved here because tool
@@ -209,6 +273,8 @@ mcpRouter.all(
                         account: oauthAuth,
                         headerUserAttributes,
                         headerProjectUuid,
+                        userAgent,
+                        protocolVersion,
                     };
                     authReq.auth = {
                         token: oauthAuth.authentication.token,
@@ -225,6 +291,8 @@ mcpRouter.all(
                         account: apiKeyAuth,
                         headerUserAttributes,
                         headerProjectUuid,
+                        userAgent,
+                        protocolVersion,
                     };
                     authReq.auth = {
                         token: apiKeyAuth.authentication.source,
@@ -242,6 +310,8 @@ mcpRouter.all(
                         account: serviceAccountAuth,
                         headerUserAttributes,
                         headerProjectUuid,
+                        userAgent,
+                        protocolVersion,
                     };
                     authReq.auth = {
                         token: serviceAccountAuth.authentication.source,

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -255,6 +255,7 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
+    [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: () => ({}),
     [SCHEDULER_TASKS.COMPACT_USAGE_EVENTS]: () => ({}),
     [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: (payload) => ({

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -83,6 +83,7 @@ export const EE_SCHEDULER_TASKS = {
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
     APP_BUILD_FROM_SOURCE: 'appBuildFromSource',
     SWEEP_STALE_APP_LOCKS: 'sweepStaleAppLocks',
+    CLEAN_MCP_TOOL_CALLS: 'cleanMcpToolCalls',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -179,6 +180,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [SCHEDULER_TASKS.APP_BUILD_FROM_SOURCE]: AppBuildFromSourceJobPayload;
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
 }
 
 export interface EETaskPayloadMap {
@@ -195,6 +197,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [EE_SCHEDULER_TASKS.APP_BUILD_FROM_SOURCE]: AppBuildFromSourceJobPayload;
     [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
 }
 
 export type SchedulerTaskName =


### PR DESCRIPTION
First part of the MCP observability stack (data layer — no user-facing changes yet).

Every tool call made against the Lightdash MCP server is now recorded: who ran which tool, with what arguments, whether it succeeded or failed, how long it took, and which MCP client it came from (client name/version from the MCP handshake, user agent, auth method, protocol version). Recording is fire-and-forget, so it never slows down or fails a tool call.

Activity is retained for 90 days and cleaned up automatically by a daily scheduler job.

Relates: PROD-6844

🤖 Generated with [Claude Code](https://claude.com/claude-code)