### PR TITLE
refactor(frontend): migrate Flex to mantine-8

### DIFF
--- a/packages/frontend/src/components/DataOps/index.tsx
+++ b/packages/frontend/src/components/DataOps/index.tsx
@@ -1,6 +1,6 @@
 import { ProjectType } from '@lightdash/common';
-import { Button } from '@mantine-8/core';
-import { Flex, Select, Title, Text } from '@mantine/core';
+import { Button, Flex } from '@mantine-8/core';
+import { Select, Title, Text } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useProject } from '../../hooks/useProject';
 import { useProjects } from '../../hooks/useProjects';

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -5,8 +5,8 @@ import {
     type CartesianChartDisplay,
     type ChartKind,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
-import { Flex, SegmentedControl, TextInput, Text } from '@mantine/core';
+import { Box, Flex, Group, Stack } from '@mantine-8/core';
+import { SegmentedControl, TextInput, Text } from '@mantine/core';
 import { IconAlignLeft, IconAlignRight } from '@tabler/icons-react';
 import MantineIcon from '../../common/MantineIcon';
 import ColorSelector from '../../VisualizationConfigs/ColorSelector';

--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
@@ -4,14 +4,8 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import {
-    Badge,
-    Flex,
-    Tooltip,
-    useMantineTheme,
-    type FlexProps,
-} from '@mantine/core';
+import { Flex, Group, type FlexProps } from '@mantine-8/core';
+import { Badge, Tooltip, useMantineTheme } from '@mantine/core';
 import { IconArrowDown, IconArrowUp } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import { useMemo } from 'react';
@@ -56,14 +50,10 @@ export const ChartDataTable = ({
             direction="column"
             miw="100%"
             {...flexProps}
-            sx={{
+            style={{
                 overflow: 'auto',
                 fontFeatureSettings: "'tnum'",
                 flexGrow: 1,
-                ...(typeof flexProps?.sx === 'object' &&
-                !Array.isArray(flexProps.sx)
-                    ? flexProps.sx
-                    : {}),
             }}
             className="sentry-block ph-no-capture"
             data-testid="chart-data-table"

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -5,8 +5,8 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Group, Menu } from '@mantine-8/core';
-import { Badge, Flex, useMantineTheme, type FlexProps } from '@mantine/core';
+import { Flex, Group, Menu, type FlexProps } from '@mantine-8/core';
+import { Badge, useMantineTheme } from '@mantine/core';
 import { IconArrowDown, IconArrowUp, IconCopy } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -91,14 +91,10 @@ export const Table = <T extends IResultsRunner>({
             direction="column"
             miw="100%"
             {...flexProps}
-            sx={{
+            style={{
                 overflow: 'auto',
                 fontFeatureSettings: "'tnum'",
                 flexGrow: 1,
-                ...(typeof flexProps?.sx === 'object' &&
-                !Array.isArray(flexProps.sx)
-                    ? flexProps.sx
-                    : {}),
             }}
             className="sentry-block ph-no-capture"
         >

--- a/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
@@ -1,5 +1,5 @@
-import { Button, Stack } from '@mantine-8/core';
-import { ActionIcon, Flex, Input, TextInput } from '@mantine/core';
+import { Button, Flex, Stack } from '@mantine-8/core';
+import { ActionIcon, Input, TextInput } from '@mantine/core';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import get from 'lodash/get';
 import { useState, type ReactNode } from 'react';

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -1,6 +1,6 @@
 import { ProjectType, type DbtProjectType } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Avatar, Flex, TextInput, Title, Text } from '@mantine/core';
+import { Flex, Stack } from '@mantine-8/core';
+import { Avatar, TextInput, Title, Text } from '@mantine/core';
 import { type FC } from 'react';
 import useApp from '../../providers/App/useApp';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';

--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -6,8 +6,8 @@ import {
     type CreateWarehouseCredentials,
     type Project,
 } from '@lightdash/common';
-import { Box, Button } from '@mantine-8/core';
-import { Alert, Anchor, Card, Flex } from '@mantine/core';
+import { Box, Button, Flex } from '@mantine-8/core';
+import { Alert, Anchor, Card } from '@mantine/core';
 import { IconExclamationCircle, IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -1,10 +1,9 @@
 import { subject } from '@casl/ability';
 import { hasIntersection, TableSelectionType } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
+import { Box, Button, Flex, Stack } from '@mantine-8/core';
 import {
     Anchor,
     Collapse,
-    Flex,
     Highlight,
     Loader,
     MultiSelect,

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Button } from '@mantine-8/core';
-import { Flex, Text } from '@mantine/core';
+import { Box, Button, Flex } from '@mantine-8/core';
+import { Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -6,10 +6,9 @@ import {
     validateOrganizationEmailDomains,
     type AllowedEmailDomains,
 } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
+import { Button, Flex, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Flex,
     MultiSelect,
     Select,
     Title,

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,10 +1,9 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { Button, Group } from '@mantine-8/core';
+import { Button, Flex, Group } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
     ColorSwatch,
-    Flex,
     Menu,
     Paper,
     Tooltip,

--- a/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
@@ -1,6 +1,6 @@
 import { ProjectType } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { Flex, Select } from '@mantine/core';
+import { Button, Flex, Stack } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useEffect, type FC } from 'react';
 import { z } from 'zod';

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -1,13 +1,5 @@
-import { Box, Button, Group, Stack } from '@mantine-8/core';
-import {
-    Alert,
-    Avatar,
-    Flex,
-    Loader,
-    Title,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Flex, Group, Stack } from '@mantine-8/core';
+import { Alert, Avatar, Loader, Title, Tooltip, Text } from '@mantine/core';
 import {
     IconAlertCircle,
     IconClock,

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Button, Group, Stack } from '@mantine-8/core';
-import { Alert, Avatar, Flex, Loader, Title, Text } from '@mantine/core';
+import { Box, Button, Flex, Group, Stack } from '@mantine-8/core';
+import { Alert, Avatar, Loader, Title, Text } from '@mantine/core';
 import { IconAlertCircle, IconRefresh, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import gitlabIcon from '../../../svgs/gitlab-icon.svg';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Button, Group } from '@mantine-8/core';
-import { Flex, Loader, useMantineTheme, Text } from '@mantine/core';
+import { Button, Flex, Group } from '@mantine-8/core';
+import { Loader, useMantineTheme, Text } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
@@ -1,5 +1,6 @@
 import type { EchartsGrid, EchartsLegend } from '@lightdash/common';
-import { Badge, Center, Flex, SimpleGrid } from '@mantine/core';
+import { Flex } from '@mantine-8/core';
+import { Badge, Center, SimpleGrid } from '@mantine/core';
 import { type FC } from 'react';
 import UnitInput from '../../../common/UnitInput';
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -10,7 +10,8 @@ import {
     type BaseFilterRule,
     type DateFilterRule,
 } from '@lightdash/common';
-import { Flex, NumberInput, Text } from '@mantine/core';
+import { Flex } from '@mantine-8/core';
+import { NumberInput, Text } from '@mantine/core';
 import dayjs from 'dayjs';
 import { type FilterInputsProps } from '.';
 import useFiltersContext from '../useFiltersContext';

--- a/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/PresetsForm/AudienceInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/PresetsForm/AudienceInput.tsx
@@ -1,11 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Flex,
-    TextInput,
-    type SystemProp,
-    Text,
-} from '@mantine/core';
+import { Flex, Stack } from '@mantine-8/core';
+import { ActionIcon, TextInput, type SystemProp, Text } from '@mantine/core';
 import { type UseFormReturnType } from '@mantine/form';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
 import {

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -14,12 +14,11 @@ import {
     type DashboardTile,
     type Field,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Flex, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Checkbox,
     Collapse,
-    Flex,
     Select,
     Tooltip,
     useMantineTheme,

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -19,15 +19,8 @@ import {
     type DashboardTile,
     type ResultColumn,
 } from '@lightdash/common';
-import { Box, Button, Group, Stack } from '@mantine-8/core';
-import {
-    Flex,
-    Select,
-    Tabs,
-    Tooltip,
-    type PopoverProps,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Flex, Group, Stack } from '@mantine-8/core';
+import { Select, Tabs, Tooltip, type PopoverProps, Text } from '@mantine/core';
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';

--- a/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.test.tsx
+++ b/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.test.tsx
@@ -1,6 +1,17 @@
 import { render, screen } from '@testing-library/react';
+import { type FC, type PropsWithChildren } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import Mantine8Provider from '../../providers/Mantine8Provider';
+import MantineProvider from '../../providers/MantineProvider';
 import ChunkErrorRouteBoundary from './ChunkErrorRouteBoundary';
+
+// ChunkErrorRouteBoundary renders a Mantine 8 <Flex>, which needs both the v6
+// and v8 providers (the v8 provider reads color scheme from the v6 one).
+const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <MantineProvider>
+        <Mantine8Provider>{children}</Mantine8Provider>
+    </MantineProvider>
+);
 
 const mockUseRouteError = vi.fn();
 const mockIsChunkLoadErrorObject = vi.fn();
@@ -39,6 +50,8 @@ describe('ChunkErrorRouteBoundary', () => {
         mockIsChunkLoadErrorObject.mockReturnValue(true);
         mockHasRecentChunkReload.mockReturnValue(false);
 
+        // This path auto-reloads and renders nothing (no Mantine tree), so it
+        // needs no provider wrapper — asserting an empty container.
         const { container } = render(<ChunkErrorRouteBoundary />);
 
         expect(mockTriggerChunkErrorReload).toHaveBeenCalledTimes(1);
@@ -50,7 +63,7 @@ describe('ChunkErrorRouteBoundary', () => {
         mockIsChunkLoadErrorObject.mockReturnValue(true);
         mockHasRecentChunkReload.mockReturnValue(true);
 
-        render(<ChunkErrorRouteBoundary />);
+        render(<ChunkErrorRouteBoundary />, { wrapper: Wrapper });
 
         expect(mockTriggerChunkErrorReload).not.toHaveBeenCalled();
         expect(screen.getByText('chunk-fallback')).toBeInTheDocument();
@@ -60,7 +73,7 @@ describe('ChunkErrorRouteBoundary', () => {
         mockUseRouteError.mockReturnValue(new Error('boom'));
         mockIsChunkLoadErrorObject.mockReturnValue(false);
 
-        render(<ChunkErrorRouteBoundary />);
+        render(<ChunkErrorRouteBoundary />, { wrapper: Wrapper });
 
         expect(mockCaptureException).toHaveBeenCalledTimes(1);
         expect(mockTriggerChunkErrorReload).not.toHaveBeenCalled();

--- a/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/ChunkErrorRouteBoundary.tsx
@@ -1,5 +1,5 @@
 import { ERROR_BOUNDARY_ID } from '@lightdash/common';
-import { Flex } from '@mantine/core';
+import { Flex } from '@mantine-8/core';
 import * as Sentry from '@sentry/react';
 import { useEffect, useState, type FC } from 'react';
 import { useRouteError } from 'react-router';

--- a/packages/frontend/src/features/errorBoundary/ErrorBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { ERROR_BOUNDARY_ID } from '@lightdash/common';
-import { Flex, type FlexProps } from '@mantine/core';
+import { Flex, type FlexProps } from '@mantine-8/core';
 import * as Sentry from '@sentry/react';
 import { type FC, type PropsWithChildren } from 'react';
 import {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,6 +1,6 @@
 import { SpotlightTableColumns, type CatalogField } from '@lightdash/common';
-import { Box, Button, Group } from '@mantine-8/core';
-import { Flex, Text } from '@mantine/core';
+import { Box, Button, Flex, Group } from '@mantine-8/core';
+import { Text } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus, IconUser } from '@tabler/icons-react';
 import { useMemo } from 'react';
@@ -273,7 +273,7 @@ export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
 
                         table.setEditingCell(cell);
                     }}
-                    sx={{
+                    style={{
                         cursor: canManageTags ? 'pointer' : 'default',
                     }}
                 >

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -2,11 +2,10 @@ import type {
     ApiError,
     GeneratedFormulaTableCalculation,
 } from '@lightdash/common';
-import { Box, Button } from '@mantine-8/core';
+import { Box, Button, Flex } from '@mantine-8/core';
 import {
     Alert,
     Anchor,
-    Flex,
     ScrollArea,
     useMantineTheme,
     Text,


### PR DESCRIPTION
## What & why

Part 4 of the Mantine v6 → v8 migration. Migrates **`Flex`** (and `FlexProps`) from `@mantine/core` to `@mantine-8/core` across 24 files. **Stacked on #25238** (Group) → #25234 → #25233 — merge those first.

## Changes

- **24 files**: import splits only. **Zero prop renames** — v8 `Flex` keeps `gap`/`align`/`justify`/`direction`/`wrap` identically.
- The 3 `sx` usages on `<Flex>` tags → inline `style` (static/dynamic layout objects, no selectors → no CSS module needed).
- Dropped a dead `flexProps?.sx` passthrough branch in `ChartDataTable`/`Table` DataViz wrappers — verified all callers pass only layout props, and v8 `FlexProps` has no `sx` field.

## Scope / regression analysis

- **Only** `Flex` changes alias; every other component stays on v6.
- Pure import move + `sx` removal — v8 accepts identical props, so typecheck backstops the whole change.
- One cross-version render to spot-check: `UpdateProjectConnection` has a v6 `<Card component={Flex}>` whose root is now the v8 `Flex` (Card's own `sx` stays v6). Renders fine; noted for awareness.

## Verification

- `pnpm -F frontend typecheck:fast` — 0 errors
- `oxlint` on all 24 changed files — 0 warnings / 0 errors
- `oxfmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UJY1ihpNm7LBPLqnMd8j3
