### PR TITLE
refactor(frontend): migrate Center to mantine-8

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
@@ -1,6 +1,6 @@
 import type { EchartsGrid, EchartsLegend } from '@lightdash/common';
-import { Flex } from '@mantine-8/core';
-import { Badge, Center, SimpleGrid } from '@mantine/core';
+import { Center, Flex } from '@mantine-8/core';
+import { Badge, SimpleGrid } from '@mantine/core';
 import { type FC } from 'react';
 import UnitInput from '../../../common/UnitInput';
 

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -3,9 +3,8 @@ import {
     getItemId,
     getItemLabelWithoutTableName,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Center, Group, Stack } from '@mantine-8/core';
 import {
-    Center,
     Checkbox,
     NumberInput,
     SegmentedControl,

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -10,9 +10,8 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Accordion, Group, Stack } from '@mantine-8/core';
+import { Accordion, Center, Group, Stack } from '@mantine-8/core';
 import {
-    Center,
     SegmentedControl,
     Select,
     TextInput,

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,9 +14,8 @@ import {
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
-import { Button, Group } from '@mantine-8/core';
+import { Button, Center, Group } from '@mantine-8/core';
 import {
-    Center,
     Loader,
     Skeleton,
     Tooltip,

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.tsx
@@ -1,4 +1,4 @@
-import { Center } from '@mantine/core';
+import { Center } from '@mantine-8/core';
 import { IconCheck } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -22,7 +22,7 @@ export const CatalogCategorySwatch: FC<Props> = ({
             w={18}
             className={cx(classes.base, classes.withHover)}
             onClick={onClick}
-            sx={{
+            style={{
                 borderRadius: theme.radius.sm,
             }}
         >

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,8 +5,8 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box, Divider, Group } from '@mantine-8/core';
-import { Anchor, Center, Paper, useMantineTheme, Text } from '@mantine/core';
+import { Box, Center, Divider, Group } from '@mantine-8/core';
+import { Anchor, Paper, useMantineTheme, Text } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowsSort,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -23,6 +23,7 @@ import {
 import {
     Box,
     Button,
+    Center,
     Divider,
     Group,
     Stack,
@@ -31,7 +32,6 @@ import {
 import {
     ActionIcon,
     Badge,
-    Center,
     Popover,
     SegmentedControl,
     TextInput,

--- a/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
@@ -3,14 +3,8 @@ import {
     DownloadFileType,
     type VizTableConfig,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Center,
-    Popover,
-    SegmentedControl,
-    Text,
-} from '@mantine/core';
+import { Center, Stack } from '@mantine-8/core';
+import { ActionIcon, Popover, SegmentedControl, Text } from '@mantine/core';
 import { IconDownload, IconPhoto, IconTableExport } from '@tabler/icons-react';
 import { memo, useState } from 'react';
 import ChartDownloadOptions from '../../../../components/common/ChartDownload/ChartDownloadOptions';

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -1,4 +1,5 @@
-import { Center, Loader, useMantineTheme } from '@mantine/core';
+import { Center } from '@mantine-8/core';
+import { Loader, useMantineTheme } from '@mantine/core';
 import Editor, {
     useMonaco,
     type BeforeMount,

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -1,7 +1,6 @@
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Center, Group, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Center,
     CopyButton,
     Highlight,
     Loader,

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -1,8 +1,7 @@
 import { PartitionType, type PartitionColumn } from '@lightdash/common';
-import { Box, Group, Stack, type BoxProps } from '@mantine-8/core';
+import { Box, Center, Group, Stack, type BoxProps } from '@mantine-8/core';
 import {
     ActionIcon,
-    Center,
     CopyButton,
     Highlight,
     Loader,

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -1,6 +1,6 @@
 import { getEmailSchema } from '@lightdash/common';
-import { Button, Stack } from '@mantine-8/core';
-import { Anchor, Center, List, TextInput, Title, Text } from '@mantine/core';
+import { Button, Center, Stack } from '@mantine-8/core';
+import { Anchor, List, TextInput, Title, Text } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -1,12 +1,5 @@
-import { Box, Button, Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    Card,
-    Center,
-    PasswordInput,
-    Title,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Center, Stack } from '@mantine-8/core';
+import { Anchor, Card, PasswordInput, Title, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';


### PR DESCRIPTION
## What & why

Part 6 of the Mantine v6 → v8 migration. Migrates **`Center`** (and `CenterProps`) from `@mantine/core` to `@mantine-8/core` across 13 files. **Stacked on #25241** (Divider) → #25239 → #25238 → #25234 → #25233.

## Changes

- **13 files**: import splits only. **Zero prop renames** — v8 `Center` keeps `inline` + all layout props.
- One `sx` on a `<Center>` (a static `borderRadius` object) → inline `style`. No CSS modules needed.

## Scope / regression analysis

- **Only** `Center` changes alias; every other component stays on v6.
- Pure import move — typecheck backstops the change.

## Verification

- `pnpm -F frontend typecheck:fast` — 0 errors
- `oxlint` on all 13 changed files — 0 warnings / 0 errors
- `oxfmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UJY1ihpNm7LBPLqnMd8j3
