### PR TITLE
fix(charts): render stack total labels for bars cut off by the y-axis max

### DIFF
--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -346,6 +346,8 @@ export type EChartsSeries = {
         fontWeight?: string;
         position?: 'left' | 'top' | 'right' | 'bottom' | 'inside';
         formatter?: (param: { data: Record<string, unknown> }) => string;
+        textBorderColor?: string;
+        textBorderWidth?: number;
     };
     labelLayout?:
         | {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -1435,6 +1435,181 @@ describe('getStackTotalSeries', () => {
         );
         expect(result).toHaveLength(0);
     });
+
+    // Totals above a user-configured axis max used to be dropped entirely:
+    // the zero-height synthetic bar landed outside the grid and was clipped
+    // away together with its label. Those totals are carried on an extra
+    // invisible un-stacked line series pinned to the axis max so the label
+    // renders at the plot's top edge instead.
+    describe('axis max clamping', () => {
+        const verticalSeries: EChartsSeries[] = [
+            {
+                type: CartesianSeriesType.BAR,
+                stack: 'my_stack',
+                stackLabel: { show: true },
+                yAxisIndex: 0,
+                encode: { x: 'cat', y: 'a', tooltip: [], seriesName: 'a' },
+            },
+            {
+                type: CartesianSeriesType.BAR,
+                stack: 'my_stack',
+                stackLabel: { show: true },
+                yAxisIndex: 0,
+                encode: { x: 'cat', y: 'b', tooltip: [], seriesName: 'b' },
+            },
+        ];
+        const rows = [
+            { cat: 'A', a: 600, b: 300 }, // total 900 — above max
+            { cat: 'B', a: 400, b: 300 }, // total 700 — exactly max
+            { cat: 'C', a: 300, b: 200 }, // total 500 — below max
+        ];
+
+        test('carries totals above the configured value-axis max on an invisible line series', () => {
+            const result = getStackTotalSeries(
+                rows,
+                verticalSeries,
+                itemsMap,
+                false,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                [700],
+            );
+            expect(result).toHaveLength(2);
+            // The stacked total series is untouched
+            expect(result[0].stack).toBe('my_stack');
+            expect(result[0].data).toEqual([
+                ['A', 0, 900],
+                ['B', 0, 700],
+                ['C', 0, 500],
+            ]);
+            // The carrier only holds the overflowing total, pinned to the max
+            expect(result[1].type).toBe(CartesianSeriesType.LINE);
+            expect(result[1].stack).toBeUndefined();
+            expect(result[1].data).toEqual([['A', 700, 900]]);
+            expect(result[1].label?.position).toBe('bottom');
+            expect(result[1].lineStyle?.opacity).toBe(0);
+        });
+
+        test('carrier formatter renders the total, not the pinned value', () => {
+            const result = getStackTotalSeries(
+                rows,
+                [
+                    {
+                        ...verticalSeries[0],
+                        pivotReference: { field: 'a' },
+                    },
+                    verticalSeries[1],
+                ],
+                itemsMap,
+                false,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                [700],
+            );
+            const formatter = result[1].label?.formatter;
+            expect(formatter).toBeDefined();
+            expect(formatter!({ data: ['A', 700, 900] } as any)).toContain(
+                '900',
+            );
+        });
+
+        test('pins flipped-axis totals to the max with a left label', () => {
+            const flippedSeries: EChartsSeries[] = verticalSeries.map((s) => ({
+                ...s,
+                encode: {
+                    ...s.encode!,
+                    x: s.encode!.y,
+                    y: s.encode!.x,
+                },
+            }));
+            const result = getStackTotalSeries(
+                rows,
+                flippedSeries,
+                itemsMap,
+                true,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                [700],
+            );
+            expect(result).toHaveLength(2);
+            expect(result[1].data).toEqual([[700, 'A', 900]]);
+            expect(result[1].label?.position).toBe('left');
+        });
+
+        test('emits no carrier when no axis max is configured', () => {
+            const result = getStackTotalSeries(
+                rows,
+                verticalSeries,
+                itemsMap,
+                false,
+                undefined,
+                false,
+            );
+            expect(result).toHaveLength(1);
+            expect(result[0].data).toEqual([
+                ['A', 0, 900],
+                ['B', 0, 700],
+                ['C', 0, 500],
+            ]);
+        });
+
+        test('emits no carrier when all totals fit under the max', () => {
+            const result = getStackTotalSeries(
+                rows,
+                verticalSeries,
+                itemsMap,
+                false,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                [1000],
+            );
+            expect(result).toHaveLength(1);
+        });
+
+        test('emits no carrier for 100% stacked charts', () => {
+            const result = getStackTotalSeries(
+                rows,
+                verticalSeries,
+                itemsMap,
+                false,
+                undefined,
+                true,
+                undefined,
+                undefined,
+                [50],
+            );
+            expect(result).toHaveLength(1);
+        });
+
+        test('reads the max for the series axis index', () => {
+            const rightAxisSeries = verticalSeries.map((s) => ({
+                ...s,
+                yAxisIndex: 1,
+            }));
+            const result = getStackTotalSeries(
+                rows,
+                rightAxisSeries,
+                itemsMap,
+                false,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                [10, 700],
+            );
+            expect(result).toHaveLength(2);
+            expect(result[1].data).toEqual([['A', 700, 900]]);
+            expect(result[1].yAxisIndex).toBe(1);
+        });
+    });
 });
 
 describe('mergeLegendSettings', () => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2504,6 +2504,8 @@ export const getStackTotalSeries = (
     isStack100: boolean,
     connectNulls: boolean | undefined = true,
     resolvedTimezone?: string,
+    // User-configured max per value axis, used to clamp overflowing totals
+    valueAxisMaxes?: (number | undefined)[],
 ) => {
     const seriesGroupedByStack = groupBy(seriesWithStack, 'stack');
     return Object.entries(seriesGroupedByStack).reduce<EChartsSeries[]>(
@@ -2519,6 +2521,30 @@ export const getStackTotalSeries = (
             ) {
                 return acc;
             }
+            const formatTotal = (param: { data: unknown }) => {
+                const stackTotal = Array.isArray(param.data)
+                    ? param.data[2]
+                    : undefined;
+                const fieldId = series[0].pivotReference?.field;
+                if (fieldId) {
+                    return getFormattedValue(
+                        stackTotal,
+                        fieldId,
+                        itemsMap,
+                        undefined,
+                        undefined,
+                        undefined,
+                        resolvedTimezone,
+                    );
+                }
+                return '';
+            };
+            const totalRows = getStackTotalRows(
+                rows,
+                series,
+                flipAxis,
+                selectedLegendNames,
+            );
             const stackSeries: EChartsSeries = {
                 type: series[0].type,
                 ...(series[0].type === CartesianSeriesType.LINE ||
@@ -2532,22 +2558,7 @@ export const getStackTotalSeries = (
                 label: {
                     ...getBarTotalLabelStyle(),
                     show: true,
-                    formatter: (param) => {
-                        const stackTotal = param.data[2];
-                        const fieldId = series[0].pivotReference?.field;
-                        if (fieldId) {
-                            return getFormattedValue(
-                                stackTotal,
-                                fieldId,
-                                itemsMap,
-                                undefined,
-                                undefined,
-                                undefined,
-                                resolvedTimezone,
-                            );
-                        }
-                        return '';
-                    },
+                    formatter: formatTotal,
                     position: flipAxis ? 'right' : 'top',
                 },
                 labelLayout: {
@@ -2556,15 +2567,61 @@ export const getStackTotalSeries = (
                 tooltip: {
                     show: false,
                 },
-                data: getStackTotalRows(
-                    rows,
-                    series,
-                    flipAxis,
-                    selectedLegendNames,
-                ),
+                data: totalRows,
                 yAxisIndex: series[0].yAxisIndex,
             };
-            return [...acc, stackSeries];
+            acc.push(stackSeries);
+
+            // Totals above a user-configured axis max sit outside the grid, so
+            // the zero-height label bar above gets clipped away together with
+            // its label. Carry those totals on an invisible, un-stacked line
+            // series pinned to the axis max so the label renders at the plot's
+            // top edge. In 100% mode data values are transformed ratios while
+            // totals stay raw, so the raw-total vs axis-max comparison is
+            // meaningless there.
+            const axisMax = isStack100
+                ? undefined
+                : valueAxisMaxes?.[
+                      series[0].yAxisIndex ?? series[0].xAxisIndex ?? 0
+                  ];
+            const clampedRows =
+                axisMax === undefined
+                    ? []
+                    : totalRows
+                          .filter((row) => row[2] > axisMax)
+                          .map((row) =>
+                              flipAxis
+                                  ? [axisMax, row[1], row[2]]
+                                  : [row[0], axisMax, row[2]],
+                          );
+            if (clampedRows.length > 0) {
+                acc.push({
+                    type: CartesianSeriesType.LINE,
+                    showSymbol: true,
+                    symbolSize: 0,
+                    lineStyle: { opacity: 0 },
+                    itemStyle: { color: 'transparent' },
+                    label: {
+                        ...getBarTotalLabelStyle(),
+                        show: true,
+                        formatter: formatTotal,
+                        position: flipAxis ? 'left' : 'bottom',
+                        // Keep the label readable over the bar fill
+                        textBorderColor: '#fff',
+                        textBorderWidth: 2,
+                    },
+                    labelLayout: {
+                        hideOverlap: !isStack100,
+                    },
+                    tooltip: {
+                        show: false,
+                    },
+                    data: clampedRows,
+                    yAxisIndex: series[0].yAxisIndex,
+                    xAxisIndex: series[0].xAxisIndex,
+                });
+            }
+            return acc;
         },
         [],
     );
@@ -3354,6 +3411,17 @@ const useEchartsCartesianConfig = (
                   )
                 : stackedSeriesWithColorAssignments;
 
+        // User-configured value-axis maxes; the value axis config lives in
+        // eChartsConfig.yAxis for both orientations (flipped charts apply it
+        // to the echarts x axis).
+        const valueAxisMaxes = [0, 1].map((axisIndex) => {
+            const rawMax =
+                validCartesianConfig?.eChartsConfig?.yAxis?.[axisIndex]?.max;
+            if (rawMax === undefined || rawMax === '') return undefined;
+            const parsedMax = parseFloat(rawMax);
+            return Number.isNaN(parsedMax) ? undefined : parsedMax;
+        });
+
         return [
             ...seriesWithRoundedStacks,
             ...getStackTotalSeries(
@@ -3365,6 +3433,7 @@ const useEchartsCartesianConfig = (
                 isStack100,
                 validCartesianConfig?.layout.connectNulls,
                 resolvedTimezone,
+                valueAxisMaxes,
             ),
         ];
     }, [
@@ -3375,6 +3444,7 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,
         validCartesianConfig?.layout.connectNulls,
+        validCartesianConfig?.eChartsConfig?.yAxis,
         validCartesianConfigLegend,
         resolvedTimezone,
     ]);


### PR DESCRIPTION
### Description

On stacked bar charts with the **Total** label enabled, totals were dropped entirely when the bar's stack top sits at/above the configured value-axis max. The totals are rendered by a synthetic zero-height bar stacked on top of each stack; when the stack top is above the axis max that bar lies outside the grid, and `clip: !isStack100` (added in #19225) clips it away together with its label. #19225 itself fixed #19216, where `clip: false` (from #19173) let those labels float far outside the chart — so simply unclipping would regress that.

**Fix:** totals above the configured axis max are additionally carried on an invisible, un-stacked line series pinned to the axis max, so the label renders just inside the plot's top edge (with a white text border for readability over the bar fill). The original synthetic bar series is untouched, so all in-range totals behave exactly as before.

Why a separate un-stacked series: a first attempt clamped the synthetic bar itself via a negative value + `stackStrategy: 'all'`, but under `'all'` a null anywhere in the stack (months with missing pivot values) poisons the cumulative and silently drops that month's total label. The line carrier avoids stacking semantics entirely.

### Verification (live app)

- Repro config (axis max just below the tallest total): the total now renders at the top edge; every other label identical to baseline
- Auto axis (no max): unchanged
- Deep cut (max far below several totals): cut-off totals pinned at the top edge, no floating labels — #19216 stays fixed
- Horizontal (flipped) bars with a max: total renders inside the right edge
- 100% stacking: unchanged (carrier suppressed — totals are raw values while data is transformed ratios, so the comparison is meaningless there)

Known trade-off: when several adjacent bars all exceed the max, their pinned labels share the same height and `hideOverlap` keeps the ones that fit — same overlap behavior totals have always had, now at the top edge instead of dropped.

Closes: PROD-8699
Closes: #25199
