### PR TITLE
refactor(frontend): migrate Group to mantine-8

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -1,11 +1,10 @@
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Burger,
     Divider,
     Drawer,
     getDefaultZIndex,
-    Group,
     Header,
     MantineProvider,
     Title,
@@ -100,7 +99,11 @@ export const MobileNavBar: FC = () => {
                     boxShadow: 'lg',
                 }}
             >
-                <Group align="center" position="apart" sx={{ flex: 1 }}>
+                <Group
+                    align="center"
+                    justify="space-between"
+                    style={{ flex: 1 }}
+                >
                     <ActionIcon
                         component={Link}
                         to={'/'}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -34,10 +34,9 @@ import {
     type SavedChart,
     type Series,
 } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Stack } from '@mantine-8/core';
+import { ActionIcon, Box, Group, Menu, Stack } from '@mantine-8/core';
 import {
     Badge,
-    Group,
     HoverCard,
     Portal,
     Tooltip,

--- a/packages/frontend/src/components/DataViz/config/CartesianChartDisplayConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartDisplayConfig.tsx
@@ -1,6 +1,6 @@
 import { VizIndexType, type ChartKind } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Group, TextInput } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import {
     useAppDispatch as useVizDispatch,
     useAppSelector as useVizSelector,
@@ -55,7 +55,7 @@ export const CartesianChartDisplayConfig = ({
             <Config>
                 <Config.Section>
                     <Config.Heading>{`X-axis`}</Config.Heading>
-                    <Group noWrap w="100%">
+                    <Group wrap="nowrap" w="100%">
                         <Config.Label>{`Label`}</Config.Label>
                         <TextInput
                             w="100%"
@@ -93,7 +93,7 @@ export const CartesianChartDisplayConfig = ({
                         <Config.Heading>{`Y-axis ${
                             rightYAxisFields.length > 0 ? '(left)' : ''
                         }`}</Config.Heading>
-                        <Group noWrap w="100%">
+                        <Group wrap="nowrap" w="100%">
                             <Config.Label>{`Label`}</Config.Label>
                             <TextInput
                                 w="100%"
@@ -133,7 +133,7 @@ export const CartesianChartDisplayConfig = ({
                 <Config>
                     <Config.Section>
                         <Config.Heading>{`Y-axis (right)`}</Config.Heading>
-                        <Group noWrap w="100%">
+                        <Group wrap="nowrap" w="100%">
                             <Config.Label>{`Label`}</Config.Label>
                             <TextInput
                                 w="100%"

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -7,8 +7,8 @@ import {
     type VizIndexLayoutOptions,
     type VizPivotLayoutOptions,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { ActionIcon, Group, Tooltip } from '@mantine/core';
+import { Box, Group, Stack } from '@mantine-8/core';
+import { ActionIcon, Tooltip } from '@mantine/core';
 import { IconMinus, IconPlus, IconX } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
@@ -51,7 +51,7 @@ const YFieldsAxisConfig: FC<{
             >
                 <Config>
                     <Config.Section>
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <FieldReferenceSelect
                                 flex={1}
                                 data={yLayoutOptions.map((y) => ({
@@ -141,7 +141,7 @@ const XFieldAxisConfig = ({
     const dispatch = useVizDispatch();
 
     return (
-        <Group spacing="xs">
+        <Group gap="xs">
             <FieldReferenceSelect
                 flex={1}
                 data={xLayoutOptions.map((x) => ({

--- a/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
@@ -3,8 +3,8 @@ import {
     ChartKind,
     type CartesianChartDisplay,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { Group, Select, Text } from '@mantine/core';
+import { Box, Group } from '@mantine-8/core';
+import { Select, Text } from '@mantine/core';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { getChartIcon } from '../../common/ResourceIcon/utils';
@@ -34,7 +34,7 @@ const ChartTypeItem = forwardRef<
     }
 >(({ value, label, ...others }, ref) => (
     <Box ref={ref} {...others}>
-        <Group noWrap spacing="xs">
+        <Group wrap="nowrap" gap="xs">
             <ChartTypeIcon type={value} />
             <Text>{label}</Text>
         </Group>

--- a/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
@@ -1,6 +1,6 @@
 import { ValueLabelPositionOptions } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { Group, Select, Text } from '@mantine/core';
+import { Box, Group } from '@mantine-8/core';
+import { Select, Text } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowLeft,
@@ -59,7 +59,7 @@ const ValueLabelItem = forwardRef<
     }
 >(({ value, ...others }, ref) => (
     <Box ref={ref} {...others}>
-        <Group noWrap spacing="xs">
+        <Group wrap="nowrap" gap="xs">
             <ValueLabelIcon position={value} />
             <Text>{capitalize(value)}</Text>
         </Group>

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -3,8 +3,8 @@ import {
     VizAggregationOptions,
     type VizValuesLayoutOptions,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { Group, Select, Tooltip, useMantineTheme, Text } from '@mantine/core';
+import { Box, Group } from '@mantine-8/core';
+import { Select, Tooltip, useMantineTheme, Text } from '@mantine/core';
 import {
     IconAsterisk,
     IconMathFunction,
@@ -64,7 +64,7 @@ const AggregationItem = forwardRef<
     ComponentPropsWithoutRef<'div'> & { value: string; selected: boolean }
 >(({ value, ...others }, ref) => (
     <Box ref={ref} {...others}>
-        <Group noWrap spacing="xs">
+        <Group wrap="nowrap" gap="xs">
             <AggregationIcon aggregation={value} />
             <Text>{capitalize(value)}</Text>
         </Group>

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -5,8 +5,8 @@ import {
     type CartesianChartDisplay,
     type ChartKind,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { Flex, Group, SegmentedControl, TextInput, Text } from '@mantine/core';
+import { Box, Group, Stack } from '@mantine-8/core';
+import { Flex, SegmentedControl, TextInput, Text } from '@mantine/core';
 import { IconAlignLeft, IconAlignRight } from '@tabler/icons-react';
 import MantineIcon from '../../common/MantineIcon';
 import ColorSelector from '../../VisualizationConfigs/ColorSelector';
@@ -68,9 +68,9 @@ export const SingleSeriesConfiguration = ({
                 <Flex justify="flex-start" align="center" wrap="nowrap">
                     <Config.Label w={LABEL_WIDTH}>Label</Config.Label>
                     <Group
-                        spacing="xs"
-                        position="left"
-                        noWrap
+                        gap="xs"
+                        justify="flex-start"
+                        wrap="nowrap"
                         grow
                         style={{ flex: 3 }}
                     >
@@ -130,7 +130,7 @@ export const SingleSeriesConfiguration = ({
                             {
                                 value: 'left',
                                 label: (
-                                    <Group spacing="xs" noWrap>
+                                    <Group gap="xs" wrap="nowrap">
                                         <MantineIcon
                                             icon={IconAlignLeft}
                                             color="ldDark.8"
@@ -142,7 +142,11 @@ export const SingleSeriesConfiguration = ({
                             {
                                 value: 'right',
                                 label: (
-                                    <Group spacing="xs" noWrap position="right">
+                                    <Group
+                                        gap="xs"
+                                        wrap="nowrap"
+                                        justify="flex-end"
+                                    >
                                         <Text>Right</Text>
                                         <MantineIcon
                                             icon={IconAlignRight}

--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
@@ -4,10 +4,10 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
+import { Group } from '@mantine-8/core';
 import {
     Badge,
     Flex,
-    Group,
     Tooltip,
     useMantineTheme,
     type FlexProps,
@@ -106,7 +106,7 @@ export const ChartDataTable = ({
                                                 position="top"
                                                 withinPortal
                                             >
-                                                <Group spacing="two" fz={13}>
+                                                <Group gap="two" fz={13}>
                                                     {columnsConfig?.[header.id]
                                                         ?.aggregation && (
                                                         <Badge

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -5,14 +5,8 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
-import {
-    Badge,
-    Flex,
-    Group,
-    useMantineTheme,
-    type FlexProps,
-} from '@mantine/core';
+import { Group, Menu } from '@mantine-8/core';
+import { Badge, Flex, useMantineTheme, type FlexProps } from '@mantine/core';
 import { IconArrowDown, IconArrowUp, IconCopy } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -138,7 +132,7 @@ export const Table = <T extends IResultsRunner>({
                                                   }
                                         }
                                     >
-                                        <Group spacing="two" fz={13}>
+                                        <Group gap="two" fz={13}>
                                             {columnsConfig[header.id]
                                                 ?.aggregation && (
                                                 <Badge

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -6,8 +6,8 @@ import {
     findReplaceableCustomMetrics,
     getMetrics,
 } from '@lightdash/common';
-import { Menu, Stack } from '@mantine-8/core';
-import { ActionIcon, Group, HoverCard, Text } from '@mantine/core';
+import { Group, Menu, Stack } from '@mantine-8/core';
+import { ActionIcon, HoverCard, Text } from '@mantine/core';
 import {
     IconAlertTriangle,
     IconCode,
@@ -203,8 +203,8 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                     display: isVisualizationConfigOpen ? 'none' : 'flex',
                 }}
             >
-                <Group position="apart">
-                    <Group spacing="xs">
+                <Group justify="space-between">
+                    <Group gap="xs">
                         <PageBreadcrumbs size="md" items={breadcrumbs} />
                         {explore.warnings && explore.warnings.length > 0 && (
                             <HoverCard

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -1,12 +1,6 @@
 import { hasIntersection } from '@lightdash/common';
-import {
-    Badge,
-    Group,
-    Highlight,
-    HoverCard,
-    NavLink,
-    Text,
-} from '@mantine/core';
+import { Group } from '@mantine-8/core';
+import { Badge, Highlight, HoverCard, NavLink, Text } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import intersectionBy from 'lodash/intersectionBy';
 import { memo, useCallback, useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -17,9 +17,9 @@ import {
     type FilterableField,
     type Item,
 } from '@lightdash/common';
+import { Group } from '@mantine-8/core';
 import {
     ActionIcon,
-    Group,
     Highlight,
     HoverCard,
     NavLink,
@@ -428,7 +428,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
             onMouseLeave={handleMouseLeave}
             pl={pl}
             label={
-                <Group noWrap spacing="xs">
+                <Group wrap="nowrap" gap="xs">
                     <HoverCard
                         openDelay={300}
                         keepMounted={false}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
-import { Button } from '@mantine-8/core';
-import { ActionIcon, Group, Tooltip, Text } from '@mantine/core';
+import { Button, Group } from '@mantine-8/core';
+import { ActionIcon, Tooltip, Text } from '@mantine/core';
 import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import {
@@ -140,8 +140,8 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
         customDimensionsToWriteBack.length > 0;
 
     return (
-        <Group mt="sm" mb="xs" pl={pl} pr="sm" position="apart">
-            <Group spacing="xs">
+        <Group mt="sm" mb="xs" pl={pl} pr="sm" justify="space-between">
+            <Group gap="xs">
                 <Text fw={600} c={color}>
                     {label}
                 </Text>
@@ -156,7 +156,7 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
                 )}
             </Group>
 
-            <Group spacing="xs">
+            <Group gap="xs">
                 {showAddButton && (
                     <Tooltip
                         label="Add a custom dimension with SQL"

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
-import { ActionIcon, Group, Popover, SegmentedControl } from '@mantine/core';
+import { Group } from '@mantine-8/core';
+import { ActionIcon, Popover, SegmentedControl } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import {
     memo,
@@ -121,7 +122,7 @@ const ResultsCard: FC = memo(() => {
             headerElement={
                 // Hide header controls when in grouped view
                 isGroupedView ? null : (
-                    <Group noWrap spacing="xs">
+                    <Group wrap="nowrap" gap="xs">
                         {tableName && sorts.length > 0 && (
                             <SortButton isEditMode={isEditMode} sorts={sorts} />
                         )}
@@ -132,7 +133,7 @@ const ResultsCard: FC = memo(() => {
                 projectUuid &&
                 resultsIsOpen &&
                 tableName && (
-                    <Group spacing="xs" noWrap>
+                    <Group gap="xs" wrap="nowrap">
                         {!isGroupedDisabled && (
                             <SegmentedControl
                                 size="xs"

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -4,11 +4,10 @@ import {
     isCustomSqlDimension,
     isSqlTableCalculation,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
+import { Box, Group } from '@mantine-8/core';
 import {
     ActionIcon,
     CopyButton,
-    Group,
     SegmentedControl,
     Skeleton,
     Tooltip,
@@ -144,7 +143,7 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
             rightHeaderElement={
                 sqlIsOpen &&
                 !cannotViewSqlAuthoredFields && (
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         {hasPivotQuery && (
                             <SegmentedControl
                                 size="xs"

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -1,8 +1,8 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
+import { Group } from '@mantine-8/core';
 import {
     ActionIcon,
     Divider,
-    Group,
     Loader,
     ScrollArea,
     Tooltip,
@@ -75,7 +75,7 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
 
     return (
         <>
-            <Group position="apart">
+            <Group justify="space-between">
                 <Text fz={16} fw={600}>
                     Configure chart
                 </Text>

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -4,13 +4,12 @@ import {
     type Job,
     type JobStep,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Alert,
     CopyButton,
     Drawer,
-    Group,
     Loader,
     Title,
     type DefaultMantineColor,
@@ -154,7 +153,7 @@ const JobDetailsDrawer: FC = () => {
                 },
             }}
             title={
-                <Group noWrap align="center" spacing="xs">
+                <Group wrap="nowrap" align="center" gap="xs">
                     <DrawerIcon job={activeJob} />
 
                     <Box>

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -1,10 +1,9 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     Avatar,
-    Group,
     PasswordInput,
     ScrollArea,
     Select,
@@ -106,7 +105,7 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
         return (
             <>
                 {repos && repos.length > 0 && (
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <Select
                             name="dbt.repository"
                             searchable
@@ -296,7 +295,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
     return (
         <>
             <Stack style={{ marginTop: '8px' }}>
-                <Group spacing="sm">
+                <Group gap="sm">
                     <Select
                         name="dbt.authorization_method"
                         {...form.getInputProps('dbt.authorization_method')}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,11 +1,10 @@
 import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import type { SelectItem } from '@mantine/core';
 import {
     Anchor,
     Autocomplete,
     FileInput,
-    Group,
     Image,
     Loader,
     NumberInput,
@@ -189,7 +188,7 @@ const BigQueryForm: FC<{
         <>
             <Stack mt={8}>
                 {
-                    <Group spacing="sm">
+                    <Group gap="sm">
                         <Select
                             name="warehouse.authenticationType"
                             {...form.getInputProps(
@@ -239,7 +238,7 @@ const BigQueryForm: FC<{
                         openLoginPopup={openLoginPopup}
                     />
                 )}
-                <Group spacing="sm">
+                <Group gap="sm">
                     {isSso && isAuthenticated ? (
                         <Autocomplete
                             name="warehouse.project"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -2,11 +2,10 @@ import {
     DatabricksAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Group,
     PasswordInput,
     Select,
     TextInput,
@@ -250,7 +249,7 @@ const DatabricksForm: FC<{
                     placeholder="/sql/protocolv1/o/xxxx/xxxx"
                 />
 
-                <Group spacing="sm">
+                <Group gap="sm">
                     <Select
                         name="warehouse.authenticationType"
                         {...form.getInputProps('warehouse.authenticationType')}
@@ -398,8 +397,8 @@ const DatabricksForm: FC<{
                                         <Group
                                             // @ts-expect-error
                                             key={field.key}
-                                            noWrap
-                                            spacing="xs"
+                                            wrap="nowrap"
+                                            gap="xs"
                                         >
                                             <TextInput
                                                 style={{

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -1,9 +1,8 @@
 import { SnowflakeAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import {
     Anchor,
     FileInput,
-    Group,
     NumberInput,
     PasswordInput,
     Radio,
@@ -276,7 +275,7 @@ const SnowflakeForm: FC<{
                             labelProps={{ style: { marginTop: '8px' } }}
                         />
 
-                        <Group spacing="sm">
+                        <Group gap="sm">
                             <Select
                                 name="warehouse.authenticationType"
                                 {...form.getInputProps(

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/ChartPreviewComponent.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/ChartPreviewComponent.tsx
@@ -1,6 +1,6 @@
 import { ChartKind } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { Group, SegmentedControl } from '@mantine/core';
+import { Box, Group, Stack } from '@mantine-8/core';
+import { SegmentedControl } from '@mantine/core';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { getChartIcon } from '../../common/ResourceIcon/utils';
@@ -237,7 +237,7 @@ export const ChartPreviewComponent: FC<ChartPreviewComponentProps> = ({
 
     return (
         <Stack gap="sm" h="100%" style={{ flex: 1, backgroundColor }} pt="xs">
-            <Group position="center">
+            <Group justify="center">
                 <SegmentedControl
                     value={chartType}
                     onChange={(value) => setChartType(value as ChartKind)}

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,11 +1,10 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { Button } from '@mantine-8/core';
+import { Button, Group } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
     ColorSwatch,
     Flex,
-    Group,
     Menu,
     Paper,
     Tooltip,
@@ -72,10 +71,10 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                 onMouseLeave={() => setIsHovered(false)}
             >
                 <Flex justify="space-between" align="center">
-                    <Group spacing="sm">
-                        <Group spacing="two">
+                    <Group gap="sm">
+                        <Group gap="two">
                             <Tooltip label="Light mode" position="top">
-                                <Group spacing="two">
+                                <Group gap="two">
                                     <MantineIcon
                                         icon={IconSun}
                                         size="sm"
@@ -98,7 +97,7 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                                         /
                                     </Text>
                                     <Tooltip label="Dark mode" position="top">
-                                        <Group spacing="two">
+                                        <Group gap="two">
                                             <MantineIcon
                                                 icon={IconMoon}
                                                 size="sm"
@@ -133,7 +132,7 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                                 variant="xs"
                             >
                                 <Badge color="gray" variant="light">
-                                    <Group spacing={2}>
+                                    <Group gap={2}>
                                         Override
                                         <MantineIcon
                                             size="sm"
@@ -145,7 +144,7 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                         )}
                     </Group>
 
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         {onSetActive && (
                             <Button
                                 onClick={() =>

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -1,9 +1,8 @@
-import { Box, Button, Stack } from '@mantine-8/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
 import {
     Alert,
     Avatar,
     Flex,
-    Group,
     Loader,
     Title,
     Tooltip,
@@ -67,7 +66,7 @@ const GithubSettingsPanel: FC = () => {
     return (
         <SettingsGridCard>
             <Box>
-                <Group spacing="sm">
+                <Group gap="sm">
                     <Avatar src={githubIcon} size="md" />
                     <Title order={4}>Github</Title>
                 </Group>

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Button, Stack } from '@mantine-8/core';
-import { Alert, Avatar, Flex, Group, Loader, Title, Text } from '@mantine/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
+import { Alert, Avatar, Flex, Loader, Title, Text } from '@mantine/core';
 import { IconAlertCircle, IconRefresh, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import gitlabIcon from '../../../svgs/gitlab-icon.svg';
@@ -26,7 +26,7 @@ const GitlabSettingsPanel: FC = () => {
     return (
         <SettingsGridCard>
             <Box>
-                <Group spacing="sm">
+                <Group gap="sm">
                     <Avatar src={gitlabIcon} size="md" />
                     <Title order={4}>GitLab</Title>
                 </Group>

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
@@ -1,5 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { ActionIcon, Group, Paper, Table, Text } from '@mantine/core';
+import { Group } from '@mantine-8/core';
+import { ActionIcon, Paper, Table, Text } from '@mantine/core';
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { Group, LoadingOverlay, Title, Text } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
+import { LoadingOverlay, Title, Text } from '@mantine/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
@@ -30,7 +30,7 @@ export const OrganizationWarehouseCredentialsPanel = () => {
             <Stack mb="lg">
                 {credentials && credentials.length > 0 ? (
                     <>
-                        <Group position="apart">
+                        <Group justify="space-between">
                             <Stack gap="one">
                                 <Title order={5}>
                                     Organization warehouse credentials

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -9,10 +9,9 @@ import {
     XAxisSort,
     type ItemsMap,
 } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import {
     Checkbox,
-    Group,
     NumberInput,
     SegmentedControl,
     Select,
@@ -41,7 +40,7 @@ const XAxisSortSelectItem = forwardRef<
     HTMLDivElement,
     { icon: Icon; label: string; mirrorIcon: boolean }
 >(({ icon, label, mirrorIcon, ...others }, ref) => (
-    <Group ref={ref} spacing="xs" {...others} noWrap>
+    <Group ref={ref} gap="xs" {...others} wrap="nowrap">
         <MantineIcon
             style={mirrorIcon ? { transform: 'rotateY(180deg)' } : undefined}
             icon={icon}
@@ -220,8 +219,8 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             />
                         </>
                     )}
-                    <Group spacing="xs">
-                        <Group spacing="xs">
+                    <Group gap="xs">
+                        <Group gap="xs">
                             <Config.Label>Sort</Config.Label>
                             <Select
                                 value={getXAxisSort(
@@ -267,7 +266,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             />
                         </Group>
                         {!dirtyLayout?.flipAxes && (
-                            <Group noWrap spacing="xs" align="baseline">
+                            <Group wrap="nowrap" gap="xs" align="baseline">
                                 <Config.Label>Rotation</Config.Label>
                                 <NumberInput
                                     type="number"
@@ -302,7 +301,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             />
                             {dirtyEchartsConfig?.xAxis?.[0]?.enableDataZoom && (
                                 <>
-                                    <Group spacing="xs">
+                                    <Group gap="xs">
                                         <Config.Label>
                                             Initial scroll position
                                         </Config.Label>
@@ -328,7 +327,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                             }
                                         />
                                     </Group>
-                                    <Group spacing="xs">
+                                    <Group gap="xs">
                                         <Config.Label>
                                             Visible items
                                         </Config.Label>
@@ -566,7 +565,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
             <Config>
                 <Config.Section>
                     <Config.Heading>Tick label size (px)</Config.Heading>
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <NumberInput
                             value={
                                 dirtyEchartsConfig?.axisLabelFontSize ?? 11.5
@@ -600,7 +599,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
             <Config>
                 <Config.Section>
                     <Config.Heading>Axis title size (px)</Config.Heading>
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <NumberInput
                             value={dirtyEchartsConfig?.axisTitleFontSize ?? 12}
                             min={8}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Button } from '@mantine-8/core';
-import { Flex, Group, Loader, useMantineTheme, Text } from '@mantine/core';
+import { Button, Group } from '@mantine-8/core';
+import { Flex, Loader, useMantineTheme, Text } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';
@@ -261,7 +261,7 @@ export const ConfigTabs: React.FC = memo(() => {
                 h="calc(100vh - 300px)"
                 align="top"
                 mt="4px"
-                sx={{
+                style={{
                     borderTop: '0.125rem solid #dee2e6',
                 }}
             >

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -10,11 +10,10 @@ import {
     type Field,
     type TableCalculation,
 } from '@lightdash/common';
-import { NumberInput, Stack } from '@mantine-8/core';
+import { Group, NumberInput, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     CloseButton,
-    Group,
     SegmentedControl,
     TextInput,
     Tooltip,
@@ -215,7 +214,7 @@ export const Layout: FC<Props> = ({ items }) => {
                         <Config.Heading>{`${
                             validConfig?.layout.flipAxes ? 'Y' : 'X'
                         }-axis`}</Config.Heading>
-                        <Group spacing="two">
+                        <Group gap="two">
                             <Tooltip variant="xs" label="Flip Axes">
                                 <ActionIcon
                                     onClick={() =>
@@ -325,7 +324,7 @@ export const Layout: FC<Props> = ({ items }) => {
                 <Config.Section>
                     <Stack gap="xs">
                         <Config.Group>
-                            <Group spacing="one">
+                            <Group gap="one">
                                 <Config.Heading>Group</Config.Heading>
                             </Group>
                             {canAddPivot && (
@@ -391,7 +390,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                     );
                                 }
                                 return (
-                                    <Group spacing="xs" key={pivotKey}>
+                                    <Group gap="xs" key={pivotKey}>
                                         <FieldSelect
                                             disabled={
                                                 !chartHasMetricOrTableCalc
@@ -445,7 +444,7 @@ export const Layout: FC<Props> = ({ items }) => {
                             position="top-start"
                             disabled={!isXAxisFieldNumeric}
                         >
-                            <Group spacing="xs">
+                            <Group gap="xs">
                                 <Config.Label>Stacking</Config.Label>
                                 <SegmentedControl
                                     disabled={isXAxisFieldNumeric}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -10,15 +10,9 @@ import {
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
-import {
-    Collapse,
-    Group,
-    Loader,
-    SegmentedControl,
-    Switch,
-} from '@mantine/core';
+import { Collapse, Loader, SegmentedControl, Switch } from '@mantine/core';
 import { lazy, Suspense, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useToggle } from 'react-use';
@@ -206,7 +200,7 @@ export const Legend: FC<Props> = ({ items }) => {
         <Stack>
             <Config>
                 <Config.Section>
-                    <Group spacing="xs" align="center">
+                    <Group gap="xs" align="center">
                         <Config.Heading>Legend</Config.Heading>
                         <Switch
                             checked={legendConfig.show ?? showDefault}
@@ -218,7 +212,7 @@ export const Legend: FC<Props> = ({ items }) => {
 
                     <Collapse in={legendConfig.show ?? showDefault}>
                         <Stack gap="xs">
-                            <Group spacing="xs">
+                            <Group gap="xs">
                                 <Config.Label>Placement</Config.Label>
                                 <SegmentedControl
                                     name="placement"
@@ -248,7 +242,7 @@ export const Legend: FC<Props> = ({ items }) => {
                             {(legendConfig.placement ?? 'custom') ===
                                 'custom' && (
                                 <>
-                                    <Group spacing="xs">
+                                    <Group gap="xs">
                                         <Config.Label>
                                             Scroll behavior
                                         </Config.Label>
@@ -272,7 +266,7 @@ export const Legend: FC<Props> = ({ items }) => {
                                             }
                                         />
                                     </Group>
-                                    <Group spacing="xs">
+                                    <Group gap="xs">
                                         <Config.Label>Orientation</Config.Label>
                                         <SegmentedControl
                                             name="orient"
@@ -303,7 +297,7 @@ export const Legend: FC<Props> = ({ items }) => {
                             )}
                             {(legendConfig.placement === 'outsideRight' ||
                                 legendConfig.placement === 'outsideLeft') && (
-                                <Group spacing="xs">
+                                <Group gap="xs">
                                     <Config.Label>
                                         Legend area width
                                     </Config.Label>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -7,8 +7,7 @@ import {
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { Group } from '@mantine/core';
+import { Box, Group } from '@mantine-8/core';
 import { useDebouncedState } from '@mantine/hooks';
 import { IconPalette } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -54,7 +53,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
     return (
         <Config>
             <Config.Section>
-                <Group noWrap spacing="two">
+                <Group wrap="nowrap" gap="two">
                     <GrabIcon
                         dragHandleProps={dragHandleProps}
                         disabled={isDragDisabled}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
@@ -6,11 +6,10 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Collapse,
-    Group,
     Select,
     TextInput,
     Tooltip,
@@ -69,8 +68,8 @@ export const ChartConditionalFormattingRule: FC<Props> = ({
 
     return (
         <Stack gap="xs" ref={ref}>
-            <Group noWrap position="apart">
-                <Group spacing="xs">
+            <Group wrap="nowrap" justify="space-between">
+                <Group gap="xs">
                     <Text fw={500} fz="xs">
                         Condition {ruleIndex + 1}
                     </Text>
@@ -93,7 +92,7 @@ export const ChartConditionalFormattingRule: FC<Props> = ({
                 </ActionIcon>
             </Group>
             <Collapse in={isOpen}>
-                <Group noWrap spacing="xs">
+                <Group wrap="nowrap" gap="xs">
                     <Select
                         value={rule.operator}
                         data={filterOperatorOptions}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
@@ -8,8 +8,8 @@ import {
     type ResultRow,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, ScrollArea, Stack } from '@mantine-8/core';
-import { Divider, Group, SegmentedControl, Text } from '@mantine/core';
+import { Box, Group, ScrollArea, Stack } from '@mantine-8/core';
+import { Divider, SegmentedControl, Text } from '@mantine/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import ColorSelector from '../../ColorSelector';
 import { ChartConditionalFormatting } from './ChartConditionalFormatting';
@@ -148,7 +148,7 @@ export const CustomColors: FC<Props> = ({
                 uniqueCategories.length > 0 && (
                     <>
                         <Divider />
-                        <Group spacing="xs" noWrap>
+                        <Group gap="xs" wrap="nowrap">
                             <ColorSelector
                                 color={setAllColor ?? colorPalette[0]}
                                 swatches={colorPalette}
@@ -172,8 +172,8 @@ export const CustomColors: FC<Props> = ({
                                         ([rawKey, label], idx) => (
                                             <Group
                                                 key={rawKey}
-                                                spacing="xs"
-                                                noWrap
+                                                gap="xs"
+                                                wrap="nowrap"
                                             >
                                                 <ColorSelector
                                                     color={

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -19,8 +19,8 @@ import {
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { Checkbox, Group, Select, Switch } from '@mantine/core';
+import { Box, Group, Stack } from '@mantine-8/core';
+import { Checkbox, Select, Switch } from '@mantine/core';
 import React, { useCallback, type FC } from 'react';
 import { createPortal } from 'react-dom';
 import type useCartesianChartConfig from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
@@ -153,7 +153,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     return (
         <Config>
             <Config.Section>
-                <Group noWrap spacing="two">
+                <Group wrap="nowrap" gap="two">
                     <GrabIcon
                         dragHandleProps={dragHandleProps}
                         disabled={isDragDisabled}
@@ -165,7 +165,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                     </Config.Heading>
                 </Group>
                 <Stack gap="xs" ml="md">
-                    <Group noWrap spacing="xs" align="start">
+                    <Group wrap="nowrap" gap="xs" align="start">
                         <ChartTypeSelect
                             chartValue={chartValue}
                             showMixed={!isChartTypeTheSameForAllSeries}
@@ -264,7 +264,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                     </Group>
                     {(chartValue === CartesianSeriesType.LINE ||
                         chartValue === CartesianSeriesType.AREA) && (
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <Checkbox
                                 checked={Boolean(seriesGroup[0].showSymbol)}
                                 label="Show symbol"

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -5,15 +5,8 @@ import {
     type CartesianChartLayout,
     type Series,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Checkbox,
-    Collapse,
-    Group,
-    Popover,
-    Select,
-} from '@mantine/core';
+import { Box, Group, Stack } from '@mantine-8/core';
+import { ActionIcon, Checkbox, Collapse, Popover, Select } from '@mantine/core';
 import { useDebouncedState, useHover } from '@mantine/hooks';
 import {
     IconChevronDown,
@@ -77,11 +70,11 @@ const SingleSeriesConfiguration: FC<Props> = ({
 
     return (
         <Box>
-            <Group position="apart">
+            <Group justify="space-between">
                 <Group
-                    spacing="two"
+                    gap="two"
                     ref={ref}
-                    sx={{
+                    style={{
                         flexGrow: 1,
                     }}
                 >
@@ -146,7 +139,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                     )}
                 </Group>
 
-                <Group spacing="one">
+                <Group gap="one">
                     {isGrouped && (
                         <ActionIcon
                             onClick={() => {
@@ -173,7 +166,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
             </Group>
             <Collapse in={!isCollapsable || isOpen || false}>
                 <Stack ml="lg" gap="xs">
-                    <Group spacing="xs" noWrap>
+                    <Group gap="xs" wrap="nowrap">
                         <ChartTypeSelect
                             showLabel={!isGrouped}
                             chartValue={type}
@@ -341,7 +334,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                     </Group>
                     {(type === CartesianSeriesType.LINE ||
                         type === CartesianSeriesType.AREA) && (
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <Checkbox
                                 checked={Boolean(series.showSymbol)}
                                 label="Show symbol"

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -9,11 +9,10 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Group, Stack } from '@mantine-8/core';
 import {
     Checkbox,
     Collapse,
-    Group,
     MantineProvider,
     SegmentedControl,
     Switch,
@@ -88,7 +87,7 @@ export const ConfigTabs: FC = memo(() => {
                                 <Config.Heading>
                                     Data orientation
                                 </Config.Heading>
-                                <Group spacing="xs">
+                                <Group gap="xs">
                                     <Config.Label>Steps are</Config.Label>
                                     <SegmentedControl
                                         value={dataInput}
@@ -172,7 +171,7 @@ export const ConfigTabs: FC = memo(() => {
                             <Config.Section>
                                 <Config.Heading>Labels</Config.Heading>
 
-                                <Group spacing="xs" noWrap>
+                                <Group gap="xs" wrap="nowrap">
                                     <Config.Label>Position</Config.Label>
                                     <SegmentedControl
                                         value={labels?.position}
@@ -205,7 +204,7 @@ export const ConfigTabs: FC = memo(() => {
                                     />
                                 </Group>
 
-                                <Group spacing="xs">
+                                <Group gap="xs">
                                     <Checkbox
                                         checked={labels?.showValue}
                                         onChange={(newValue) =>
@@ -278,7 +277,7 @@ export const ConfigTabs: FC = memo(() => {
                         </Config>
 
                         <Collapse in={showLegend}>
-                            <Group spacing="xs">
+                            <Group gap="xs">
                                 <Config.Label>Orientation</Config.Label>
                                 <SegmentedControl
                                     name="orient"

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -3,11 +3,10 @@ import {
     getItemId,
     getItemLabelWithoutTableName,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
     Center,
     Checkbox,
-    Group,
     NumberInput,
     SegmentedControl,
     Tooltip,
@@ -74,7 +73,7 @@ export const GaugeDisplayConfig: FC = memo(() => {
                         precision={2}
                         removeTrailingZeros={true}
                     />
-                    <Group spacing="xs" align="flex-end">
+                    <Group gap="xs" align="flex-end">
                         {maxValueMode === GaugeValueMode.FIXED ? (
                             <NumberInput
                                 label="Maximum value"

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
@@ -1,6 +1,6 @@
 import { getItemLabelWithoutTableName } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { ActionIcon, Group, TextInput, Tooltip } from '@mantine/core';
+import { Box, Group } from '@mantine-8/core';
+import { ActionIcon, TextInput, Tooltip } from '@mantine/core';
 import { useDebouncedState } from '@mantine/hooks';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
@@ -78,7 +78,7 @@ const MapFieldConfiguration: FC<MapFieldConfigurationProps> = ({ fieldId }) => {
     const isVisible = isFieldVisible(fieldId);
 
     return (
-        <Group spacing="xs" noWrap style={{ flexGrow: 1 }}>
+        <Group gap="xs" wrap="nowrap" style={{ flexGrow: 1 }}>
             <Box style={{ flexGrow: 1 }}>
                 <MapFieldConfigurationInput
                     fieldId={fieldId}

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapLayoutConfig.tsx
@@ -9,9 +9,8 @@ import {
     MapChartLocation,
     MapChartType,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
-    Group,
     Loader,
     SegmentedControl,
     Select,
@@ -350,7 +349,7 @@ export const Layout: FC = memo(() => {
                 <Config>
                     <Config.Section>
                         <Config.Heading>Coordinates</Config.Heading>
-                        <Group spacing="md" grow>
+                        <Group gap="md" grow>
                             <FieldSelect
                                 label="Latitude"
                                 placeholder="Select field"

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
@@ -5,8 +5,8 @@ import {
     type PieChartValueLabel,
     type PieChartValueOptions,
 } from '@lightdash/common';
-import { Box, Stack, type StackProps } from '@mantine-8/core';
-import { ActionIcon, Collapse, Group, Tooltip } from '@mantine/core';
+import { Box, Group, Stack, type StackProps } from '@mantine-8/core';
+import { ActionIcon, Collapse, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { forwardRef } from 'react';
@@ -79,7 +79,7 @@ export const GroupItem = forwardRef<
 
         return (
             <Stack ref={ref} gap="xs" {...rest}>
-                <Group spacing="xs">
+                <Group gap="xs">
                     {!isOnlyItem && (
                         <GrabIcon dragHandleProps={dragHandleProps} />
                     )}

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -9,8 +9,8 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { Group, SegmentedControl, Tooltip } from '@mantine/core';
+import { Box, Group, Stack } from '@mantine-8/core';
+import { SegmentedControl, Tooltip } from '@mantine/core';
 import FieldSelect from '../../common/FieldSelect';
 import { isPieVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -146,7 +146,7 @@ export const Layout: React.FC = () => {
                 </Config.Section>
             </Config>
 
-            <Group spacing="xs">
+            <Group gap="xs">
                 <Config.Label>Display as</Config.Label>
                 <SegmentedControl
                     value={isDonut ? 'donut' : 'pie'}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItemColorRange.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItemColorRange.tsx
@@ -5,8 +5,8 @@ import {
     type ConditionalFormattingMinMax,
     type FilterableItem,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Group, Select } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import { IconPercentage } from '@tabler/icons-react';
 import capitalize from 'lodash/capitalize';
 import { startTransition, useCallback, type FC } from 'react';
@@ -58,7 +58,7 @@ const ConditionalFormattingItemColorRange: FC<Props> = ({
     return (
         <Stack gap="xs">
             {groups.map(([rangeName, minMaxName]) => (
-                <Group key={rangeName} spacing="xs" noWrap align="end">
+                <Group key={rangeName} gap="xs" wrap="nowrap" align="end">
                     <Select
                         sx={{ flexBasis: '100%' }}
                         label={`${capitalize(minMaxName)} value type`}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -10,10 +10,9 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Accordion, Stack } from '@mantine-8/core';
+import { Accordion, Group, Stack } from '@mantine-8/core';
 import {
     Center,
-    Group,
     SegmentedControl,
     Select,
     TextInput,
@@ -218,7 +217,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
 
             <Accordion.Panel>
                 <Stack gap="xs">
-                    <Group noWrap spacing="xs">
+                    <Group wrap="nowrap" gap="xs">
                         <Text fw={500} fz="xs" c="dimmed">
                             Compare:
                         </Text>
@@ -278,7 +277,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                                 placeholder="Compare field"
                             />
                         )}
-                    <Group noWrap spacing="xs">
+                    <Group wrap="nowrap" gap="xs">
                         <Select
                             value={rule.operator}
                             data={filterOperatorOptions}

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
@@ -8,8 +8,8 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { Grid, Group, NumberInput, Switch, Tooltip, Text } from '@mantine/core';
+import { Box, Group, Stack } from '@mantine-8/core';
+import { Grid, NumberInput, Switch, Tooltip, Text } from '@mantine/core';
 import { IconHelpCircle } from '@tabler/icons-react';
 import FieldSelect from '../../common/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';
@@ -66,8 +66,8 @@ export const Layout: React.FC = () => {
                           {(provided, snapshot) => (
                               <DraggablePortalHandler snapshot={snapshot}>
                                   <Group
-                                      noWrap
-                                      spacing="xs"
+                                      wrap="nowrap"
+                                      gap="xs"
                                       ref={provided.innerRef}
                                       {...provided.draggableProps}
                                       className={`${classes.item} ${
@@ -102,7 +102,7 @@ export const Layout: React.FC = () => {
         <Stack>
             <Config>
                 <Config.Section>
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <Config.Heading>Dimension hierarchy</Config.Heading>
                         <Tooltip
                             withinPortal={true}
@@ -145,7 +145,7 @@ export const Layout: React.FC = () => {
 
             <Config>
                 <Config.Section>
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <Config.Heading>Size metric</Config.Heading>
                         <Tooltip
                             withinPortal={true}
@@ -186,7 +186,7 @@ export const Layout: React.FC = () => {
 
             <Config>
                 <Config.Section>
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <Config.Heading>Color metric</Config.Heading>
                         <Tooltip
                             withinPortal={true}
@@ -239,7 +239,7 @@ export const Layout: React.FC = () => {
                                     />
                                 </Grid.Col>
                                 <Grid.Col span={8}>
-                                    <Group spacing="xs" position="right">
+                                    <Group gap="xs" justify="flex-end">
                                         <Config.Label>Threshold</Config.Label>
                                         <NumberInput
                                             value={startColorThreshold}
@@ -263,10 +263,10 @@ export const Layout: React.FC = () => {
                                 </Grid.Col>
                                 <Grid.Col span={8}>
                                     <Group
-                                        noWrap
+                                        wrap="nowrap"
                                         w="100%"
-                                        spacing="xs"
-                                        position="right"
+                                        gap="xs"
+                                        justify="flex-end"
                                     >
                                         <Config.Label>Threshold</Config.Label>
                                         <NumberInput

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
@@ -1,4 +1,5 @@
-import { Group, MultiSelect, type MultiSelectProps, Text } from '@mantine/core';
+import { Group } from '@mantine-8/core';
+import { MultiSelect, type MultiSelectProps, Text } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import uniq from 'lodash/uniq';
 import { useCallback, useMemo, useState, type FC } from 'react';
@@ -124,7 +125,7 @@ const FilterMultiStringInput: FC<Props> = ({
                 disabled={disabled}
                 creatable
                 getCreateLabel={(query) => (
-                    <Group spacing="xxs">
+                    <Group gap="xxs">
                         <MantineIcon icon={IconPlus} color="blue" size="sm" />
                         <Text c="blue">Add "{query}"</Text>
                     </Group>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -1,8 +1,7 @@
 import { isDimension, type FilterableItem } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Group,
     Highlight,
     Loader,
     MultiSelect,
@@ -494,7 +493,7 @@ const FilterStringAutoComplete: FC<Props> = ({
                             query.trim().length > 0 && !values.includes(query)
                         }
                         getCreateLabel={(query: string) => (
-                            <Group spacing="xxs">
+                            <Group gap="xxs">
                                 <MantineIcon
                                     icon={IconPlus}
                                     color="blue.6"
@@ -521,9 +520,9 @@ const FilterStringAutoComplete: FC<Props> = ({
                         rightSectionWidth={30}
                         rightSection={
                             <Group
-                                spacing="xxs"
-                                noWrap
-                                sx={{
+                                gap="xxs"
+                                wrap="nowrap"
+                                style={{
                                     visibility: disabled ? 'hidden' : 'visible',
                                 }}
                             >

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -27,8 +27,8 @@ import {
     type ResultValue,
     type SortField,
 } from '@lightdash/common';
-import { Box, Button, Menu, type BoxProps } from '@mantine-8/core';
-import { Group, useMantineColorScheme, Text } from '@mantine/core';
+import { Box, Button, Group, Menu, type BoxProps } from '@mantine-8/core';
+import { useMantineColorScheme, Text } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import {
     flexRender,
@@ -1184,8 +1184,8 @@ const PivotTable: FC<PivotTableProps> = ({
                                         titleSortIcon ? (
                                             <Group
                                                 display="inline-flex"
-                                                spacing={4}
-                                                noWrap
+                                                gap={4}
+                                                wrap="nowrap"
                                                 align="center"
                                             >
                                                 {getFieldLabel(
@@ -1406,8 +1406,8 @@ const PivotTable: FC<PivotTableProps> = ({
                             const headerInnerContent = sortIcon ? (
                                 <Group
                                     display="inline-flex"
-                                    spacing={4}
-                                    noWrap
+                                    gap={4}
+                                    wrap="nowrap"
                                     align="center"
                                 >
                                     {isLabel
@@ -1965,7 +1965,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     cell.getContext(),
                                                 )
                                             ) : (
-                                                <Group spacing="two" noWrap>
+                                                <Group gap="two" wrap="nowrap">
                                                     <Button
                                                         size="compact-xs"
                                                         variant="subtle"

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,13 +13,12 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Box, Button } from '@mantine-8/core';
+import { Box, Button, Group } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
 import {
     ActionIcon,
     Anchor,
     Divider,
-    Group,
     TextInput,
     Tooltip,
     useMantineTheme,
@@ -698,7 +697,7 @@ const InfiniteResourceTable = ({
             return (
                 <Box>
                     <Group p={`${theme.spacing.lg} ${theme.spacing.xl}`}>
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <DebouncedSearchInput onSearch={setSearch} />
 
                             {contentTypeFilter &&
@@ -761,7 +760,7 @@ const InfiniteResourceTable = ({
                 {isFetching ? (
                     <Text>Loading more...</Text>
                 ) : (
-                    <Group spacing="two">
+                    <Group gap="two">
                         <Text>
                             {hasNextPage
                                 ? 'Scroll for more results'

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -3,9 +3,8 @@ import {
     getErrorMessage,
     type Space,
 } from '@lightdash/common';
-import { Button } from '@mantine-8/core';
+import { Button, Group } from '@mantine-8/core';
 import {
-    Group,
     MantineProvider,
     useMantineColorScheme,
     type DefaultMantineColor,
@@ -136,7 +135,7 @@ const SpaceModal: FC<ActionModalProps> = ({
                 title={title}
                 onClose={onClose}
                 actions={
-                    <Group spacing="xs" position="right">
+                    <Group gap="xs" justify="flex-end">
                         <Button
                             type="submit"
                             disabled={isDisabled || !form.isValid}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,10 +14,9 @@ import {
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
-import { Button } from '@mantine-8/core';
+import { Button, Group } from '@mantine-8/core';
 import {
     Center,
-    Group,
     Loader,
     Skeleton,
     Tooltip,
@@ -285,7 +284,7 @@ const TableRow: FC<TableRowProps> = ({
                         tooltipContent={tooltipContent || undefined}
                     >
                         {cell.getIsGrouped() ? (
-                            <Group spacing="xxs">
+                            <Group gap="xxs">
                                 <Button
                                     size="compact-xs"
                                     variant="subtle"

--- a/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
@@ -1,5 +1,5 @@
-import { Box } from '@mantine-8/core';
-import { ActionIcon, Group, Textarea, Text } from '@mantine/core';
+import { Box, Group } from '@mantine-8/core';
+import { ActionIcon, Textarea, Text } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import { IconArrowUp, IconSparkles } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -52,7 +52,7 @@ export const AiTooltipInput: FC<Props> = ({ fields, currentHtml, onApply }) => {
 
     return (
         <Box className={styles.container}>
-            <Group spacing="xs" mb="xs">
+            <Group gap="xs" mb="xs">
                 <MantineIcon icon={IconSparkles} color="indigo.4" />
                 <Text size="xs" c="ldDark.9" fw={500}>
                     {currentHtml

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Button, Stack } from '@mantine-8/core';
-import { Anchor, Group, TextInput, Title, Text } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
+import { Anchor, TextInput, Title, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -30,7 +30,7 @@ const ScimAccessTokensPanel: FC = () => {
 
     return (
         <Stack mb="lg">
-            <Group position="apart">
+            <Group justify="space-between">
                 <Title order={5}>SCIM access tokens</Title>
                 <Button onClick={() => setIsCreatingToken(true)}>
                     Generate new token

--- a/packages/frontend/src/features/dashboardFilters/DashboardFiltersBar.tsx
+++ b/packages/frontend/src/features/dashboardFilters/DashboardFiltersBar.tsx
@@ -102,14 +102,19 @@ export const DashboardFiltersBar: FC<Props> = ({
     return (
         <div>
             <Group
-                justify="apart"
+                justify="space-between"
                 align="flex-start"
                 wrap="nowrap"
                 px="lg"
                 py="xxs"
             >
                 {/* Left section - filters and parameters */}
-                <Group justify="apart" align="flex-start" wrap="nowrap" grow>
+                <Group
+                    justify="space-between"
+                    align="flex-start"
+                    wrap="nowrap"
+                    grow
+                >
                     {hasTilesThatSupportFilters && (
                         <Group align="flex-start" gap="xs" wrap="wrap">
                             {renderFilters && (

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -7,11 +7,10 @@ import {
     type DashboardFilterRule,
     type FilterRule,
 } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Checkbox,
-    Group,
     Select,
     Switch,
     TextInput,
@@ -205,7 +204,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                 )}
 
                 {(showValueInput || filterRule.required) && (
-                    <Group spacing="xs" noWrap align="flex-start">
+                    <Group gap="xs" wrap="nowrap" align="flex-start">
                         <Box style={{ flex: 1 }}>
                             <FilterInputComponent
                                 popoverProps={popoverProps}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -19,10 +19,9 @@ import {
     type DashboardTile,
     type ResultColumn,
 } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
 import {
     Flex,
-    Group,
     Select,
     Tabs,
     Tooltip,
@@ -464,7 +463,7 @@ const FilterConfiguration: FC<Props> = ({
                                 />
                             )
                         ) : selectedField ? (
-                            <Group spacing="xs">
+                            <Group gap="xs">
                                 <FieldIcon item={selectedField} />
                                 {originalFilterRule?.label && !isEditMode ? (
                                     <Text span fw={500}>
@@ -475,7 +474,7 @@ const FilterConfiguration: FC<Props> = ({
                                 )}
                             </Group>
                         ) : (
-                            <Group spacing="xs">
+                            <Group gap="xs">
                                 <MantineIcon
                                     icon={IconSql}
                                     size={'lg'}

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
@@ -1,6 +1,6 @@
 import type { CatalogMetricsTreeEdge } from '@lightdash/common';
-import { Box, Button } from '@mantine-8/core';
-import { Group, useMantineTheme, Text } from '@mantine/core';
+import { Box, Button, Group } from '@mantine-8/core';
+import { useMantineTheme, Text } from '@mantine/core';
 import { IconLayoutGridRemove } from '@tabler/icons-react';
 import {
     Background,
@@ -144,7 +144,7 @@ const SavedTreeCanvasFlow: FC<Props> = ({
                                 position="top-left"
                                 style={{ margin: '14px 27px' }}
                             >
-                                <Group spacing="xs">
+                                <Group gap="xs">
                                     <Text fz={14} fw={500} c="ldGray.6">
                                         Canvas mode:
                                     </Text>

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
@@ -1,5 +1,6 @@
 import type { CatalogItem } from '@lightdash/common';
-import { ActionIcon, Badge, Group, Tooltip } from '@mantine/core';
+import { Group } from '@mantine-8/core';
+import { ActionIcon, Badge, Tooltip } from '@mantine/core';
 import { IconCode, IconX } from '@tabler/icons-react';
 import type { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -63,7 +64,7 @@ export const CatalogCategory: FC<Props> = ({
                 },
             })}
         >
-            <Group spacing={1}>
+            <Group gap={1}>
                 {category.name}
                 {onRemove && (
                     <ActionIcon

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.module.css
@@ -1,0 +1,10 @@
+.formItem {
+    border-radius: var(--mantine-radius-md);
+    outline: none;
+}
+
+.formItem:focus,
+.formItem:hover {
+    background-color: var(--mantine-color-ldGray-0);
+    transition: background-color 200ms ease-in-out;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -1,9 +1,8 @@
 import { getErrorMessage, type CatalogItem } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Divider,
-    Group,
     Popover,
     SimpleGrid,
     TextInput,
@@ -20,6 +19,7 @@ import { useDeleteTag, useUpdateTag } from '../hooks/useProjectTags';
 import { TAG_COLOR_SWATCHES } from '../utils/getRandomTagColor';
 import { CatalogCategory } from './CatalogCategory';
 import { CatalogCategorySwatch } from './CatalogCategorySwatch';
+import classes from './MetricCatalogCategoryFormItem.module.css';
 
 type EditPopoverProps = {
     hovered: boolean;
@@ -144,7 +144,7 @@ const EditPopover: FC<EditPopoverProps> = ({
                         })}
                     />
 
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <Tooltip
                             variant="xs"
                             label="Delete this tag permanently"
@@ -211,18 +211,11 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
             px={4}
             py={3}
             pos="relative"
-            position="apart"
+            justify="space-between"
             tabIndex={0}
             role="button"
             onKeyDown={handleKeyDown}
-            sx={(theme) => ({
-                borderRadius: theme.radius.md,
-                outline: 'none',
-                '&:focus, &:hover': {
-                    backgroundColor: theme.colors.ldGray[0],
-                    transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                },
-            })}
+            className={classes.formItem}
         >
             <UnstyledButton
                 onClick={onClick}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -1,12 +1,6 @@
 import { type CatalogField, type Tag } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
-import {
-    Group,
-    Popover,
-    UnstyledButton,
-    useMantineTheme,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
+import { Popover, UnstyledButton, useMantineTheme, Text } from '@mantine/core';
 import differenceBy from 'lodash/differenceBy';
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';
@@ -351,7 +345,7 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                                     },
                                 }}
                             >
-                                <Group spacing={4}>
+                                <Group gap={4}>
                                     <Text>Create</Text>
                                     {tagColor && (
                                         <CatalogCategory

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -1,9 +1,8 @@
 import { isEmojiIcon, type CatalogField } from '@lightdash/common';
-import { Box, Button } from '@mantine-8/core';
+import { Box, Button, Group } from '@mantine-8/core';
 import {
     ActionIcon,
     getDefaultZIndex,
-    Group,
     Highlight,
     Paper,
     Portal,
@@ -68,7 +67,7 @@ const SharedEmojiPicker = forwardRef(
                         })}
                     >
                         {emoji && (
-                            <Group position="right">
+                            <Group justify="flex-end">
                                 <Button
                                     variant="light"
                                     size="compact-xs"
@@ -210,7 +209,7 @@ export const MetricsCatalogColumnName = forwardRef<HTMLDivElement, Props>(
 
         return (
             <Box ref={ref}>
-                <Group noWrap spacing="xs">
+                <Group wrap="nowrap" gap="xs">
                     <ActionIcon
                         ref={setIconRef}
                         variant="default"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,6 +1,6 @@
 import { SpotlightTableColumns, type CatalogField } from '@lightdash/common';
-import { Box, Button } from '@mantine-8/core';
-import { Flex, Group, Text } from '@mantine/core';
+import { Box, Button, Group } from '@mantine-8/core';
+import { Flex, Text } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus, IconUser } from '@tabler/icons-react';
 import { useMemo } from 'react';
@@ -200,11 +200,11 @@ export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
                     h="100%"
                     left={0}
                     top={0}
-                    sx={{
+                    style={{
                         cursor: canManageTags ? 'pointer' : 'default',
                     }}
                 >
-                    <Group mx="md" spacing="xxs">
+                    <Group mx="md" gap="xxs">
                         {categories.map((category) => (
                             <CatalogCategory
                                 key={category.tagUuid}
@@ -278,7 +278,7 @@ export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
                     }}
                 >
                     {categories.length === 0 && hovered && canManageTags ? (
-                        <Group spacing={2}>
+                        <Group gap={2}>
                             <MantineIcon
                                 color="ldGray.4"
                                 icon={IconPlus}
@@ -290,11 +290,11 @@ export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
                         </Group>
                     ) : (
                         <Group
-                            spacing="xxs"
+                            gap="xxs"
                             pos="relative"
                             w="100%"
                             h="100%"
-                            sx={{
+                            style={{
                                 rowGap: 'unset',
                             }}
                         >

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,13 +1,7 @@
 import { subject } from '@casl/ability';
 import { CatalogCategoryFilterMode, isCompileJob } from '@lightdash/common';
-import { Box, Button, Stack, type ButtonProps } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Group,
-    Popover,
-    useMantineTheme,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Group, Stack, type ButtonProps } from '@mantine-8/core';
+import { ActionIcon, Popover, useMantineTheme, Text } from '@mantine/core';
 import { useClickOutside, useDisclosure } from '@mantine/hooks';
 import { IconRefresh, IconSparkles, IconX } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
@@ -103,7 +97,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                 }}
             >
                 <Stack gap="sm" w="100%" ref={ref}>
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <Text fw={600} fz={14}>
                             ✨ Lightdash Spotlight is here!
                         </Text>
@@ -127,7 +121,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                         </Text>
                         .
                     </Text>
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <Button
                             variant="outline"
                             radius="md"
@@ -443,7 +437,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
 
     return (
         <Stack w="100%" gap="xxl">
-            <Group position="apart">
+            <Group justify="space-between">
                 <Box>
                     <Text c="ldGray.8" fw={600} size="xl">
                         Metrics Catalog
@@ -452,7 +446,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
                         Browse all Metrics & KPIs across this project
                     </Text>
                 </Box>
-                <Group spacing="xs">
+                <Group gap="xs">
                     {isIndexingCatalog ? (
                         <Button
                             size="xs"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,12 +5,11 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
+import { Box, Group } from '@mantine-8/core';
 import {
     Anchor,
     Center,
     Divider,
-    Group,
     Paper,
     useMantineTheme,
     Text,
@@ -502,7 +501,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                     setSelectedTables={handleSetTableFilters}
                     selectedOwners={ownerFilters}
                     setSelectedOwners={handleSetOwnerFilters}
-                    position="apart"
+                    justify="space-between"
                     p={`${theme.spacing.lg} ${theme.spacing.xl}`}
                     showCategoriesFilter={canManageTags || dataHasCategories}
                     metricCatalogView={metricCatalogView}
@@ -524,7 +523,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                 {isFetching ? (
                     <Text>Loading more...</Text>
                 ) : (
-                    <Group spacing="two">
+                    <Group gap="two">
                         <Text>
                             {hasNextPage
                                 ? 'Scroll for more metrics'
@@ -659,7 +658,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                                 setSelectedTables={handleSetTableFilters}
                                 selectedOwners={ownerFilters}
                                 setSelectedOwners={handleSetOwnerFilters}
-                                position="apart"
+                                justify="space-between"
                                 p={`${theme.spacing.lg} ${theme.spacing.xl}`}
                                 showCategoriesFilter={
                                     canManageTags || dataHasCategories

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -20,18 +20,16 @@ import {
     type CatalogCategoryFilterMode,
     type CatalogField,
 } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
+import { Box, Button, Group, Stack, type GroupProps } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
     Center,
     Divider,
-    Group,
     Popover,
     SegmentedControl,
     TextInput,
     Tooltip,
-    type GroupProps,
     Text,
 } from '@mantine/core';
 import {
@@ -104,8 +102,8 @@ const SortableColumn: FC<{
     };
 
     return (
-        <Group ref={setNodeRef} style={style} position="apart" h={28}>
-            <Group spacing={4}>
+        <Group ref={setNodeRef} style={style} justify="space-between" h={28}>
+            <Group gap={4}>
                 <Tooltip
                     variant="xs"
                     disabled={!column.frozen}
@@ -326,7 +324,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
 
         return (
             <Group {...props}>
-                <Group spacing="xs">
+                <Group gap="xs">
                     {/* Search input */}
                     <TextInput
                         size="xs"
@@ -410,7 +408,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                         setSelectedOwners={setSelectedOwners}
                     />
                 </Group>
-                <Group spacing="xs">
+                <Group gap="xs">
                     <Badge
                         bg="ldGray.1"
                         c="ldGray.8"
@@ -420,7 +418,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                         tt="none"
                         h={32}
                     >
-                        <Group spacing={6}>
+                        <Group gap={6}>
                             <TotalMetricsDot />
                             <Text fz="sm" fw={500}>
                                 {totalResults} metrics
@@ -491,7 +489,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                 </Stack>
 
                                 <Divider color="ldGray.1" />
-                                <Group position="apart" mt={4}>
+                                <Group justify="space-between" mt={4}>
                                     {canManageSpotlight ? (
                                         <>
                                             <Tooltip

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -5,10 +5,9 @@ import {
     type MetricExplorerQuery,
     type MetricWithAssociatedTimeDimension,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
     Anchor,
-    Group,
     Loader,
     Paper,
     Radio,
@@ -170,10 +169,10 @@ export const MetricExploreComparison: FC<Props> = ({
                                 <Stack>
                                     <Group
                                         align="center"
-                                        noWrap
-                                        position="apart"
+                                        wrap="nowrap"
+                                        justify="space-between"
                                     >
-                                        <Group noWrap>
+                                        <Group wrap="nowrap">
                                             <Paper
                                                 p="xs"
                                                 radius="md"

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -4,10 +4,9 @@ import {
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
 import {
     Divider,
-    Group,
     Popover,
     SegmentedControl,
     TextInput,
@@ -148,7 +147,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
             shadow="sm"
         >
             <Popover.Target>
-                <Group position="apart" w="fill-available" noWrap>
+                <Group justify="space-between" w="fill-available" wrap="nowrap">
                     <SegmentedControl
                         disabled={isFetching || disabled}
                         size="xs"
@@ -246,7 +245,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
             </Popover.Target>
 
             <Popover.Dropdown p={0}>
-                <Group spacing={0} align="flex-start">
+                <Group gap={0} align="flex-start">
                     <Stack gap={2} py="xs" px="sm">
                         {presets.map((preset) => (
                             <UnstyledButton
@@ -304,8 +303,8 @@ export const MetricExploreDatePicker: FC<Props> = ({
                         </Box>
                         <Divider color="ldGray.2" />
                         <Box p="sm">
-                            <Group position="apart" spacing="xl">
-                                <Group spacing="xs">
+                            <Group justify="space-between" gap="xl">
+                                <Group gap="xs">
                                     <TextInput
                                         size="xs"
                                         radius="md"
@@ -339,7 +338,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
                                     />
                                 </Group>
 
-                                <Group spacing="xs">
+                                <Group gap="xs">
                                     <Button
                                         size="xs"
                                         radius="md"

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -4,8 +4,8 @@ import {
     type CompiledDimension,
     type FilterRule,
 } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { Group, Select, Text } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
+import { Select, Text } from '@mantine/core';
 import { IconFilter, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -190,14 +190,14 @@ export const MetricExploreFilter: FC<Props> = ({
 
     return (
         <Stack gap="xs">
-            <Group position="apart">
-                <Group spacing="xs" align="normal">
+            <Group justify="space-between">
+                <Group gap="xs" align="normal">
                     <Text fw={500} c="ldGray.7">
                         Filter
                     </Text>
                 </Group>
 
-                <Group spacing="xs">
+                <Group gap="xs">
                     <Button
                         variant="subtle"
                         color="dark"
@@ -231,7 +231,7 @@ export const MetricExploreFilter: FC<Props> = ({
                     borderRadius: theme.radius.md,
                 }}
             >
-                <Group spacing={0} noWrap>
+                <Group gap={0} wrap="nowrap">
                     <Select
                         placeholder="Filter by"
                         icon={<MantineIcon icon={IconFilter} />}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
@@ -1,7 +1,6 @@
 import { type CompiledDimension } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
-    Group,
     Highlight,
     Loader,
     MultiSelect,
@@ -237,7 +236,7 @@ export const MetricExploreFilterAutoComplete: FC<Props> = ({
                     query.trim().length > 0 && !values.includes(query)
                 }
                 getCreateLabel={(query) => (
-                    <Group spacing="xxs">
+                    <Group gap="xxs">
                         <MantineIcon icon={IconPlus} color="blue" size="sm" />
                         <Text c="blue">Add "{query}"</Text>
                     </Group>

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -5,8 +5,8 @@ import {
     type CompiledDimension,
     type MetricExplorerQuery,
 } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
-import { Alert, Group, Loader, Select, Tooltip, Text } from '@mantine/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
+import { Alert, Loader, Select, Tooltip, Text } from '@mantine/core';
 import { IconInfoCircle, IconX } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useMemo, type FC } from 'react';
@@ -45,7 +45,7 @@ export const MetricExploreSegmentationPicker: FC<Props> = ({
 
     return (
         <Stack gap="xs">
-            <Group position="apart">
+            <Group justify="space-between">
                 <Text fw={500} c="ldGray.7">
                     Segment
                 </Text>

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -8,10 +8,9 @@ import {
     type VizTableHeaderSortConfig,
     formatSql,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Group,
     Indicator,
     LoadingOverlay,
     Paper,
@@ -453,8 +452,8 @@ export const ContentPanel: FC = () => {
                         borderColor: theme.colors.ldGray[3],
                     })}
                 >
-                    <Group position="apart">
-                        <Group position="apart">
+                    <Group justify="space-between">
+                        <Group justify="space-between">
                             <Indicator
                                 color="red.6"
                                 offset={10}
@@ -478,7 +477,10 @@ export const ContentPanel: FC = () => {
                                                     withinPortal
                                                     label="You haven't run this query yet."
                                                 >
-                                                    <Group spacing={4} noWrap>
+                                                    <Group
+                                                        gap={4}
+                                                        wrap="nowrap"
+                                                    >
                                                         <SqlEditorPreferencesPopover />
 
                                                         <Text>SQL</Text>
@@ -498,7 +500,10 @@ export const ContentPanel: FC = () => {
                                                     withinPortal
                                                     label="Run a query to see the chart"
                                                 >
-                                                    <Group spacing={4} noWrap>
+                                                    <Group
+                                                        gap={4}
+                                                        wrap="nowrap"
+                                                    >
                                                         <MantineIcon
                                                             color="ldGray.6"
                                                             icon={
@@ -530,7 +535,7 @@ export const ContentPanel: FC = () => {
                                 />
                             </Indicator>
                         </Group>
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <Parameters
                                 isEditMode={false}
                                 parameters={projectParameters}
@@ -885,8 +890,8 @@ export const ContentPanel: FC = () => {
                                                     {hasReachedPivotColumnLimit &&
                                                         maxColumnLimit && (
                                                             <Group
-                                                                position="center"
-                                                                spacing="xs"
+                                                                justify="center"
+                                                                gap="xs"
                                                             >
                                                                 <MantineIcon
                                                                     color="gray"

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { ActionIcon, Group, Menu, Paper, Tooltip, Text } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
+import { ActionIcon, Menu, Paper, Tooltip, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,
@@ -269,8 +269,8 @@ export const HeaderCreate: FC = () => {
                     }`,
                 })}
             >
-                <Group position="apart">
-                    <Group spacing="two">
+                <Group justify="space-between">
+                    <Group gap="two">
                         {hasAnyAction && (
                             <EditableText
                                 size="md"
@@ -284,7 +284,7 @@ export const HeaderCreate: FC = () => {
                         )}
                     </Group>
 
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         {hasAnyAction && (
                             <Button.Group>
                                 <Button
@@ -332,7 +332,7 @@ export const HeaderCreate: FC = () => {
                                             disabled={canSaveChart}
                                         >
                                             <Group
-                                                sx={{
+                                                style={{
                                                     cursor: 'pointer',
                                                 }}
                                             >
@@ -387,7 +387,7 @@ export const HeaderCreate: FC = () => {
                                             disabled={canCreateVirtualView}
                                         >
                                             <Group
-                                                sx={{
+                                                style={{
                                                     cursor: 'pointer',
                                                 }}
                                             >
@@ -454,7 +454,7 @@ export const HeaderCreate: FC = () => {
                                             }}
                                         >
                                             <Group
-                                                sx={{
+                                                style={{
                                                     cursor: 'pointer',
                                                 }}
                                             >

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,8 +1,7 @@
 import { type SqlChart } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Group,
     HoverCard,
     Menu,
     Paper,
@@ -171,9 +170,9 @@ export const HeaderEdit: FC = () => {
                     }`,
                 })}
             >
-                <Group position="apart">
+                <Group justify="space-between">
                     <Stack gap="none">
-                        <Group spacing="two">
+                        <Group gap="two">
                             <TitleBreadCrumbs
                                 projectUuid={savedSqlChart.project.projectUuid}
                                 spaceUuid={savedSqlChart.space.uuid}
@@ -191,7 +190,7 @@ export const HeaderEdit: FC = () => {
                                 <MantineIcon icon={IconPencil} />
                             </ActionIcon>
                         </Group>
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <UpdatedInfo
                                 updatedAt={savedSqlChart.lastUpdatedAt}
                                 user={savedSqlChart.lastUpdatedBy}
@@ -210,7 +209,7 @@ export const HeaderEdit: FC = () => {
                         </Group>
                     </Stack>
 
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <HoverCard disabled={!hasUnrunChanges} withArrow>
                             <HoverCard.Target>
                                 <Button

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DashboardTileTypes } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { ActionIcon, Group, Menu, Paper, Title, Tooltip } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
+import { ActionIcon, Menu, Paper, Title, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,
@@ -156,9 +156,9 @@ export const HeaderView: FC = () => {
                     }`,
                 })}
             >
-                <Group position="apart">
+                <Group justify="space-between">
                     <Stack gap="none">
-                        <Group spacing="two">
+                        <Group gap="two">
                             {space && (
                                 <TitleBreadCrumbs
                                     projectUuid={projectUuid}
@@ -170,7 +170,7 @@ export const HeaderView: FC = () => {
                                 {savedSqlChart.name}
                             </Title>
                         </Group>
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <UpdatedInfo
                                 updatedAt={savedSqlChart.lastUpdatedAt}
                                 user={savedSqlChart.lastUpdatedBy}
@@ -189,7 +189,7 @@ export const HeaderView: FC = () => {
                         </Group>
                     </Stack>
 
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         {canManageSqlRunner && canManageChart && (
                             <Button
                                 size="xs"

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { ChartKind } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { ActionIcon, Group, ScrollArea, Title, Tooltip } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { ActionIcon, ScrollArea, Title, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftCollapse, IconReload } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -34,8 +34,8 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
 
     return (
         <Stack gap="xs" style={{ flex: 1, overflow: 'hidden' }}>
-            <Group position="apart" p="sm">
-                <Group noWrap spacing="xs">
+            <Group justify="space-between" p="sm">
+                <Group wrap="nowrap" gap="xs">
                     <Title order={5} fz="sm" c="ldGray.6">
                         {activeSidebarTab === SidebarTabs.TABLES
                             ? 'TABLES'

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditorPreferencesPopover.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditorPreferencesPopover.tsx
@@ -1,12 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Group,
-    Popover,
-    SegmentedControl,
-    Text,
-} from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { ActionIcon, Popover, SegmentedControl, Text } from '@mantine/core';
 import { IconCodeCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
@@ -1,7 +1,6 @@
-import { Stack } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Group,
     HoverCard,
     Popover,
     Tooltip,
@@ -58,7 +57,7 @@ const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
                             dispatch(setSql(sql));
                         }}
                     >
-                        <Group spacing="xs" lh={1} noWrap>
+                        <Group gap="xs" lh={1} wrap="nowrap">
                             <MantineIcon
                                 icon={hovered ? IconCornerDownLeft : IconClock}
                             />
@@ -80,7 +79,7 @@ const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
                     </UnstyledButton>
                 </HoverCard.Target>
                 <HoverCard.Dropdown maw={600} sx={{ overflow: 'scroll' }}>
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <Text
                             fz="xs"
                             fw={500}

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -1,9 +1,8 @@
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Center,
     CopyButton,
-    Group,
     Highlight,
     Loader,
     ScrollArea,
@@ -31,7 +30,7 @@ const TableField: FC<{
     const { ref: hoverRef, hovered } = useHover();
     const { ref: truncatedRef, isTruncated } = useIsTruncated<HTMLDivElement>();
     return (
-        <Group spacing={'xs'} noWrap ref={hoverRef}>
+        <Group gap={'xs'} wrap="nowrap" ref={hoverRef}>
             {hovered ? (
                 <Box display={hovered ? 'block' : 'none'}>
                     <CopyButton value={`${activeTable}.${field.name}`}>

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -1,10 +1,9 @@
 import { PartitionType, type PartitionColumn } from '@lightdash/common';
-import { Box, Stack, type BoxProps } from '@mantine-8/core';
+import { Box, Group, Stack, type BoxProps } from '@mantine-8/core';
 import {
     ActionIcon,
     Center,
     CopyButton,
-    Group,
     Highlight,
     Loader,
     ScrollArea,
@@ -221,7 +220,7 @@ const Table: FC<{
                     },
                 })}
             >
-                <Group noWrap spacing="two">
+                <Group wrap="nowrap" gap="two">
                     <Text p={6} fz="sm" c="ldGray.8">
                         {schema}
                     </Text>

--- a/packages/frontend/src/features/tableCalculation/components/TemplateViewer/TemplateViewer.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TemplateViewer/TemplateViewer.tsx
@@ -5,8 +5,8 @@ import {
     WindowFunctionType,
     type TableCalculationTemplate,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Badge, Group, MultiSelect, Text } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { Badge, MultiSelect, Text } from '@mantine/core';
 import { useCallback, useMemo, type FC } from 'react';
 import { useColumns } from '../../../../hooks/useColumns';
 import { selectDimensions, useExplorerSelector } from '../../../explorer/store';

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,10 +1,9 @@
 import { LightdashMode, type ApiErrorDetail } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     CopyButton,
-    Group,
     Modal,
     Tooltip,
     useMantineTheme,
@@ -82,7 +81,7 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
                 <Text mb={0} fw="bold">
                     Contact support with the following information:
                 </Text>
-                <Group spacing="xxs" align="flex-start">
+                <Group gap="xxs" align="flex-start">
                     <Text mb={0} fw="bold">
                         Error ID: {apiError.sentryEventId || 'n/a'}
                         <br />
@@ -170,7 +169,7 @@ const ApiErrorDisplayWithHealth = ({
                     <Text mb={0} c="red.6" style={{ whiteSpace: 'pre-wrap' }}>
                         {apiError.message}
                     </Text>
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <Button
                             size="compact-xs"
                             variant="outline"
@@ -215,7 +214,7 @@ const ApiErrorDisplayWithHealth = ({
                 <Text mb={0} fw="bold">
                     Contact support with the following information:
                 </Text>
-                <Group spacing="xxs" align="flex-start">
+                <Group gap="xxs" align="flex-start">
                     <Text mb={0} fw="bold">
                         Error ID: {apiError.sentryEventId || 'n/a'}
                         <br />

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -26,7 +26,8 @@ import {
     type ResultValue,
     type TableCalculation,
 } from '@lightdash/common';
-import { Group, Tooltip } from '@mantine/core';
+import { Group } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { IconExclamationCircle } from '@tabler/icons-react';
 import { type CellContext } from '@tanstack/react-table';
 import omit from 'lodash/omit';
@@ -711,7 +712,7 @@ export const useColumns = (): TableColumn[] => {
                     {
                         id: fieldId,
                         header: () => (
-                            <Group spacing="two">
+                            <Group gap="two">
                                 <Tooltip
                                     withinPortal
                                     label="This field was not found in the dbt project."

--- a/packages/frontend/src/pages/MobileCharts.tsx
+++ b/packages/frontend/src/pages/MobileCharts.tsx
@@ -3,8 +3,8 @@ import {
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { ActionIcon, Group, TextInput } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { ActionIcon, TextInput } from '@mantine/core';
 import { IconChartBar, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
@@ -49,7 +49,7 @@ const MobileCharts: FC = () => {
 
     return (
         <Stack gap="md" m="lg">
-            <Group position="apart">
+            <Group justify="space-between">
                 <PageBreadcrumbs
                     items={[
                         { title: 'Home', to: '/home' },

--- a/packages/frontend/src/pages/MobileDashboards.tsx
+++ b/packages/frontend/src/pages/MobileDashboards.tsx
@@ -3,8 +3,8 @@ import {
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { ActionIcon, Group, TextInput } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { ActionIcon, TextInput } from '@mantine/core';
 import { IconLayoutDashboard, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState } from 'react';
@@ -46,7 +46,7 @@ const MobileDashboards = () => {
 
     return (
         <Stack gap="md" m="lg">
-            <Group position="apart">
+            <Group justify="space-between">
                 <PageBreadcrumbs
                     items={[
                         { title: 'Home', to: '/home' },

--- a/packages/frontend/src/pages/MobileSpace.tsx
+++ b/packages/frontend/src/pages/MobileSpace.tsx
@@ -6,8 +6,8 @@ import {
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { ActionIcon, Group, TextInput } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { ActionIcon, TextInput } from '@mantine/core';
 import { IconLayoutDashboard, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
@@ -107,7 +107,7 @@ const MobileSpace: FC = () => {
 
     return (
         <Stack gap="md" m="lg">
-            <Group position="apart">
+            <Group justify="space-between">
                 <PageBreadcrumbs
                     items={[
                         {

--- a/packages/frontend/src/pages/MobileSpaces.tsx
+++ b/packages/frontend/src/pages/MobileSpaces.tsx
@@ -5,8 +5,8 @@ import {
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { ActionIcon, Group, TextInput } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { ActionIcon, TextInput } from '@mantine/core';
 import { IconFolders, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
@@ -70,7 +70,7 @@ const MobileSpaces: FC = () => {
     return (
         <>
             <Stack gap="md" m="lg">
-                <Group position="apart">
+                <Group justify="space-between">
                     <PageBreadcrumbs
                         items={[
                             { to: '/home', title: 'Home' },

--- a/packages/frontend/src/pages/SavedApps.tsx
+++ b/packages/frontend/src/pages/SavedApps.tsx
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import { ContentType, FeatureFlags } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { Group } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { Link, Navigate, useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
@@ -39,7 +38,7 @@ const SavedApps = () => {
                 withLargeContent
             >
                 <Stack gap="xxl" w="100%">
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <PageBreadcrumbs
                             items={[
                                 { title: 'Home', to: '/home' },

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -1,6 +1,5 @@
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { Group } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -52,7 +51,7 @@ const SavedDashboards = () => {
                 withLargeContent
             >
                 <Stack gap="xxl" w="100%">
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <PageBreadcrumbs
                             items={[
                                 { title: 'Home', to: '/home' },

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -1,6 +1,5 @@
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { Group } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -36,7 +35,7 @@ const SavedQueries: FC = () => {
                 withLargeContent
             >
                 <Stack gap="xxl" w="100%">
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <PageBreadcrumbs
                             items={[
                                 { title: 'Home', to: '/home' },

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -6,8 +6,8 @@ import {
     ResourceViewItemType,
     type ResourceViewSpaceItem,
 } from '@lightdash/common';
-import { Box, Button, Menu, Stack } from '@mantine-8/core';
-import { ActionIcon, Group } from '@mantine/core';
+import { Box, Button, Group, Menu, Stack } from '@mantine-8/core';
+import { ActionIcon } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconDots,
@@ -171,7 +171,7 @@ const Space: FC = () => {
                 withLargeContent
             >
                 <Stack gap="xxl" w="100%">
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <PageBreadcrumbs
                             items={[
                                 {
@@ -245,7 +245,7 @@ const Space: FC = () => {
                             ]}
                         />
 
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             {!isDemo &&
                                 (userCanCreateDashboards ||
                                     userCanCreateCharts ||

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { Group } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
 import { IconFolderPlus, IconPlus } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useParams } from 'react-router';
@@ -68,7 +67,7 @@ const Spaces: FC = () => {
                 withLargeContent
             >
                 <Stack gap="xxl" w="100%">
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <PageBreadcrumbs
                             items={[
                                 { to: '/home', title: 'Home' },
@@ -76,7 +75,7 @@ const Spaces: FC = () => {
                             ]}
                         />
 
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             {!isDemo && userCanManageSpace && (
                                 <Button
                                     leftSection={<IconPlus size={18} />}

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,6 +1,6 @@
 import { getFieldQuoteChar } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { ActionIcon, Group, Paper, Tooltip } from '@mantine/core';
+import { Group, Stack } from '@mantine-8/core';
+import { ActionIcon, Paper, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
@@ -189,7 +189,7 @@ const SqlRunner = ({
             <Group
                 align="stretch"
                 grow
-                spacing="none"
+                gap="none"
                 p={0}
                 style={{ flex: 1 }}
                 w={'100%'}

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -3,16 +3,8 @@ import {
     type UserActivity as UserActivityResponse,
     type UserWithCount,
 } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    Card,
-    Group,
-    Table,
-    Title,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
+import { Anchor, Card, Table, Title, Tooltip, Text } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';
@@ -232,7 +224,7 @@ const UserActivity: FC = () => {
 
     return (
         <Page title={`User activity for ${project?.name}`} withFitContent>
-            <Group mt={10} mb={30} position="apart">
+            <Group mt={10} mb={30} justify="space-between">
                 <PageBreadcrumbs
                     items={[
                         {

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -1,5 +1,5 @@
-import { Button, Stack } from '@mantine-8/core';
-import { Group, Title } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine-8/core';
+import { Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import MultipleToastBody from '../hooks/toaster/MultipleToastBody';


### PR DESCRIPTION
## What & why

Part 3 (final) of the Mantine v6 → v8 migration. Migrates **`Group`** (and `GroupProps`) from `@mantine/core` to `@mantine-8/core` across 94 files. **Stacked on #25234** (Button), which is stacked on #25233 (Stack/Box/Text) — review/merge those first.

Mixed imports are split; every other component stays on v6.

## Changes

- **94 files**: import splits + v8 Group prop renames on `<Group>` tags only:
  - `spacing` → `gap`
  - `noWrap` → `wrap="nowrap"`
  - `position` → `justify` **with the value remap**: `apart`→`space-between`, `center`→`center`, `left`→`flex-start`, `right`→`flex-end`
- **`sx` (removed in v8)** → CSS module where a selector is involved (`MetricCatalogCategoryFormItem.module.css`, `:focus`/`:hover`), otherwise inline `style` for static/dynamic layout values.

### Drive-by bugfix

`DashboardFiltersBar.tsx` (already fully on v8, not part of the import migration) had two `<Group justify="apart">` — `apart` is a **v6 `position` value, not a valid v8 `justify` / CSS `justify-content` value**, so it silently rendered as `flex-start` instead of `space-between`. Introduced by #24771. Fixed both to `justify="space-between"`. Surfaced by the migration's value-audit grep.

## Scope / regression analysis

- **Only** `Group` changes alias. Critically, `position` also exists on `<Tooltip>`, `<Popover>`, `<Menu>`, `<HoverCard>`, `<Drawer>`, `<Indicator>` — there it's a real v8 prop and is left untouched. Only `<Group>`'s `position` becomes `justify`.
- **Two-directional type safety**: v8 `Group` rejects `position`/`spacing`/`noWrap` (a missed rename fails typecheck), and non-Group components have no `justify` (a wrongly-renamed Tooltip fails typecheck).
- **The one gap types don't cover** is the `justify` *value* (`justify="apart"` compiles but renders wrong). Covered by an explicit repo-wide grep for `justify="apart|left|right"` — now zero (which is how the DashboardFiltersBar bug was found).
- `Config.Group` / `Tooltip.Group` / `Button.Group` compound components are unrelated and untouched.

## Verification

- `pnpm -F frontend typecheck:fast` — 0 errors
- `oxlint` on all 95 changed source files — 0 warnings / 0 errors
- `oxfmt --check` — clean
- `grep 'justify="(apart|left|right)"'` across `frontend/src` — 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UJY1ihpNm7LBPLqnMd8j3
