### PR TITLE
feat(ai-writeback): dbt/SQL best-practice skill for the writeback agent (PROD-8719)

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/__snapshots__/templates.test.ts.snap
+++ b/packages/backend/src/ee/services/AiWritebackService/__snapshots__/templates.test.ts.snap
@@ -18,6 +18,8 @@ exports[`buildSystemPrompt — warehouse skill guidance > matches the snapshot f
 
 BEFORE editing a \`schema.yml\` \`type:\` field or modifying SQL that changes a column's emitted type, you MUST read /home/user/.lightdash-skills/shared.md. It contains cross-warehouse type-coercion rules. Skipping this step has produced PRs that broke filters and silently changed query results.
 
+Before writing or modifying dbt model SQL (a \`.sql\` model, or a \`schema.yml\` \`sql:\` expression), use the \`effective-dbt-sql\` skill for how to structure it. In particular: reuse an existing dimension or metric instead of re-deriving its value, and never compute a value with a correlated subquery — join an aggregated CTE or use a window function instead. This is separate from the type-coercion rules above: that guidance governs a column's emitted type; this governs the shape of the SQL.
+
 If you made any file changes, perform these follow-up steps before you finish:
 
 1. The dbt project directory (containing \`dbt_project.yml\`) is
@@ -91,6 +93,8 @@ exports[`buildSystemPrompt — warehouse skill guidance > matches the snapshot f
 - Do NOT commit, push, or run any git commands — the host handles git.
 
 This Lightdash project's warehouse is **postgres**. BEFORE editing a \`schema.yml\` \`type:\` field or modifying SQL that changes a column's emitted type, you MUST read /home/user/.lightdash-skills/warehouse.md and /home/user/.lightdash-skills/shared.md. They contain warehouse-specific type-coercion rules. Skipping this step has produced PRs that broke filters and silently changed query results.
+
+Before writing or modifying dbt model SQL (a \`.sql\` model, or a \`schema.yml\` \`sql:\` expression), use the \`effective-dbt-sql\` skill for how to structure it. In particular: reuse an existing dimension or metric instead of re-deriving its value, and never compute a value with a correlated subquery — join an aggregated CTE or use a window function instead. This is separate from the type-coercion rules above: that guidance governs a column's emitted type; this governs the shape of the SQL.
 
 If you made any file changes, perform these follow-up steps before you finish:
 

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -35,6 +35,12 @@ export const SHARED_SKILL_PATH = `${SKILLS_DIR}/shared.md`;
 // it must be both allowlisted (ALLOWED_TOOLS) and passed via --add-dir.
 export const CLAUDE_SKILLS_DIR = '/home/user/.claude/skills';
 
+// Name of the baked dbt/SQL best-practice skill (repo-root `skills/<name>/`,
+// installed into CLAUDE_SKILLS_DIR). The system prompt names it so the agent
+// loads it via the `Skill` tool — auto-discovery alone doesn't pull in a
+// skill's body, so the reference is what triggers the load.
+export const EFFECTIVE_DBT_SQL_SKILL = 'effective-dbt-sql';
+
 // Files the agent writes for the host to open a PR from. Kept as a fallback
 // — the primary channel is now structured output blocks in the agent's stdout
 // (see PR_TITLE_OPEN/CLOSE etc.).

--- a/packages/backend/src/ee/services/AiWritebackService/templates.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.test.ts
@@ -1,7 +1,11 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { SHARED_SKILL_PATH, WAREHOUSE_SKILL_PATH } from './constants';
+import {
+    EFFECTIVE_DBT_SQL_SKILL,
+    SHARED_SKILL_PATH,
+    WAREHOUSE_SKILL_PATH,
+} from './constants';
 import { warehouseTypeToSkillKey } from './skills';
-import { buildSystemPrompt } from './templates';
+import { buildGeneralSystemPrompt, buildSystemPrompt } from './templates';
 
 const DBT_PROJECT_DIR = 'analytics/dbt';
 const BASE_CONTEXT = {
@@ -73,5 +77,39 @@ describe('buildSystemPrompt — warehouse skill guidance', () => {
 
     it('matches the snapshot for a no-skill warehouse (duckdb)', () => {
         expect(buildFor(WarehouseTypes.DUCKDB)).toMatchSnapshot();
+    });
+});
+
+describe('buildSystemPrompt — dbt/SQL skill guidance', () => {
+    it('names the effective-dbt-sql skill and calls out correlated subqueries', () => {
+        const prompt = buildFor(WarehouseTypes.POSTGRES);
+        expect(prompt).toContain(EFFECTIVE_DBT_SQL_SKILL);
+        expect(prompt).toContain('correlated subquery');
+        expect(prompt).toMatch(/reuse an existing dimension or metric/);
+    });
+
+    it('injects the nudge regardless of warehouse (warehouse-agnostic)', () => {
+        expect(buildFor(null)).toContain(EFFECTIVE_DBT_SQL_SKILL);
+        expect(buildFor(WarehouseTypes.CLICKHOUSE)).toContain(
+            EFFECTIVE_DBT_SQL_SKILL,
+        );
+    });
+
+    it('de-conflicts with the warehouse guidance rather than restating it', () => {
+        const prompt = buildFor(WarehouseTypes.POSTGRES);
+        // The SQL nudge points to the type-coercion guidance as a separate
+        // concern instead of adding a second competing "you MUST read" block.
+        expect(prompt).toContain('separate from the type-coercion rules');
+        expect(prompt).not.toMatch(
+            /BEFORE writing.*dbt model SQL.*you MUST read/,
+        );
+    });
+
+    it('is scoped to the dbt writeback agent — absent from the general prompt', () => {
+        const general = buildGeneralSystemPrompt({
+            repository: 'acme/jaffle',
+            repoContext: null,
+        });
+        expect(general).not.toContain(EFFECTIVE_DBT_SQL_SKILL);
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -1,6 +1,7 @@
 import type { WarehouseTypes } from '@lightdash/common';
 import {
     COMPILE_WRAPPER_PATH,
+    EFFECTIVE_DBT_SQL_SKILL,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
     PR_SUMMARY_CLOSE,
@@ -33,6 +34,15 @@ const buildWarehouseSkillGuidance = (
     // agent still gets the cross-warehouse rules.
     return `${trigger} ${SHARED_SKILL_PATH}. It contains cross-warehouse type-coercion rules. ${consequence}`;
 };
+
+// Points the agent at the baked dbt/SQL best-practice skill before it writes
+// model SQL. Separate concern from the warehouse skill above (which is about a
+// column's emitted TYPE); this one is about SQL STRUCTURE — reusing existing
+// fields instead of re-deriving them with correlated subqueries. Named so the
+// agent loads it via the `Skill` tool: auto-discovery surfaces a skill's
+// frontmatter but does not pull in its body on its own.
+const buildDbtSqlSkillGuidance = (): string =>
+    `Before writing or modifying dbt model SQL (a \`.sql\` model, or a \`schema.yml\` \`sql:\` expression), use the \`${EFFECTIVE_DBT_SQL_SKILL}\` skill for how to structure it. In particular: reuse an existing dimension or metric instead of re-deriving its value, and never compute a value with a correlated subquery — join an aggregated CTE or use a window function instead. This is separate from the type-coercion rules above: that guidance governs a column's emitted type; this governs the shape of the SQL.`;
 
 // Instructions prepended to every user prompt. The host owns git, so the agent
 // must not touch it; instead it leaves the PR title/description on disk.
@@ -99,6 +109,8 @@ You are an autonomous coding agent working inside a checkout of a git repository
 - Do NOT commit, push, or run any git commands — the host handles git.
 
 ${buildWarehouseSkillGuidance(context.warehouseType, context.hasWarehouseSkill)}
+
+${buildDbtSqlSkillGuidance()}
 ${
     context.repoContext
         ? `

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -1,0 +1,104 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Repo-root `skills/` packages are baked into the writeback sandbox by
+// `lightdash install-skills` (see handlers/installSkills.ts). Unlike the
+// chat-agent copies under packages/backend/.../builtInSkills, nothing else
+// validates these at build time, so this test guards their shape: valid
+// frontmatter, name matching the directory, and no dead resource links.
+
+const SKILLS_DIR = path.resolve(__dirname, '../../../skills');
+
+const listSkillDirs = (): string[] =>
+    fs
+        .readdirSync(SKILLS_DIR, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+
+// Minimal YAML-frontmatter reader — the CLI package has no gray-matter dep and
+// we only need the two scalar fields the skill contract requires.
+const parseFrontmatter = (
+    markdown: string,
+): { name: string | null; description: string | null } => {
+    const match = markdown.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) {
+        return { name: null, description: null };
+    }
+    const readField = (field: string): string | null => {
+        const line = match[1]
+            .split('\n')
+            .find((l) => l.startsWith(`${field}:`));
+        if (!line) {
+            return null;
+        }
+        return line.slice(field.length + 1).trim() || null;
+    };
+    return { name: readField('name'), description: readField('description') };
+};
+
+describe('repo-root skills packages', () => {
+    const skillDirs = listSkillDirs();
+
+    it('has at least one skill package', () => {
+        expect(skillDirs.length).toBeGreaterThan(0);
+    });
+
+    it.each(skillDirs)(
+        'skill "%s" has valid frontmatter, matching name, and resolvable resource links',
+        (dir) => {
+            const skillPath = path.join(SKILLS_DIR, dir, 'SKILL.md');
+            expect(fs.existsSync(skillPath)).toBe(true);
+
+            const markdown = fs.readFileSync(skillPath, 'utf-8');
+            const { name, description } = parseFrontmatter(markdown);
+
+            expect(name).toBe(dir);
+            expect(description).toEqual(expect.any(String));
+            expect((description ?? '').length).toBeGreaterThan(0);
+
+            // Every ./resources/*.md link referenced in SKILL.md must resolve.
+            const linked = [
+                ...markdown.matchAll(/\]\((\.\/resources\/[^)]+)\)/g),
+            ].map((m) => m[1]);
+            linked.forEach((rel) => {
+                const resolved = path.join(SKILLS_DIR, dir, rel);
+                expect(
+                    fs.existsSync(resolved),
+                    `dead resource link ${rel} in ${dir}/SKILL.md`,
+                ).toBe(true);
+            });
+        },
+    );
+});
+
+describe('effective-dbt-sql skill content policy', () => {
+    const skillDir = path.join(SKILLS_DIR, 'effective-dbt-sql');
+    const skillMd = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8');
+
+    it('exists', () => {
+        expect(fs.existsSync(skillDir)).toBe(true);
+    });
+
+    it('encodes the core semantic rules', () => {
+        const body = skillMd.toLowerCase();
+        expect(body).toContain('correlated subquer');
+        expect(body).toContain('cte');
+        expect(body).toContain('reuse');
+    });
+
+    it('carries the "match the target repo" fallback-defaults guardrail', () => {
+        expect(skillMd.toLowerCase()).toContain('fallback default');
+        expect(skillMd.toLowerCase()).toMatch(/match the (target )?repo/);
+    });
+
+    it('declares itself semantics-only (defers naming/formatting to the repo)', () => {
+        // The skill deliberately drops house-style opinions so it never fights
+        // the target repo's conventions. Assert the contract is stated rather
+        // than grepping for banned tokens (a disclaimer legitimately names
+        // them), so the semantics-only scope can't silently drift into
+        // prescribing naming or formatting.
+        const body = skillMd.toLowerCase();
+        expect(body).toContain('semantics only');
+        expect(body).toMatch(/does not prescribe|not in scope/);
+    });
+});

--- a/skills/effective-dbt-sql/SKILL.md
+++ b/skills/effective-dbt-sql/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: effective-dbt-sql
+description: Use when writing or modifying dbt model SQL — deciding whether to add a subquery or reuse an existing dimension/metric, structuring a query, joining models, or refactoring a metric's SQL. Encodes SQL semantic-correctness rules: reuse existing fields, prefer CTEs over correlated subqueries, and make joins and column lists explicit.
+---
+
+# Effective dbt SQL
+
+Write dbt model SQL that is correct, readable, and idiomatic. This skill is about the **semantics** of the SQL you write — not naming or formatting.
+
+## Scope
+
+**Use this when** you are about to write or change SQL inside a dbt model (`.sql`), or a metric/dimension whose value is defined by SQL.
+
+**This skill covers semantics only.** It does **not** prescribe naming schemes, file layout, or indentation. For those, follow the rule below.
+
+> **Match the target repo first.** These are fallback defaults, not mandates. Before applying any rule, read the models around the one you are changing and match the repo's established conventions where they differ. Apply these rules to new or changed SQL only — do **not** reformat, rename, or restructure existing code that already works.
+
+## The rules
+
+1. **Reuse before you re-derive.** If the value you are asked for is already expressed by an existing dimension or metric — or by two of them combined — compose those fields instead of writing new SQL to recompute it. Read the model's existing dimensions/metrics before adding one. See [reuse-over-subqueries](./resources/reuse-over-subqueries.md).
+
+2. **No correlated subqueries.** Never compute a value with a subquery that references the outer query's rows (a per-row correlated subquery in `SELECT` or `WHERE`). Reuse an existing field, or join to an aggregated CTE instead. This is the single most common mistake. See [cte-pipelines](./resources/cte-pipelines.md).
+
+3. **CTEs over nested subqueries.** Structure a query as a pipeline of named CTEs, each referenced by the next, ending in a final `select`. Prefer this over subqueries nested inside `from`/`where`. See [cte-pipelines](./resources/cte-pipelines.md).
+
+4. **Explicit joins.** Always state the join type (`inner`/`left`/…) and the `on` condition. Never comma-join. Know the grain: a join that fans out rows silently changes every downstream aggregate.
+
+5. **Explicit columns.** Select named columns rather than `select *` when adding or changing what a model emits, so a change to an upstream model can't silently alter this model's output. (A pass-through `select * from final` at the very end of a CTE pipeline is fine — the columns are already pinned by the CTEs.)
+
+6. **Don't break references.** Before editing a model's SQL, read the `source()`/`ref()` models it selects from. Do not rename or remove a column that downstream models or `schema.yml` reference without checking the impact first.
+
+## Not in scope
+
+- **Emitted-type / casting safety** (e.g. boolean-vs-numeric column types): follow the **warehouse skill** the system prompt points you to (`/home/user/.lightdash-skills/`). This skill does not restate casting rules.
+- **Naming and formatting conventions:** match the target repo (see the rule above).

--- a/skills/effective-dbt-sql/resources/cte-pipelines.md
+++ b/skills/effective-dbt-sql/resources/cte-pipelines.md
@@ -1,0 +1,82 @@
+# CTE pipelines (and why not subqueries)
+
+Structure a model as a pipeline of named CTEs. Each CTE does one job and is referenced by the next; the query ends in a single final `select`.
+
+```sql
+with
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+order_payments as (
+    select
+        orders.order_id,
+        orders.customer_id,
+        sum(payments.amount) as total_amount
+    from orders
+    left join payments on orders.order_id = payments.order_id
+    group by 1, 2
+),
+
+final as (
+    select
+        order_id,
+        customer_id,
+        total_amount
+    from order_payments
+)
+
+select * from final
+```
+
+Why a pipeline:
+
+- Each step is independently readable and testable.
+- The grain is explicit at every stage — you can see where an aggregate collapses rows.
+- The final `select * from final` is safe because the columns were already pinned by the CTEs.
+
+## Never use a correlated subquery
+
+A correlated subquery recomputes a value **per outer row** by referencing that row inside the subquery. It is the most common non-idiomatic pattern the agent produces, and it is almost always wrong here — it is slow, hard to read, and easy to get wrong on grain.
+
+Do **not** write:
+
+```sql
+-- correlated subquery: recomputed for every order row
+select
+    o.order_id,
+    (
+        select sum(p.amount)
+        from payments p
+        where p.order_id = o.order_id   -- references the outer row
+    ) as total_amount
+from orders o
+```
+
+Instead, aggregate once in a CTE and join:
+
+```sql
+with payment_totals as (
+    select order_id, sum(amount) as total_amount
+    from {{ ref('stg_payments') }}
+    group by 1
+)
+
+select
+    orders.order_id,
+    payment_totals.total_amount
+from {{ ref('stg_orders') }} as orders
+left join payment_totals on orders.order_id = payment_totals.order_id
+```
+
+Or, if the value is already a metric/dimension on the model, **reuse that field** rather than recomputing it (see [reuse-over-subqueries](./reuse-over-subqueries.md)).
+
+## Other structural preferences
+
+- `union all`, not `union`, unless you specifically need to deduplicate (dedup is a real cost and usually a modelling smell).
+- For "latest/first row per group", use a window function in a CTE (`row_number()` / `qualify`) referenced once — not a repeated subquery in `where`.

--- a/skills/effective-dbt-sql/resources/reuse-over-subqueries.md
+++ b/skills/effective-dbt-sql/resources/reuse-over-subqueries.md
@@ -1,0 +1,27 @@
+# Reuse existing fields before re-deriving them
+
+The most valuable thing you can do when asked to add a metric or column is to check whether the semantic layer **already expresses it**, and compose the existing fields instead of writing new SQL to recompute the value.
+
+## The pattern to avoid
+
+A request like *"add a metric for the average order value"* on a model that already has `total_revenue` and `order_count` metrics. The wrong move is to write fresh SQL — often a subquery — that recomputes revenue and counts from the raw rows. The right move is to define the new metric in terms of the two that already exist.
+
+## How to do it
+
+1. **Read the model first.** Before adding anything, read the model's existing `dimensions:` and `metrics:` (in `schema.yml` and the `.sql`). List what is already defined.
+2. **Check whether the request is a combination of existing fields.** Ratios, differences, and rates are usually two existing measures combined — not a new base computation.
+3. **Compose, don't recompute.** Express the new field using the existing ones. In Lightdash, a metric can reference other metrics/dimensions; a derived column in SQL can reference already-selected columns in a later CTE. Either way you inherit the existing field's tested definition instead of forking it.
+4. **Only add base SQL when the value genuinely isn't modelled.** If nothing existing expresses it, add it — as a clean CTE-based derivation (see [cte-pipelines](./cte-pipelines.md)), never a correlated subquery.
+
+## Why reuse matters here
+
+- **Correctness by inheritance.** The existing field already encodes the right grain, filters, and casting. Recomputing risks diverging from it — a subtle bug that produces two "revenue" numbers that disagree.
+- **Less to review.** A PR that composes existing fields is small and obviously correct; one that recomputes is large and has to be re-verified from scratch.
+- **This is the exact class of change this skill exists to fix.**
+
+## Guardrail: don't break what references the field
+
+Before editing a model's SQL:
+
+- Read the `source()`/`ref()` models it selects from so you know the real columns and their grain.
+- Do not rename or remove a column that downstream models or `schema.yml` reference without checking the impact first. A rename that compiles can still break a downstream `ref` or a chart that used the old name.


### PR DESCRIPTION
## What

Adds a baked Claude Code skill, `skills/effective-dbt-sql/`, that gives the dbt-writeback sandbox agent curated guidance on how to write good dbt SQL.

Linear: [PROD-8719](https://linear.app/lightdash/issue/PROD-8719)

## Why

The writeback agent has repo/knowledge context and file discovery but no curated domain knowledge about idiomatic dbt/SQL. On repos whose existing models use non-idiomatic patterns, it imitates them — e.g. adding a new field via a **correlated subquery** instead of reusing existing fields or joining an aggregated CTE (a pattern seen in a recent writeback incident).

## What's in the skill

Deliberately **semantics-only** — SQL correctness/idiom, no house-style opinions:
- Reuse an existing dimension/metric instead of re-deriving its value
- Never compute a value with a correlated subquery — join an aggregated CTE or use a window function
- Explicit joins and explicit column lists
- Guardrail: match the target repo's existing conventions; treat these as fallback defaults and apply them to new/changed code only (don't reformat working code)

It defers naming/formatting entirely to the target repo, and cross-references (rather than restating) the existing warehouse type-coercion skill.

## Delivery & the prompt nudge

The skill ships via the existing `lightdash install-skills` step (repo-root `skills/` → `/home/user/.claude/skills/`), so no sandbox/Dockerfile/allowlist changes are needed.

Claude Code's auto-discovery injects a skill's frontmatter but does **not** load its body on its own, so `buildSystemPrompt` now names the skill to trigger the load — mirroring the existing `buildWarehouseSkillGuidance` nudge, and framed as a separate concern (SQL *structure* vs. a column's emitted *type*) so it doesn't compete with it. Scoped to the dbt-writeback agent only; the general editRepo prompt is untouched.

## Testing

- New `packages/cli/src/skills.test.ts` validates every repo-root skill package (frontmatter, name↔dir, resolvable resource links) — also guards the existing `developing-in-lightdash` package.
- `templates.test.ts` asserts the nudge is present in the dbt prompt, absent from the general prompt, and de-conflicts with the warehouse guidance; snapshots updated.
- Verified end-to-end against a local writeback run: with the skill baked but no nudge the agent never loads it; with the nudge it does (`Skill` tool invoked). On a model that already contains correlated subqueries, the un-nudged agent imitates the pattern while the nudged agent refactors the new column to a CTE + join, leaving existing code untouched.

## Notes

The skill content is an initial, semantics-only pass and is expected to be refined with more authoritative dbt/SQL guidance in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)