### PR TITLE
fix: support hyphenated model names in field references

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -668,6 +668,126 @@ describe('Parse dimension reference', () => {
     });
 });
 
+describe('Hyphenated table names in references', () => {
+    const hyphenatedTable = 'some_schema-order_events';
+    const exploreWithHyphenatedJoinedTable: UncompiledExplore = {
+        ...simpleJoinedExplore,
+        joinedTables: [
+            {
+                table: hyphenatedTable,
+                sqlOn: `\${a.dim1} = \${${hyphenatedTable}.dim1}`,
+            },
+        ],
+        tables: {
+            a: simpleJoinedExplore.tables.a,
+            [hyphenatedTable]: {
+                ...simpleJoinedExplore.tables.b,
+                name: hyphenatedTable,
+                dimensions: {
+                    dim1: {
+                        ...simpleJoinedExplore.tables.b.dimensions.dim1,
+                        table: hyphenatedTable,
+                    },
+                },
+            },
+        },
+    };
+
+    test('should parse references with hyphenated table names', () => {
+        expect(
+            parseAllReferences(`\${${hyphenatedTable}.dim1}`, 'a'),
+        ).toStrictEqual([{ refName: 'dim1', refTable: hyphenatedTable }]);
+    });
+
+    test('should parse single-part references containing hyphens', () => {
+        expect(parseAllReferences('${my-field}', 'a')).toStrictEqual([
+            { refName: 'my-field', refTable: 'a' },
+        ]);
+    });
+
+    test('should compile join sql_on referencing a hyphenated table', () => {
+        const result = compiler.compileExplore(
+            exploreWithHyphenatedJoinedTable,
+        );
+
+        expect(result.joinedTables[0].compiledSqlOn).toBe(
+            '("a".dim1) = ("some_schema-order_events".dim1)',
+        );
+        expect(result.joinedTables[0].tablesReferences).toStrictEqual([
+            'a',
+            hyphenatedTable,
+        ]);
+    });
+
+    test('should compile a dimension referencing a field in a hyphenated table', () => {
+        const explore: UncompiledExplore = {
+            ...exploreWithHyphenatedJoinedTable,
+            tables: {
+                ...exploreWithHyphenatedJoinedTable.tables,
+                a: {
+                    ...exploreWithHyphenatedJoinedTable.tables.a,
+                    dimensions: {
+                        ...exploreWithHyphenatedJoinedTable.tables.a.dimensions,
+                        dim2: {
+                            ...exploreWithHyphenatedJoinedTable.tables.a
+                                .dimensions.dim1,
+                            name: 'dim2',
+                            label: 'dim2',
+                            sql: `\${${hyphenatedTable}.dim1}`,
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = compiler.compileExplore(explore);
+
+        expect(result.tables.a.dimensions.dim2.compiledSql).toBe(
+            '("some_schema-order_events".dim1)',
+        );
+        expect(result.tables.a.dimensions.dim2.tablesReferences).toEqual(
+            expect.arrayContaining([hyphenatedTable]),
+        );
+    });
+
+    test('should compile a metric referencing a dimension in a hyphenated table', () => {
+        const explore: UncompiledExplore = {
+            ...exploreWithHyphenatedJoinedTable,
+            tables: {
+                ...exploreWithHyphenatedJoinedTable.tables,
+                a: {
+                    ...exploreWithHyphenatedJoinedTable.tables.a,
+                    metrics: {
+                        m1: {
+                            fieldType: FieldType.METRIC,
+                            type: MetricType.SUM,
+                            name: 'm1',
+                            label: 'm1',
+                            table: 'a',
+                            tableLabel: 'a',
+                            sql: `\${${hyphenatedTable}.dim1}`,
+                            hidden: false,
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = compiler.compileExplore(explore);
+
+        expect(result.tables.a.metrics.m1.compiledSql).toBe(
+            'SUM(("some_schema-order_events".dim1))',
+        );
+    });
+
+    test('should still not parse lightdash/ld prefixed references with hyphenated names', () => {
+        expect(
+            parseAllReferences('${lightdash.attributes.my-attr}', 'a'),
+        ).toStrictEqual([]);
+        expect(parseAllReferences('${ld.attr.my-attr}', 'a')).toStrictEqual([]);
+    });
+});
+
 describe('Explore with user attributes', () => {
     test('should compile explore with table and field required attributes', () => {
         expect(

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -63,8 +63,9 @@ import {
 } from './referenceLookup';
 
 // exclude lightdash prefix from variable pattern
+// hyphens are allowed so references to hyphenated dbt model names resolve
 export const lightdashVariablePattern =
-    /\$\{((?!(lightdash|ld)\.)[a-zA-Z0-9_.]+)\}/g;
+    /\$\{((?!(lightdash|ld)\.)[a-zA-Z0-9_.-]+)\}/g;
 
 type Reference = {
     refTable: string;


### PR DESCRIPTION
## Summary

`${table.field}` references fail silently when the referenced table name contains a hyphen (e.g. `${some_schema-order_events.order_id}`): `lightdashVariablePattern` excluded `-` from its character class, so the reference was never matched, and the raw `${...}` text passed through to the warehouse SQL, erroring at query time with a syntax error. Hyphenated dbt model names occur in the wild (e.g. macros that generate schema-prefixed model names to work around dbt's unique-model-name constraint).

This widens the character class to allow hyphens. Compiled references are always identifier-quoted with the warehouse quote char (backticks on BigQuery/Databricks, double quotes elsewhere), so the emitted SQL is safe across dialects.

## Scope

- Hyphenated model names already work everywhere else (explores, field IDs, query API); the reference regex was the only gate.
- The pattern is shared by join `sql_on`, dimension/metric `sql`, table calculations, and the frontend, so all reference sites are fixed consistently.
- `${lightdash.*}` / `${ld.*}` exclusions are unchanged (locked by test).

## Behavior change

Literal `${...}` text containing hyphens that previously passed through to SQL unchanged is now parsed as a reference; if it doesn't resolve, it becomes a per-model compile error instead of broken SQL at query time.

## Testing

- New compiler tests lock the feature: reference parsing, join `sql_on`, dimension refs, and metric refs against a hyphenated table, plus regression tests for the `lightdash`/`ld` exclusions (all new feature tests fail on the old regex).
- Full `common` (2664) and `backend` (3677) suites pass.
- Verified end to end against a local project: a hyphenated model joined via a `${}` reference compiles to correctly quoted SQL and returns correct rows.

Closes: #25244
