### PR TITLE
feat(tracing): OTLP/GCP as sole trace exporter, quieter traces, always-sample AI (ZAP-581, ZAP-562, ZAP-582)

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -11,6 +11,7 @@ import {
     UnexpectedServerError,
     UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES,
 } from '@lightdash/common';
+import { trace } from '@opentelemetry/api';
 import * as Sentry from '@sentry/node';
 import flash from 'connect-flash';
 import connectSessionKnex from 'connect-session-knex';
@@ -692,6 +693,17 @@ export default class App {
                         req.user.organizationName,
                     );
                 }
+                // Sentry tags are error-scope only; stamp the same attribution
+                // on the request span so it's queryable in the trace backend.
+                trace.getActiveSpan()?.setAttributes({
+                    'user.uuid': req.user.userUuid,
+                    ...(req.user.organizationUuid && {
+                        'organization.uuid': req.user.organizationUuid,
+                    }),
+                    ...(req.user.organizationName && {
+                        'organization.name': req.user.organizationName,
+                    }),
+                });
             }
             next();
         });

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -24,7 +24,7 @@ import {
     shouldSelfRegisterHttpInstrumentation,
 } from './prometheus/otelHttpMetrics';
 import PrometheusMetrics from './prometheus/PrometheusMetrics';
-import { IGNORE_ERRORS } from './sentry';
+import { errorsOnlyIntegrations, IGNORE_ERRORS } from './sentry';
 import { createOrganizationNameResolver } from './sentry/organizationNameResolver';
 import {
     OperationContext,
@@ -206,11 +206,17 @@ export default class NatsWorkerApp {
                     : this.lightdashConfig.mode,
             skipOpenTelemetrySetup: otelTracingEnabled(),
             registerEsmLoaderHooks: !otelTracingEnabled(),
-            integrations: [],
+            // OTel mode owns traces; strip Sentry's span-emitting default
+            // integrations (postgres etc.) so the worker is errors-only.
+            integrations: otelTracingEnabled() ? errorsOnlyIntegrations : [],
             ignoreErrors: IGNORE_ERRORS,
-            tracesSampleRate:
-                this.lightdashConfig.sentry.queryTracesSampleRate ??
-                this.lightdashConfig.sentry.tracesSampleRate,
+            ...(otelTracingEnabled()
+                ? {}
+                : {
+                      tracesSampleRate:
+                          this.lightdashConfig.sentry.queryTracesSampleRate ??
+                          this.lightdashConfig.sentry.tracesSampleRate,
+                  }),
         });
         initOtelTracing();
     }

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -31,7 +31,7 @@ import {
     derivePoolIdFromEnv,
     SchedulerWorkerHealth,
 } from './scheduler/SchedulerWorkerHealth';
-import { IGNORE_ERRORS } from './sentry';
+import { errorsOnlyIntegrations, IGNORE_ERRORS } from './sentry';
 import { createOrganizationNameResolver } from './sentry/organizationNameResolver';
 import {
     OperationContext,
@@ -248,7 +248,9 @@ export default class SchedulerApp {
                     : this.lightdashConfig.mode,
             skipOpenTelemetrySetup: otelTracingEnabled(),
             registerEsmLoaderHooks: !otelTracingEnabled(),
-            integrations: [],
+            // OTel mode owns traces; strip Sentry's span-emitting default
+            // integrations (postgres etc.) so the worker is errors-only.
+            integrations: otelTracingEnabled() ? errorsOnlyIntegrations : [],
             ignoreErrors: IGNORE_ERRORS,
         });
         initOtelTracing();

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -8,7 +8,7 @@ import { ParameterError } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import type { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
-import { traceSpan } from '../../tracing/tracing';
+import { traceSpan, type TraceSpan } from '../../tracing/tracing';
 import {
     getManagedAgentConfigHash,
     renderManagedAgentConfig,
@@ -319,7 +319,7 @@ export class ManagedAgentClient {
         sessionConfig: ManagedAgentSessionConfig,
         projectName: string,
         onCustomToolUse: CustomToolHandler,
-        span: Sentry.Span,
+        span: TraceSpan,
         onSessionCreated?: (sessionId: string) => void,
     ): Promise<{
         sessionId: string;

--- a/packages/backend/src/nats/NatsWorker.ts
+++ b/packages/backend/src/nats/NatsWorker.ts
@@ -1,4 +1,5 @@
 import { getErrorMessage } from '@lightdash/common';
+import { trace } from '@opentelemetry/api';
 import * as Sentry from '@sentry/node';
 import { StringCodec, type Consumer, type JsMsg } from 'nats';
 import { z } from 'zod';
@@ -345,6 +346,18 @@ export class NatsWorker {
             }
 
             Sentry.setTags({
+                ...(organizationUuid && {
+                    'organization.uuid': organizationUuid,
+                }),
+                ...(organizationName && {
+                    'organization.name': organizationName,
+                }),
+            });
+
+            // Sentry tags are error-scope only; stamp the same attribution on
+            // the queue_consumer span so it's queryable in the trace backend.
+            trace.getActiveSpan()?.setAttributes({
+                ...(createdByUserUuid && { 'user.uuid': createdByUserUuid }),
                 ...(organizationUuid && {
                     'organization.uuid': organizationUuid,
                 }),

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.test.ts
@@ -38,7 +38,8 @@ continueTraceMock.mockImplementation(
 );
 startSpanMock.mockImplementation(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (_opts: unknown, cb: any) => cb({ setStatus: vi.fn() }),
+    (_opts: unknown, cb: any) =>
+        cb({ setStatus: vi.fn(), setAttributes: vi.fn() }),
 );
 
 const makeHelpers = () =>

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -332,6 +332,16 @@ export const traceTask = <T extends SchedulerTaskName>(
                               ).catch(() => undefined)
                             : undefined;
 
+                        // Sentry tags below are error-scope only; stamp the
+                        // attribution on the task span so it's queryable in
+                        // the trace backend.
+                        span.setAttributes({
+                            ...payloadTags,
+                            ...(organizationName && {
+                                'organization.name': organizationName,
+                            }),
+                        });
+
                         if ('user.uuid' in payloadTags) {
                             Sentry.setUser({
                                 id: payloadTags['user.uuid'],

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -1,3 +1,4 @@
+import type { NodeOptions } from '@sentry/node';
 import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { lightdashConfig } from './config/lightdashConfig';
@@ -33,6 +34,59 @@ initOtelHttpMetrics(lightdashConfig.prometheus, {
     }),
 });
 
+/**
+ * Sentry default integrations whose job is emitting spans via bundled OTel
+ * instrumentations. When OTLP/GCP is the trace backend, Sentry is errors-only:
+ * left in place these register global instrumentation whose spans flood our
+ * OTLP exporter (e.g. a pg.query span per Postgres query — Sentry's
+ * postgresIntegration, not our NodeSDK, was the source of those).
+ */
+const SENTRY_SPAN_INTEGRATIONS = new Set([
+    'Http',
+    'NodeFetch',
+    'Express',
+    'Postgres',
+    'PostgresJs',
+    'Knex',
+    'Mysql',
+    'Mysql2',
+    'Graphql',
+    'Mongo',
+    'Mongoose',
+    'Redis',
+    'Prisma',
+    'Hapi',
+    'Koa',
+    'Connect',
+    'Fastify',
+    'Tedious',
+    'GenericPool',
+    'Dataloader',
+    'Amqplib',
+    'Kafka',
+    'LruMemoizer',
+    'VercelAI',
+]);
+
+/**
+ * Errors-only integration set for OTel mode: strips span-emitting defaults and
+ * re-adds Http/NodeFetch with spans disabled — they still provide per-request
+ * isolation and breadcrumbs for error capture.
+ */
+// Two @sentry/core versions coexist in the dependency tree; derive the
+// Integration type from @sentry/node so it matches the SDK we call.
+type Integration = ReturnType<typeof Sentry.httpIntegration>;
+
+export const errorsOnlyIntegrations = (
+    defaultIntegrations: Integration[],
+): Integration[] => [
+    ...defaultIntegrations.filter(
+        (integration) => !SENTRY_SPAN_INTEGRATIONS.has(integration.name),
+    ),
+    Sentry.httpIntegration({ spans: false }),
+    Sentry.nativeNodeFetchIntegration({ spans: false }),
+];
+
 export const IGNORE_ERRORS = [
     'WarehouseConnectionError',
     'WarehouseQueryError',
@@ -53,6 +107,70 @@ export const IGNORE_ERRORS = [
     'ParameterError',
 ];
 
+const anrIntegrations = lightdashConfig.sentry.anr.enabled
+    ? [
+          Sentry.anrIntegration({
+              pollInterval: 50, // ms
+              anrThreshold: lightdashConfig.sentry.anr.timeout || 5000, // ms
+              captureStackTrace: lightdashConfig.sentry.anr.captureStacktrace,
+          }),
+      ]
+    : [];
+
+const tracesSampler: NodeOptions['tracesSampler'] = (context) => {
+    if (spotlightEnabled) {
+        return 1.0;
+    }
+
+    const request = context.normalizedRequest;
+    if (
+        request?.url?.endsWith('/status') ||
+        request?.url?.endsWith('/health') ||
+        request?.url?.endsWith('/favicon.ico') ||
+        request?.url?.endsWith('/robots.txt') ||
+        request?.url?.endsWith('livez') ||
+        request?.headers?.['user-agent']?.includes('GoogleHC')
+    ) {
+        return 0.0;
+    }
+
+    if (context.parentSampled) {
+        return context.parentSampled;
+    }
+
+    // Boost sampling for async query execution when queryTracesSampleRate is set
+    // Set SENTRY_QUERY_TRACES_SAMPLE_RATE=1.0 for 100% attribution on query traces
+    const { queryTracesSampleRate } = lightdashConfig.sentry;
+    if (queryTracesSampleRate !== null) {
+        // Match by span/transaction name (e.g. scheduler-triggered queries)
+        const spanName = context.name ?? '';
+        if (spanName.includes('ProjectService.executeAsyncQuery')) {
+            return queryTracesSampleRate;
+        }
+
+        // Match query endpoints (metric-query/dashboard-chart)
+        if (request?.url) {
+            try {
+                const url = new URL(
+                    request.url,
+                    `http://${request.headers?.host || 'localhost'}`,
+                );
+                if (
+                    /\/api\/v2\/projects\/[^/]+\/query\/(?:metric-query|dashboard-chart)$/.test(
+                        url.pathname,
+                    )
+                ) {
+                    return queryTracesSampleRate;
+                }
+            } catch {
+                // Ignore URL parse errors, fall through to default
+            }
+        }
+    }
+
+    return lightdashConfig.sentry.tracesSampleRate;
+};
+
 Sentry.init({
     release: VERSION,
     enabled: process.env.NODE_ENV !== 'test',
@@ -64,87 +182,39 @@ Sentry.init({
     skipOpenTelemetrySetup: otelTracingEnabled(),
     registerEsmLoaderHooks: !otelTracingEnabled(),
     spotlight: spotlightEnabled,
-    integrations: [
-        /**
-         * Some integrations are enabled by default
-         * @ref https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/
-         */
-        nodeProfilingIntegration(),
-        ...(lightdashConfig.sentry.anr.enabled
-            ? [
-                  Sentry.anrIntegration({
-                      pollInterval: 50, // ms
-                      anrThreshold: lightdashConfig.sentry.anr.timeout || 5000, // ms
-                      captureStackTrace:
-                          lightdashConfig.sentry.anr.captureStacktrace,
-                  }),
-              ]
-            : []),
-        ...(lightdashConfig.ai.copilot.enabled &&
-        lightdashConfig.ai.copilot.telemetryEnabled
-            ? [
-                  Sentry.vercelAIIntegration({
-                      recordInputs: true,
-                      recordOutputs: true,
-                  }),
-              ]
-            : []),
-    ],
+    /**
+     * OTel mode (LIGHTDASH_OTEL_TRACES_ENABLED): Sentry is errors-only — span
+     * integrations are stripped and no sampler/profiler is configured; traces
+     * are owned by the OTel SDK (see tracing.ts). Otherwise Sentry tracing
+     * behaves as it always has (self-hosted, local Spotlight).
+     * @ref https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/
+     */
+    integrations: otelTracingEnabled()
+        ? (defaultIntegrations) => [
+              ...errorsOnlyIntegrations(defaultIntegrations),
+              ...anrIntegrations,
+          ]
+        : [
+              nodeProfilingIntegration(),
+              ...anrIntegrations,
+              ...(lightdashConfig.ai.copilot.enabled &&
+              lightdashConfig.ai.copilot.telemetryEnabled
+                  ? [
+                        Sentry.vercelAIIntegration({
+                            recordInputs: true,
+                            recordOutputs: true,
+                        }),
+                    ]
+                  : []),
+          ],
     ignoreErrors: IGNORE_ERRORS,
-    tracesSampler: (context) => {
-        if (spotlightEnabled) {
-            return 1.0;
-        }
-
-        const request = context.normalizedRequest;
-        if (
-            request?.url?.endsWith('/status') ||
-            request?.url?.endsWith('/health') ||
-            request?.url?.endsWith('/favicon.ico') ||
-            request?.url?.endsWith('/robots.txt') ||
-            request?.url?.endsWith('livez') ||
-            request?.headers?.['user-agent']?.includes('GoogleHC')
-        ) {
-            return 0.0;
-        }
-
-        if (context.parentSampled) {
-            return context.parentSampled;
-        }
-
-        // Boost sampling for async query execution when queryTracesSampleRate is set
-        // Set SENTRY_QUERY_TRACES_SAMPLE_RATE=1.0 for 100% attribution on query traces
-        const { queryTracesSampleRate } = lightdashConfig.sentry;
-        if (queryTracesSampleRate !== null) {
-            // Match by span/transaction name (e.g. scheduler-triggered queries)
-            const spanName = context.name ?? '';
-            if (spanName.includes('ProjectService.executeAsyncQuery')) {
-                return queryTracesSampleRate;
-            }
-
-            // Match query endpoints (metric-query/dashboard-chart)
-            if (request?.url) {
-                try {
-                    const url = new URL(
-                        request.url,
-                        `http://${request.headers?.host || 'localhost'}`,
-                    );
-                    if (
-                        /\/api\/v2\/projects\/[^/]+\/query\/(?:metric-query|dashboard-chart)$/.test(
-                            url.pathname,
-                        )
-                    ) {
-                        return queryTracesSampleRate;
-                    }
-                } catch {
-                    // Ignore URL parse errors, fall through to default
-                }
-            }
-        }
-
-        return lightdashConfig.sentry.tracesSampleRate;
-    },
-    profilesSampleRate: lightdashConfig.sentry.profilesSampleRate, // x% of samples will be profiled
+    ...(otelTracingEnabled()
+        ? {}
+        : {
+              tracesSampler,
+              // x% of samples will be profiled
+              profilesSampleRate: lightdashConfig.sentry.profilesSampleRate,
+          }),
     beforeBreadcrumb(breadcrumb) {
         if (
             breadcrumb.category === 'http' &&

--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -1,0 +1,140 @@
+import { context, SpanKind } from '@opentelemetry/api';
+import { SamplingDecision, type Sampler } from '@opentelemetry/sdk-trace-base';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    AlwaysSampleAiRootsSampler,
+    sentryTraceToTraceparent,
+} from './tracing';
+
+const TRACE_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const SPAN_ID = 'bbbbbbbbbbbbbbbb';
+
+const makeDelegate = (decision: SamplingDecision): Sampler => ({
+    shouldSample: vi.fn().mockReturnValue({ decision }),
+    toString: () => 'delegate',
+});
+
+const sample = (
+    sampler: AlwaysSampleAiRootsSampler,
+    spanName: string,
+    attributes: Record<string, string> = {},
+) =>
+    sampler.shouldSample(
+        context.active(),
+        TRACE_ID,
+        spanName,
+        SpanKind.SERVER,
+        attributes,
+        [],
+    ).decision;
+
+describe('AlwaysSampleAiRootsSampler', () => {
+    it('always samples AI worker task roots', () => {
+        const delegate = makeDelegate(SamplingDecision.NOT_RECORD);
+        const sampler = new AlwaysSampleAiRootsSampler(delegate);
+
+        expect(sample(sampler, 'worker.task.slackAiPrompt')).toBe(
+            SamplingDecision.RECORD_AND_SAMPLED,
+        );
+        expect(sample(sampler, 'worker.task.aiAgentReviewRemediationRun')).toBe(
+            SamplingDecision.RECORD_AND_SAMPLED,
+        );
+        expect(sample(sampler, 'worker.task.appGeneratePipeline')).toBe(
+            SamplingDecision.RECORD_AND_SAMPLED,
+        );
+        expect(delegate.shouldSample).not.toHaveBeenCalled();
+    });
+
+    it('delegates non-AI worker tasks', () => {
+        const delegate = makeDelegate(SamplingDecision.NOT_RECORD);
+        const sampler = new AlwaysSampleAiRootsSampler(delegate);
+
+        expect(sample(sampler, 'worker.task.handleScheduledDelivery')).toBe(
+            SamplingDecision.NOT_RECORD,
+        );
+        expect(delegate.shouldSample).toHaveBeenCalledTimes(1);
+    });
+
+    it('always samples AI HTTP roots by raw request path', () => {
+        const delegate = makeDelegate(SamplingDecision.NOT_RECORD);
+        const sampler = new AlwaysSampleAiRootsSampler(delegate);
+
+        expect(
+            sample(sampler, 'POST', {
+                'http.target':
+                    '/api/v1/projects/1234/aiAgents/5678/threads?foo=1',
+            }),
+        ).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+        expect(
+            sample(sampler, 'POST', {
+                'http.target': '/api/v1/ai/1234/chart/generate-metadata',
+            }),
+        ).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+        expect(
+            sample(sampler, 'POST', {
+                'url.path': '/api/v1/org/aiRouter/route',
+            }),
+        ).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+        expect(sample(sampler, 'POST', { 'http.target': '/api/v1/mcp' })).toBe(
+            SamplingDecision.RECORD_AND_SAMPLED,
+        );
+    });
+
+    it('delegates non-AI HTTP roots, including lookalike paths', () => {
+        const delegate = makeDelegate(SamplingDecision.RECORD_AND_SAMPLED);
+        const sampler = new AlwaysSampleAiRootsSampler(delegate);
+
+        expect(
+            sample(sampler, 'GET', {
+                'http.target': '/api/v1/projects/1234/spaces',
+            }),
+        ).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+        expect(delegate.shouldSample).toHaveBeenCalledTimes(1);
+
+        // 'aiAgentsFoo' must not match the aiAgents prefix
+        expect(
+            sample(sampler, 'GET', {
+                'http.target': '/api/v1/projects/1234/aiAgentsFoo',
+            }),
+        ).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+        expect(delegate.shouldSample).toHaveBeenCalledTimes(2);
+    });
+
+    it('delegates spans with no recognizable entrypoint attributes', () => {
+        const delegate = makeDelegate(SamplingDecision.NOT_RECORD);
+        const sampler = new AlwaysSampleAiRootsSampler(delegate);
+
+        expect(sample(sampler, 'queue_consumer')).toBe(
+            SamplingDecision.NOT_RECORD,
+        );
+        expect(delegate.shouldSample).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('sentryTraceToTraceparent', () => {
+    it('converts a sampled sentry-trace header', () => {
+        expect(sentryTraceToTraceparent(`${TRACE_ID}-${SPAN_ID}-1`)).toBe(
+            `00-${TRACE_ID}-${SPAN_ID}-01`,
+        );
+    });
+
+    it('converts an unsampled sentry-trace header', () => {
+        expect(sentryTraceToTraceparent(`${TRACE_ID}-${SPAN_ID}-0`)).toBe(
+            `00-${TRACE_ID}-${SPAN_ID}-00`,
+        );
+    });
+
+    it('treats a missing sampled flag as sampled', () => {
+        expect(sentryTraceToTraceparent(`${TRACE_ID}-${SPAN_ID}`)).toBe(
+            `00-${TRACE_ID}-${SPAN_ID}-01`,
+        );
+    });
+
+    it('returns undefined for malformed input', () => {
+        expect(sentryTraceToTraceparent('not-a-trace')).toBeUndefined();
+        expect(sentryTraceToTraceparent('')).toBeUndefined();
+        expect(
+            sentryTraceToTraceparent(`${TRACE_ID}-${SPAN_ID}-2`),
+        ).toBeUndefined();
+    });
+});

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -1,7 +1,24 @@
+/**
+ * Tracing runs in one of two exclusive modes, selected by
+ * LIGHTDASH_OTEL_TRACES_ENABLED:
+ *
+ * - OTel mode (Lightdash Cloud): spans are created via the OTel SDK and
+ *   exported over OTLP (GCP Cloud Trace). Sentry does NOT receive or create
+ *   spans — it is errors-only (see sentry.ts, which strips Sentry's
+ *   span-emitting integrations in this mode).
+ * - Sentry mode (self-hosted / local Spotlight dev): spans are created via
+ *   Sentry's SDK exactly as before OTLP export existed.
+ *
+ * The modes must not run together: the previous dual export created two spans
+ * per traceSpan call and oddly-parented traces.
+ */
 import type {
     Attributes,
     AttributeValue,
+    Context,
+    Link,
     Span as OtelSpan,
+    SpanKind,
 } from '@opentelemetry/api';
 import {
     context,
@@ -15,7 +32,10 @@ import {
     W3CTraceContextPropagator,
 } from '@opentelemetry/core';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
+import {
+    ExpressInstrumentation,
+    ExpressLayerType,
+} from '@opentelemetry/instrumentation-express';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import {
     defaultResource,
@@ -25,14 +45,25 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import {
     BatchSpanProcessor,
     ParentBasedSampler,
+    SamplingDecision,
     TraceIdRatioBasedSampler,
+    type Sampler,
+    type SamplingResult,
 } from '@opentelemetry/sdk-trace-base';
 import * as Sentry from '@sentry/node';
-import { SentryPropagator, SentrySpanProcessor } from '@sentry/opentelemetry';
 import Logger from '../logging/logger';
 import { VERSION } from '../version';
 
 type TraceSpanOptions = Parameters<typeof Sentry.startSpan>[0];
+
+/**
+ * The span handed to traceSpan callbacks. Both the OTel span and the Sentry
+ * span satisfy this surface, so call sites work in either mode.
+ */
+export type TraceSpan = Pick<
+    OtelSpan,
+    'setAttribute' | 'setAttributes' | 'setStatus' | 'end' | 'spanContext'
+>;
 
 export type TraceHeaders = {
     traceparent?: string;
@@ -45,6 +76,10 @@ type TracingStrategy = {
     shutdown(): Promise<void>;
     getTraceHeaders(): TraceHeaders;
     continueTrace<T>(headers: TraceHeaders, callback: () => T): T;
+    startSpan<T>(
+        options: TraceSpanOptions,
+        callback: (span: TraceSpan) => T,
+    ): T;
 };
 
 const serviceVersion = String(VERSION);
@@ -58,6 +93,8 @@ export const otelTracingEnabled = () =>
 
 const getSampleRate = () => {
     const sampleRate = Number(
+        // SENTRY_TRACES_SAMPLE_RATE is a deprecated fallback kept while deploy
+        // configs migrate; LIGHTDASH_OTEL_TRACES_SAMPLE_RATE is the knob.
         process.env.LIGHTDASH_OTEL_TRACES_SAMPLE_RATE ??
             process.env.SENTRY_TRACES_SAMPLE_RATE ??
             '1',
@@ -67,12 +104,120 @@ const getSampleRate = () => {
     return Math.min(Math.max(sampleRate, 0), 1);
 };
 
+/**
+ * AI/agent entrypoints whose traces are always sampled: when a customer
+ * reports a broken agent run, the trace must exist regardless of the global
+ * sample rate. Cost reporting does not depend on traces (it uses unsampled
+ * ai.usage logs), so this is purely a debugging-quality decision.
+ *
+ * Worker task names mirror SCHEDULER_TASKS / EE_SCHEDULER_TASKS in
+ * packages/common/src/types/schedulerTaskList.ts. String literals are used
+ * (not imports) so this module stays dependency-free and safe to load before
+ * instrumentation patches modules.
+ */
+const AI_WORKER_TASKS = new Set([
+    'slackAiPrompt',
+    'aiAgentEvalResult',
+    'aiAgentReviewClassifier',
+    'aiAgentReviewWriteback',
+    'aiAgentReviewRemediationPreview',
+    'aiAgentReviewRemediationCompile',
+    'aiAgentReviewRemediationRun',
+    'embedArtifactVersion',
+    'generateArtifactQuestion',
+    'appGeneratePipeline',
+    'appBuildFromSource',
+    'managedAgentHeartbeat',
+    'ingestProjectContext',
+]);
+
+// Matched against the raw request path: at head-sampling time the HTTP span
+// has no resolved http.route yet, only http.target/url.path.
+const AI_HTTP_PATHS = [
+    /^\/api\/v1\/projects\/[^/]+\/aiAgents(\/|$)/,
+    /^\/api\/v1\/projects\/[^/]+\/managed-agent(\/|$)/,
+    /^\/api\/v1\/ai\/[^/]+(\/|$)/,
+    /^\/api\/v1\/org\/aiRouter(\/|$)/,
+    /^\/api\/v1\/aiAgents\/documents(\/|$)/,
+    /^\/api\/v1\/ee\/projects\/[^/]+\/(ai-writeback|apps)(\/|$)/,
+    /^\/api\/v1\/ee\/user\/apps(\/|$)/,
+    /^\/api\/v1\/mcp(\/|$)/,
+];
+
+const isAiEntrypoint = (spanName: string, attributes: Attributes): boolean => {
+    if (spanName.startsWith('worker.task.')) {
+        return AI_WORKER_TASKS.has(spanName.slice('worker.task.'.length));
+    }
+
+    const target = attributes['http.target'] ?? attributes['url.path'];
+    if (typeof target === 'string') {
+        const [path] = target.split('?');
+        return AI_HTTP_PATHS.some((pattern) => pattern.test(path));
+    }
+
+    return false;
+};
+
+/**
+ * Head sampler that always samples AI/agent entrypoint roots and delegates
+ * everything else. Child spans (including the AI SDK's ai.* spans) follow the
+ * root decision via ParentBasedSampler, so sampling the root captures the
+ * whole waterfall.
+ */
+export class AlwaysSampleAiRootsSampler implements Sampler {
+    constructor(private readonly delegate: Sampler) {}
+
+    shouldSample(
+        samplingContext: Context,
+        traceId: string,
+        spanName: string,
+        spanKind: SpanKind,
+        attributes: Attributes,
+        links: Link[],
+    ): SamplingResult {
+        if (isAiEntrypoint(spanName, attributes)) {
+            return { decision: SamplingDecision.RECORD_AND_SAMPLED };
+        }
+        return this.delegate.shouldSample(
+            samplingContext,
+            traceId,
+            spanName,
+            spanKind,
+            attributes,
+            links,
+        );
+    }
+
+    toString() {
+        return `AlwaysSampleAiRoots(${this.delegate.toString()})`;
+    }
+}
+
 const createTraceSampler = () => {
-    const sampler = new TraceIdRatioBasedSampler(getSampleRate());
+    const ratioSampler = new TraceIdRatioBasedSampler(getSampleRate());
+    const rootSampler =
+        process.env.LIGHTDASH_OTEL_ALWAYS_SAMPLE_AI_TRACES === 'false'
+            ? ratioSampler
+            : new AlwaysSampleAiRootsSampler(ratioSampler);
     return new ParentBasedSampler({
-        root: sampler,
-        remoteParentNotSampled: sampler,
+        root: rootSampler,
+        // A worker task queued from an unsampled request still gets the
+        // AI-aware decision, so agent worker traces are never lost.
+        remoteParentNotSampled: rootSampler,
     });
+};
+
+// Convert a sentry-trace header ("<traceId>-<spanId>(-<0|1>)?") to W3C
+// traceparent so payloads queued by an older Sentry-tracing producer still
+// stitch into one trace during a rolling deploy.
+export const sentryTraceToTraceparent = (
+    sentryTrace: string,
+): string | undefined => {
+    const match = sentryTrace.match(
+        /^([0-9a-f]{32})-([0-9a-f]{16})(?:-([01]))?$/,
+    );
+    if (!match) return undefined;
+    return `00-${match[1]}-${match[2]}-${match[3] === '0' ? '00' : '01'}`;
 };
 
 const toOtelAttributes = (
@@ -142,11 +287,32 @@ class SentryTracingStrategy implements TracingStrategy {
 
     startSpan<T>(
         options: TraceSpanOptions,
-        callback: (span: Sentry.Span) => T,
+        callback: (span: TraceSpan) => T,
     ): T {
-        return this.sentry.startSpan(options, callback);
+        return this.sentry.startSpan(options, (span) =>
+            callback(span as unknown as TraceSpan),
+        );
     }
 }
+
+// Paths whose incoming requests are not traced at all: health checks and
+// high-frequency status polling (mirrors the drop list the Sentry
+// tracesSampler used).
+const isIgnoredIncomingRequest = (
+    url: string,
+    userAgent: string | undefined,
+): boolean => {
+    const [path] = url.split('?');
+    return (
+        path === '/api/v1/health' ||
+        path === '/health' ||
+        path.endsWith('/status') ||
+        path.endsWith('/favicon.ico') ||
+        path.endsWith('/robots.txt') ||
+        path.endsWith('livez') ||
+        (userAgent ?? '').includes('GoogleHC')
+    );
+};
 
 class OtelTracingStrategy implements TracingStrategy {
     private readonly isEnabled = otelTracingEnabled;
@@ -159,6 +325,9 @@ class OtelTracingStrategy implements TracingStrategy {
         if (!this.isEnabled() || this.sdk) return;
 
         this.sdk = new NodeSDK({
+            // Sentry's context manager (an AsyncLocalStorage manager that also
+            // forks Sentry scopes per context) is required for per-request
+            // error isolation — Sentry still captures errors in OTel mode.
             contextManager: new Sentry.SentryContextManager(),
             resource: defaultResource().merge(
                 resourceFromAttributes({
@@ -173,24 +342,30 @@ class OtelTracingStrategy implements TracingStrategy {
                 propagators: [
                     new W3CTraceContextPropagator(),
                     new W3CBaggagePropagator(),
-                    new SentryPropagator(),
                 ],
             }),
-            spanProcessors: [
-                new SentrySpanProcessor(),
-                new BatchSpanProcessor(new OTLPTraceExporter()),
-            ],
+            spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter())],
             instrumentations: [
                 new HttpInstrumentation({
                     ignoreIncomingRequestHook: (req) =>
-                        req.url === '/api/v1/health' || req.url === '/health',
+                        isIgnoredIncomingRequest(
+                            req.url ?? '',
+                            req.headers['user-agent'],
+                        ),
                 }),
-                new ExpressInstrumentation(),
+                new ExpressInstrumentation({
+                    // A span per middleware layer floods traces; the request
+                    // handler layer alone still names the HTTP span with the
+                    // resolved route.
+                    ignoreLayersType: [
+                        ExpressLayerType.MIDDLEWARE,
+                        ExpressLayerType.ROUTER,
+                    ],
+                }),
             ],
         });
         this.sdk.start();
         this.tracer = trace.getTracer('lightdash-backend', serviceVersion);
-        Sentry.validateOpenTelemetrySetup();
 
         Logger.info('OTEL trace export enabled');
     }
@@ -209,24 +384,21 @@ class OtelTracingStrategy implements TracingStrategy {
             ...(carrier.traceparent
                 ? { traceparent: carrier.traceparent }
                 : {}),
-            ...(carrier['sentry-trace']
-                ? { sentryTrace: carrier['sentry-trace'] }
-                : {}),
             ...(carrier.baggage ? { baggage: carrier.baggage } : {}),
         };
     }
 
     continueTrace<T>(headers: TraceHeaders, callback: () => T): T {
-        if (!this.isEnabled() || (!headers.traceparent && !headers.sentryTrace))
-            return callback();
+        const traceparent =
+            headers.traceparent ??
+            (headers.sentryTrace
+                ? sentryTraceToTraceparent(headers.sentryTrace)
+                : undefined);
+
+        if (!this.isEnabled() || !traceparent) return callback();
 
         const carrier: Record<string, string> = {
-            ...(headers.traceparent
-                ? { traceparent: headers.traceparent }
-                : {}),
-            ...(headers.sentryTrace
-                ? { 'sentry-trace': headers.sentryTrace }
-                : {}),
+            traceparent,
             ...(headers.baggage ? { baggage: headers.baggage } : {}),
         };
 
@@ -236,11 +408,15 @@ class OtelTracingStrategy implements TracingStrategy {
         );
     }
 
-    runWithSpan<T>(
+    startSpan<T>(
         options: TraceSpanOptions,
-        callback: (span?: OtelSpan) => T,
+        callback: (span: TraceSpan) => T,
     ): T {
-        if (!this.isEnabled()) return callback();
+        if (!this.isEnabled()) {
+            // Non-recording span from the un-started tracer keeps the
+            // callback contract without emitting anything.
+            return callback(this.tracer.startSpan(options.name));
+        }
 
         const span = this.tracer.startSpan(
             options.name,
@@ -288,6 +464,12 @@ class TracingService {
         private readonly otel: OtelTracingStrategy,
     ) {}
 
+    // Exclusive: OTel mode owns spans + propagation entirely, otherwise
+    // Sentry does. Running both duplicated every span.
+    private get strategy(): TracingStrategy {
+        return otelTracingEnabled() ? this.otel : this.sentry;
+    }
+
     initialize() {
         this.sentry.initialize();
         this.otel.initialize();
@@ -299,32 +481,25 @@ class TracingService {
     }
 
     getTraceHeaders(): TraceHeaders {
-        return {
-            ...this.sentry.getTraceHeaders(),
-            ...this.otel.getTraceHeaders(),
-        };
+        return this.strategy.getTraceHeaders();
     }
 
     continueTrace<T>(headers: TraceHeaders, callback: () => T): T {
-        return this.sentry.continueTrace(headers, () =>
-            this.otel.continueTrace(headers, callback),
-        );
+        return this.strategy.continueTrace(headers, callback);
     }
 
     startSpan<T>(
         options: TraceSpanOptions,
-        callback: (span: Sentry.Span) => T,
+        callback: (span: TraceSpan) => T,
     ): T {
-        return this.otel.runWithSpan(options, () =>
-            this.sentry.startSpan(options, callback),
-        );
+        return this.strategy.startSpan(options, callback);
     }
 
     runWithOtelSpanContext<T>(
         options: TraceSpanOptions,
-        callback: (span?: OtelSpan) => T,
+        callback: (span: TraceSpan) => T,
     ): T {
-        return this.otel.runWithSpan(options, callback);
+        return this.otel.startSpan(options, callback);
     }
 }
 
@@ -344,7 +519,7 @@ export const continueTrace = <T>(headers: TraceHeaders, callback: () => T): T =>
 
 export const traceSpan = <T>(
     options: TraceSpanOptions,
-    callback: (span: Sentry.Span) => T,
+    callback: (span: TraceSpan) => T,
 ): T => tracingService.startSpan(options, callback);
 
 export const getOtelTraceHeaders = getTraceHeaders;
@@ -353,5 +528,5 @@ export const continueOtelTrace = continueTrace;
 
 export const runWithOtelSpanContext = <T>(
     options: TraceSpanOptions,
-    callback: (span?: OtelSpan) => T,
+    callback: (span: TraceSpan) => T,
 ): T => tracingService.runWithOtelSpanContext(options, callback);

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -12,7 +12,7 @@ import {
     DBPinnedSpace,
 } from './database/entities/pinnedList';
 import Logger from './logging/logger';
-import { traceSpan } from './tracing/tracing';
+import { traceSpan, type TraceSpan } from './tracing/tracing';
 
 export const isDbPinnedChart = (data: DbPinnedItem): data is DbPinnedChart =>
     'saved_chart_uuid' in data && !!data.saved_chart_uuid;
@@ -31,7 +31,7 @@ export const isDbPinnedApp = (data: DbPinnedItem): data is DbPinnedApp =>
 export const wrapSentryTransaction = <T>(
     name: string,
     context: CustomSamplingContext,
-    funct: (span: Sentry.Span) => Promise<T>,
+    funct: (span: TraceSpan) => Promise<T>,
 ): Promise<T> => {
     const startTime = Date.now();
     return traceSpan(
@@ -77,7 +77,7 @@ export const wrapSentryTransaction = <T>(
 export function wrapSentryTransactionSync<T>(
     name: string,
     context: CustomSamplingContext,
-    funct: (span: Sentry.Span) => T,
+    funct: (span: TraceSpan) => T,
 ): T {
     const startTime = Date.now();
 


### PR DESCRIPTION
Relates: ZAP-581
Relates: ZAP-562
Relates: ZAP-582

### Description:

Tracing now runs in one of two **exclusive modes** on `LIGHTDASH_OTEL_TRACES_ENABLED`, instead of dual-exporting every span to both Sentry and OTLP. `Relates` (not `Closes`): the tickets stay open for post-deploy verification — span counts, trace stitching, and Cloud Trace ingest cost are acceptance criteria that can only be measured in prod.

**ZAP-581 — remove the Sentry trace path (OTel mode):**
- Drop `SentrySpanProcessor` and `SentryPropagator`; W3C `traceparent`/`baggage` is the only propagation contract. `traceSpan` creates a single OTel span (previously two: an OTel span wrapping `Sentry.startSpan`, which caused duplicated/oddly-parented traces).
- Sentry becomes **errors-only**: span-emitting default integrations (Postgres, Express, Http, VercelAI, …) are stripped in `sentry.ts` and both worker apps; `httpIntegration({spans:false})`/`nativeNodeFetchIntegration({spans:false})` are re-added for request isolation and breadcrumbs. `SentryContextManager` is deliberately kept — it's required for per-request error-scope isolation and emits no spans.
- New `TraceSpan` type replaces `Sentry.Span` in the `traceSpan` callback contract (method-compatible with both span kinds; only 3 explicit annotations changed).
- `continueTrace` converts legacy `sentry-trace` queue payloads to `traceparent` so in-flight jobs stitch across a rolling deploy.
- Org/user attribution (previously Sentry scope tags only) is now stamped as OTel span attributes in the auth middleware, scheduler task tracer, and NATS query worker — without this, `organization.name`/`user.uuid` would vanish from traces.
- **Sentry mode (self-hosted / local Spotlight dev) is unchanged** — when OTel tracing is off, Sentry tracing behaves exactly as before.

**ZAP-562 — cut instrumentation noise:**
- The `pg.query` span flood came from Sentry's default `postgresIntegration` (bundled OTel pg instrumentation), not our NodeSDK — stripping it removes those spans entirely.
- Express instrumentation ignores middleware/router layers (request-handler layer kept so HTTP spans get route names).
- Health checks, `/status` polling, favicon/robots, and GoogleHC requests are no longer traced (mirrors the drop list the Sentry `tracesSampler` used).

**ZAP-582 — always-sample AI/agent traces:**
- New `AlwaysSampleAiRootsSampler`: roots for 13 AI worker tasks (`worker.task.slackAiPrompt`, `appGeneratePipeline`, …) and 8 AI HTTP route prefixes (`/api/v1/projects/:id/aiAgents`, `/api/v1/ai/:id`, `/api/v1/mcp`, …) are always sampled, so the trace for an agent bug report reliably exists; everything else follows `LIGHTDASH_OTEL_TRACES_SAMPLE_RATE`. Matches raw request paths because `http.route` isn't resolved at head-sampling time. Kill-switch: `LIGHTDASH_OTEL_ALWAYS_SAMPLE_AI_TRACES=false`.

**Verification:** backend typecheck, lint, and 616 unit tests green, including new `tracing.test.ts` covering the sampler allowlist (worker tasks, HTTP paths, lookalike-path rejection) and `sentry-trace` → `traceparent` conversion.

**Deploy notes:** set `LIGHTDASH_OTEL_TRACES_SAMPLE_RATE` explicitly (the `SENTRY_TRACES_SAMPLE_RATE` fallback remains but is deprecated); audit any Sentry performance dashboards/alerts still reading transactions before rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKeichnDMjXMKUJd6GuPdF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKeichnDMjXMKUJd6GuPdF)_