### PR TITLE
feat(ai-review): deploy-resilient remediation runs (ZAP-591)

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -1011,6 +1011,9 @@ export default class App {
         await shutdownOtelTracing();
         if (this.schedulerWorker && this.schedulerWorker.runner) {
             try {
+                // Interrupt long-running AI runs first so they stop burning
+                // tokens and runner.stop() resolves inside the grace period.
+                await this.schedulerWorker.abortInFlightAiRuns();
                 await this.schedulerWorker.runner.stop();
                 Logger.info('Stopped scheduler worker');
             } catch (e) {

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -4441,6 +4441,12 @@ export class AiAgentModel {
         return row !== undefined;
     }
 
+    async deleteAiPromptInterrupt(promptUuid: string): Promise<void> {
+        await this.database(AiPromptInterruptTableName)
+            .where('ai_prompt_uuid', promptUuid)
+            .delete();
+    }
+
     async createAiPromptSteer(data: {
         promptUuid: string;
         createdByUserUuid: string;

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../database/entities/aiAgentReviewClassifier';
 import {
     AiAgentReviewClassifierModel,
+    REMEDIATION_INTERRUPTED_MESSAGE,
     WRITEBACK_STALE_MS,
 } from './AiAgentReviewClassifierModel';
 
@@ -232,6 +233,69 @@ describe('AiAgentReviewClassifierModel', () => {
             const [query] = tracker.history.select;
             expect(query.sql).toContain(AiAgentReviewRemediationTableName);
             expect(query.sql).toContain('work_thread_uuid');
+        });
+    });
+
+    describe('deploy-resilience sweep', () => {
+        it('touchReviewRemediation bumps updated_at guarded by active status', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce(1);
+
+            await model.touchReviewRemediation({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            const [update] = tracker.history.update;
+            expect(update.sql).toContain('updated_at');
+            expect(update.sql).toContain('status');
+            expect(update.bindings).toContain('queued');
+            expect(update.bindings).toContain('running');
+            // Guarded so a late heartbeat cannot resurrect a terminal row.
+            expect(update.bindings).not.toContain('failed');
+        });
+
+        it('failStaleReviewRemediations fails stale rows and returns them mapped', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce([
+                    {
+                        ai_agent_review_remediation_uuid: REMEDIATION_UUID,
+                        organization_uuid: ORGANIZATION_UUID,
+                        fingerprint: FINGERPRINT,
+                    },
+                ]);
+
+            const result = await model.failStaleReviewRemediations({
+                olderThanMs: WRITEBACK_STALE_MS,
+            });
+
+            const [update] = tracker.history.update;
+            expect(update.bindings).toContain('failed');
+            expect(update.bindings).toContain(REMEDIATION_INTERRUPTED_MESSAGE);
+            expect(update.bindings).toContain(WRITEBACK_STALE_MS / 1000);
+            expect(update.bindings).toContain('queued');
+            expect(update.bindings).toContain('running');
+            expect(result).toEqual([
+                {
+                    remediationUuid: REMEDIATION_UUID,
+                    organizationUuid: ORGANIZATION_UUID,
+                    fingerprint: FINGERPRINT,
+                },
+            ]);
+        });
+
+        it('failStaleReviewRemediations returns empty when nothing is stale', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce([]);
+
+            const result = await model.failStaleReviewRemediations({
+                olderThanMs: WRITEBACK_STALE_MS,
+            });
+
+            expect(result).toEqual([]);
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -102,14 +102,17 @@ type ReviewItemRow = DbAiAgentReviewItem & {
     updated_at_age_ms: number;
 };
 
-// Longer than the worker's 30-min job timeout — past this, a queued/running
-// writeback has lost its worker and is reported as failed so the UI recovers
-// and retries. Ages are computed in SQL (now() - updated_at) so the check is
-// immune to the driver parsing tz-less timestamps in the process's local
-// timezone and to app/DB clock drift.
-export const WRITEBACK_STALE_MS = 35 * 60 * 1000;
+// A queued/running remediation heartbeats updated_at every tool step, so past
+// this window it has lost its worker (deploy roll, OOM, crash) and is reported
+// as failed so the UI recovers and retries. Ages are computed in SQL
+// (now() - updated_at) so the check is immune to the driver parsing tz-less
+// timestamps in the process's local timezone and to app/DB clock drift.
+export const WRITEBACK_STALE_MS = 5 * 60 * 1000;
 
 const WRITEBACK_TIMED_OUT_MESSAGE = 'Writeback timed out';
+
+export const REMEDIATION_INTERRUPTED_MESSAGE =
+    'Interrupted by a deploy or restart — retry to run again';
 
 const isStaleWritebackStatus = (
     status:
@@ -1962,6 +1965,64 @@ export class AiAgentReviewClassifierModel {
                 error_message: WRITEBACK_TIMED_OUT_MESSAGE,
                 updated_at: this.database.fn.now() as never,
             });
+    }
+
+    /**
+     * Progress heartbeat — bumps updated_at so the staleness sweep can tell a
+     * live run from an abandoned one. Guarded by status so a late fire-and-forget
+     * write can never resurrect a terminal row.
+     */
+    async touchReviewRemediation(args: {
+        remediationUuid: string;
+        organizationUuid: string;
+    }): Promise<void> {
+        await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .where('ai_agent_review_remediation_uuid', args.remediationUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .whereIn('status', ['queued', 'running'])
+            .update({ updated_at: this.database.fn.now() as never });
+    }
+
+    /**
+     * Org-agnostic sweep: fails every queued/running remediation whose heartbeat
+     * is older than olderThanMs and returns the affected rows so the caller can
+     * emit run_interrupted events and fail the linked review-item writebacks.
+     * Backstop for interruptions the SIGTERM fast path misses (SIGKILL/OOM/crash).
+     */
+    async failStaleReviewRemediations(args: {
+        olderThanMs: number;
+    }): Promise<
+        Array<{
+            remediationUuid: string;
+            organizationUuid: string;
+            fingerprint: string;
+        }>
+    > {
+        const rows = await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .whereIn('status', ['queued', 'running'])
+            .whereRaw('updated_at < now() - make_interval(secs => ?)', [
+                args.olderThanMs / 1000,
+            ])
+            .update({
+                status: 'failed',
+                error_message: REMEDIATION_INTERRUPTED_MESSAGE,
+                updated_at: this.database.fn.now() as never,
+            })
+            .returning([
+                'ai_agent_review_remediation_uuid',
+                'organization_uuid',
+                'fingerprint',
+            ]);
+
+        return rows.map((row) => ({
+            remediationUuid: row.ai_agent_review_remediation_uuid,
+            organizationUuid: row.organization_uuid,
+            fingerprint: row.fingerprint,
+        }));
     }
 
     async setReviewRemediationPullRequest(

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -135,7 +135,11 @@ export class CommercialSchedulerClient extends SchedulerClient {
             payload,
             {
                 runAt: new Date(),
-                maxAttempts: 1,
+                // Retries are reserved for deploy/restart interruptions: genuine
+                // errors are caught and persisted (not rethrown), so only a
+                // RemediationInterruptedError consumes an attempt and requeues
+                // onto the replacement pod.
+                maxAttempts: 3,
                 jobKey: `ai-agent-review-remediation-run:${payload.remediationUuid}`,
             },
         );

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -3,6 +3,7 @@ import {
     getErrorMessage,
     getManagedAgentScheduleCron,
     isSchedulerTaskName,
+    RemediationInterruptedError,
     SCHEDULER_TASKS,
     SchedulerJobStatus,
 } from '@lightdash/common';
@@ -93,6 +94,10 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.openIdIdentityModel = args.openIdIdentityModel;
     }
 
+    override async abortInFlightAiRuns(): Promise<void> {
+        await this.aiAgentService.abortInFlightAiRuns();
+    }
+
     protected getCronItems() {
         return [
             ...super.getCronItems(),
@@ -153,44 +158,108 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 payload,
                 helpers,
             ) => {
-                await tryJobOrTimeout(
-                    SchedulerClient.processJob(
-                        EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN,
-                        helpers.job.id,
-                        helpers.job.run_at,
-                        payload,
-                        async () => {
-                            await this.aiAgentService.executeReviewRemediationRun(
-                                payload,
-                            );
-                            await this.aiAgentAdminService.recordReviewRemediationVerified(
-                                payload,
-                            );
+                // Idempotency guard: a 4h-late graphile unlock, or a retry of a
+                // run the sweep/admin already finalized, must not re-run a
+                // terminal remediation.
+                const remediation =
+                    await this.aiAgentReviewClassifierModel.getReviewRemediation(
+                        {
+                            organizationUuid: payload.organizationUuid,
+                            remediationUuid: payload.remediationUuid,
                         },
-                    ),
-                    helpers.job,
-                    AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS,
-                    async (job, e) => {
-                        // The preview stays usable on failure — the admin can
-                        // still retry the question manually from the thread.
-                        await this.schedulerService.logSchedulerJob({
-                            task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN,
-                            jobId: job.id,
-                            scheduledTime: job.run_at,
-                            status: SchedulerJobStatus.ERROR,
-                            details: {
-                                error: getErrorMessage(e),
-                                projectUuid: payload.projectUuid,
-                                organizationUuid: payload.organizationUuid,
-                                createdByUserUuid: payload.userUuid,
-                                agentUuid: payload.agentUuid,
-                                threadUuid: payload.threadUuid,
-                                remediationUuid: payload.remediationUuid,
-                                fingerprint: payload.fingerprint,
+                    );
+                if (
+                    !remediation ||
+                    remediation.status === 'resolved' ||
+                    remediation.status === 'failed'
+                ) {
+                    return;
+                }
+                try {
+                    await tryJobOrTimeout(
+                        SchedulerClient.processJob(
+                            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN,
+                            helpers.job.id,
+                            helpers.job.run_at,
+                            payload,
+                            async () => {
+                                await this.aiAgentService.executeReviewRemediationRun(
+                                    payload,
+                                );
+                                await this.aiAgentAdminService.recordReviewRemediationVerified(
+                                    payload,
+                                );
                             },
-                        });
-                    },
-                );
+                        ),
+                        helpers.job,
+                        AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS,
+                        async (job, e) => {
+                            // The preview stays usable on failure — the admin can
+                            // still retry the question manually from the thread.
+                            await this.schedulerService.logSchedulerJob({
+                                task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN,
+                                jobId: job.id,
+                                scheduledTime: job.run_at,
+                                status: SchedulerJobStatus.ERROR,
+                                details: {
+                                    error: getErrorMessage(e),
+                                    projectUuid: payload.projectUuid,
+                                    organizationUuid: payload.organizationUuid,
+                                    createdByUserUuid: payload.userUuid,
+                                    agentUuid: payload.agentUuid,
+                                    threadUuid: payload.threadUuid,
+                                    remediationUuid: payload.remediationUuid,
+                                    fingerprint: payload.fingerprint,
+                                },
+                            });
+                        },
+                    );
+                } catch (e) {
+                    if (e instanceof RemediationInterruptedError) {
+                        const willRetry =
+                            helpers.job.attempts < helpers.job.max_attempts;
+                        await this.aiAgentAdminService.recordReviewRemediationInterrupted(
+                            {
+                                remediationUuid: payload.remediationUuid,
+                                organizationUuid: payload.organizationUuid,
+                                willRetry,
+                            },
+                        );
+                        // Rethrow only to consume an attempt and requeue onto
+                        // the replacement pod; on the last attempt the event
+                        // above already marked it failed.
+                        if (willRetry) {
+                            throw e;
+                        }
+                        return;
+                    }
+                    // Genuine failure: persist and swallow so the retries
+                    // reserved for interruptions don't re-run a poison job.
+                    await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                        {
+                            remediationUuid: payload.remediationUuid,
+                            organizationUuid: payload.organizationUuid,
+                            status: 'failed',
+                            errorMessage: getErrorMessage(e),
+                        },
+                    );
+                    await this.schedulerService.logSchedulerJob({
+                        task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN,
+                        jobId: helpers.job.id,
+                        scheduledTime: helpers.job.run_at,
+                        status: SchedulerJobStatus.ERROR,
+                        details: {
+                            error: getErrorMessage(e),
+                            projectUuid: payload.projectUuid,
+                            organizationUuid: payload.organizationUuid,
+                            createdByUserUuid: payload.userUuid,
+                            agentUuid: payload.agentUuid,
+                            threadUuid: payload.threadUuid,
+                            remediationUuid: payload.remediationUuid,
+                            fingerprint: payload.fingerprint,
+                        },
+                    });
+                }
             },
             [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: async (
                 payload,

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -104,6 +104,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     maxAttempts: 1,
                 },
             },
+            {
+                task: EE_SCHEDULER_TASKS.SWEEP_STALE_AI_REMEDIATIONS,
+                pattern: '*/2 * * * *', // Every 2 minutes
+                options: {
+                    backfillPeriod: 5 * 60 * 1000, // 5 min
+                    maxAttempts: 1,
+                },
+            },
         ];
     }
 
@@ -444,6 +452,9 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             },
             [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: async () => {
                 await this.appGenerateService.sweepStaleLocks();
+            },
+            [EE_SCHEDULER_TASKS.SWEEP_STALE_AI_REMEDIATIONS]: async () => {
+                await this.aiAgentAdminService.sweepStaleReviewRemediations();
             },
             [EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: async (payload) => {
                 await sendReviewNotification({

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -2685,6 +2685,11 @@ export class AiAgentAdminService extends BaseService {
      * (SIGKILL/OOM/crash). Fails every remediation whose heartbeat is older than
      * WRITEBACK_STALE_MS, then records the interruption on the timeline and fails
      * the linked review-item writeback so the board recovers and allows a retry.
+     *
+     * System-only: invoked exclusively by the SWEEP_STALE_AI_REMEDIATIONS cron
+     * task with no user context, so there is no user permission check to apply —
+     * it deliberately operates org-agnostically across all organizations. Not
+     * reachable from any controller.
      */
     async sweepStaleReviewRemediations(): Promise<void> {
         const swept =

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -71,7 +71,11 @@ import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type ProjectService } from '../../services/ProjectService/ProjectService';
 import { AiAgentModel } from '../models/AiAgentModel';
-import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+import {
+    REMEDIATION_INTERRUPTED_MESSAGE,
+    WRITEBACK_STALE_MS,
+    type AiAgentReviewClassifierModel,
+} from '../models/AiAgentReviewClassifierModel';
 import { type AiAgentReviewNotificationModel } from '../models/AiAgentReviewNotificationModel';
 import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
 import {
@@ -1726,14 +1730,21 @@ export class AiAgentAdminService extends BaseService {
             remediationUuid,
         } = payload;
 
-        const setProgress = (message: string) =>
-            this.aiAgentReviewClassifierModel.updateReviewItemWritebackProgress(
+        const setProgress = async (message: string) => {
+            if (remediationUuid) {
+                await this.aiAgentReviewClassifierModel.touchReviewRemediation({
+                    remediationUuid,
+                    organizationUuid,
+                });
+            }
+            await this.aiAgentReviewClassifierModel.updateReviewItemWritebackProgress(
                 {
                     fingerprint,
                     organizationUuid,
                     message,
                 },
             );
+        };
 
         const scope =
             await this.aiAgentReviewClassifierModel.getReviewItemScope(
@@ -2637,6 +2648,42 @@ export class AiAgentAdminService extends BaseService {
         message: string;
     }): Promise<void> {
         await this.aiAgentReviewClassifierModel.failReviewItemWriteback(args);
+    }
+
+    /**
+     * Cron backstop for remediation runs killed without a chance to clean up
+     * (SIGKILL/OOM/crash). Fails every remediation whose heartbeat is older than
+     * WRITEBACK_STALE_MS, then records the interruption on the timeline and fails
+     * the linked review-item writeback so the board recovers and allows a retry.
+     */
+    async sweepStaleReviewRemediations(): Promise<void> {
+        const swept =
+            await this.aiAgentReviewClassifierModel.failStaleReviewRemediations({
+                olderThanMs: WRITEBACK_STALE_MS,
+            });
+        await Promise.all(
+            swept.map(
+                async ({ remediationUuid, organizationUuid, fingerprint }) => {
+                    await this.aiAgentReviewClassifierModel.createRemediationEvent(
+                        {
+                            remediationUuid,
+                            organizationUuid,
+                            event: {
+                                eventType: 'run_interrupted',
+                                payload: { reason: 'stale', willRetry: false },
+                            },
+                        },
+                    );
+                    await this.aiAgentReviewClassifierModel.failReviewItemWriteback(
+                        {
+                            fingerprint,
+                            organizationUuid,
+                            message: REMEDIATION_INTERRUPTED_MESSAGE,
+                        },
+                    );
+                },
+            ),
+        );
     }
 
     async getReviewItemPrDiff(

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -2651,6 +2651,36 @@ export class AiAgentAdminService extends BaseService {
     }
 
     /**
+     * SIGTERM fast path: a remediation run was interrupted by a graceful
+     * shutdown. Records it on the timeline; when retries are exhausted, also
+     * marks the remediation failed so it doesn't linger until the sweep.
+     */
+    async recordReviewRemediationInterrupted(args: {
+        remediationUuid: string;
+        organizationUuid: string;
+        willRetry: boolean;
+    }): Promise<void> {
+        await this.aiAgentReviewClassifierModel.createRemediationEvent({
+            remediationUuid: args.remediationUuid,
+            organizationUuid: args.organizationUuid,
+            event: {
+                eventType: 'run_interrupted',
+                payload: { reason: 'shutdown', willRetry: args.willRetry },
+            },
+        });
+        if (!args.willRetry) {
+            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                {
+                    remediationUuid: args.remediationUuid,
+                    organizationUuid: args.organizationUuid,
+                    status: 'failed',
+                    errorMessage: REMEDIATION_INTERRUPTED_MESSAGE,
+                },
+            );
+        }
+    }
+
+    /**
      * Cron backstop for remediation runs killed without a chance to clean up
      * (SIGKILL/OOM/crash). Fails every remediation whose heartbeat is older than
      * WRITEBACK_STALE_MS, then records the interruption on the timeline and fails

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -83,6 +83,7 @@ import {
     PullRequestProvider,
     QueryExecutionContext,
     ReadinessScore,
+    RemediationInterruptedError,
     ShareUrl,
     SlackPrompt,
     ToolDashboardArgs,
@@ -579,6 +580,17 @@ function validateGeneratedSuggestion(
 
 export class AiAgentService extends BaseService {
     private readonly aiAgentModel: AiAgentModel;
+
+    // Interruptible remediation runs currently streaming on this worker,
+    // mapped promptUuid -> the run owner's userUuid (a valid actor for the
+    // interrupt row). Populated when a run resolves its prompt, cleared when it
+    // settles. On shutdown, abortInFlightAiRuns() trips the interrupt seam for
+    // each, so the AI SDK's stopWhen halts them gracefully.
+    private readonly inFlightRemediationRuns = new Map<string, string>();
+
+    // promptUuids flagged by a shutdown abort, so the run can tell a deploy
+    // interruption from a normal stop and requeue itself.
+    private readonly shutdownInterruptedPromptUuids = new Set<string>();
 
     private readonly aiAgentDocumentModel: AiAgentDocumentModel;
 
@@ -4716,6 +4728,7 @@ export class AiAgentService extends BaseService {
             onStepProgress,
             suppressWritebackPreview,
             isReviewRemediationWorkThread,
+            onPromptResolved,
         }: {
             agentUuid: string;
             threadUuid: string;
@@ -4732,6 +4745,10 @@ export class AiAgentService extends BaseService {
             // Enables the work-thread-only editProjectContext tool so the agent
             // can open/change the project_context PR from this thread.
             isReviewRemediationWorkThread?: boolean;
+            // Invoked with the resolved promptUuid before streaming starts, so a
+            // caller can register the run as interruptible on shutdown. Awaited,
+            // so it can clear a stale interrupt flag first.
+            onPromptResolved?: (promptUuid: string) => Promise<void>;
         },
     ): Promise<string> {
         try {
@@ -4743,6 +4760,9 @@ export class AiAgentService extends BaseService {
                 agentUuid,
                 threadUuid,
             });
+            if (onPromptResolved) {
+                await onPromptResolved(prompt.promptUuid);
+            }
             if (!user.organizationUuid) {
                 throw new ForbiddenError();
             }
@@ -13034,11 +13054,63 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             organizationUuid,
         );
 
-        await this.generateAgentThreadResponse(sessionUser, {
-            agentUuid,
-            threadUuid,
-            autoApproveSql: true,
-        });
+        let runPromptUuid: string | null = null;
+        try {
+            await this.generateAgentThreadResponse(sessionUser, {
+                agentUuid,
+                threadUuid,
+                autoApproveSql: true,
+                onPromptResolved: async (promptUuid) => {
+                    runPromptUuid = promptUuid;
+                    // A requeue re-runs this same prompt, so clear any interrupt
+                    // left by a prior aborted attempt or the run would halt at
+                    // the first step.
+                    await this.aiAgentModel.deleteAiPromptInterrupt(promptUuid);
+                    this.inFlightRemediationRuns.set(promptUuid, userUuid);
+                },
+            });
+        } finally {
+            if (runPromptUuid) {
+                this.inFlightRemediationRuns.delete(runPromptUuid);
+            }
+        }
+
+        // A shutdown abort stops the stream gracefully (no throw), so detect it
+        // here and signal the worker to requeue onto the replacement pod.
+        if (
+            runPromptUuid &&
+            this.shutdownInterruptedPromptUuids.has(runPromptUuid)
+        ) {
+            this.shutdownInterruptedPromptUuids.delete(runPromptUuid);
+            throw new RemediationInterruptedError();
+        }
+    }
+
+    /**
+     * Trips the cooperative interrupt seam for every in-flight remediation run
+     * so the AI SDK's stopWhen halts them gracefully before the worker's
+     * runner.stop() waits on them. Called by the EE worker on shutdown.
+     */
+    async abortInFlightAiRuns(): Promise<void> {
+        const entries = [...this.inFlightRemediationRuns.entries()];
+        entries.forEach(([promptUuid]) =>
+            this.shutdownInterruptedPromptUuids.add(promptUuid),
+        );
+        await Promise.all(
+            entries.map(([promptUuid, ownerUserUuid]) =>
+                this.aiAgentModel
+                    .createAiPromptInterrupt({
+                        promptUuid,
+                        createdByUserUuid: ownerUserUuid,
+                    })
+                    .catch((e) => {
+                        Logger.error(
+                            `Failed to interrupt prompt ${promptUuid} on shutdown`,
+                            e,
+                        );
+                    }),
+            ),
+        );
     }
 
     async executeEvalResult({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15266,7 +15266,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -15274,11 +15274,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15293,7 +15289,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -15301,7 +15297,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15795,6 +15795,130 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -15877,12 +16001,6 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -15891,6 +16009,12 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -15904,130 +16028,6 @@ const models: TsoaRoute.Models = {
                                                                                 required: true,
                                                                             },
                                                                         },
-                                                                    required: true,
-                                                                },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
                                                                     required: true,
                                                                 },
                                                                 rationale: {
@@ -24247,6 +24247,37 @@ const models: TsoaRoute.Models = {
                         },
                     },
                 },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                willRetry: {
+                                    dataType: 'boolean',
+                                    required: true,
+                                },
+                                reason: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            dataType: 'enum',
+                                            enums: ['shutdown'],
+                                        },
+                                        { dataType: 'enum', enums: ['stale'] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['run_interrupted'],
+                            required: true,
+                        },
+                    },
+                },
             ],
             validators: {},
         },
@@ -29659,6 +29690,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['appGeneratePipeline'] },
                 { dataType: 'enum', enums: ['appBuildFromSource'] },
                 { dataType: 'enum', enums: ['sweepStaleAppLocks'] },
+                { dataType: 'enum', enums: ['sweepStaleAiRemediations'] },
                 { dataType: 'enum', enums: ['handleScheduledDelivery'] },
                 { dataType: 'enum', enums: ['sendSlackNotification'] },
                 { dataType: 'enum', enums: ['sendEmailNotification'] },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16714,16 +16714,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "requiredFilters": {
@@ -16965,6 +16965,66 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "fieldType",
+                                                                                "description",
+                                                                                "label",
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "requiredFilters": {
@@ -17002,14 +17062,14 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -17019,72 +17079,12 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
                                                                         "type": "object"
-                                                                    },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "fieldValueType",
-                                                                                "caseSensitiveFilters",
-                                                                                "isFromJoinedTable",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "description",
-                                                                                "label",
-                                                                                "fieldId",
-                                                                                "name",
-                                                                                "table"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
                                                                     },
                                                                     "rationale": {
                                                                         "type": "string",
@@ -17099,8 +17099,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "explore",
                                                                     "fields",
+                                                                    "explore",
                                                                     "rationale",
                                                                     "status"
                                                                 ],
@@ -24463,6 +24463,30 @@
                         },
                         "required": ["payload", "eventType"],
                         "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "willRetry": {
+                                        "type": "boolean"
+                                    },
+                                    "reason": {
+                                        "type": "string",
+                                        "enum": ["shutdown", "stale"]
+                                    }
+                                },
+                                "required": ["willRetry", "reason"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["run_interrupted"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
                     }
                 ]
             },
@@ -29937,6 +29961,7 @@
                     "appGeneratePipeline",
                     "appBuildFromSource",
                     "sweepStaleAppLocks",
+                    "sweepStaleAiRemediations",
                     "handleScheduledDelivery",
                     "sendSlackNotification",
                     "sendEmailNotification",
@@ -43633,7 +43658,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3323.0",
+        "version": "0.3326.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -255,6 +255,7 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
+    [SCHEDULER_TASKS.SWEEP_STALE_AI_REMEDIATIONS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: () => ({}),
     [SCHEDULER_TASKS.COMPACT_USAGE_EVENTS]: () => ({}),
     [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: (payload) => ({

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -1,6 +1,7 @@
 import {
     GoogleSheetsTransientError,
     QueueTraceProperties,
+    RemediationInterruptedError,
     ResultsExpiredError,
     SCHEDULER_TASKS,
     SchedulerTaskName,
@@ -428,10 +429,12 @@ export const traceTask = <T extends SchedulerTaskName>(
 
                             // Only capture to Sentry if this is the final attempt or it's not a retryable error
                             // ResultsExpiredError is expected (expired S3 cache) and should not go to Sentry
+                            // RemediationInterruptedError is expected (deploy/restart) and requeues itself
                             const isRetryableError =
                                 e instanceof GoogleSheetsTransientError;
                             const isExpectedError =
-                                e instanceof ResultsExpiredError;
+                                e instanceof ResultsExpiredError ||
+                                e instanceof RemediationInterruptedError;
                             const hasRetriesRemaining =
                                 job.attempts < job.max_attempts;
 

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -128,6 +128,16 @@ export class SchedulerWorker extends SchedulerTask {
         });
     }
 
+    /**
+     * Signals in-flight, interruptible AI runs to stop before `runner.stop()`
+     * waits on them, so a rolling deploy doesn't blow past the grace period.
+     * No-op in the base worker; the EE worker overrides it.
+     */
+    // eslint-disable-next-line class-methods-use-this
+    async abortInFlightAiRuns(): Promise<void> {
+        // No interruptible AI runs in the base worker.
+    }
+
     private startPgPing(health: SchedulerWorkerHealth) {
         if (this.pgPingInterval) return;
         void this.pingPgOnce(health);

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -133,10 +133,8 @@ export class SchedulerWorker extends SchedulerTask {
      * waits on them, so a rolling deploy doesn't blow past the grace period.
      * No-op in the base worker; the EE worker overrides it.
      */
-    // eslint-disable-next-line class-methods-use-this
-    async abortInFlightAiRuns(): Promise<void> {
-        // No interruptible AI runs in the base worker.
-    }
+    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function
+    async abortInFlightAiRuns(): Promise<void> {}
 
     private startPgPing(health: SchedulerWorkerHealth) {
         if (this.pgPingInterval) return;

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -847,7 +847,11 @@ export type AiAgentReviewRemediationEventDetail =
     | { eventType: 'pr_merged'; payload: { prUrl: string } }
     | { eventType: 'pr_closed'; payload: { prUrl: string } }
     | { eventType: 'resolved'; payload: Record<string, never> }
-    | { eventType: 'failed'; payload: { errorMessage: string | null } };
+    | { eventType: 'failed'; payload: { errorMessage: string | null } }
+    | {
+          eventType: 'run_interrupted';
+          payload: { reason: 'shutdown' | 'stale'; willRetry: boolean };
+      };
 
 export type AiAgentReviewRemediationEventType =
     AiAgentReviewRemediationEventDetail['eventType'];

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -45,6 +45,20 @@ export class ForbiddenError extends LightdashError {
     }
 }
 
+export class RemediationInterruptedError extends LightdashError {
+    constructor(
+        message = 'Remediation run interrupted by a deploy or restart',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'RemediationInterruptedError',
+            statusCode: 503,
+            data,
+        });
+    }
+}
+
 export class GoogleNotConnectedError extends LightdashError {
     constructor(message = 'Google account not connected') {
         super({

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -83,6 +83,7 @@ export const EE_SCHEDULER_TASKS = {
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
     APP_BUILD_FROM_SOURCE: 'appBuildFromSource',
     SWEEP_STALE_APP_LOCKS: 'sweepStaleAppLocks',
+    SWEEP_STALE_AI_REMEDIATIONS: 'sweepStaleAiRemediations',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -179,6 +180,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [SCHEDULER_TASKS.APP_BUILD_FROM_SOURCE]: AppBuildFromSourceJobPayload;
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [SCHEDULER_TASKS.SWEEP_STALE_AI_REMEDIATIONS]: TraceTaskBase;
 }
 
 export interface EETaskPayloadMap {
@@ -195,6 +197,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [EE_SCHEDULER_TASKS.APP_BUILD_FROM_SOURCE]: AppBuildFromSourceJobPayload;
     [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.SWEEP_STALE_AI_REMEDIATIONS]: TraceTaskBase;
 }
 
 export type SchedulerTaskName =

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
@@ -215,6 +215,14 @@ const eventRow = (
                 meta: event.payload.errorMessage,
                 tone: 'danger',
             };
+        case 'run_interrupted':
+            return {
+                label: 'Run interrupted by a deploy or restart',
+                meta: event.payload.willRetry
+                    ? 'Retrying automatically'
+                    : 'Retry to run again',
+                tone: 'danger',
+            };
         default:
             return { label: 'Updated', meta: null };
     }


### PR DESCRIPTION
## Problem

10+ minute AI-review remediation runs (`aiAgentReviewRemediationRun`, `aiAgentReviewWriteback`) are killed when a deploy rolls the worker pod. `runner.stop()` waits for the in-flight job, blows past the Kubernetes grace period, and the kubelet SIGKILLs the container. The consequences:

- The graphile job stays **locked for ~4h** (graphile-worker 0.13 lock timeout); with `maxAttempts: 1` it then becomes permanently failed — no retry ever happens.
- The `catch` handlers never run, so the remediation row sits at `running` with an empty `error_message` and **no event** in the activity feed. The only recovery was a *lazy* 35-min staleness check that fired only when someone opened the item.

## Approach

"Approach C" from the design — three cooperating mechanisms, all reusing existing machinery, delivered as two commits.

### 1. Heartbeat + staleness sweep (SIGKILL/OOM/crash backstop)

- Each writeback progress step now bumps `remediation.updated_at` (`touchReviewRemediation`), guarded by status so a late write can't resurrect a terminal row.
- New EE cron `sweepStaleAiRemediations` (`*/2m`, mirroring `sweepStaleAppLocks`) fails any `queued`/`running` remediation whose heartbeat is older than `WRITEBACK_STALE_MS`, records a `run_interrupted` timeline event, and fails the linked review-item writeback so the board recovers and allows a retry.
- `WRITEBACK_STALE_MS` drops 35m → 5m — valid **because** the heartbeat now moves every step (the two ship together, never separately).

### 2. SIGTERM fast path (graceful deploy)

- `App.stop()` calls `schedulerWorker.abortInFlightAiRuns()` **before** `runner.stop()`. Base worker is a no-op; the EE worker delegates to `AiAgentService`, which trips the existing cooperative interrupt seam (`ai_prompt_interrupt` + the AI SDK `stopWhen`) for each in-flight remediation run so the stream halts gracefully inside the grace period.
- Each run clears a stale interrupt flag on start (new `deleteAiPromptInterrupt`) so a requeue of the same prompt doesn't immediately re-halt.
- `executeReviewRemediationRun` detects the graceful stop (which doesn't throw) and throws `RemediationInterruptedError`; `maxAttempts 1→3` on the run job lets graphile requeue onto the replacement pod (seconds, not minutes).

### 3. Retries reserved for interruptions

The run handler is restructured with an idempotency guard (no-op if the remediation is already terminal), and:

- `RemediationInterruptedError` → `run_interrupted` event + rethrow-to-requeue (or fail on the last attempt).
- **Genuine errors** → persist `failed` + log, then **swallow** — so the `maxAttempts: 3` reserved for interruptions can't burn 3× tokens re-running a poison job.

`RemediationInterruptedError` is treated as an expected error in the task tracer, so a deploy doesn't spam Sentry.

## Regression analysis

- **Scope:** the SIGTERM fast-path + `maxAttempts` bump apply **only** to the remediation-run job. The writeback job stays `maxAttempts: 1` and is covered entirely by the heartbeat + sweep backstop, so its retry/token behaviour is unchanged.
- **`WRITEBACK_STALE_MS` 35m → 5m** only affects when a *lost* run is reported failed; it's gated on the heartbeat landing in the same change, so a healthy long run (which heartbeats every step) is never swept early.
- **Custom roles / service accounts / cross-project:** unaffected — this is worker-internal job lifecycle, no permission surface changes.
- **Non-EE installs:** unaffected — `abortInFlightAiRuns()` is a base no-op; all remediation logic is EE-gated.

## Testing

- typecheck (backend / common / frontend), lint, and 68 unit tests green: `SchedulerTaskTracer` tag-map completeness, scheduler worker/client, and the classifier model incl. 3 new sweep tests.
- **Outstanding:** the live SIGTERM (expect `run_interrupted` + requeue within seconds) / SIGKILL (expect sweep within ~5–7 min) manual test against a running worker — not yet run.

Closes: ZAP-591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148HnnoBFoMBv9wo3uFy12y
