### PR TITLE
fix(charts): pin daily time-axis labels to bar days

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -8,6 +8,7 @@ import {
     type EChartsSeries,
     type Field,
     type ResultRow,
+    type Series,
 } from '@lightdash/common';
 import dayjs from 'dayjs';
 import timezonePlugin from 'dayjs/plugin/timezone';
@@ -22,7 +23,9 @@ import {
     getLongestLabelsForAxis,
     getMinAndMaxValues,
     getNiceTickBound,
+    getPinnedDayTickFormatter,
     getStackTotalSeries,
+    getTimeAxisPinnedTickValues,
     mergeLegendSettings,
     padDatasetForContinuousAxis,
     relocateMarkLinesToVisibleSeries,
@@ -450,6 +453,265 @@ describe('getLongestLabelsForAxis', () => {
         expect(getLongestLabelsForAxis({ rows, axisIds: [] })).toStrictEqual(
             [],
         );
+    });
+});
+
+describe('getTimeAxisPinnedTickValues', () => {
+    const axisId = 'date_axis';
+    const createRows = (dates: (string | null)[]): ResultRow[] =>
+        dates.map((d) => ({
+            [axisId]: { value: { raw: d, formatted: String(d) } },
+        }));
+    const dayField = {
+        timeInterval: TimeFrames.DAY,
+        name: 'test_date',
+        table: 'test_table',
+    } as unknown as Field;
+    const barSeries = [
+        { type: CartesianSeriesType.BAR },
+    ] as unknown as Series[];
+    const lineSeries = [
+        { type: CartesianSeriesType.LINE },
+    ] as unknown as Series[];
+
+    test('pins sorted unique instants when day values are not UTC midnights', () => {
+        const result = getTimeAxisPinnedTickValues(
+            axisId,
+            dayField,
+            createRows([
+                '2026-03-01T04:00:00Z',
+                '2026-02-18T04:00:00Z',
+                '2026-03-01T04:00:00Z',
+            ]),
+            'time',
+            barSeries,
+        );
+        expect(result).toEqual([
+            Date.UTC(2026, 1, 18, 4),
+            Date.UTC(2026, 2, 1, 4),
+        ]);
+    });
+
+    test('parses naive timestamp strings as UTC', () => {
+        const result = getTimeAxisPinnedTickValues(
+            axisId,
+            dayField,
+            createRows(['2020-07-27T04:00:00Z', '2020-07-29T04:00:00']),
+            'time',
+            barSeries,
+        );
+        expect(result).toEqual([
+            Date.UTC(2020, 6, 27, 4),
+            Date.UTC(2020, 6, 29, 4),
+        ]);
+    });
+
+    test('keeps auto ticks for UTC-midnight days, consecutive or sparse', () => {
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                dayField,
+                createRows(['2026-02-18', '2026-02-19', '2026-02-20']),
+                'time',
+                barSeries,
+            ),
+        ).toBeUndefined();
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                dayField,
+                createRows(['2026-02-18', '2026-02-25', '2026-03-03']),
+                'time',
+                barSeries,
+            ),
+        ).toBeUndefined();
+    });
+
+    test('skips null raw values', () => {
+        const result = getTimeAxisPinnedTickValues(
+            axisId,
+            dayField,
+            createRows(['2026-02-18T04:00:00Z', null]),
+            'time',
+            barSeries,
+        );
+        expect(result).toEqual([Date.UTC(2026, 1, 18, 4)]);
+    });
+
+    test('returns undefined when the time axis is timezone-shifted', () => {
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                dayField,
+                createRows(['2026-02-18T04:00:00Z']),
+                'time',
+                barSeries,
+                true,
+            ),
+        ).toBeUndefined();
+    });
+
+    test('returns undefined without a bar series', () => {
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                dayField,
+                createRows(['2026-02-18']),
+                'time',
+                lineSeries,
+            ),
+        ).toBeUndefined();
+    });
+
+    test('returns undefined for non-day intervals', () => {
+        const monthField = {
+            ...(dayField as object),
+            timeInterval: TimeFrames.MONTH,
+        } as unknown as Field;
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                monthField,
+                createRows(['2026-02-01']),
+                'time',
+                barSeries,
+            ),
+        ).toBeUndefined();
+    });
+
+    test('returns undefined for non-time axis types', () => {
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                dayField,
+                createRows(['2026-02-18']),
+                'category',
+                barSeries,
+            ),
+        ).toBeUndefined();
+    });
+
+    test('returns undefined when rows are empty', () => {
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                dayField,
+                [],
+                'time',
+                barSeries,
+            ),
+        ).toBeUndefined();
+    });
+
+    test('pins non-midnight day values (days truncated in a non-UTC timezone)', () => {
+        const result = getTimeAxisPinnedTickValues(
+            axisId,
+            dayField,
+            createRows(['2025-07-01T04:00:00Z', '2025-07-02T04:00:00Z']),
+            'time',
+            barSeries,
+        );
+        expect(result).toEqual([
+            Date.UTC(2025, 6, 1, 4),
+            Date.UTC(2025, 6, 2, 4),
+        ]);
+    });
+
+    test('returns undefined for interval-less dimensions', () => {
+        const noIntervalField = {
+            name: 'test_date',
+            table: 'test_table',
+        } as unknown as Field;
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                noIntervalField,
+                createRows(['2025-07-01T04:00:00Z', '2025-07-02T04:00:00Z']),
+                'time',
+                barSeries,
+            ),
+        ).toBeUndefined();
+    });
+
+    test('returns undefined above the pinned tick cap', () => {
+        // Non-midnight values so only the cap rule applies
+        const manyDays = Array.from({ length: 401 }, (_, i) => {
+            const d = new Date(Date.UTC(2024, 0, 1, 4) + i * 24 * 3600 * 1000);
+            return d.toISOString();
+        });
+        expect(
+            getTimeAxisPinnedTickValues(
+                axisId,
+                dayField,
+                createRows(manyDays),
+                'time',
+                barSeries,
+            ),
+        ).toBeUndefined();
+    });
+});
+
+describe('getPinnedDayTickFormatter', () => {
+    const ticks = [
+        Date.UTC(2025, 11, 1), // Dec 1
+        Date.UTC(2025, 11, 29), // Dec 29
+        Date.UTC(2026, 0, 5), // Jan 5 — first tick of Jan, not the 1st
+        Date.UTC(2026, 0, 8), // Jan 8
+        Date.UTC(2026, 1, 1), // Feb 1
+        Date.UTC(2026, 1, 3), // Feb 3
+    ];
+    const formatter = getPinnedDayTickFormatter(ticks);
+
+    test('renders month starts as bold month', () => {
+        expect(formatter(Date.UTC(2025, 11, 1))).toBe('{bold|Dec}');
+        expect(formatter(Date.UTC(2026, 1, 1))).toBe('{bold|Feb}');
+    });
+
+    test('renders Jan 1 as bold year', () => {
+        expect(
+            getPinnedDayTickFormatter([Date.UTC(2026, 0, 1)])(
+                Date.UTC(2026, 0, 1),
+            ),
+        ).toBe('{bold|2026}');
+    });
+
+    test('keeps month context when a month has no tick on the 1st', () => {
+        expect(formatter(Date.UTC(2026, 0, 5))).toBe('{bold|Jan} 5');
+    });
+
+    test('renders remaining ticks as plain day numbers', () => {
+        expect(formatter(Date.UTC(2025, 11, 29))).toBe('29');
+        expect(formatter(Date.UTC(2026, 0, 8))).toBe('8');
+        expect(formatter(Date.UTC(2026, 1, 3))).toBe('3');
+    });
+
+    test('renders non-midnight instants by their UTC day (negative-offset warehouse tz)', () => {
+        // Local Jul 2 midnight in America/New_York = Jul 2 T04:00Z — UTC and
+        // local calendar days agree
+        const tz = [Date.UTC(2025, 6, 1, 4), Date.UTC(2025, 6, 2, 4)];
+        const f = getPinnedDayTickFormatter(tz);
+        expect(f(Date.UTC(2025, 6, 1, 4))).toBe('{bold|Jul}');
+        expect(f(Date.UTC(2025, 6, 2, 4))).toBe('2');
+    });
+
+    test('renders non-midnight instants by their UTC day (positive-offset warehouse tz)', () => {
+        // Local Jul 1 midnight at UTC+2 = Jun 30 T22:00Z. Intentionally
+        // labelled "30" — the UTC calendar day — because the results table
+        // and tooltips format the same raw value in UTC and must agree with
+        // the chart. The bold month marker lands on the first tick whose UTC
+        // month changes (local Jul 2 = Jul 1 T22:00Z → "Jul").
+        const tz = [
+            Date.UTC(2025, 5, 29, 22), // local Jun 30
+            Date.UTC(2025, 5, 30, 22), // local Jul 1
+            Date.UTC(2025, 6, 1, 22), // local Jul 2
+            Date.UTC(2025, 6, 2, 22), // local Jul 3
+        ];
+        const f = getPinnedDayTickFormatter(tz);
+        // First tick of the sequence doubles as first tick of its month
+        expect(f(Date.UTC(2025, 5, 29, 22))).toBe('{bold|Jun} 29');
+        expect(f(Date.UTC(2025, 5, 30, 22))).toBe('30');
+        expect(f(Date.UTC(2025, 6, 1, 22))).toBe('{bold|Jul}');
+        expect(f(Date.UTC(2025, 6, 2, 22))).toBe('2');
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1717,6 +1717,108 @@ export const getCategoryDateAxisConfig = (
     return {};
 };
 
+// Past this many ticks labels are thinned to illegibility anyway; fall back
+// to ECharts auto ticks instead of paying the per-tick label layout cost.
+const MAX_PINNED_TICKS = 400;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Pin time-axis ticks/labels to the actual data instants for daily bar
+ * charts whose day values are not UTC midnights. That happens when the
+ * warehouse truncates days in a non-UTC timezone (e.g. Snowflake session
+ * timezone), yielding instants like T04:00:00Z: bars render at those
+ * instants while ECharts draws its automatic tick labels at UTC midnights,
+ * so every label sits a constant few hours away from its bar group.
+ * Returning the distinct data instants lets the axis use `customValues` so
+ * every label sits exactly under its bar.
+ *
+ * Deliberately narrow: only explicit DAY granularity, only bar series, only
+ * when timezone shifting is inactive, and only when a non-midnight value
+ * proves the chart is misaligned today. Every other chart keeps ECharts'
+ * automatic ticks and renders exactly as before. The shift gate is required
+ * because the wall-clock shift rewrites plotted values after options are
+ * built, which would desync pinned values; under current code DAY truncs
+ * resolve to DATE and are never client-shifted, but the gate holds even if
+ * that classification changes.
+ */
+export const getTimeAxisPinnedTickValues = (
+    axisId?: string,
+    axisField?: Field | TableCalculation | CustomDimension,
+    rows?: ResultRow[],
+    axisType?: string,
+    series?: Series[],
+    isTimeAxisShifted?: boolean,
+): number[] | undefined => {
+    if (!axisId || !axisField || !rows || rows.length === 0) return undefined;
+    if (axisType !== 'time' || isTimeAxisShifted) return undefined;
+    if (
+        !('timeInterval' in axisField) ||
+        axisField.timeInterval !== TimeFrames.DAY
+    ) {
+        return undefined;
+    }
+    const hasBarSeries = series?.some(
+        (s) => s.type === CartesianSeriesType.BAR,
+    );
+    if (!hasBarSeries) return undefined;
+
+    const values = new Set<number>();
+    for (const row of rows) {
+        const raw = row[axisId]?.value.raw;
+        if (raw === null || raw === undefined) continue;
+        const parsed = dayjs.utc(String(raw));
+        if (parsed.isValid()) values.add(parsed.valueOf());
+    }
+    if (values.size === 0 || values.size > MAX_PINNED_TICKS) return undefined;
+
+    // UTC-midnight days already get ECharts ticks on bar days; only pin when
+    // a non-midnight value proves the labels are misaligned today.
+    const hasNonMidnightValue = Array.from(values).some(
+        (value) => value % DAY_MS !== 0,
+    );
+    if (!hasNonMidnightValue) return undefined;
+
+    return Array.from(values).sort((a, b) => a - b);
+};
+
+/**
+ * Label formatter for pinned daily ticks. Mirrors the leveled time-axis
+ * template (bold month at boundaries, plain day numbers), but since ticks
+ * only exist on data days a month may have no tick on the 1st — mark the
+ * first tick of each month with a bold "MMM D" so month context survives.
+ *
+ * Renders the tick's UTC calendar day, matching how the results table and
+ * tooltips format the same raw value. For positive-offset warehouse
+ * timezones a local midnight is the previous UTC day (Jul 1 at UTC+2 =
+ * Jun 30T22:00Z, labelled "30") — intentional: the chart must agree with
+ * the table for the same row rather than guess the warehouse-local day.
+ */
+export const getPinnedDayTickFormatter = (
+    tickValues: number[],
+): ((value: number) => string) => {
+    const firstTickOfMonth = new Set<number>();
+    let lastMonthKey: string | undefined;
+    for (const value of tickValues) {
+        const monthKey = dayjs.utc(value).format('YYYY-MM');
+        if (monthKey !== lastMonthKey) {
+            firstTickOfMonth.add(value);
+            lastMonthKey = monthKey;
+        }
+    }
+    return (value: number) => {
+        const date = dayjs.utc(value);
+        if (date.date() === 1) {
+            return date.month() === 0
+                ? `{bold|${date.format('YYYY')}}`
+                : `{bold|${date.format('MMM')}}`;
+        }
+        if (firstTickOfMonth.has(value)) {
+            return `{bold|${date.format('MMM')}} ${date.format('D')}`;
+        }
+        return date.format('D');
+    };
+};
+
 // Read from the axis holding the X field — bottom (normal) or left (flipped).
 // Top/right hold Y-field metrics; leaking them corrupts the X field column.
 export const selectContinuousDateRange = (
@@ -1743,6 +1845,7 @@ const getEchartAxes = ({
     parameters,
     resolvedTimezone,
     displayTimezone,
+    isTimeAxisShifted,
 }: {
     validCartesianConfig: CartesianChart;
     itemsMap: ItemsMap;
@@ -1753,6 +1856,7 @@ const getEchartAxes = ({
     parameters?: ParametersValuesMap;
     resolvedTimezone?: string;
     displayTimezone?: string;
+    isTimeAxisShifted?: boolean;
 }) => {
     const xAxisItemId = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.layout?.yField?.[0]
@@ -2037,6 +2141,14 @@ const getEchartAxes = ({
         leftAxisType,
         eChartsSeries,
         resolvedTimezone,
+    );
+    const bottomAxisPinnedTickValues = getTimeAxisPinnedTickValues(
+        bottomAxisXId,
+        bottomAxisXField,
+        axisRows,
+        bottomAxisType,
+        eChartsSeries,
+        isTimeAxisShifted,
     );
     const axisLabelFontSize =
         validCartesianConfig?.eChartsConfig?.axisLabelFontSize;
@@ -2362,6 +2474,15 @@ const getEchartAxes = ({
                         hideOverlap: true,
                     }
                   : {}),
+              ...(bottomAxisPinnedTickValues
+                  ? {
+                        customValues: bottomAxisPinnedTickValues,
+                        formatter: getPinnedDayTickFormatter(
+                            bottomAxisPinnedTickValues,
+                        ),
+                        rich: { bold: { fontWeight: 'bold' } },
+                    }
+                  : {}),
           }
         : undefined;
 
@@ -2448,6 +2569,9 @@ const getEchartAxes = ({
                     ...getAxisTickStyle(
                         validCartesianConfig?.eChartsConfig?.showAxisTicks,
                     ),
+                    ...(bottomAxisPinnedTickValues
+                        ? { customValues: bottomAxisPinnedTickValues }
+                        : {}),
                 },
                 // Spread last so a category-date axisTick keeps replacing the
                 // tick style (sub-day time axes never set extraConfig.axisTick).
@@ -3137,6 +3261,7 @@ const useEchartsCartesianConfig = (
             parameters,
             resolvedTimezone: axisTimezone,
             displayTimezone: axisDisplayTimezone,
+            isTimeAxisShifted: timeAxisField !== undefined,
         });
     }, [
         itemsMap,
@@ -3148,6 +3273,7 @@ const useEchartsCartesianConfig = (
         parameters,
         axisTimezone,
         axisDisplayTimezone,
+        timeAxisField,
     ]);
 
     // Shared by stackedSeriesWithColorAssignments (non-stacked bar styling) and


### PR DESCRIPTION
### Description

On daily-granularity bar charts (continuous `time` x-axis), date labels appear offset from their bar groups when the day values are not UTC midnights. That happens when the warehouse truncates days in a non-UTC timezone (e.g. Snowflake session timezone, or dbt-side `convert_timezone(...)` truncation), yielding instants like `T04:00:00Z`: bars render at those instants while ECharts draws its automatic tick labels at UTC midnights, so every label sits a constant few hours away from its bar group — and the pixel offset grows with chart width, which is why the report says "most apparent on full-width charts". Confirmed against the reporting customer's screenshot: recreating their chart 1:1 (5 grouped series, 8 consecutive days crossing a month boundary, `T04:00:00Z` day values) reproduces their label offset pixel-for-pixel. No Lightdash timezone feature involvement — the offset is baked into the warehouse values.

**Fix:** when (and only when) a non-midnight day value proves the chart is misaligned, pin the axis ticks and labels to the distinct data instants via ECharts `axisLabel.customValues` / `axisTick.customValues` (available since ECharts 5.5.1). Labels are parsed from the same raw row values the bars use, so they can't disagree. Pinned ticks are paired with a function label formatter that mirrors the multi-level look (bold month at the 1st, bold year at Jan 1, plain day numbers, bold "MMM D" on a month's first tick when it has no tick on the 1st) — this pairing is required, not cosmetic: non-midnight instants are hour-level ticks to ECharts' leveled template, whose DAY config maps `hour: ''`, so pinning without the formatter renders blank labels. Labels render the tick's UTC calendar day, matching how the results table and tooltips format the same raw value — for positive-offset warehouse timezones a local midnight is the previous UTC day (Jul 1 at UTC+2 = Jun 30T22:00Z, labelled "30"), which is intentional and unit-tested: the chart must agree with the table for the same row rather than guess the warehouse-local day.

**Deliberately narrow — every condition below must hold, otherwise the chart renders exactly as before this PR:**
- explicit `DAY` granularity dimension on a `time` x-axis (non-flipped)
- at least one bar series
- timezone shifting inactive (defensive: the shift rewrites plotted values after options are built; DAY values are calendar dates the shift never touches)
- at least one day value is not a UTC midnight
- at most 400 distinct values

Explicitly **not** in scope (unchanged behavior): all UTC-midnight charts, consecutive or sparse; interval-less timestamp dimensions; sub-day granularities; line/area charts; WEEK/MONTH/QUARTER/YEAR (already category axes); flipped charts. If the reporting customer's dimension turns out to be an interval-less pre-truncated column rather than a Lightdash DAY grain, coverage can be extended in a follow-up with their concrete config.

### Verification (live app + isolated echarts sandbox)

- Customer scenario recreated 1:1 with `T04:00:00Z` day values: before — every label offset left of its group exactly as in their screenshot; after — every label centered under its group
- UTC-midnight charts (dense and sparse) verified live: ECharts' automatic ticks, byte-identical to main
- Line chart on the same query: unchanged automatic ticks
- 150 echarts-hook unit tests pass, incl. the timezone-shift gate, midnight no-op guard, interval-less exclusion, and the 400-tick cap

Closes: PROD-8657
Closes: #25076

<details>
<summary>before/after</summary>
<img width="1512" height="749" alt="Screenshot 2026-07-08 at 15 12 24" src="https://github.com/user-attachments/assets/03d4eded-e997-4992-88d6-0186a62a767a" />
</details>
