### PR TITLE
feat(analytics): emit ai.usage token events into logs and the usage event stream (PROD-8610)

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -29,6 +29,7 @@ import path from 'path';
 import qs from 'qs';
 import reDoc from 'redoc-express';
 import { URL } from 'url';
+import { registerAiUsageTracker } from './analytics/aiUsage';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
@@ -221,6 +222,7 @@ export default class App {
                   )
                 : undefined,
         });
+        registerAiUsageTracker((event) => this.analytics.track(event));
         this.database = knex(
             this.environment === 'production'
                 ? args.knexConfig.production

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
+import { registerAiUsageTracker } from './analytics/aiUsage';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
@@ -131,6 +132,7 @@ export default class NatsWorkerApp {
                   )
                 : undefined,
         });
+        registerAiUsageTracker((event) => this.analytics.track(event));
 
         this.database = knex(
             this.environment === 'production'

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
+import { registerAiUsageTracker } from './analytics/aiUsage';
 import { BufferedEventStreamWriter } from './analytics/eventStream/BufferedEventStreamWriter';
 import { createEventStreamWriter } from './analytics/eventStream/createEventStreamWriter';
 import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
@@ -167,6 +168,7 @@ export default class SchedulerApp {
                   )
                 : undefined,
         });
+        registerAiUsageTracker((event) => this.analytics.track(event));
 
         this.database = knex(
             this.environment === 'production'

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -44,6 +44,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
 import { type ExternalConnectionEvent } from '../ee/analytics';
 import { VERSION } from '../version';
+import type { AiUsageEvent } from './aiUsage';
 import type { EventStreamSink } from './eventStream/EventStreamSink';
 
 type Identify = {
@@ -2534,7 +2535,8 @@ type TypedEvent =
     | AiRouterMessageRoutedEvent
     | ContentVerificationEvent
     | SchedulerOwnershipReassignedEvent
-    | ImpersonationEvent;
+    | ImpersonationEvent
+    | AiUsageEvent;
 
 type UntypedEvent<T extends BaseTrack> = Omit<BaseTrack, 'event'> &
     T & {

--- a/packages/backend/src/analytics/aiUsage.test.ts
+++ b/packages/backend/src/analytics/aiUsage.test.ts
@@ -134,11 +134,20 @@ describe('emitAiUsage', () => {
             ...tokens,
         };
 
-        expect(Logger.info).toHaveBeenCalledWith('AI usage', {
-            event: 'ai.usage',
-            userId: 'user-1',
-            ...expectedProperties,
-        });
+        expect(Logger.info).toHaveBeenCalledWith(
+            expect.stringContaining('AI usage:'),
+            {
+                event: 'ai.usage',
+                userId: 'user-1',
+                ...expectedProperties,
+            },
+        );
+        // Token data must be in the message string itself so the default
+        // pretty/plain log formats (which drop metadata) still surface it.
+        expect(Logger.info).toHaveBeenCalledWith(
+            expect.stringContaining('totalTokens=1200'),
+            expect.anything(),
+        );
         expect(track).toHaveBeenCalledWith({
             event: 'ai.usage',
             userId: 'user-1',

--- a/packages/backend/src/analytics/aiUsage.test.ts
+++ b/packages/backend/src/analytics/aiUsage.test.ts
@@ -1,0 +1,177 @@
+import Logger from '../logging/logger';
+import {
+    AiUsageEvent,
+    embeddingModelUsageToTokens,
+    emitAiUsage,
+    languageModelUsageToTokens,
+    registerAiUsageTracker,
+} from './aiUsage';
+
+vi.mock('../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+describe('languageModelUsageToTokens', () => {
+    it('maps AI SDK usage to token classes', () => {
+        expect(
+            languageModelUsageToTokens({
+                inputTokens: 1000,
+                inputTokenDetails: {
+                    noCacheTokens: 150,
+                    cacheReadTokens: 800,
+                    cacheWriteTokens: 50,
+                },
+                outputTokens: 200,
+                outputTokenDetails: {
+                    textTokens: 170,
+                    reasoningTokens: 30,
+                },
+                totalTokens: 1200,
+            }),
+        ).toEqual({
+            inputTokens: 1000,
+            outputTokens: 200,
+            cacheReadTokens: 800,
+            cacheWriteTokens: 50,
+            reasoningTokens: 30,
+            totalTokens: 1200,
+        });
+    });
+
+    it('maps unreported token classes to null', () => {
+        expect(
+            languageModelUsageToTokens({
+                inputTokens: undefined,
+                inputTokenDetails: {
+                    noCacheTokens: undefined,
+                    cacheReadTokens: undefined,
+                    cacheWriteTokens: undefined,
+                },
+                outputTokens: undefined,
+                outputTokenDetails: {
+                    textTokens: undefined,
+                    reasoningTokens: undefined,
+                },
+                totalTokens: undefined,
+            }),
+        ).toEqual({
+            inputTokens: null,
+            outputTokens: null,
+            cacheReadTokens: null,
+            cacheWriteTokens: null,
+            reasoningTokens: null,
+            totalTokens: null,
+        });
+    });
+});
+
+describe('embeddingModelUsageToTokens', () => {
+    it('maps embedding tokens to input and total', () => {
+        expect(embeddingModelUsageToTokens({ tokens: 42 })).toEqual({
+            inputTokens: 42,
+            outputTokens: null,
+            cacheReadTokens: null,
+            cacheWriteTokens: null,
+            reasoningTokens: null,
+            totalTokens: 42,
+        });
+    });
+});
+
+describe('emitAiUsage', () => {
+    const tokens = {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheReadTokens: 800,
+        cacheWriteTokens: 50,
+        reasoningTokens: 30,
+        totalTokens: 1200,
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        registerAiUsageTracker(() => {});
+    });
+
+    it('emits a structured log line and a tracked event', () => {
+        const track = vi.fn<(event: AiUsageEvent) => void>();
+        registerAiUsageTracker(track);
+
+        emitAiUsage(
+            {
+                functionId: 'generateAgentResponse',
+                metadata: {
+                    feature: 'agent',
+                    organizationUuid: 'org-1',
+                    projectUuid: 'project-1',
+                    agentUuid: 'agent-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    userUuid: 'user-1',
+                    model: 'claude-sonnet-5',
+                    provider: 'anthropic',
+                },
+            },
+            tokens,
+        );
+
+        const expectedProperties = {
+            feature: 'agent',
+            functionId: 'generateAgentResponse',
+            organizationId: 'org-1',
+            projectId: 'project-1',
+            aiAgentId: 'agent-1',
+            threadId: 'thread-1',
+            promptId: 'prompt-1',
+            model: 'claude-sonnet-5',
+            provider: 'anthropic',
+            ...tokens,
+        };
+
+        expect(Logger.info).toHaveBeenCalledWith('AI usage', {
+            event: 'ai.usage',
+            userId: 'user-1',
+            ...expectedProperties,
+        });
+        expect(track).toHaveBeenCalledWith({
+            event: 'ai.usage',
+            userId: 'user-1',
+            properties: expectedProperties,
+        });
+    });
+
+    it('falls back to an anonymous id when no user is attributed', () => {
+        const track = vi.fn<(event: AiUsageEvent) => void>();
+        registerAiUsageTracker(track);
+
+        emitAiUsage(
+            {
+                functionId: 'routeProject',
+                metadata: {
+                    feature: 'project-router',
+                    organizationUuid: 'org-1',
+                },
+            },
+            tokens,
+        );
+
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({ anonymousId: 'anonymous' }),
+        );
+        expect(track.mock.calls[0][0].userId).toBeUndefined();
+    });
+
+    it('still logs when no tracker is registered', () => {
+        emitAiUsage(
+            { functionId: 'fn', metadata: { feature: 'llm-judge' } },
+            tokens,
+        );
+        expect(Logger.info).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/analytics/aiUsage.ts
+++ b/packages/backend/src/analytics/aiUsage.ts
@@ -58,14 +58,20 @@ export const languageModelUsageToTokens = (
 
 export const embeddingModelUsageToTokens = (
     usage: EmbeddingModelUsage,
-): AiUsageTokens => ({
-    inputTokens: usage.tokens,
-    outputTokens: null,
-    cacheReadTokens: null,
-    cacheWriteTokens: null,
-    reasoningTokens: null,
-    totalTokens: usage.tokens,
-});
+): AiUsageTokens => {
+    // The AI SDK substitutes `{ tokens: NaN }` when the provider omits usage,
+    // and NaN is not nullish — coerce non-finite (or absent) values to null so
+    // "the provider did not report" stays honest.
+    const tokens = Number.isFinite(usage?.tokens) ? usage.tokens : null;
+    return {
+        inputTokens: tokens,
+        outputTokens: null,
+        cacheReadTokens: null,
+        cacheWriteTokens: null,
+        reasoningTokens: null,
+        totalTokens: tokens,
+    };
+};
 
 /**
  * One event per AI model call, emitted 100% unsampled (unlike traces) so
@@ -147,11 +153,22 @@ export const emitAiUsage = (
             ...tokens,
         };
 
-        Logger.info('AI usage', {
-            event: 'ai.usage',
-            userId: userUuid,
-            ...properties,
-        });
+        // Interpolate the key fields into the message itself: the default
+        // `pretty`/`plain` log formats render only the message string and drop
+        // all metadata, so log-based consumers would otherwise see a bare
+        // `AI usage` line with no token data.
+        Logger.info(
+            `AI usage: feature=${properties.feature} provider=${properties.provider} model=${properties.model} ` +
+                `inputTokens=${properties.inputTokens} outputTokens=${properties.outputTokens} ` +
+                `cacheReadTokens=${properties.cacheReadTokens} cacheWriteTokens=${properties.cacheWriteTokens} ` +
+                `reasoningTokens=${properties.reasoningTokens} totalTokens=${properties.totalTokens} ` +
+                `organizationId=${properties.organizationId} projectId=${properties.projectId} userId=${userUuid}`,
+            {
+                event: 'ai.usage',
+                userId: userUuid,
+                ...properties,
+            },
+        );
 
         aiUsageTrackFn?.({
             event: 'ai.usage',

--- a/packages/backend/src/analytics/aiUsage.ts
+++ b/packages/backend/src/analytics/aiUsage.ts
@@ -1,0 +1,166 @@
+import { Track as AnalyticsTrack } from '@rudderstack/rudder-sdk-node';
+import type { EmbeddingModelUsage, LanguageModelUsage } from 'ai';
+import Logger from '../logging/logger';
+
+type BaseTrack = Omit<AnalyticsTrack, 'context'>;
+
+/**
+ * Coarse feature bucket for an AI call. Lets us attribute token usage and cost
+ * to a product surface (data apps vs the agent vs metadata generation, etc.)
+ * independently of the fine-grained `functionId`.
+ */
+export type AiCallFeature =
+    | 'agent'
+    | 'agent-subtask'
+    | 'chart-metadata'
+    | 'document-summary'
+    | 'thread-title'
+    | 'tooltip'
+    | 'artifact-question'
+    | 'agent-suggestions'
+    | 'table-calc'
+    | 'formula-table-calc'
+    | 'compaction'
+    | 'embedding'
+    | 'project-router'
+    | 'agent-selector'
+    | 'review-classifier'
+    | 'llm-judge'
+    | 'data-app'
+    | 'managed-agent';
+
+/**
+ * Token counts for a single AI call, normalized across providers and call
+ * kinds (LLM text/object generation, embeddings). Null means the provider
+ * did not report that class of tokens.
+ */
+export type AiUsageTokens = {
+    inputTokens: number | null;
+    outputTokens: number | null;
+    cacheReadTokens: number | null;
+    cacheWriteTokens: number | null;
+    reasoningTokens: number | null;
+    totalTokens: number | null;
+};
+
+// Defensive against the type: providers (and test mocks) don't always report
+// usage, and a missing field must never throw into the AI call path.
+export const languageModelUsageToTokens = (
+    usage: LanguageModelUsage,
+): AiUsageTokens => ({
+    inputTokens: usage?.inputTokens ?? null,
+    outputTokens: usage?.outputTokens ?? null,
+    cacheReadTokens: usage?.inputTokenDetails?.cacheReadTokens ?? null,
+    cacheWriteTokens: usage?.inputTokenDetails?.cacheWriteTokens ?? null,
+    reasoningTokens: usage?.outputTokenDetails?.reasoningTokens ?? null,
+    totalTokens: usage?.totalTokens ?? null,
+});
+
+export const embeddingModelUsageToTokens = (
+    usage: EmbeddingModelUsage,
+): AiUsageTokens => ({
+    inputTokens: usage.tokens,
+    outputTokens: null,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    reasoningTokens: null,
+    totalTokens: usage.tokens,
+});
+
+/**
+ * One event per AI model call, emitted 100% unsampled (unlike traces) so
+ * token usage can be accounted per org/user/feature. Consumed by the usage
+ * event stream sink (`ai_usage` stream) and Rudderstack.
+ */
+export type AiUsageEvent = BaseTrack & {
+    event: 'ai.usage';
+    properties: {
+        feature: AiCallFeature;
+        functionId: string;
+        organizationId: string | null;
+        projectId: string | null;
+        aiAgentId: string | null;
+        threadId: string | null;
+        promptId: string | null;
+        model: string | null;
+        provider: string | null;
+    } & AiUsageTokens;
+};
+
+type AiUsageTrackFn = (event: AiUsageEvent) => void;
+
+let aiUsageTrackFn: AiUsageTrackFn | null = null;
+
+/**
+ * Registered once per process at app construction (API, scheduler, NATS
+ * worker). Module-level because `ai.usage` is emitted from pure helper
+ * functions (AI generators) that have no access to the LightdashAnalytics
+ * instance — same pattern as the global Logger.
+ */
+export const registerAiUsageTracker = (fn: AiUsageTrackFn): void => {
+    aiUsageTrackFn = fn;
+};
+
+/**
+ * Structural subset of the `experimental_telemetry` config built by
+ * `getAiCallTelemetry`, which every AI call site already holds — its metadata
+ * carries the feature + attribution dimensions.
+ */
+type AiCallTelemetryConfig = {
+    functionId: string;
+    metadata: Record<string, string | number | boolean>;
+};
+
+const getMetadataString = (
+    metadata: AiCallTelemetryConfig['metadata'],
+    key: string,
+): string | null => {
+    const value = metadata[key];
+    return typeof value === 'string' ? value : null;
+};
+
+/**
+ * Emits token usage for a single AI call in two forms:
+ * 1. A structured log line (marker `event: 'ai.usage'`) so any log stack can
+ *    consume it. Level `info` on purpose — prod log thresholds must include
+ *    it or usage silently vanishes from log-based consumers.
+ * 2. An `ai.usage` analytics event through `track()`, which the usage event
+ *    stream sink projects into the `ai_usage` stream.
+ */
+export const emitAiUsage = (
+    telemetry: AiCallTelemetryConfig,
+    tokens: AiUsageTokens,
+): void => {
+    try {
+        const { metadata } = telemetry;
+        const userUuid = getMetadataString(metadata, 'userUuid');
+        const properties: AiUsageEvent['properties'] = {
+            feature: metadata.feature as AiCallFeature,
+            functionId: telemetry.functionId,
+            organizationId: getMetadataString(metadata, 'organizationUuid'),
+            projectId: getMetadataString(metadata, 'projectUuid'),
+            aiAgentId: getMetadataString(metadata, 'agentUuid'),
+            threadId: getMetadataString(metadata, 'threadUuid'),
+            promptId: getMetadataString(metadata, 'promptUuid'),
+            model: getMetadataString(metadata, 'model'),
+            provider: getMetadataString(metadata, 'provider'),
+            ...tokens,
+        };
+
+        Logger.info('AI usage', {
+            event: 'ai.usage',
+            userId: userUuid,
+            ...properties,
+        });
+
+        aiUsageTrackFn?.({
+            event: 'ai.usage',
+            ...(userUuid !== null
+                ? { userId: userUuid }
+                : { anonymousId: 'anonymous' }),
+            properties,
+        });
+    } catch (error) {
+        Logger.warn(`Failed to emit AI usage: ${error}`);
+    }
+};

--- a/packages/backend/src/analytics/eventStream/aiUsageStream.test.ts
+++ b/packages/backend/src/analytics/eventStream/aiUsageStream.test.ts
@@ -1,0 +1,126 @@
+import type { AiUsageEvent } from '../aiUsage';
+import { EventStreamSink } from './EventStreamSink';
+import { EVENT_STREAM_SCHEMA_VERSION } from './projection';
+import { eventStreamRegistry } from './registry';
+import { EventStreamRow } from './types';
+
+vi.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const createWriterMock = () => ({
+    push: vi.fn<(stream: string, row: EventStreamRow) => void>(),
+    flush: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+});
+
+const aiUsageEvent: AiUsageEvent = {
+    event: 'ai.usage',
+    userId: 'user-1',
+    properties: {
+        feature: 'agent',
+        functionId: 'generateAgentResponse',
+        organizationId: 'org-1',
+        projectId: 'project-1',
+        aiAgentId: 'agent-1',
+        threadId: 'thread-1',
+        promptId: 'prompt-1',
+        model: 'claude-sonnet-5',
+        provider: 'anthropic',
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheReadTokens: 800,
+        cacheWriteTokens: 50,
+        reasoningTokens: 30,
+        totalTokens: 1200,
+    },
+};
+
+describe('ai_usage stream projection', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('projects an ai.usage event', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle(aiUsageEvent);
+        expect(writer.push).toHaveBeenCalledTimes(1);
+        const [stream, row] = writer.push.mock.calls[0];
+        expect(stream).toBe('ai_usage');
+        expect(row).toMatchObject({
+            event_name: 'ai.usage',
+            org_id: 'org-1',
+            user_id: 'user-1',
+            schema_version: EVENT_STREAM_SCHEMA_VERSION,
+            project_id: 'project-1',
+            feature: 'agent',
+            function_id: 'generateAgentResponse',
+            agent_id: 'agent-1',
+            thread_id: 'thread-1',
+            prompt_id: 'prompt-1',
+            model: 'claude-sonnet-5',
+            provider: 'anthropic',
+            input_tokens: 1000,
+            output_tokens: 200,
+            cache_read_tokens: 800,
+            cache_write_tokens: 50,
+            reasoning_tokens: 30,
+            total_tokens: 1200,
+        });
+        expect(new Date(row.event_ts).toISOString()).toBe(row.event_ts);
+    });
+
+    it('projects null dimensions and token classes as null columns', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle({
+            ...aiUsageEvent,
+            properties: {
+                ...aiUsageEvent.properties,
+                projectId: null,
+                aiAgentId: null,
+                threadId: null,
+                promptId: null,
+                model: null,
+                provider: null,
+                cacheReadTokens: null,
+                cacheWriteTokens: null,
+                reasoningTokens: null,
+            },
+        });
+        expect(writer.push).toHaveBeenCalledTimes(1);
+        const [, row] = writer.push.mock.calls[0];
+        expect(row).toMatchObject({
+            event_name: 'ai.usage',
+            project_id: null,
+            agent_id: null,
+            thread_id: null,
+            prompt_id: null,
+            model: null,
+            provider: null,
+            cache_read_tokens: null,
+            cache_write_tokens: null,
+            reasoning_tokens: null,
+        });
+    });
+
+    it('drops events without an organization id', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle({
+            ...aiUsageEvent,
+            properties: {
+                ...aiUsageEvent.properties,
+                organizationId: null,
+            },
+        });
+        expect(writer.push).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/analytics/eventStream/aiUsageStream.ts
+++ b/packages/backend/src/analytics/eventStream/aiUsageStream.ts
@@ -1,0 +1,64 @@
+import type { AiUsageEvent } from '../aiUsage';
+import { buildEnvelope, ProjectionResult } from './projection';
+import type { CompactedStreamColumn } from './types';
+
+/**
+ * Typed column list for the compacted (parquet) zone of the `ai_usage`
+ * stream, v1. Envelope columns first, then one typed column per field of the
+ * ai.usage projection below — one row per AI model call.
+ */
+export const aiUsageCompactedColumns: CompactedStreamColumn[] = [
+    { name: 'event_name', type: 'VARCHAR' },
+    { name: 'org_id', type: 'VARCHAR' },
+    { name: 'user_id', type: 'VARCHAR' },
+    { name: 'event_ts', type: 'TIMESTAMP' },
+    { name: 'schema_version', type: 'INTEGER' },
+    { name: 'project_id', type: 'VARCHAR' },
+    { name: 'feature', type: 'VARCHAR' },
+    { name: 'function_id', type: 'VARCHAR' },
+    { name: 'agent_id', type: 'VARCHAR' },
+    { name: 'thread_id', type: 'VARCHAR' },
+    { name: 'prompt_id', type: 'VARCHAR' },
+    { name: 'model', type: 'VARCHAR' },
+    { name: 'provider', type: 'VARCHAR' },
+    { name: 'input_tokens', type: 'BIGINT' },
+    { name: 'output_tokens', type: 'BIGINT' },
+    { name: 'cache_read_tokens', type: 'BIGINT' },
+    { name: 'cache_write_tokens', type: 'BIGINT' },
+    { name: 'reasoning_tokens', type: 'BIGINT' },
+    { name: 'total_tokens', type: 'BIGINT' },
+];
+
+/**
+ * Projection for the `ai_usage` stream (v1): one row per AI model call,
+ * emitted via `emitAiUsage`. Returns null when the call can't be attributed
+ * to an organization.
+ */
+const projectAiUsageEvent = (payload: AiUsageEvent): ProjectionResult => {
+    const { properties } = payload;
+    if (!properties.organizationId) return null;
+    return {
+        stream: 'ai_usage',
+        row: {
+            ...buildEnvelope(payload, properties.organizationId),
+            project_id: properties.projectId,
+            feature: properties.feature,
+            function_id: properties.functionId,
+            agent_id: properties.aiAgentId,
+            thread_id: properties.threadId,
+            prompt_id: properties.promptId,
+            model: properties.model,
+            provider: properties.provider,
+            input_tokens: properties.inputTokens,
+            output_tokens: properties.outputTokens,
+            cache_read_tokens: properties.cacheReadTokens,
+            cache_write_tokens: properties.cacheWriteTokens,
+            reasoning_tokens: properties.reasoningTokens,
+            total_tokens: properties.totalTokens,
+        },
+    };
+};
+
+export const aiUsageProjections = {
+    'ai.usage': projectAiUsageEvent,
+};

--- a/packages/backend/src/analytics/eventStream/projection.ts
+++ b/packages/backend/src/analytics/eventStream/projection.ts
@@ -3,7 +3,7 @@ import { EventStreamRow } from './types';
 
 export const EVENT_STREAM_SCHEMA_VERSION = 1;
 
-export type StreamName = 'query_events';
+export type StreamName = 'query_events' | 'ai_usage';
 
 /**
  * Common envelope stamped on every row pushed into the usage event stream.

--- a/packages/backend/src/analytics/eventStream/registry.ts
+++ b/packages/backend/src/analytics/eventStream/registry.ts
@@ -1,4 +1,6 @@
+import type { AiUsageEvent } from '../aiUsage';
 import type { QueryCompletedEvent } from '../LightdashAnalytics';
+import { aiUsageCompactedColumns, aiUsageProjections } from './aiUsageStream';
 import type { ProjectionResult, StreamName } from './projection';
 import {
     queryEventsCompactedColumns,
@@ -11,7 +13,7 @@ import type { CompactedStreamColumn } from './types';
  * Adding a new stream/event = add the event type here and a projection entry
  * below; nothing else needs to change.
  */
-export type ProjectedEvent = QueryCompletedEvent;
+export type ProjectedEvent = QueryCompletedEvent | AiUsageEvent;
 
 export type EventStreamRegistry = {
     [E in ProjectedEvent as E['event']]: (payload: E) => ProjectionResult;
@@ -23,6 +25,7 @@ export type EventStreamRegistry = {
  */
 export const eventStreamRegistry: EventStreamRegistry = {
     ...queryEventsProjections,
+    ...aiUsageProjections,
 };
 
 /**
@@ -35,6 +38,7 @@ export const compactedStreamSchemas: Record<
     CompactedStreamColumn[]
 > = {
     query_events: queryEventsCompactedColumns,
+    ai_usage: aiUsageCompactedColumns,
 };
 
 export const getCompactedStreamColumns = (

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
@@ -13,7 +13,9 @@ vi.mock('ai', () => ({ generateObject: vi.fn() }));
 vi.mock('./ai/models', () => ({ getModel: vi.fn() }));
 vi.mock('./ai/agents/agentV2', () => ({ defaultAgentOptions: {} }));
 vi.mock('./ai/utils/aiCallTelemetry', () => ({
-    getAiCallTelemetry: () => ({}),
+    // Valid shape so the real emitAiUsage doesn't throw internally when the
+    // classifier emits usage (it reads telemetry.metadata).
+    getAiCallTelemetry: () => ({ functionId: 'test', metadata: {} }),
     getLanguageModelAttribution: () => ({}),
 }));
 

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
@@ -14,6 +14,7 @@ vi.mock('./ai/models', () => ({ getModel: vi.fn() }));
 vi.mock('./ai/agents/agentV2', () => ({ defaultAgentOptions: {} }));
 vi.mock('./ai/utils/aiCallTelemetry', () => ({
     getAiCallTelemetry: () => ({}),
+    getLanguageModelAttribution: () => ({}),
 }));
 
 const generateObjectMock = vi.mocked(generateObject);

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -33,6 +33,10 @@ import {
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { createHash } from 'crypto';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../analytics/aiUsage';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { type CatalogModel } from '../../models/CatalogModel/CatalogModel';
@@ -45,7 +49,10 @@ import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassi
 import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
-import { getAiCallTelemetry } from './ai/utils/aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from './ai/utils/aiCallTelemetry';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
@@ -1545,20 +1552,22 @@ export class AiAgentReviewClassifierService extends BaseService {
                 evidencePacket.suggestedEvidenceExcerpts.length,
         });
 
+        const telemetry = getAiCallTelemetry({
+            functionId: 'aiAgentReviewClassifierJudge',
+            feature: 'review-classifier',
+            organizationUuid: candidate.subject.organizationUuid,
+            projectUuid: candidate.subject.projectUuid,
+            agentUuid: candidate.subject.agentUuid,
+            threadUuid: candidate.subject.threadUuid,
+            promptUuid: candidate.subject.assistantPromptUuid,
+            ...getLanguageModelAttribution(model.model),
+        });
         const result = await generateObject({
             model: model.model,
             ...defaultAgentOptions,
             ...model.callOptions,
             providerOptions: model.providerOptions,
-            experimental_telemetry: getAiCallTelemetry({
-                functionId: 'aiAgentReviewClassifierJudge',
-                feature: 'review-classifier',
-                organizationUuid: candidate.subject.organizationUuid,
-                projectUuid: candidate.subject.projectUuid,
-                agentUuid: candidate.subject.agentUuid,
-                threadUuid: candidate.subject.threadUuid,
-                promptUuid: candidate.subject.assistantPromptUuid,
-            }),
+            experimental_telemetry: telemetry,
             schema: aiAgentReviewClassifierJudgeOutputSchema,
             messages: [
                 {
@@ -1670,6 +1679,7 @@ Existing review items — dedup rules. The evidence packet field existingReviewI
                 },
             ],
         });
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
         return result.object as AiAgentReviewClassifierJudgeOutput;
     }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -55,10 +55,12 @@ import {
     DbtProjectType,
     derivePivotConfigurationFromChart,
     DownloadFileType,
+    EmbedArtifactVersionJobPayload,
     Explore,
     FeatureFlags,
     followUpToolsText,
     ForbiddenError,
+    GenerateArtifactQuestionJobPayload,
     getErrorMessage,
     getGroupByDimensions,
     getItemId,
@@ -285,6 +287,7 @@ import {
     UpdateSlackMessageFn,
 } from '../ai/types/aiAgentDependencies';
 import { AiAgentContentValidation } from '../ai/utils/AiAgentContentValidation';
+import { AiCallAttribution } from '../ai/utils/aiCallTelemetry';
 import { getUserFacingErrorMessage } from '../ai/utils/errorMessages';
 import {
     buildFeedbackContextActions,
@@ -5583,11 +5586,9 @@ export class AiAgentService extends BaseService {
         }
     }
 
-    async embedArtifactVersion(payload: {
-        artifactVersionUuid: string;
-        title: string | null;
-        description: string | null;
-    }): Promise<void> {
+    async embedArtifactVersion(
+        payload: EmbedArtifactVersionJobPayload,
+    ): Promise<void> {
         try {
             const text = [payload.title, payload.description]
                 .filter(Boolean)
@@ -5600,7 +5601,12 @@ export class AiAgentService extends BaseService {
             const embeddingResult = await generateEmbedding(
                 text,
                 this.lightdashConfig,
-                { artifactVersionUuid: payload.artifactVersionUuid },
+                {
+                    organizationUuid: payload.organizationUuid,
+                    projectUuid: payload.projectUuid,
+                    userUuid: payload.userUuid,
+                    extra: { artifactVersionUuid: payload.artifactVersionUuid },
+                },
             );
 
             if (!embeddingResult) {
@@ -5623,11 +5629,9 @@ export class AiAgentService extends BaseService {
         }
     }
 
-    async generateArtifactQuestion(payload: {
-        artifactVersionUuid: string;
-        title: string | null;
-        description: string | null;
-    }): Promise<void> {
+    async generateArtifactQuestion(
+        payload: GenerateArtifactQuestionJobPayload,
+    ): Promise<void> {
         try {
             if (!payload.title && !payload.description) {
                 return;
@@ -5638,7 +5642,14 @@ export class AiAgentService extends BaseService {
             });
 
             const question = await generateArtifactQuestion(
-                modelOptions,
+                {
+                    ...modelOptions,
+                    telemetry: {
+                        organizationUuid: payload.organizationUuid,
+                        projectUuid: payload.projectUuid,
+                        userUuid: payload.userUuid,
+                    },
+                },
                 payload.title,
                 payload.description,
                 { artifactVersionUuid: payload.artifactVersionUuid },
@@ -6117,6 +6128,7 @@ export class AiAgentService extends BaseService {
         const embeddingResult = await generateEmbedding(
             searchQuery,
             this.lightdashConfig,
+            { organizationUuid, projectUuid, agentUuid },
         );
         if (!embeddingResult) {
             return { relevantVerifiedAnswers: [] };
@@ -10621,6 +10633,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         name: project.name,
                     })),
                     promptText,
+                    { organizationUuid, userUuid },
                 );
                 if (routedProjectUuid) {
                     return await resolveAgentForProject(routedProjectUuid);
@@ -10736,6 +10749,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             model,
             candidates: availableAgents,
             prompt: messageText,
+            telemetry: { organizationUuid, userUuid },
         });
 
         const selectedAgent =
@@ -13081,7 +13095,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             });
             const agent = await this.getAgent(sessionUser, agentUuid);
             const canAccessData = agent.enableDataAccess;
-            await this.assessResult(result.resultUuid, canAccessData);
+            await this.assessResult(result.resultUuid, canAccessData, {
+                organizationUuid,
+                projectUuid: agent.projectUuid,
+                userUuid,
+                agentUuid,
+                threadUuid,
+            });
 
             // Mark as completed with assessment status
             await this.aiAgentModel.updateEvalRunResult(result.resultUuid, {
@@ -13120,6 +13140,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     async assessResult(
         resultUuid: string,
         canAccessData: boolean,
+        telemetry?: AiCallAttribution,
     ): Promise<boolean | null> {
         Logger.info(`Assessing result ${resultUuid}`);
         const { query, response, expectedAnswer, artifact, toolResults } =
@@ -13171,6 +13192,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                   judge,
                   callOptions,
                   scorerType: 'factuality',
+                  telemetry,
               })
             : null;
 
@@ -13183,6 +13205,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                       judge,
                       callOptions,
                       scorerType: 'contextRelevancy',
+                      telemetry,
                   })
                 : null;
 

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -180,6 +180,7 @@ describe('AiRouterService', () => {
             candidates,
             prompt: 'show revenue by month',
             instructions: 'Route finance questions to @[Finance](agent-2)',
+            telemetry: { organizationUuid, projectUuid, userUuid },
         });
         expect(result.candidates).toEqual(candidates);
         expect(result.suggestedAgent.uuid).toBe('agent-2');

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -188,6 +188,11 @@ export class AiRouterService extends BaseService {
             candidates,
             prompt,
             instructions: instruction?.instruction ?? null,
+            telemetry: {
+                organizationUuid,
+                projectUuid,
+                userUuid: account.user.userUuid,
+            },
         });
 
         const suggestedAgent =

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -73,6 +73,10 @@ import { PassThrough, Readable } from 'node:stream';
 import { extract, pack as tarPack, type Headers } from 'tar-stream';
 import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../analytics/aiUsage';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
 import { resolveS3Credentials } from '../../../clients/Aws/S3BaseClient';
@@ -105,7 +109,10 @@ import type { SandboxRegistryModel } from '../../models/SandboxRegistryModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
 import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
-import { getAiCallTelemetry } from '../ai/utils/aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../ai/utils/aiCallTelemetry';
 import {
     createSandboxManager,
     S3SnapshotStore,
@@ -3339,6 +3346,33 @@ export class AppGenerateService extends BaseService {
                 )}, numTurns=${generationUsage.numTurns}, inputTokens=${generationUsage.inputTokens}, outputTokens=${generationUsage.outputTokens}, cacheReadTokens=${generationUsage.cacheReadInputTokens}, cacheCreationTokens=${generationUsage.cacheCreationInputTokens}, costUsd=${generationUsage.costUsd})`,
         );
 
+        // Aggregated across every `claude` CLI invocation in the pipeline;
+        // the CLI reports inputTokens excluding cache reads/writes.
+        emitAiUsage(
+            getAiCallTelemetry({
+                functionId: 'appClaudeGeneration',
+                feature: 'data-app',
+                organizationUuid: payload.organizationUuid,
+                projectUuid,
+                userUuid: payload.userUuid,
+                model: claudeModel,
+                provider: 'anthropic',
+                extra: { appUuid },
+            }),
+            {
+                inputTokens: generationUsage.inputTokens,
+                outputTokens: generationUsage.outputTokens,
+                cacheReadTokens: generationUsage.cacheReadInputTokens,
+                cacheWriteTokens: generationUsage.cacheCreationInputTokens,
+                reasoningTokens: null,
+                totalTokens:
+                    generationUsage.inputTokens +
+                    generationUsage.cacheReadInputTokens +
+                    generationUsage.cacheCreationInputTokens +
+                    generationUsage.outputTokens,
+            },
+        );
+
         this.analytics.track({
             event: 'data_app.version.completed',
             userId: payload.userUuid,
@@ -3702,19 +3736,21 @@ export class AppGenerateService extends BaseService {
         const CLARIFY_TIMEOUT_MS = 15_000;
 
         const start = performance.now();
+        const telemetry = getAiCallTelemetry({
+            functionId: 'clarifyApp',
+            feature: 'data-app',
+            organizationUuid,
+            projectUuid,
+            userUuid: user.userUuid,
+            ...getLanguageModelAttribution(modelOptions.model),
+        });
         let result;
         try {
             result = await generateObject({
                 model: modelOptions.model,
                 ...modelOptions.callOptions,
                 providerOptions: modelOptions.providerOptions,
-                experimental_telemetry: getAiCallTelemetry({
-                    functionId: 'clarifyApp',
-                    feature: 'data-app',
-                    organizationUuid,
-                    projectUuid,
-                    userUuid: user.userUuid,
-                }),
+                experimental_telemetry: telemetry,
                 schema: clarifySchema,
                 abortSignal: AbortSignal.timeout(CLARIFY_TIMEOUT_MS),
                 messages: [
@@ -3770,6 +3806,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             );
             return { questions: [] };
         }
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
         const elapsedMs = AppGenerateService.elapsed(start);
 
         const questions = result.object.questions

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -3346,8 +3346,10 @@ export class AppGenerateService extends BaseService {
                 )}, numTurns=${generationUsage.numTurns}, inputTokens=${generationUsage.inputTokens}, outputTokens=${generationUsage.outputTokens}, cacheReadTokens=${generationUsage.cacheReadInputTokens}, cacheCreationTokens=${generationUsage.cacheCreationInputTokens}, costUsd=${generationUsage.costUsd})`,
         );
 
-        // Aggregated across every `claude` CLI invocation in the pipeline;
-        // the CLI reports inputTokens excluding cache reads/writes.
+        // Aggregated across every `claude` CLI invocation in the pipeline. The
+        // CLI reports inputTokens excluding cache reads/writes, but AI-SDK rows
+        // store cache-inclusive inputTokens — normalize to SDK semantics here so
+        // `SUM(input_tokens)` (and cost) is comparable across every feature.
         emitAiUsage(
             getAiCallTelemetry({
                 functionId: 'appClaudeGeneration',
@@ -3360,7 +3362,10 @@ export class AppGenerateService extends BaseService {
                 extra: { appUuid },
             }),
             {
-                inputTokens: generationUsage.inputTokens,
+                inputTokens:
+                    generationUsage.inputTokens +
+                    generationUsage.cacheReadInputTokens +
+                    generationUsage.cacheCreationInputTokens,
                 outputTokens: generationUsage.outputTokens,
                 cacheReadTokens: generationUsage.cacheReadInputTokens,
                 cacheWriteTokens: generationUsage.cacheCreationInputTokens,

--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -1,7 +1,14 @@
 import { AiAgentWithContext } from '@lightdash/common';
 import { generateObject, LanguageModel } from 'ai';
 import { z } from 'zod';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 const AgentSelectionSchema = z.object({
     agentUuid: z
@@ -146,12 +153,14 @@ export async function selectAgent({
         buildAdminInstructionsSection(instructions),
     );
 
+    const telemetry = getAiCallTelemetry({
+        functionId: 'selectAgent',
+        feature: 'agent-selector',
+        ...getLanguageModelAttribution(model),
+    });
     const result = await generateObject({
         model,
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'selectAgent',
-            feature: 'agent-selector',
-        }),
+        experimental_telemetry: telemetry,
         schema: AgentSelectionSchema,
         messages: [
             { role: 'system', content: systemPrompt },
@@ -161,6 +170,7 @@ export async function selectAgent({
             },
         ],
     });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     const selection = result.object;
     const exists = candidates.some((c) => c.uuid === selection.agentUuid);

--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -6,6 +6,7 @@ import {
     languageModelUsageToTokens,
 } from '../../../../analytics/aiUsage';
 import {
+    AiCallAttribution,
     getAiCallTelemetry,
     getLanguageModelAttribution,
 } from '../utils/aiCallTelemetry';
@@ -126,11 +127,13 @@ export async function selectAgent({
     candidates,
     prompt,
     instructions = null,
+    telemetry,
 }: {
     model: LanguageModel;
     candidates: AiAgentWithContext[];
     prompt: string;
     instructions?: string | null;
+    telemetry?: AiCallAttribution;
 }): Promise<RouterDecision> {
     if (candidates.length === 0) {
         throw new Error('No agents available for selection');
@@ -153,14 +156,15 @@ export async function selectAgent({
         buildAdminInstructionsSection(instructions),
     );
 
-    const telemetry = getAiCallTelemetry({
+    const telemetryConfig = getAiCallTelemetry({
         functionId: 'selectAgent',
         feature: 'agent-selector',
         ...getLanguageModelAttribution(model),
+        ...telemetry,
     });
     const result = await generateObject({
         model,
-        experimental_telemetry: telemetry,
+        experimental_telemetry: telemetryConfig,
         schema: AgentSelectionSchema,
         messages: [
             { role: 'system', content: systemPrompt },
@@ -170,7 +174,7 @@ export async function selectAgent({
             },
         ],
     });
-    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+    emitAiUsage(telemetryConfig, languageModelUsageToTokens(result.usage));
 
     const selection = result.object;
     const exists = candidates.some((c) => c.uuid === selection.agentUuid);

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -987,7 +987,9 @@ export const generateAgentResponse = async ({
             promptUuid: args.promptUuid,
             response: result.text,
             tokenUsage: {
-                totalTokens: result.usage.totalTokens ?? 0,
+                // All-steps total (matches the ai.usage stream). `usage` is
+                // last-step only and undercounts multi-step tool-calling runs.
+                totalTokens: result.totalUsage.totalTokens ?? 0,
             },
         });
 
@@ -1331,6 +1333,10 @@ export const streamAgentResponse = async ({
 
                 const stepCapReached = steps.length >= STEP_CAP;
 
+                // All-steps total (matches the ai.usage stream). `usage` is
+                // last-step only and undercounts multi-step tool-calling runs.
+                const promptTotalTokens = totalUsage.totalTokens ?? 0;
+
                 if (stepCapReached && !completeResponse) {
                     void dependencies.updatePrompt({
                         promptUuid: args.promptUuid,
@@ -1338,7 +1344,7 @@ export const streamAgentResponse = async ({
                             new AiAgentStepCapReachedError(steps.length),
                         ),
                         tokenUsage: {
-                            totalTokens: usage.totalTokens ?? 0,
+                            totalTokens: promptTotalTokens,
                         },
                     });
                 } else {
@@ -1346,7 +1352,7 @@ export const streamAgentResponse = async ({
                         response: completeResponse,
                         promptUuid: args.promptUuid,
                         tokenUsage: {
-                            totalTokens: usage.totalTokens ?? 0,
+                            totalTokens: promptTotalTokens,
                         },
                     });
                 }
@@ -1363,7 +1369,7 @@ export const streamAgentResponse = async ({
                         projectId: args.agentSettings.projectUuid,
                         aiAgentId: args.agentSettings.uuid,
                         agentName: args.agentSettings.name,
-                        usageTokensCount: usage.totalTokens ?? 0,
+                        usageTokensCount: promptTotalTokens,
                         stepsCount: steps.length,
                         model:
                             typeof args.model === 'string'

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -15,6 +15,10 @@ import {
     type Output,
     type ToolSet,
 } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import Logger from '../../../../logging/logger';
 import { getSystemPromptV2 } from '../prompts/systemV2';
 import { getAnalyzeFieldImpact } from '../tools/analyzeFieldImpact';
@@ -834,6 +838,10 @@ export const generateAgentResponse = async ({
             tools,
             logger,
         });
+        const telemetry = getAgentTelemetryConfig(
+            'generateAgentResponse',
+            args,
+        );
         const result = await generateText({
             ...defaultAgentOptions,
             ...args.callOptions,
@@ -961,11 +969,10 @@ export const generateAgentResponse = async ({
                     promptUuid: args.promptUuid,
                 });
             },
-            experimental_telemetry: getAgentTelemetryConfig(
-                'generateAgentResponse',
-                args,
-            ),
+            experimental_telemetry: telemetry,
         });
+
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.totalUsage));
 
         logger(
             'Generate Agent Response',
@@ -1094,6 +1101,7 @@ export const streamAgentResponse = async ({
             }
             return interrupted;
         };
+        const telemetry = getAgentTelemetryConfig('streamAgentResponse', args);
         const result = streamText({
             ...defaultAgentOptions,
             ...args.callOptions,
@@ -1303,7 +1311,14 @@ export const streamAgentResponse = async ({
                         });
                 }
             },
-            onFinish: async ({ usage, steps, reasoning, finishReason }) => {
+            onFinish: async ({
+                usage,
+                totalUsage,
+                steps,
+                reasoning,
+                finishReason,
+            }) => {
+                emitAiUsage(telemetry, languageModelUsageToTokens(totalUsage));
                 logger(
                     'On Finish',
                     `Stream finished. Updating prompt with response. finishReason: ${finishReason}, steps: ${steps.length}`,
@@ -1402,10 +1417,7 @@ export const streamAgentResponse = async ({
 
                 void cleanupMcpClients();
             },
-            experimental_telemetry: getAgentTelemetryConfig(
-                'streamAgentResponse',
-                args,
-            ),
+            experimental_telemetry: telemetry,
         });
 
         logger('Stream Agent Response', 'Returning stream result.');

--- a/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
@@ -1,6 +1,10 @@
 import { Field, Filters } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -63,16 +67,17 @@ export async function generateChartMetadata(
 ): Promise<GeneratedChartMetadata> {
     const fieldLabelMap = buildFieldLabelMap(context.fieldsContext);
 
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateChartMetadata',
+        'chart-metadata',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
         schema: ChartMetadataSchema,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateChartMetadata',
-            'chart-metadata',
-        ),
+        experimental_telemetry: telemetry,
         messages: [
             {
                 role: 'system',
@@ -102,5 +107,6 @@ ${
             },
         ],
     });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/agents/compactionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/compactionGenerator.ts
@@ -1,4 +1,8 @@
 import { generateText } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -12,15 +16,16 @@ export async function generateCompactionSummary(
         conversation: string;
     },
 ): Promise<string> {
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateCompactionSummary',
+        'compaction',
+    );
     const result = await generateText({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateCompactionSummary',
-            'compaction',
-        ),
+        experimental_telemetry: telemetry,
         messages: [
             {
                 role: 'system',
@@ -55,6 +60,8 @@ Requirements:
             },
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.totalUsage));
 
     return result.text.trim();
 }

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -9,6 +9,10 @@ import {
     type ModelMessage,
     type StreamTextResult,
 } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../../analytics/aiUsage';
 import Logger from '../../../../../logging/logger';
 import { getFindExplores } from '../../tools/findExplores';
 import { getFindFields } from '../../tools/findFields';
@@ -113,6 +117,11 @@ export const runDiscoverFieldsAgent = (
 
     const inflightWrites: Array<Promise<void>> = [];
 
+    const telemetry = getAgentTelemetryConfig(
+        'discoverFieldsSubagent',
+        args.telemetry,
+        'agent-subtask',
+    );
     const stream = streamText({
         model: args.model,
         ...args.callOptions,
@@ -127,11 +136,10 @@ export const runDiscoverFieldsAgent = (
             delayInMs: 40,
             chunking: 'line',
         }),
-        experimental_telemetry: getAgentTelemetryConfig(
-            'discoverFieldsSubagent',
-            args.telemetry,
-            'agent-subtask',
-        ),
+        experimental_telemetry: telemetry,
+        onFinish: ({ totalUsage }) => {
+            emitAiUsage(telemetry, languageModelUsageToTokens(totalUsage));
+        },
         onChunk: ({ chunk }) => {
             if (chunk.type === 'tool-call') {
                 if (!isSubagentPersistedToolName(chunk.toolName)) return;

--- a/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
@@ -4,6 +4,10 @@ import {
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { renderAvailableExplores } from '../prompts/availableExplores';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
@@ -81,15 +85,16 @@ export async function generateDocumentSummary(
         projectExplores: Explore[];
     },
 ): Promise<AiAgentDocumentStructuredSummary> {
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateDocumentSummary',
+        'document-summary',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateDocumentSummary',
-            'document-summary',
-        ),
+        experimental_telemetry: telemetry,
         schema: DocumentSummarySchema,
         messages: [
             {
@@ -113,6 +118,8 @@ Output the structured fields per the schema. Pay attention to the \`relevance\` 
             },
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
@@ -8,7 +8,10 @@ import { LightdashConfig } from '../../../../config/parseConfig';
 import { getAzureProvider } from '../models/azure-openai-gpt-4.1';
 import { getBedrockEmbeddingModel } from '../models/bedrock';
 import { getOpenAIEmbeddingModel } from '../models/openai-embedding';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    AiCallAttribution,
+    getAiCallTelemetry,
+} from '../utils/aiCallTelemetry';
 
 const EMBEDDING_DIMENSIONS = 1536;
 
@@ -61,7 +64,7 @@ function getEmbeddingModelConfig(config: LightdashConfig):
 export async function generateEmbedding(
     text: string,
     config: LightdashConfig,
-    metadata: Record<string, string> = {},
+    telemetry: AiCallAttribution & { extra?: Record<string, string> } = {},
 ): Promise<{
     embedding: number[];
     provider: string;
@@ -78,21 +81,23 @@ export async function generateEmbedding(
     }
     const { model, provider, modelName } = embeddingModelConfig;
 
-    const telemetry = getAiCallTelemetry({
+    const { extra, ...attribution } = telemetry;
+    const telemetryConfig = getAiCallTelemetry({
         functionId: 'generateEmbedding',
         feature: 'embedding',
+        ...attribution,
         model: modelName,
         provider,
-        extra: metadata,
+        extra,
     });
     const result = await embed({
         model,
         value: trimmedText,
-        experimental_telemetry: telemetry,
+        experimental_telemetry: telemetryConfig,
         // TODO :: provider options to set dimensions
     });
 
-    emitAiUsage(telemetry, embeddingModelUsageToTokens(result.usage));
+    emitAiUsage(telemetryConfig, embeddingModelUsageToTokens(result.usage));
 
     let { embedding } = result;
 

--- a/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
@@ -1,5 +1,9 @@
 import { ParameterError } from '@lightdash/common';
 import { embed, EmbeddingModel } from 'ai';
+import {
+    embeddingModelUsageToTokens,
+    emitAiUsage,
+} from '../../../../analytics/aiUsage';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import { getAzureProvider } from '../models/azure-openai-gpt-4.1';
 import { getBedrockEmbeddingModel } from '../models/bedrock';
@@ -74,16 +78,23 @@ export async function generateEmbedding(
     }
     const { model, provider, modelName } = embeddingModelConfig;
 
-    let { embedding } = await embed({
+    const telemetry = getAiCallTelemetry({
+        functionId: 'generateEmbedding',
+        feature: 'embedding',
+        model: modelName,
+        provider,
+        extra: metadata,
+    });
+    const result = await embed({
         model,
         value: trimmedText,
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'generateEmbedding',
-            feature: 'embedding',
-            extra: metadata,
-        }),
+        experimental_telemetry: telemetry,
         // TODO :: provider options to set dimensions
     });
+
+    emitAiUsage(telemetry, embeddingModelUsageToTokens(result.usage));
+
+    let { embedding } = result;
 
     if (embedding.length !== EMBEDDING_DIMENSIONS) {
         console.warn(

--- a/packages/backend/src/ee/services/ai/agents/formulaTableCalculationGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/formulaTableCalculationGenerator.ts
@@ -8,6 +8,10 @@ import {
 import { FUNCTION_CATALOG, parse } from '@lightdash/formula';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import Logger from '../../../../logging/logger';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
@@ -340,15 +344,16 @@ export async function generateFormulaTableCalculation(
             content: string;
         }> = [],
     ) => {
+        const telemetry = getGeneratorTelemetry(
+            modelOptions,
+            'generateFormulaTableCalculation',
+            'formula-table-calc',
+        );
         const result = await generateObject({
             model: modelOptions.model,
             ...modelOptions.callOptions,
             providerOptions: modelOptions.providerOptions,
-            experimental_telemetry: getGeneratorTelemetry(
-                modelOptions,
-                'generateFormulaTableCalculation',
-                'formula-table-calc',
-            ),
+            experimental_telemetry: telemetry,
             schema: FormulaTableCalculationSchema,
             messages: [
                 { role: 'system', content: systemPrompt },
@@ -356,6 +361,7 @@ export async function generateFormulaTableCalculation(
                 ...extraMessages,
             ],
         });
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
         return result.object;
     };
 

--- a/packages/backend/src/ee/services/ai/agents/projectRouter.ts
+++ b/packages/backend/src/ee/services/ai/agents/projectRouter.ts
@@ -1,6 +1,13 @@
 import { generateObject, LanguageModel } from 'ai';
 import { z } from 'zod';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 const ProjectRoutingSchema = z.object({
     reasoning: z
@@ -40,12 +47,14 @@ export async function routeProjectForSlack(
         )
         .join('\n');
 
+    const telemetry = getAiCallTelemetry({
+        functionId: 'routeProjectForSlack',
+        feature: 'project-router',
+        ...getLanguageModelAttribution(model),
+    });
     const result = await generateObject({
         model,
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'routeProjectForSlack',
-            feature: 'project-router',
-        }),
+        experimental_telemetry: telemetry,
         schema: ProjectRoutingSchema,
         messages: [
             {
@@ -68,6 +77,7 @@ Rules:
             },
         ],
     });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     const { projectUuid } = result.object;
     if (

--- a/packages/backend/src/ee/services/ai/agents/projectRouter.ts
+++ b/packages/backend/src/ee/services/ai/agents/projectRouter.ts
@@ -5,6 +5,7 @@ import {
     languageModelUsageToTokens,
 } from '../../../../analytics/aiUsage';
 import {
+    AiCallAttribution,
     getAiCallTelemetry,
     getLanguageModelAttribution,
 } from '../utils/aiCallTelemetry';
@@ -35,6 +36,7 @@ export async function routeProjectForSlack(
     model: LanguageModel,
     projects: { projectUuid: string; name: string }[],
     userQuery: string,
+    telemetry?: AiCallAttribution,
 ): Promise<string | null> {
     if (projects.length === 0) {
         return null;
@@ -47,14 +49,15 @@ export async function routeProjectForSlack(
         )
         .join('\n');
 
-    const telemetry = getAiCallTelemetry({
+    const telemetryConfig = getAiCallTelemetry({
         functionId: 'routeProjectForSlack',
         feature: 'project-router',
         ...getLanguageModelAttribution(model),
+        ...telemetry,
     });
     const result = await generateObject({
         model,
-        experimental_telemetry: telemetry,
+        experimental_telemetry: telemetryConfig,
         schema: ProjectRoutingSchema,
         messages: [
             {
@@ -77,7 +80,7 @@ Rules:
             },
         ],
     });
-    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+    emitAiUsage(telemetryConfig, languageModelUsageToTokens(result.usage));
 
     const { projectUuid } = result.object;
     if (

--- a/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
@@ -34,6 +34,7 @@ export async function generateArtifactQuestion(
         functionId: 'generateArtifactQuestion',
         feature: 'artifact-question',
         ...getLanguageModelAttribution(modelOptions.model),
+        ...(modelOptions.telemetry ?? {}),
         extra: metadata,
     });
     const result = await generateObject({

--- a/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
@@ -1,7 +1,14 @@
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 const QUESTION_MAX_LENGTH_CHARS = 200;
 const QuestionSchema = z.object({
@@ -23,6 +30,12 @@ export async function generateArtifactQuestion(
     description: string | null,
     metadata: Record<string, string> = {},
 ): Promise<string> {
+    const telemetry = getAiCallTelemetry({
+        functionId: 'generateArtifactQuestion',
+        feature: 'artifact-question',
+        ...getLanguageModelAttribution(modelOptions.model),
+        extra: metadata,
+    });
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
@@ -50,12 +63,10 @@ Title: ${title || 'N/A'}
 Description: ${description || 'N/A'}`,
             },
         ],
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'generateArtifactQuestion',
-            feature: 'artifact-question',
-            extra: metadata,
-        }),
+        experimental_telemetry: telemetry,
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object.question;
 }

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -5,8 +5,15 @@ import {
     type AgentSuggestionsModelObject,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
-import { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 const EMPTY_STATE_PROMPT = `You write 3-6 starter "chips" that appear above an empty AI agent chat input in a business-intelligence tool.
 
@@ -225,6 +232,15 @@ export async function generateAgentSuggestions(
         canManageContent: context.canManageContent,
     });
 
+    const telemetry = getAiCallTelemetry({
+        functionId: 'generateAgentSuggestions',
+        feature: 'agent-suggestions',
+        ...getLanguageModelAttribution(modelOptions.model),
+        extra: {
+            ...metadata,
+            mode: isPostResponse ? 'post-response' : 'empty-state',
+        },
+    });
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
@@ -242,15 +258,10 @@ export async function generateAgentSuggestions(
                     : `Generate empty-state suggestion chips for this agent.\n\nContext:\n${userContent}`,
             },
         ],
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'generateAgentSuggestions',
-            feature: 'agent-suggestions',
-            extra: {
-                ...metadata,
-                mode: isPostResponse ? 'post-response' : 'empty-state',
-            },
-        }),
+        experimental_telemetry: telemetry,
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/agents/tableCalculationGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/tableCalculationGenerator.ts
@@ -12,6 +12,10 @@ import {
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -261,15 +265,16 @@ export async function generateTableCalculation(
 ): Promise<GeneratedTableCalculation> {
     const fieldReferenceGuide = buildFieldReferenceGuide(context.fieldsContext);
 
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateTableCalculation',
+        'table-calc',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateTableCalculation',
-            'table-calc',
-        ),
+        experimental_telemetry: telemetry,
         schema: TableCalculationSchema,
         messages: [
             {
@@ -411,6 +416,8 @@ export async function generateTableCalculation(
             },
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/agents/telemetry.ts
+++ b/packages/backend/src/ee/services/ai/agents/telemetry.ts
@@ -1,5 +1,9 @@
 import type { AiAgentArgs } from '../types/aiAgent';
-import { AiCallFeature, getAiCallTelemetry } from '../utils/aiCallTelemetry';
+import {
+    AiCallFeature,
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../utils/aiCallTelemetry';
 
 export const getAiAgentModelName = (model: AiAgentArgs['model']) =>
     typeof model === 'string' ? model : model.modelId;
@@ -48,6 +52,6 @@ export const getAgentTelemetryConfig = (
         threadUuid,
         promptUuid,
         userUuid: userId,
-        model: getAiAgentModelName(model),
+        ...getLanguageModelAttribution(model),
         recordIO: telemetryEnabled,
     });

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -1,5 +1,9 @@
 import { generateObject, ModelMessage } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -21,15 +25,16 @@ export async function generateThreadTitle(
     modelOptions: GeneratorModelOptions,
     messages: ModelMessage[],
 ): Promise<string> {
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateThreadTitle',
+        'thread-title',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateThreadTitle',
-            'thread-title',
-        ),
+        experimental_telemetry: telemetry,
         schema: TitleSchema,
         messages: [
             {
@@ -54,6 +59,8 @@ The title should be clear, specific, and helpful for someone browsing a list of 
             ...messages,
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object.title;
 }

--- a/packages/backend/src/ee/services/ai/agents/tooltipGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/tooltipGenerator.ts
@@ -1,6 +1,10 @@
 import { GenerateTooltipRequest, TooltipFieldContext } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
 
@@ -36,15 +40,16 @@ export async function generateTooltip(
 ): Promise<GeneratedTooltip> {
     const fieldReferenceGuide = buildFieldReferenceGuide(context.fieldsContext);
 
+    const telemetry = getGeneratorTelemetry(
+        modelOptions,
+        'generateTooltip',
+        'tooltip',
+    );
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
-        experimental_telemetry: getGeneratorTelemetry(
-            modelOptions,
-            'generateTooltip',
-            'tooltip',
-        ),
+        experimental_telemetry: telemetry,
         schema: TooltipSchema,
         messages: [
             {
@@ -107,6 +112,8 @@ ${
             },
         ],
     });
+
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
     return result.object;
 }

--- a/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
+++ b/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
@@ -21,22 +21,36 @@ export type AiCallAttribution = {
 };
 
 /**
+ * The AI SDK provider id (e.g. `amazon-bedrock`) doesn't always match our
+ * configured provider vocabulary (`openai/azure/anthropic/bedrock/openrouter`)
+ * that cost accounting joins on. Normalize the mismatches here so the same
+ * provider gets one label across LLM and embedding rows.
+ */
+const normalizeProvider = (provider: string): string =>
+    provider === 'amazon-bedrock' ? 'bedrock' : provider;
+
+/**
  * Model name + provider attribution derived from an AI SDK model object.
  * The SDK provider id is dot-namespaced (e.g. `azure.chat`,
- * `bedrock.anthropic.messages`); the first segment matches our configured
- * provider names (openai/azure/anthropic/bedrock/openrouter), which is what
- * cost accounting joins on — the same model name bills differently per
+ * `amazon-bedrock`); the first segment (after normalization) matches our
+ * configured provider names (openai/azure/anthropic/bedrock/openrouter), which
+ * is what cost accounting joins on — the same model name bills differently per
  * provider. Bare string models carry no provider information.
  */
 export const getLanguageModelAttribution = (
     model: LanguageModel,
-): Pick<AiCallAttribution, 'model' | 'provider'> =>
-    typeof model === 'string'
-        ? { model, provider: null }
-        : {
-              model: model.modelId,
-              provider: model.provider?.split('.')[0] ?? null,
-          };
+): Pick<AiCallAttribution, 'model' | 'provider'> => {
+    if (typeof model === 'string') {
+        return { model, provider: null };
+    }
+    // `|| null` (not `??`) so an empty provider id collapses to null rather
+    // than a phantom `''` provider that would pass the metadata filter.
+    const provider = model.provider?.split('.')[0] || null;
+    return {
+        model: model.modelId,
+        provider: provider === null ? null : normalizeProvider(provider),
+    };
+};
 
 export type AiCallTelemetryOptions = AiCallAttribution & {
     functionId: string;

--- a/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
+++ b/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
@@ -1,27 +1,7 @@
-/**
- * Coarse feature bucket for an AI call. Lets us attribute token usage and cost
- * to a product surface (data apps vs the agent vs metadata generation, etc.) in
- * tracing, independently of the fine-grained `functionId`.
- */
-export type AiCallFeature =
-    | 'agent'
-    | 'agent-subtask'
-    | 'chart-metadata'
-    | 'document-summary'
-    | 'thread-title'
-    | 'tooltip'
-    | 'artifact-question'
-    | 'agent-suggestions'
-    | 'table-calc'
-    | 'formula-table-calc'
-    | 'compaction'
-    | 'embedding'
-    | 'project-router'
-    | 'agent-selector'
-    | 'review-classifier'
-    | 'llm-judge'
-    | 'data-app'
-    | 'managed-agent';
+import type { LanguageModel } from 'ai';
+import type { AiCallFeature } from '../../../../analytics/aiUsage';
+
+export type { AiCallFeature };
 
 /**
  * Attribution dimensions stamped on an AI-call span. All optional because not
@@ -37,7 +17,26 @@ export type AiCallAttribution = {
     promptUuid?: string | null;
     userUuid?: string | null;
     model?: string | null;
+    provider?: string | null;
 };
+
+/**
+ * Model name + provider attribution derived from an AI SDK model object.
+ * The SDK provider id is dot-namespaced (e.g. `azure.chat`,
+ * `bedrock.anthropic.messages`); the first segment matches our configured
+ * provider names (openai/azure/anthropic/bedrock/openrouter), which is what
+ * cost accounting joins on — the same model name bills differently per
+ * provider. Bare string models carry no provider information.
+ */
+export const getLanguageModelAttribution = (
+    model: LanguageModel,
+): Pick<AiCallAttribution, 'model' | 'provider'> =>
+    typeof model === 'string'
+        ? { model, provider: null }
+        : {
+              model: model.modelId,
+              provider: model.provider?.split('.')[0] ?? null,
+          };
 
 export type AiCallTelemetryOptions = AiCallAttribution & {
     functionId: string;
@@ -60,6 +59,7 @@ const ATTRIBUTION_KEYS: (keyof AiCallAttribution)[] = [
     'promptUuid',
     'userUuid',
     'model',
+    'provider',
 ];
 
 /**
@@ -111,12 +111,15 @@ export const getAiCallTelemetry = ({
  * avoid an import cycle with the models package.
  */
 export const getGeneratorTelemetry = (
-    modelOptions: { telemetry?: AiCallAttribution },
+    modelOptions: { model?: LanguageModel; telemetry?: AiCallAttribution },
     functionId: string,
     feature: AiCallFeature,
 ) =>
     getAiCallTelemetry({
         functionId,
         feature,
+        ...(modelOptions.model != null
+            ? getLanguageModelAttribution(modelOptions.model)
+            : {}),
         ...(modelOptions.telemetry ?? {}),
     });

--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -2,9 +2,16 @@ import { assertUnreachable } from '@lightdash/common';
 import { generateObject, LanguageModel } from 'ai';
 import { JSONDiff, Score } from 'autoevals';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { defaultAgentOptions } from '../agents/agentV2';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
-import { getAiCallTelemetry } from './aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from './aiCallTelemetry';
 
 export const factualityScores = {
     A: 0.4,
@@ -179,14 +186,16 @@ export async function llmAsAJudge({
       ************`
                     : '';
 
-            const { object } = await generateObject({
+            const telemetry = getAiCallTelemetry({
+                functionId: 'llmAsAJudge',
+                feature: 'llm-judge',
+                ...getLanguageModelAttribution(judge),
+            });
+            const result = await generateObject({
                 model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
-                experimental_telemetry: getAiCallTelemetry({
-                    functionId: 'llmAsAJudge',
-                    feature: 'llm-judge',
-                }),
+                experimental_telemetry: telemetry,
                 schema: z.object({
                     answer: z
                         .enum(['A', 'B', 'C', 'D', 'E'])
@@ -231,6 +240,8 @@ ${
       (E) The answers differ, but these differences don't matter from the perspective of factuality.
       `,
             });
+            emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+            const { object } = result;
 
             const factualityResult = {
                 answer: object.answer,
@@ -261,14 +272,16 @@ ${
                 throw new Error('context is required for contextRelevancy');
             }
 
-            const { object } = await generateObject({
+            const telemetry = getAiCallTelemetry({
+                functionId: 'llmAsAJudge',
+                feature: 'llm-judge',
+                ...getLanguageModelAttribution(judge),
+            });
+            const result = await generateObject({
                 model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
-                experimental_telemetry: getAiCallTelemetry({
-                    functionId: 'llmAsAJudge',
-                    feature: 'llm-judge',
-                }),
+                experimental_telemetry: telemetry,
                 schema: z.object({
                     score: z
                         .number()
@@ -301,6 +314,8 @@ Evaluate how relevant the provided context is to answering the query. Consider:
 Provide a relevancy score between 0 (not relevant at all) and 1 (highly relevant), and explain your reasoning.
                 `,
             });
+            emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+            const { object } = result;
 
             const contextResult = {
                 score: object.score,

--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -9,6 +9,7 @@ import {
 import { defaultAgentOptions } from '../agents/agentV2';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
 import {
+    AiCallAttribution,
     getAiCallTelemetry,
     getLanguageModelAttribution,
 } from './aiCallTelemetry';
@@ -89,6 +90,7 @@ type BaseLlmAsJudgeParams = {
     contextRelevancyThreshold?: number; // Threshold for context relevancy (default 0.7)
     factualityThreshold?: 'A' | 'B' | 'C' | 'D' | 'E'; // Minimum acceptable factuality score (default 'A' = subset or better)
     jsonDiffThreshold?: number; // Threshold for JSON diff score (default 0.9)
+    telemetry?: AiCallAttribution; // org/project/user attribution for the ai.usage stream
 };
 
 // Function overloads for type safety
@@ -134,6 +136,7 @@ export async function llmAsAJudge({
     contextRelevancyThreshold = 0.7,
     factualityThreshold = 'A',
     jsonDiffThreshold = 0.9,
+    telemetry,
 }: BaseLlmAsJudgeParams & {
     scorerType: 'factuality' | 'jsonDiff' | 'contextRelevancy';
 }): Promise<{
@@ -186,16 +189,17 @@ export async function llmAsAJudge({
       ************`
                     : '';
 
-            const telemetry = getAiCallTelemetry({
+            const telemetryConfig = getAiCallTelemetry({
                 functionId: 'llmAsAJudge',
                 feature: 'llm-judge',
                 ...getLanguageModelAttribution(judge),
+                ...telemetry,
             });
             const result = await generateObject({
                 model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
-                experimental_telemetry: telemetry,
+                experimental_telemetry: telemetryConfig,
                 schema: z.object({
                     answer: z
                         .enum(['A', 'B', 'C', 'D', 'E'])
@@ -240,7 +244,10 @@ ${
       (E) The answers differ, but these differences don't matter from the perspective of factuality.
       `,
             });
-            emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+            emitAiUsage(
+                telemetryConfig,
+                languageModelUsageToTokens(result.usage),
+            );
             const { object } = result;
 
             const factualityResult = {
@@ -272,16 +279,17 @@ ${
                 throw new Error('context is required for contextRelevancy');
             }
 
-            const telemetry = getAiCallTelemetry({
+            const telemetryConfig = getAiCallTelemetry({
                 functionId: 'llmAsAJudge',
                 feature: 'llm-judge',
                 ...getLanguageModelAttribution(judge),
+                ...telemetry,
             });
             const result = await generateObject({
                 model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
-                experimental_telemetry: telemetry,
+                experimental_telemetry: telemetryConfig,
                 schema: z.object({
                     score: z
                         .number()
@@ -314,7 +322,10 @@ Evaluate how relevant the provided context is to answering the query. Consider:
 Provide a relevancy score between 0 (not relevant at all) and 1 (highly relevant), and explain your reasoning.
                 `,
             });
-            emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+            emitAiUsage(
+                telemetryConfig,
+                languageModelUsageToTokens(result.usage),
+            );
             const { object } = result;
 
             const contextResult = {

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -7,10 +7,17 @@ import { generateObject } from 'ai';
 import { JSONDiff } from 'autoevals';
 import { compact, differenceWith } from 'lodash';
 import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
 import { DbAiAgentToolCall } from '../../../database/entities/ai';
 import { defaultAgentOptions } from '../agents/agentV2';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
-import { getAiCallTelemetry } from './aiCallTelemetry';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from './aiCallTelemetry';
 
 const TOOL_NAME_TO_DB_TOOL_NAME = {
     findExplores: 'find_explores',
@@ -285,14 +292,16 @@ export const evaluateToolCallSequence = async (
         .map((score) => score.description)
         .join('\n\n');
 
-    const { object: evaluationResult } = await generateObject({
+    const telemetry = getAiCallTelemetry({
+        functionId: 'evaluateToolCallSequence',
+        feature: 'llm-judge',
+        ...getLanguageModelAttribution(judge),
+    });
+    const result = await generateObject({
         model: judge,
         ...defaultAgentOptions,
         ...callOptions,
-        experimental_telemetry: getAiCallTelemetry({
-            functionId: 'evaluateToolCallSequence',
-            feature: 'llm-judge',
-        }),
+        experimental_telemetry: telemetry,
         schema: toolEvaluationSchema,
         prompt: `
 You are evaluating AI agent tool usage for business logic testing. Here is the data:
@@ -368,8 +377,9 @@ For passed, return true if effectiveness is excellent/good AND appropriateTools 
 Use empty arrays for suggestions, missingTools, unnecessaryTools, validationErrors, and expectedArgsValidation when not applicable.
         `,
     });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
-    return evaluationResult;
+    return result.object;
 };
 
 export const llmAsJudgeForTools = async ({


### PR DESCRIPTION
Every AI model call now emits its token usage in two forms, with full attribution dimensions:

1. **A structured log line** — Winston `info` with marker `event: 'ai.usage'`, consumable by any log stack (Cloud Logging, Loki, Datadog, `grep`). Infra-agnostic, always emitted.
2. **An `ai.usage` analytics event through `track()`** — projected by the usage-events sink into a new **`ai_usage` stream** (raw JSONL → nightly parquet compaction), and forwarded to Rudderstack as `lightdash_server.ai.usage` like any other typed event.

## Dimensions

`feature` (agent / agent-subtask / data-app / llm-judge / …), `functionId`, `organizationId`, `projectId`, `userId`, `aiAgentId`, `threadId`, `promptId`, `model`, **`provider`** (openai / azure / anthropic / bedrock / openrouter — derived from the AI SDK model object, since the same model name bills differently per provider), plus token classes: `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`, `reasoningTokens`, `totalTokens`.

## How

- `packages/backend/src/analytics/aiUsage.ts` — `emitAiUsage(telemetry, tokens)` reads attribution from the `experimental_telemetry` config every AI call site already builds (ZAP-558 tracing work), and emits both forms. Never-throw (try/catch + defensive usage mappers): usage emission can't break an AI call.
- Call sites reach `track()` via a module-level tracker registered by API / SchedulerApp / NatsWorkerApp at boot — generators are pure functions without the analytics instance (same pattern as the global `Logger`).
- Wired at every AI SDK call site (~20): agentV2 generate + stream (`totalUsage` for multi-step), discoverFields subagent, all generators, LLM judges, project router, agent selector, review classifier, data-app clarify, plus the aggregated data-app Claude CLI usage.
- New stream = one registry entry: projection + typed parquet schema (`aiUsageStream.ts`). No changes to writer/compactor.
- `AiCallFeature` moved from `aiCallTelemetry.ts` into `analytics/aiUsage.ts` (re-exported from the old location) to keep imports acyclic.

## Why not traces

Traces are head-sampled → any cost figure derived from them undercounts by construction. The `ai.usage` event is 100% emitted. Traces remain for debugging.

## Verified locally (e2e)

Ran a real agent thread: log lines in stdout → raw events in `events/raw/org_id=…/stream=ai_usage/dt=…/` → triggered `compactUsageEvents` → typed parquet (18+1 columns) → DuckDB `GROUP BY feature, model, provider` returns correct token sums. Existing `query_events` stream unaffected.

## Notes for reviewers

- `ai.usage` goes to Rudderstack (consistent with `query.completed`); volume is one event per model call. Easy to suppress from Rudder if we'd rather keep token data first-party only.
- Known gaps (documented): `ManagedAgentClient` (Anthropic Agents API) doesn't surface usage; data-app CLI usage is emitted only on successful completion; failed AI SDK calls throw before usage is available.
- The `lightdash_ai_usage` SYSTEM explore will be added in the PROD-8608 read-layer stack (#25062) as a follow-up.
- Durable (billing-grade) transport remains PROD-8605; this uses the same best-effort buffered path as `query_events`.

Relates: PROD-8610
