### PR TITLE
feat(mcp): MCP activity tab in AI admin settings

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -54,6 +54,7 @@ import type {
     ApiManagedAgentActionResponse,
     ApiManagedAgentRunResponse,
     ApiManagedAgentRunsListResponse,
+    ApiMcpActivityResponse,
     ApiMyAppsResponse,
     ApiOrganizationDesignFileResponse,
     ApiOrganizationDesignResponse,
@@ -1139,6 +1140,7 @@ type ApiResults =
     | Account
     | ApiAiAgentAdminConversationsResponse['results']
     | ApiAiAgentAdminPromptActivityResponse['results']
+    | ApiMcpActivityResponse['results']
     | ApiAiAgentReviewItemWritebackPreviewResponse['results']
     | ApiAiAgentReviewItemPrDiffResponse['results']
     | ApiAiAgentReviewItemActivityResponse['results']

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDetail.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDetail.tsx
@@ -1,0 +1,113 @@
+import { type McpActivityItem } from '@lightdash/common';
+import {
+    Badge,
+    Code,
+    Divider,
+    Group,
+    ScrollArea,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { type FC } from 'react';
+import Callout from '../../../../../components/common/Callout';
+
+const DetailRow: FC<{ label: string; children: React.ReactNode }> = ({
+    label,
+    children,
+}) => (
+    <Group justify="space-between" wrap="nowrap" gap="md">
+        <Text fz="sm" c="ldGray.6" fw={500} style={{ whiteSpace: 'nowrap' }}>
+            {label}
+        </Text>
+        {children}
+    </Group>
+);
+
+export const McpActivityDetail: FC<{ toolCall: McpActivityItem }> = ({
+    toolCall,
+}) => {
+    const durationLabel =
+        toolCall.durationMs >= 1000
+            ? `${(toolCall.durationMs / 1000).toFixed(1)}s`
+            : `${toolCall.durationMs}ms`;
+
+    return (
+        <Stack gap="sm" p="md">
+            <Group gap="xs">
+                <Badge variant="light" color="indigo" tt="none">
+                    {toolCall.toolName}
+                </Badge>
+                <Badge
+                    variant="light"
+                    color={toolCall.status === 'error' ? 'red' : 'green'}
+                >
+                    {toolCall.status}
+                </Badge>
+            </Group>
+
+            {toolCall.errorMessage && (
+                <Callout variant="danger" title="Error">
+                    {toolCall.errorMessage}
+                </Callout>
+            )}
+
+            <Stack gap="xs">
+                <DetailRow label="Time">
+                    <Text fz="sm">
+                        {new Date(toolCall.createdAt).toLocaleString()}
+                    </Text>
+                </DetailRow>
+                <DetailRow label="User">
+                    <Text fz="sm" truncate>
+                        {toolCall.user.name}
+                        {toolCall.user.email ? ` (${toolCall.user.email})` : ''}
+                    </Text>
+                </DetailRow>
+                <DetailRow label="Project">
+                    <Text fz="sm">{toolCall.project?.name ?? '—'}</Text>
+                </DetailRow>
+                <DetailRow label="Agent">
+                    <Text fz="sm">{toolCall.agent?.name ?? '—'}</Text>
+                </DetailRow>
+                <DetailRow label="Duration">
+                    <Text fz="sm">{durationLabel}</Text>
+                </DetailRow>
+                <DetailRow label="Client">
+                    <Text fz="sm" truncate>
+                        {toolCall.clientName
+                            ? `${toolCall.clientName}${
+                                  toolCall.clientVersion
+                                      ? ` ${toolCall.clientVersion}`
+                                      : ''
+                              }`
+                            : '—'}
+                    </Text>
+                </DetailRow>
+                <DetailRow label="User agent">
+                    <Text fz="sm" truncate>
+                        {toolCall.userAgent ?? '—'}
+                    </Text>
+                </DetailRow>
+                <DetailRow label="Auth">
+                    <Text fz="sm">{toolCall.authType}</Text>
+                </DetailRow>
+                <DetailRow label="Protocol">
+                    <Text fz="sm">{toolCall.protocolVersion ?? '—'}</Text>
+                </DetailRow>
+            </Stack>
+
+            <Divider />
+
+            <Stack gap="xs">
+                <Text fz="sm" fw={500} c="ldGray.7">
+                    Arguments
+                </Text>
+                <ScrollArea.Autosize mah={400}>
+                    <Code block fz="xs">
+                        {JSON.stringify(toolCall.toolArgs, null, 2)}
+                    </Code>
+                </ScrollArea.Autosize>
+            </Stack>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTable.tsx
@@ -1,0 +1,486 @@
+import {
+    type McpActivityItem,
+    type McpActivitySortField,
+} from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Group,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
+import {
+    IconArrowDown,
+    IconArrowsSort,
+    IconArrowUp,
+    IconBox,
+    IconClock,
+    IconDeviceLaptop,
+    IconHourglass,
+    IconPlugConnected,
+    IconRobotFace,
+    IconTool,
+    IconUser,
+} from '@tabler/icons-react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type UIEvent,
+} from 'react';
+import {
+    ContentTable,
+    useContentTable,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
+    type ContentTableVirtualizer,
+} from '../../../../../components/common/ContentTable';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useIsTruncated } from '../../../../../hooks/useIsTruncated';
+import { useInfiniteMcpActivity } from '../../hooks/useMcpActivity';
+import { useMcpActivityFilters } from '../../hooks/useMcpActivityFilters';
+import { AgentNamePill } from '../AgentNamePill';
+import { McpActivityTopToolbar } from './McpActivityTopToolbar';
+
+type McpActivityTableProps = {
+    onCallSelect?: (toolCall: McpActivityItem) => void;
+    selectedCall?: McpActivityItem | null;
+};
+
+const McpActivityTable = ({
+    onCallSelect,
+    selectedCall,
+}: McpActivityTableProps) => {
+    const theme = useMantineTheme();
+
+    const {
+        selectedProjectUuids,
+        selectedAgentUuids,
+        selectedStatus,
+        sortField,
+        sortDirection,
+        apiFilters,
+        setSelectedProjectUuids,
+        setSelectedAgentUuids,
+        setSelectedStatus,
+        setSorting,
+        hasActiveFilters,
+        resetFilters,
+    } = useMcpActivityFilters();
+
+    const sorting = useMemo<ContentTableSortingState>(
+        () => [{ id: sortField, desc: sortDirection === 'desc' }],
+        [sortField, sortDirection],
+    );
+
+    const handleSortingChange = useCallback(
+        (
+            updaterOrValue:
+                | ContentTableSortingState
+                | ((old: ContentTableSortingState) => ContentTableSortingState),
+        ) => {
+            const newSorting =
+                typeof updaterOrValue === 'function'
+                    ? updaterOrValue(sorting)
+                    : updaterOrValue;
+
+            if (newSorting.length > 0) {
+                const { id, desc } = newSorting[0];
+                const newSortField: McpActivitySortField =
+                    id === 'durationMs' ? 'durationMs' : 'createdAt';
+                setSorting(newSortField, desc ? 'desc' : 'asc');
+            }
+        },
+        [sorting, setSorting],
+    );
+
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const rowVirtualizerInstanceRef =
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
+
+    const { data, isInitialLoading, isFetching, hasNextPage, fetchNextPage } =
+        useInfiniteMcpActivity(
+            {
+                pagination: {},
+                filters: apiFilters,
+                sort: {
+                    field: sortField,
+                    direction: sortDirection,
+                },
+            },
+            { keepPreviousData: true },
+        );
+
+    const flatData = useMemo(() => {
+        if (!data) return [];
+        return data.pages.flatMap((page) => page.data.toolCalls);
+    }, [data]);
+
+    // Temporary workaround to resolve a memoization issue with react-mantine-table
+    const [tableData, setTableData] = useState<McpActivityItem[]>([]);
+    useEffect(() => {
+        setTableData(flatData);
+    }, [flatData]);
+
+    const totalResults = useMemo(() => {
+        if (!data) return 0;
+        const lastPage = data.pages[data.pages.length - 1];
+        return lastPage.pagination?.totalResults ?? 0;
+    }, [data]);
+
+    const fetchMoreOnBottomReached = useCallback(
+        (containerRefElement?: HTMLDivElement | null) => {
+            if (containerRefElement) {
+                const { scrollHeight, scrollTop, clientHeight } =
+                    containerRefElement;
+                if (
+                    scrollHeight - scrollTop - clientHeight < 200 &&
+                    !isFetching &&
+                    hasNextPage
+                ) {
+                    void fetchNextPage();
+                }
+            }
+        },
+        [fetchNextPage, isFetching, hasNextPage],
+    );
+
+    useEffect(() => {
+        fetchMoreOnBottomReached(tableContainerRef.current);
+    }, [fetchMoreOnBottomReached]);
+
+    const columns: ContentTableColumnDef<McpActivityItem>[] = [
+        {
+            accessorKey: 'createdAt',
+            header: 'Time',
+            enableSorting: true,
+            enableEditing: false,
+            size: 170,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconClock} color="ldGray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => (
+                <Text fz="sm" c="ldGray.7">
+                    {new Date(row.original.createdAt).toLocaleString()}
+                </Text>
+            ),
+        },
+        {
+            accessorKey: 'toolName',
+            header: 'Tool',
+            enableSorting: false,
+            enableEditing: false,
+            size: 190,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconTool} color="ldGray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => (
+                <Badge variant="light" color="indigo" tt="none">
+                    {row.original.toolName}
+                </Badge>
+            ),
+        },
+        {
+            accessorKey: 'user.name',
+            header: 'User',
+            enableSorting: false,
+            enableEditing: false,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconUser} color="ldGray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => (
+                <Tooltip
+                    withinPortal
+                    variant="xs"
+                    label={row.original.user.email}
+                >
+                    <Text c="ldGray.9" fz="sm" fw={400}>
+                        {row.original.user.name}
+                    </Text>
+                </Tooltip>
+            ),
+        },
+        {
+            accessorKey: 'project.name',
+            header: 'Project',
+            enableSorting: false,
+            enableEditing: false,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconBox} color="ldGray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => (
+                <Text c="ldGray.9" fz="sm" fw={400}>
+                    {row.original.project?.name ?? '—'}
+                </Text>
+            ),
+        },
+        {
+            accessorKey: 'agent.name',
+            header: 'Agent',
+            enableSorting: false,
+            enableEditing: false,
+            size: 150,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconRobotFace} color="ldGray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) =>
+                row.original.agent ? (
+                    <AgentNamePill
+                        name={row.original.agent.name}
+                        imageUrl={null}
+                    />
+                ) : (
+                    <Text c="ldGray.5" fz="sm">
+                        —
+                    </Text>
+                ),
+        },
+        {
+            accessorKey: 'clientName',
+            header: 'Client',
+            enableSorting: false,
+            enableEditing: false,
+            size: 180,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconDeviceLaptop} color="ldGray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const isTruncated = useIsTruncated<HTMLDivElement>();
+                const { clientName, clientVersion, userAgent } = row.original;
+                const label = clientName
+                    ? `${clientName}${clientVersion ? ` ${clientVersion}` : ''}`
+                    : (userAgent ?? 'Unknown');
+                return (
+                    <Tooltip
+                        withinPortal
+                        variant="xs"
+                        label={userAgent ?? label}
+                        disabled={!isTruncated.isTruncated && !userAgent}
+                        multiline
+                        maw={300}
+                    >
+                        <Text
+                            c="ldGray.9"
+                            fz="sm"
+                            fw={400}
+                            truncate
+                            ref={isTruncated.ref}
+                        >
+                            {label}
+                        </Text>
+                    </Tooltip>
+                );
+            },
+        },
+        {
+            accessorKey: 'status',
+            header: 'Status',
+            enableSorting: false,
+            enableEditing: false,
+            size: 110,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconPlugConnected} color="ldGray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => (
+                <Badge
+                    variant="light"
+                    color={row.original.status === 'error' ? 'red' : 'green'}
+                >
+                    {row.original.status}
+                </Badge>
+            ),
+        },
+        {
+            accessorKey: 'durationMs',
+            header: 'Duration',
+            enableSorting: true,
+            enableEditing: false,
+            size: 120,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconHourglass} color="ldGray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const { durationMs } = row.original;
+                const label =
+                    durationMs >= 1000
+                        ? `${(durationMs / 1000).toFixed(1)}s`
+                        : `${durationMs}ms`;
+                return (
+                    <Text fz="sm" c="ldGray.7">
+                        {label}
+                    </Text>
+                );
+            },
+        },
+    ];
+
+    const table = useContentTable({
+        columns,
+        data: tableData,
+        enableColumnResizing: true,
+        enableRowNumbers: false,
+        enableRowVirtualization: true,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        enableSorting: true,
+        manualSorting: true,
+        onSortingChange: handleSortingChange,
+        enableTopToolbar: true,
+        mantinePaperProps: {
+            shadow: undefined,
+            sx: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableContainerProps: {
+            ref: tableContainerRef,
+            sx: {
+                maxHeight: 'calc(100dvh - 420px)',
+                minHeight: '400px',
+                display: 'flex',
+                flexDirection: 'column',
+            },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.target as HTMLDivElement),
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: Boolean(flatData.length),
+            sx: {
+                flexGrow: 1,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableBodyRowProps: ({ row, table: mantineTable }) => {
+            if (mantineTable.getState().showSkeletons) {
+                return {};
+            }
+            const toolCall = row.original;
+            const isSelected = selectedCall?.uuid === toolCall.uuid;
+            return {
+                style: {
+                    cursor: 'pointer',
+                    backgroundColor: isSelected
+                        ? theme.colors.ldGray[1]
+                        : undefined,
+                },
+                onClick: () => onCallSelect?.(toolCall),
+            };
+        },
+        renderTopToolbar: () => (
+            <McpActivityTopToolbar
+                selectedProjectUuids={selectedProjectUuids}
+                setSelectedProjectUuids={setSelectedProjectUuids}
+                selectedAgentUuids={selectedAgentUuids}
+                setSelectedAgentUuids={setSelectedAgentUuids}
+                selectedStatus={selectedStatus}
+                setSelectedStatus={setSelectedStatus}
+                totalResults={totalResults}
+                isFetching={isFetching}
+                hasNextPage={hasNextPage ?? false}
+                currentResultsCount={flatData.length}
+                hasActiveFilters={hasActiveFilters}
+                onClearFilters={resetFilters}
+            />
+        ),
+        renderBottomToolbar: () => (
+            <Box
+                p={`${theme.spacing.sm} ${theme.spacing.xl} ${theme.spacing.md} ${theme.spacing.xl}`}
+                fz="xs"
+                fw={500}
+                color="ldGray.8"
+                style={{
+                    borderTop: `1px solid ${theme.colors.ldGray[3]}`,
+                }}
+            >
+                {isFetching ? (
+                    <Text c="ldGray.8" fz="xs">
+                        Loading more...
+                    </Text>
+                ) : (
+                    <Group gap="two">
+                        <Text fz="xs" c="ldGray.8">
+                            {hasNextPage
+                                ? 'Scroll for more results'
+                                : 'All results loaded'}
+                        </Text>
+                        <Text fz="xs" fw={400} c="ldGray.6">
+                            {hasNextPage
+                                ? `(${flatData.length} of ${totalResults} loaded)`
+                                : `(${flatData.length})`}
+                        </Text>
+                    </Group>
+                )}
+            </Box>
+        ),
+        icons: {
+            IconArrowsSort: () => (
+                <MantineIcon icon={IconArrowsSort} size="md" color="ldGray.5" />
+            ),
+            IconSortAscending: () => (
+                <MantineIcon icon={IconArrowUp} size="md" color="blue.6" />
+            ),
+            IconSortDescending: () => (
+                <MantineIcon icon={IconArrowDown} size="md" color="blue.6" />
+            ),
+        },
+        state: {
+            sorting,
+            showProgressBars: false,
+            showSkeletons: isInitialLoading,
+            density: 'md',
+        },
+        mantineLoadingOverlayProps: {
+            loaderProps: {
+                color: 'violet',
+            },
+        },
+        rowVirtualizerInstanceRef,
+        rowVirtualizerProps: { estimateSize: () => 56, overscan: 40 },
+        enableRowActions: false,
+    });
+
+    return <ContentTable table={table} />;
+};
+
+export default McpActivityTable;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTopToolbar.tsx
@@ -1,0 +1,152 @@
+import {
+    Box,
+    Button,
+    Divider,
+    Group,
+    SegmentedControl,
+    Text,
+    useMantineTheme,
+    type GroupProps,
+} from '@mantine-8/core';
+import { IconTrash } from '@tabler/icons-react';
+import { memo, type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { type useMcpActivityFilters } from '../../hooks/useMcpActivityFilters';
+import AgentsFilter from './AgentsFilter';
+import ProjectsFilter from './ProjectsFilter';
+
+type McpActivityTopToolbarProps = GroupProps &
+    Pick<
+        ReturnType<typeof useMcpActivityFilters>,
+        | 'selectedProjectUuids'
+        | 'selectedAgentUuids'
+        | 'selectedStatus'
+        | 'setSelectedProjectUuids'
+        | 'setSelectedAgentUuids'
+        | 'setSelectedStatus'
+    > & {
+        totalResults: number;
+        isFetching: boolean;
+        hasNextPage: boolean;
+        currentResultsCount: number;
+        hasActiveFilters?: boolean;
+        onClearFilters?: () => void;
+    };
+
+export const McpActivityTopToolbar: FC<McpActivityTopToolbarProps> = memo(
+    ({
+        selectedProjectUuids,
+        setSelectedProjectUuids,
+        selectedAgentUuids,
+        setSelectedAgentUuids,
+        selectedStatus,
+        setSelectedStatus,
+        totalResults,
+        isFetching,
+        hasNextPage,
+        currentResultsCount,
+        hasActiveFilters,
+        onClearFilters,
+        ...props
+    }) => {
+        const theme = useMantineTheme();
+
+        return (
+            <Box>
+                <Group
+                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
+                    justify="space-between"
+                    {...props}
+                >
+                    <Group gap="xs">
+                        <ProjectsFilter
+                            selectedProjectUuids={selectedProjectUuids}
+                            setSelectedProjectUuids={setSelectedProjectUuids}
+                        />
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{ alignSelf: 'center' }}
+                        />
+                        <AgentsFilter
+                            selectedAgentUuids={selectedAgentUuids}
+                            setSelectedAgentUuids={setSelectedAgentUuids}
+                            selectedProjectUuids={selectedProjectUuids}
+                        />
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{ alignSelf: 'center' }}
+                        />
+                        <SegmentedControl
+                            size="xs"
+                            radius="md"
+                            value={selectedStatus}
+                            onChange={(value) =>
+                                setSelectedStatus(
+                                    value as 'all' | 'success' | 'error',
+                                )
+                            }
+                            data={[
+                                { label: 'All', value: 'all' },
+                                { label: 'Success', value: 'success' },
+                                { label: 'Errors', value: 'error' },
+                            ]}
+                        />
+
+                        {hasActiveFilters && onClearFilters && (
+                            <>
+                                <Divider
+                                    orientation="vertical"
+                                    w={1}
+                                    h={20}
+                                    style={{ alignSelf: 'center' }}
+                                />
+                                <Button
+                                    variant="subtle"
+                                    size="xs"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconTrash}
+                                            size="sm"
+                                        />
+                                    }
+                                    onClick={onClearFilters}
+                                >
+                                    Clear all filters
+                                </Button>
+                            </>
+                        )}
+                    </Group>
+
+                    <Group gap="xs">
+                        <Box
+                            bg="ldGray.1"
+                            c="ldGray.9"
+                            style={{
+                                borderRadius: 6,
+                                padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
+                                height: 32,
+                                display: 'flex',
+                                alignItems: 'center',
+                            }}
+                        >
+                            <Text fz="sm" fw={500}>
+                                {isFetching
+                                    ? 'Loading...'
+                                    : hasNextPage
+                                      ? `${currentResultsCount} of ${totalResults} tool calls`
+                                      : `${totalResults} tool calls`}
+                            </Text>
+                        </Box>
+                    </Group>
+                </Group>
+                <Divider color="ldGray.2" />
+            </Box>
+        );
+    },
+);
+
+McpActivityTopToolbar.displayName = 'McpActivityTopToolbar';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage.tsx
@@ -1,0 +1,58 @@
+import { type McpActivityItem } from '@lightdash/common';
+import { Drawer, Group, Stack, Text } from '@mantine-8/core';
+import { useState } from 'react';
+import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
+import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
+import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
+import { McpActivityDetail } from '../McpActivityDetail';
+import McpActivityTable from '../McpActivityTable';
+import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
+import drawerClasses from './ThreadPreviewDrawer.module.css';
+
+export const McpActivitySettingsPage = () => {
+    const { data: settings } = useAiOrganizationSettings();
+
+    const [selectedCall, setSelectedCall] = useState<McpActivityItem | null>(
+        null,
+    );
+
+    return (
+        <Stack mb="lg" gap="md">
+            <Group justify="space-between" align="flex-start">
+                <PageBreadcrumbs
+                    items={[
+                        { title: 'Ask AI', to: '/generalSettings/ai/general' },
+                        { title: 'MCP', active: true },
+                    ]}
+                />
+                <Text fz="xs" c="ldGray.6">
+                    Showing the last 90 days of MCP tool calls
+                </Text>
+            </Group>
+
+            {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
+
+            <McpActivityTable
+                onCallSelect={setSelectedCall}
+                selectedCall={selectedCall}
+            />
+
+            <Drawer
+                opened={!!selectedCall}
+                onClose={() => setSelectedCall(null)}
+                position="right"
+                size="lg"
+                title="Tool call details"
+                classNames={{
+                    inner: drawerClasses.inner,
+                    overlay: drawerClasses.overlay,
+                }}
+                __vars={{
+                    '--drawer-top-offset': `${NAVBAR_HEIGHT}px`,
+                }}
+            >
+                {selectedCall && <McpActivityDetail toolCall={selectedCall} />}
+            </Drawer>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useMcpActivity.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useMcpActivity.ts
@@ -1,0 +1,80 @@
+import {
+    type ApiError,
+    type ApiMcpActivityResponse,
+    type McpActivityFilters,
+    type McpActivitySort,
+} from '@lightdash/common';
+import {
+    useInfiniteQuery,
+    type UseInfiniteQueryOptions,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+export type McpActivityArgs = {
+    filters: McpActivityFilters;
+    sort: McpActivitySort;
+    pagination: {
+        pageSize?: number;
+        page?: number;
+    };
+};
+
+function createQueryString(params: Record<string, unknown>): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (Array.isArray(value)) {
+            value.forEach((v) => query.append(key, String(v)));
+        } else if (value !== undefined) {
+            query.append(key, String(value));
+        }
+    }
+    return query.toString();
+}
+
+const getMcpActivity = async (
+    args: McpActivityFilters & {
+        sortField: McpActivitySort['field'];
+        sortDirection: McpActivitySort['direction'];
+    } & {
+        pageSize?: number;
+        page?: number;
+    },
+) => {
+    const params = createQueryString(args);
+    return lightdashApi<ApiMcpActivityResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/mcp-activity?${params}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useInfiniteMcpActivity = (
+    args: McpActivityArgs,
+    infinityQueryOpts: UseInfiniteQueryOptions<
+        ApiMcpActivityResponse['results'],
+        ApiError
+    > = {},
+) => {
+    return useInfiniteQuery<ApiMcpActivityResponse['results'], ApiError>({
+        queryKey: ['mcp-activity', args],
+        queryFn: async ({ pageParam }) => {
+            return getMcpActivity({
+                ...args.filters,
+                sortField: args.sort.field,
+                sortDirection: args.sort.direction,
+                ...args.pagination,
+                page: (pageParam as number) ?? 1,
+            });
+        },
+        getNextPageParam: (lastPage) => {
+            if (lastPage.pagination) {
+                return lastPage.pagination.page <
+                    lastPage.pagination.totalPageCount
+                    ? lastPage.pagination.page + 1
+                    : undefined;
+            }
+        },
+        ...infinityQueryOpts,
+    });
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useMcpActivityFilters.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useMcpActivityFilters.ts
@@ -1,0 +1,169 @@
+import type {
+    McpActivityFilters,
+    McpActivitySort,
+    McpActivitySortField,
+    McpActivityStatus,
+} from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import useSearchParams from '../../../../hooks/useSearchParams';
+
+type McpActivityFiltersState = {
+    selectedProjectUuids: NonNullable<McpActivityFilters['projectUuids']>;
+    selectedAgentUuids: NonNullable<McpActivityFilters['agentUuids']>;
+    selectedStatus: 'all' | McpActivityStatus;
+    sortField: McpActivitySortField;
+    sortDirection: McpActivitySort['direction'];
+};
+
+const DEFAULT_FILTERS: McpActivityFiltersState = {
+    selectedProjectUuids: [],
+    selectedAgentUuids: [],
+    selectedStatus: 'all',
+    sortField: 'createdAt',
+    sortDirection: 'desc',
+};
+
+/**
+ * Manages MCP activity filters with URL persistence, mirroring
+ * useAiAgentAdminFilters.
+ */
+export const useMcpActivityFilters = () => {
+    const navigate = useNavigate();
+    const { search: locationSearch, pathname } = useLocation();
+
+    const projectsParam = useSearchParams<string>('projects');
+    const agentsParam = useSearchParams<string>('agents');
+    const statusParam = useSearchParams<McpActivityStatus>('status');
+    const sortByParam = useSearchParams<McpActivitySortField>('sortBy');
+    const sortDirectionParam = useSearchParams<'asc' | 'desc'>('sortDirection');
+
+    const currentFilters = useMemo<McpActivityFiltersState>(
+        () => ({
+            selectedProjectUuids:
+                projectsParam?.split(',').filter(Boolean) ||
+                DEFAULT_FILTERS.selectedProjectUuids,
+            selectedAgentUuids:
+                agentsParam?.split(',').filter(Boolean) ||
+                DEFAULT_FILTERS.selectedAgentUuids,
+            selectedStatus: statusParam || DEFAULT_FILTERS.selectedStatus,
+            sortField: sortByParam || DEFAULT_FILTERS.sortField,
+            sortDirection: sortDirectionParam || DEFAULT_FILTERS.sortDirection,
+        }),
+        [
+            projectsParam,
+            agentsParam,
+            statusParam,
+            sortByParam,
+            sortDirectionParam,
+        ],
+    );
+
+    const updateUrl = useCallback(
+        (newFilters: McpActivityFiltersState) => {
+            const searchParams = new URLSearchParams();
+
+            if (newFilters.selectedProjectUuids.length > 0) {
+                searchParams.set(
+                    'projects',
+                    newFilters.selectedProjectUuids.join(','),
+                );
+            }
+            if (newFilters.selectedAgentUuids.length > 0) {
+                searchParams.set(
+                    'agents',
+                    newFilters.selectedAgentUuids.join(','),
+                );
+            }
+            if (newFilters.selectedStatus !== DEFAULT_FILTERS.selectedStatus) {
+                searchParams.set('status', newFilters.selectedStatus);
+            }
+            if (newFilters.sortField !== DEFAULT_FILTERS.sortField) {
+                searchParams.set('sortBy', newFilters.sortField);
+            }
+            if (newFilters.sortDirection !== DEFAULT_FILTERS.sortDirection) {
+                searchParams.set('sortDirection', newFilters.sortDirection);
+            }
+
+            const newSearch = searchParams.toString();
+            if (newSearch !== new URLSearchParams(locationSearch).toString()) {
+                void navigate(
+                    { pathname, search: newSearch },
+                    { replace: true },
+                );
+            }
+        },
+        [navigate, pathname, locationSearch],
+    );
+
+    const setSelectedProjectUuids = useCallback(
+        (projectUuids: string[]) => {
+            updateUrl({
+                ...currentFilters,
+                selectedProjectUuids: projectUuids,
+            });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedAgentUuids = useCallback(
+        (agentUuids: string[]) => {
+            updateUrl({ ...currentFilters, selectedAgentUuids: agentUuids });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedStatus = useCallback(
+        (status: McpActivityFiltersState['selectedStatus']) => {
+            updateUrl({ ...currentFilters, selectedStatus: status });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSorting = useCallback(
+        (
+            sortField: McpActivitySortField,
+            sortDirection: McpActivitySort['direction'],
+        ) => {
+            updateUrl({ ...currentFilters, sortField, sortDirection });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const resetFilters = useCallback(() => {
+        updateUrl(DEFAULT_FILTERS);
+    }, [updateUrl]);
+
+    const hasActiveFilters = useMemo(
+        () =>
+            currentFilters.selectedProjectUuids.length > 0 ||
+            currentFilters.selectedAgentUuids.length > 0 ||
+            currentFilters.selectedStatus !== DEFAULT_FILTERS.selectedStatus,
+        [currentFilters],
+    );
+
+    const apiFilters = useMemo(() => {
+        const result: McpActivityFilters = {};
+        if (currentFilters.selectedProjectUuids.length > 0) {
+            result.projectUuids = currentFilters.selectedProjectUuids;
+        }
+        if (currentFilters.selectedAgentUuids.length > 0) {
+            result.agentUuids = currentFilters.selectedAgentUuids;
+        }
+        if (currentFilters.selectedStatus !== 'all') {
+            result.status = currentFilters.selectedStatus;
+        }
+        return result;
+    }, [currentFilters]);
+
+    return {
+        ...currentFilters,
+        apiFilters,
+        setSelectedProjectUuids,
+        setSelectedAgentUuids,
+        setSelectedStatus,
+        setSorting,
+        resetFilters,
+        hasActiveFilters,
+    };
+};

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -409,6 +409,14 @@ export const useSettingsNavigation = (
                     children: [],
                     exact: true,
                 },
+                {
+                    label: 'MCP',
+                    to: '/generalSettings/ai/mcp',
+                    icon: IconPlugConnected,
+                    keywords: ['mcp', 'tools', 'activity', 'claude', 'cursor'],
+                    children: [],
+                    exact: true,
+                },
             );
 
             if (shouldShowAiAgentReviews) {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -73,6 +73,7 @@ import { AiGeneralSettingsPage } from '../ee/features/aiCopilot/components/Admin
 import { AiReviewsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage';
 import { AiSettingsProviders } from '../ee/features/aiCopilot/components/Admin/settings/AiSettingsProviders';
 import { AiThreadsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiThreadsSettingsPage';
+import { McpActivitySettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage';
 import ScimAccessTokensPanel from '../ee/features/scim/components/ScimAccessTokensPanel';
 import { ServiceAccountsPage } from '../ee/features/serviceAccounts';
 import { CustomRoleCreate } from '../ee/pages/customRoles/CustomRoleCreate';
@@ -605,6 +606,14 @@ const Settings: FC = () => {
                     </AiSettingsProviders>
                 ),
             });
+            allowedRoutes.push({
+                path: '/ai/mcp',
+                element: (
+                    <AiSettingsProviders>
+                        <McpActivitySettingsPage />
+                    </AiSettingsProviders>
+                ),
+            });
             if (shouldShowAiAgentReviews) {
                 allowedRoutes.push({
                     path: '/ai/issues',
@@ -768,6 +777,10 @@ const Settings: FC = () => {
             ) &&
             !matchPath(
                 { path: '/generalSettings/ai/agents' },
+                location.pathname,
+            ) &&
+            !matchPath(
+                { path: '/generalSettings/ai/mcp' },
                 location.pathname,
             ) &&
             !matchPath(


### PR DESCRIPTION
Final part of the MCP observability stack (UI).

Adds an **MCP** tab to the Ask AI section in organization settings, giving admins the same kind of visibility into MCP usage that they already have for AI agent threads:

- An activity feed of every tool call, filterable by project, agent, and success/error, with infinite scroll and URL-persisted filters.
- A detail view per call showing the full tool arguments, error message, duration, and client identity (which MCP client and version, user agent, auth method).

Activity covers the last 90 days.

Closes: PROD-6844

🤖 Generated with [Claude Code](https://claude.com/claude-code)