### PR TITLE
refactor(frontend): migrate Paper to mantine-8

### DIFF
--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,11 +1,10 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { Button, Flex, Group } from '@mantine-8/core';
+import { Button, Flex, Group, Paper } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
     ColorSwatch,
     Menu,
-    Paper,
     Tooltip,
     Text,
 } from '@mantine/core';

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import { ActionIcon, Paper, Table, Text } from '@mantine/core';
+import { Group, Paper } from '@mantine-8/core';
+import { ActionIcon, Table, Text } from '@mantine/core';
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
@@ -72,7 +72,7 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
     const { cx, classes } = useTableStyles();
 
     return (
-        <Paper withBorder sx={{ overflow: 'hidden' }}>
+        <Paper withBorder style={{ overflow: 'hidden' }}>
             <Table
                 className={cx(classes.root, classes.alignLastTdRight)}
                 ta="left"

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -4,8 +4,8 @@ import {
     type ResourceViewItemType,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Paper, TextInput } from '@mantine/core';
+import { Paper, Stack } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { useMemo, useState } from 'react';
 import useApp from '../../../providers/App/useApp';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.module.css
@@ -1,0 +1,3 @@
+.emojiPickerPaper {
+    border: 1px solid var(--mantine-color-ldGray-2);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -1,12 +1,6 @@
 import { isEmojiIcon, type CatalogField } from '@lightdash/common';
-import { Box, Button, Group } from '@mantine-8/core';
-import {
-    ActionIcon,
-    getDefaultZIndex,
-    Highlight,
-    Paper,
-    Portal,
-} from '@mantine/core';
+import { Box, Button, Group, Paper } from '@mantine-8/core';
+import { ActionIcon, getDefaultZIndex, Highlight, Portal } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
 import { IconTrash } from '@tabler/icons-react';
 import EmojiPicker, {
@@ -26,6 +20,7 @@ import { EventName } from '../../../types/Events';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useUpdateCatalogItemIcon } from '../hooks/useCatalogItemIcon';
 import { MetricDetailPopover } from './MetricDetailPopover';
+import classes from './MetricsCatalogColumnName.module.css';
 import '../../../styles/emoji-picker-react.css';
 
 const PICKER_HEIGHT = 300;
@@ -62,9 +57,7 @@ const SharedEmojiPicker = forwardRef(
                         withBorder
                         pt="xs"
                         px="two"
-                        sx={(theme) => ({
-                            border: `1px solid ${theme.colors.ldGray[2]}`,
-                        })}
+                        className={classes.emojiPickerPaper}
                     >
                         {emoji && (
                             <Group justify="flex-end">

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.module.css
@@ -1,0 +1,7 @@
+.canvasPaper {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-spacing-sm);
+    box-shadow: 0px 1px 2px 0px rgba(10, 13, 18, 0.05);
+    display: flex;
+    flex-direction: column;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,8 +5,8 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box, Center, Divider, Group } from '@mantine-8/core';
-import { Anchor, Paper, useMantineTheme, Text } from '@mantine/core';
+import { Box, Center, Divider, Group, Paper } from '@mantine-8/core';
+import { Anchor, useMantineTheme, Text } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowsSort,
@@ -52,6 +52,7 @@ import {
 import { MetricCatalogView } from '../types';
 import { MetricExploreModal } from './MetricExploreModal';
 import { MetricsCatalogColumns } from './MetricsCatalogColumns';
+import classes from './MetricsTable.module.css';
 import { MetricsTableTopToolbar } from './MetricsTableTopToolbar';
 import SavedTreesContainer from './SavedTrees/SavedTreesContainer';
 
@@ -635,7 +636,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
         case MetricCatalogView.CANVAS:
             return (
                 <>
-                    <Paper {...mantinePaperProps}>
+                    <Paper className={classes.canvasPaper}>
                         <Box>
                             <MetricsTableTopToolbar
                                 search={search}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.module.css
@@ -1,0 +1,27 @@
+.comparisonCard {
+    cursor: pointer;
+    transition: all 200ms ease-in-out;
+    background-color: var(--mantine-color-background-0);
+}
+
+.comparisonCard[data-with-border='true'] {
+    border: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.comparisonCard[data-selected='true'][data-with-border='true'] {
+    border: 1px solid var(--mantine-color-indigo-5);
+}
+
+.comparisonCard[data-selected='true'] {
+    background-color: light-dark(
+        color-mix(in srgb, var(--mantine-color-ldGray-1), white 30%),
+        var(--mantine-color-ldDark-2)
+    );
+}
+
+.comparisonCard:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-3)
+    );
+}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -5,22 +5,15 @@ import {
     type MetricExplorerQuery,
     type MetricWithAssociatedTimeDimension,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    Loader,
-    Paper,
-    Radio,
-    Select,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Group, Paper, Stack } from '@mantine-8/core';
+import { Anchor, Loader, Radio, Select, Tooltip, Text } from '@mantine/core';
 import { IconCalendar, IconStack } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useCallback, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useSelectStyles } from '../../styles/useSelectStyles';
 import SelectItem from '../SelectItem';
+import comparisonClasses from './MetricExploreComparison.module.css';
 
 type Props = {
     baseMetricLabel: string | undefined;
@@ -137,31 +130,10 @@ export const MetricExploreComparison: FC<Props> = ({
                                 p="sm"
                                 withBorder
                                 radius="md"
-                                sx={(theme) => ({
-                                    cursor: 'pointer',
-                                    transition: `all ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                                    '&[data-with-border="true"]': {
-                                        border:
-                                            query.comparison === comparison.type
-                                                ? `1px solid ${theme.colors.indigo[5]}`
-                                                : `1px solid ${theme.colors.ldGray[2]}`,
-                                    },
-                                    '&:hover': {
-                                        backgroundColor:
-                                            theme.colorScheme === 'dark'
-                                                ? theme.colors.ldDark[3]
-                                                : theme.colors.ldGray[0],
-                                    },
-                                    backgroundColor:
-                                        query.comparison === comparison.type
-                                            ? theme.colorScheme === 'dark'
-                                                ? theme.colors.ldDark[2]
-                                                : theme.fn.lighten(
-                                                      theme.colors.ldGray[1],
-                                                      0.3,
-                                                  )
-                                            : theme.colors.background[0],
-                                })}
+                                className={comparisonClasses.comparisonCard}
+                                data-selected={
+                                    query.comparison === comparison.type
+                                }
                                 onClick={() =>
                                     handleComparisonChange(comparison.type)
                                 }

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -8,12 +8,11 @@ import {
     type VizTableHeaderSortConfig,
     formatSql,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Paper, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Indicator,
     LoadingOverlay,
-    Paper,
     SegmentedControl,
     Tooltip,
     Transition,
@@ -446,11 +445,11 @@ export const ContentPanel: FC = () => {
                     radius={0}
                     px="md"
                     py={6}
-                    sx={(theme) => ({
+                    style={{
                         borderWidth: '0 0 1px 1px',
                         borderStyle: 'solid',
-                        borderColor: theme.colors.ldGray[3],
-                    })}
+                        borderColor: 'var(--mantine-color-ldGray-3)',
+                    }}
                 >
                     <Group justify="space-between">
                         <Group justify="space-between">
@@ -636,17 +635,15 @@ export const ContentPanel: FC = () => {
                             ref={inputSectionRef}
                             shadow="none"
                             radius={0}
-                            style={{ flex: 1 }}
-                            sx={(theme) => ({
+                            style={{
+                                flex: 1,
                                 borderWidth: '0 0 0 1px',
                                 borderStyle: 'solid',
-                                borderColor: theme.colors.ldGray[3],
+                                borderColor: 'var(--mantine-color-ldGray-3)',
                                 overflow: 'auto',
                                 backgroundColor:
-                                    theme.colorScheme === 'dark'
-                                        ? theme.colors.dark[6]
-                                        : 'white',
-                            })}
+                                    'light-dark(white, var(--mantine-color-dark-6))',
+                            }}
                         >
                             <Box
                                 style={{

--- a/packages/frontend/src/features/sqlRunner/components/Header/Header.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/Header/Header.module.css
@@ -1,0 +1,4 @@
+.pageHeader {
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-8));
+}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
-import { Button, Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Menu, Paper, Tooltip, Text } from '@mantine/core';
+import { Button, Group, Paper, Stack } from '@mantine-8/core';
+import { ActionIcon, Menu, Tooltip, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,
@@ -32,6 +32,7 @@ import {
 import { ChartErrorsAlert } from '../ChartErrorsAlert';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { WriteBackToDbtModal } from '../WriteBackToDbtModal';
+import classes from './Header.module.css';
 
 type CtaAction = 'save' | 'createVirtualView' | 'writeBackToDbt';
 
@@ -261,13 +262,7 @@ export const HeaderCreate: FC = () => {
                 withBorder={false}
                 px="md"
                 py="xs"
-                sx={(theme) => ({
-                    borderBottom: `1px solid ${
-                        theme.colorScheme === 'dark'
-                            ? theme.colors.ldDark[8]
-                            : theme.colors.ldGray[3]
-                    }`,
-                })}
+                className={classes.pageHeader}
             >
                 <Group justify="space-between">
                     <Group gap="two">

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,13 +1,6 @@
 import { type SqlChart } from '@lightdash/common';
-import { Button, Group, Stack } from '@mantine-8/core';
-import {
-    ActionIcon,
-    HoverCard,
-    Menu,
-    Paper,
-    Title,
-    Tooltip,
-} from '@mantine/core';
+import { Button, Group, Paper, Stack } from '@mantine-8/core';
+import { ActionIcon, HoverCard, Menu, Title, Tooltip } from '@mantine/core';
 import {
     IconArrowBack,
     IconDots,
@@ -39,6 +32,7 @@ import { DeleteSqlChartModal } from '../DeleteSqlChartModal';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { SqlQueryBeforeSaveAlert } from '../SqlQueryBeforeSaveAlert';
 import { UpdateSqlChartModal } from '../UpdateSqlChartModal';
+import classes from './Header.module.css';
 
 export const HeaderEdit: FC = () => {
     const queryClient = useQueryClient();
@@ -162,13 +156,7 @@ export const HeaderEdit: FC = () => {
                 withBorder={false}
                 px="md"
                 py="xs"
-                sx={(theme) => ({
-                    borderBottom: `1px solid ${
-                        theme.colorScheme === 'dark'
-                            ? theme.colors.ldDark[8]
-                            : theme.colors.ldGray[3]
-                    }`,
-                })}
+                className={classes.pageHeader}
             >
                 <Group justify="space-between">
                     <Stack gap="none">

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DashboardTileTypes } from '@lightdash/common';
-import { Button, Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Menu, Paper, Title, Tooltip } from '@mantine/core';
+import { Button, Group, Paper, Stack } from '@mantine-8/core';
+import { ActionIcon, Menu, Title, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,
@@ -33,6 +33,7 @@ import {
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { toggleModal } from '../../store/sqlRunnerSlice';
 import { DeleteSqlChartModal } from '../DeleteSqlChartModal';
+import classes from './Header.module.css';
 
 export const HeaderView: FC = () => {
     const navigate = useNavigate();
@@ -148,13 +149,7 @@ export const HeaderView: FC = () => {
                 withBorder={false}
                 px="md"
                 py="xs"
-                sx={(theme) => ({
-                    borderBottom: `1px solid ${
-                        theme.colorScheme === 'dark'
-                            ? theme.colors.ldDark[8]
-                            : theme.colors.ldGray[3]
-                    }`,
-                })}
+                className={classes.pageHeader}
             >
                 <Group justify="space-between">
                     <Stack gap="none">

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,6 +1,6 @@
 import { getFieldQuoteChar } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Paper, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack } from '@mantine-8/core';
+import { ActionIcon, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';

--- a/packages/frontend/src/stories/Tree.stories.tsx
+++ b/packages/frontend/src/stories/Tree.stories.tsx
@@ -1,4 +1,5 @@
-import { Paper, ScrollArea } from '@mantine/core';
+import { Paper } from '@mantine-8/core';
+import { ScrollArea } from '@mantine/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import Tree from '../components/common/Tree/Tree';
 


### PR DESCRIPTION
## What & why

Part 7 of the Mantine v6 → v8 migration. Migrates **`Paper`** (and `PaperProps`) from `@mantine/core` to `@mantine-8/core` across 12 files. **Stacked on #25243** (Center) → #25241 → #25239 → #25238 → #25234 → #25233.

## Changes

- **12 files**: import splits only. **Zero prop renames** — v8 `Paper` keeps `radius`/`shadow`/`withBorder`/padding.
- Removed `sx` → CSS modules where a selector / color-scheme branch is involved (4 new modules: SQL Runner `Header`, `MetricsCatalogColumnName`, `MetricExploreComparison`, `MetricsTable`), inline `style` for static objects.
- `theme.colorScheme` (removed in v8) → CSS `light-dark()`.

## Reviewer attention (the one non-trivial conversion)

`MetricExploreComparison` had a **dynamic** `sx` (selected-state border/background). Converted to a `.comparisonCard` module driven by a `data-selected` attribute + CSS selectors (v8 `withBorder` still emits `data-with-border`, so the selectors hold). Two theme values with no CSS-var equivalent were inlined as literals: `theme.other.transition*` → `all 200ms ease-in-out`, and `theme.fn.lighten(ldGray[1], 0.3)` → `color-mix(in srgb, var(--mantine-color-ldGray-1), white 30%)`. Behaviorally equivalent — worth a visual check on the metrics-catalog comparison cards.

`MetricsTable` shares a memoized `mantinePaperProps` (with `sx`) that's still consumed by the v6 mantine-react-table config; that object is left intact for MRT, and the migrated v8 `<Paper>` got a dedicated `.canvasPaper` class instead.

## Verification

- `pnpm -F frontend typecheck:fast` — 0 errors
- `oxlint` on all changed files — 0 warnings / 0 errors
- `oxfmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UJY1ihpNm7LBPLqnMd8j3
