### PR TITLE
refactor(frontend): migrate Divider to mantine-8

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -1,8 +1,7 @@
-import { Group, Stack } from '@mantine-8/core';
+import { Divider, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Burger,
-    Divider,
     Drawer,
     getDefaultZIndex,
     Header,

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
@@ -1,6 +1,6 @@
 import { type QueryWarning } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { ActionIcon, Divider, Popover, Title, Tooltip } from '@mantine/core';
+import { Box, Divider, Stack } from '@mantine-8/core';
+import { ActionIcon, Popover, Title, Tooltip } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { Fragment, useState, type FC } from 'react';

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -1,13 +1,6 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Divider,
-    Loader,
-    ScrollArea,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Divider, Group } from '@mantine-8/core';
+import { ActionIcon, Loader, ScrollArea, Tooltip, Text } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { lazy, Suspense, useMemo, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
@@ -8,8 +8,8 @@ import {
     type ResultRow,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Group, ScrollArea, Stack } from '@mantine-8/core';
-import { Divider, SegmentedControl, Text } from '@mantine/core';
+import { Box, Divider, Group, ScrollArea, Stack } from '@mantine-8/core';
+import { SegmentedControl, Text } from '@mantine/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import ColorSelector from '../../ColorSelector';
 import { ChartConditionalFormatting } from './ChartConditionalFormatting';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -15,8 +15,8 @@ import {
     type Series as SeriesType,
     type TableCalculation,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Checkbox, Divider, Switch } from '@mantine/core';
+import { Divider, Stack } from '@mantine-8/core';
+import { Checkbox, Switch } from '@mantine/core';
 import { produce } from 'immer';
 import React, { Fragment, useCallback, useMemo, type FC } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,12 +13,11 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Box, Button, Group } from '@mantine-8/core';
+import { Box, Button, Divider, Group } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
 import {
     ActionIcon,
     Anchor,
-    Divider,
     TextInput,
     Tooltip,
     useMantineTheme,
@@ -707,7 +706,7 @@ const InfiniteResourceTable = ({
                                         orientation="vertical"
                                         w={1}
                                         h={20}
-                                        sx={{
+                                        style={{
                                             alignSelf: 'center',
                                             borderColor: '#DEE2E6',
                                         }}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -1,8 +1,7 @@
 import { getErrorMessage, type CatalogItem } from '@lightdash/common';
-import { Box, Button, Group, Stack } from '@mantine-8/core';
+import { Box, Button, Divider, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Divider,
     Popover,
     SimpleGrid,
     TextInput,
@@ -139,9 +138,9 @@ const EditPopover: FC<EditPopoverProps> = ({
 
                     <Divider
                         c="ldGray.2"
-                        sx={(theme) => ({
-                            borderTopColor: theme.colors.ldGray[2],
-                        })}
+                        style={{
+                            borderTopColor: 'var(--mantine-color-ldGray-2)',
+                        }}
                     />
 
                     <Group justify="space-between">

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,15 +5,8 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
-import {
-    Anchor,
-    Center,
-    Divider,
-    Paper,
-    useMantineTheme,
-    Text,
-} from '@mantine/core';
+import { Box, Divider, Group } from '@mantine-8/core';
+import { Anchor, Center, Paper, useMantineTheme, Text } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowsSort,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -20,12 +20,18 @@ import {
     type CatalogCategoryFilterMode,
     type CatalogField,
 } from '@lightdash/common';
-import { Box, Button, Group, Stack, type GroupProps } from '@mantine-8/core';
+import {
+    Box,
+    Button,
+    Divider,
+    Group,
+    Stack,
+    type GroupProps,
+} from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
     Center,
-    Divider,
     Popover,
     SegmentedControl,
     TextInput,
@@ -382,9 +388,9 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            sx={{
+                            style={{
                                 alignSelf: 'center',
-                                borderColor: 'ldGray.3',
+                                borderColor: 'var(--mantine-color-ldGray-3)',
                             }}
                         />
                     )}
@@ -563,7 +569,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                         orientation="vertical"
                         w={1}
                         h={20}
-                        sx={{
+                        style={{
                             alignSelf: 'center',
                             borderColor: '#DEE2E6',
                         }}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -4,9 +4,8 @@ import {
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { Box, Button, Group, Stack } from '@mantine-8/core';
+import { Box, Button, Divider, Group, Stack } from '@mantine-8/core';
 import {
-    Divider,
     Popover,
     SegmentedControl,
     TextInput,

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -8,12 +8,11 @@ import {
     SEED_ORG_1_ADMIN_PASSWORD,
     type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine-8/core';
+import { Box, Button, Divider, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     Card,
-    Divider,
     PasswordInput,
     TextInput,
     Title,


### PR DESCRIPTION
## What & why

Part 5 of the Mantine v6 → v8 migration. Migrates **`Divider`** (and `DividerProps`) from `@mantine/core` to `@mantine-8/core` across 11 files. **Stacked on #25239** (Flex) → #25238 → #25234 → #25233.

## Changes

- **11 files**: import splits only. **Zero prop renames** — v8 `Divider` keeps `label`/`labelPosition`/`orientation`/`size`/`color`.
- A few `sx` usages on `<Divider>` → inline `style` (static layout/color objects, no selectors). Color tokens (`ldGray.3`) mapped to CSS vars (`var(--mantine-color-ldGray-3)`) since plain `style` doesn't resolve Mantine tokens.

## Scope / regression analysis

- **Only** `Divider` changes alias; every other component stays on v6.
- Pure import move — typecheck backstops the change.
- Minor: three Dividers set their border color via the converted `style` `borderColor`; renders the same, but `color` is arguably the more idiomatic v8 prop — noted for reviewer preference.

## Verification

- `pnpm -F frontend typecheck:fast` — 0 errors
- `oxlint` on all 11 changed files — 0 warnings / 0 errors
- `oxfmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UJY1ihpNm7LBPLqnMd8j3
