### PR TITLE
feat(custom-roles): show scope dependencies

### DIFF
--- a/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
@@ -3,6 +3,7 @@ import {
     Box,
     Button,
     Flex,
+    Group,
     Input,
     SegmentedControl,
     Stack,
@@ -11,10 +12,20 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import {
+    IconAlertTriangleFilled,
+    IconCircleCheckFilled,
+    IconCircleXFilled,
+} from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
 import { SettingsCard } from '../../../../../components/common/Settings/SettingsCard';
 import { validateRoleName, validateScopes } from '../../utils/roleValidation';
+import {
+    getScopeDependencyStatusCounts,
+    type DependencyStatus,
+} from '../../utils/scopeUtils';
 import { ScopeSelector } from '../ScopeSelector';
 import { type RoleFormValues } from '../types';
 import styles from './RoleBuilder.module.css';
@@ -48,6 +59,16 @@ type Props = {
      */
     rederiveScopesOnLevelChange?: boolean;
 };
+
+const dependencyStatusItems = [
+    { key: 'full', icon: IconCircleCheckFilled, color: 'green' },
+    { key: 'partial', icon: IconAlertTriangleFilled, color: 'yellow' },
+    { key: 'empty', icon: IconCircleXFilled, color: 'red' },
+] as const satisfies Array<{
+    key: DependencyStatus;
+    icon: typeof IconCircleCheckFilled;
+    color: string;
+}>;
 
 /**
  * Allows admins to create and edit roles. Includes a selectable list of scopes to assign to the role.
@@ -135,6 +156,11 @@ export const RoleBuilder: FC<Props> = ({
               ? levelLockedHint
               : undefined;
 
+    const dependencyStatusCounts = getScopeDependencyStatusCounts({
+        level: form.values.level,
+        scopes: form.values.scopes || {},
+    });
+
     return (
         <form onSubmit={handleSubmit} className={styles.container}>
             <Box className={styles.content}>
@@ -189,27 +215,49 @@ export const RoleBuilder: FC<Props> = ({
                             />
                         </Box>
                         <Flex
-                            justify="flex-end"
+                            justify="space-between"
+                            align="center"
                             gap="sm"
                             className={styles.footer}
                         >
-                            <Button
-                                variant="default"
-                                component={Link}
-                                to="/generalSettings/customRoles"
-                                disabled={isWorking}
-                            >
-                                Cancel
-                            </Button>
-                            <Button
-                                type="submit"
-                                loading={isWorking}
-                                disabled={mode === 'edit' && !form.isDirty()}
-                            >
-                                {mode === 'create'
-                                    ? 'Create role'
-                                    : 'Save changes'}
-                            </Button>
+                            <Group gap={4}>
+                                {dependencyStatusItems.map((status) => (
+                                    <Group key={status.key} gap={4}>
+                                        <MantineIcon
+                                            icon={status.icon}
+                                            size={13}
+                                            color={status.color}
+                                        />
+                                        <Text fz="sm" c="dimmed">
+                                            {dependencyStatusCounts[status.key]}
+                                        </Text>
+                                    </Group>
+                                ))}
+                                <Text fz="sm" c="dimmed">
+                                    dependencies
+                                </Text>
+                            </Group>
+                            <Group gap="sm">
+                                <Button
+                                    variant="default"
+                                    component={Link}
+                                    to="/generalSettings/customRoles"
+                                    disabled={isWorking}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    type="submit"
+                                    loading={isWorking}
+                                    disabled={
+                                        mode === 'edit' && !form.isDirty()
+                                    }
+                                >
+                                    {mode === 'create'
+                                        ? 'Create role'
+                                        : 'Save changes'}
+                                </Button>
+                            </Group>
                         </Flex>
                     </SettingsCard>
                 </Stack>

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.module.css
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.module.css
@@ -48,3 +48,21 @@
 .scopeDescription {
     line-height: 1.4;
 }
+
+.dependencyToggleIcon {
+    color: var(--mantine-color-dimmed);
+    transition: transform 150ms ease;
+}
+
+.dependencyToggleIcon[data-open='true'] {
+    transform: rotate(180deg);
+}
+
+.dependencyItem {
+    padding-left: var(--mantine-spacing-md);
+}
+
+.dependencyContent {
+    flex: 1;
+    min-width: 0;
+}

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -4,6 +4,7 @@ import {
     Box,
     Button,
     Checkbox,
+    Collapse,
     Divider,
     Flex,
     Group,
@@ -13,20 +14,28 @@ import {
     Text,
     TextInput,
     Title,
+    UnstyledButton,
 } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconSearch } from '@tabler/icons-react';
+import {
+    IconAlertTriangleFilled,
+    IconChevronDown,
+    IconCircleCheckFilled,
+    IconCircleXFilled,
+    IconSearch,
+} from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../../../components/common/PolymorphicGroupButton';
 import {
     filterScopes,
     formatScopeName,
+    getScopeDependencies,
+    getScopeNamesWithDependencies,
     getScopesByGroup,
     isGroupFullySelected,
     isGroupPartiallySelected,
-    toggleGroupScopes,
     type GroupedScopes,
 } from '../../utils/scopeUtils';
 import { type RoleFormValues } from '../types';
@@ -35,6 +44,21 @@ import styles from './ScopeSelector.module.css';
 type ScopeSelectorProps = {
     form: UseFormReturnType<RoleFormValues>;
     level: RoleLevel;
+};
+
+const getDependencyStatusIcon = (
+    selectedDependencyCount: number,
+    dependencyCount: number,
+) => {
+    if (selectedDependencyCount === dependencyCount) {
+        return { icon: IconCircleCheckFilled, color: 'green' };
+    }
+
+    if (selectedDependencyCount === 0) {
+        return { icon: IconCircleXFilled, color: 'red' };
+    }
+
+    return { icon: IconAlertTriangleFilled, color: 'yellow' };
 };
 
 const GroupListItem: FC<{
@@ -70,6 +94,9 @@ const ScopePanel: FC<{
     group: GroupedScopes;
     form: UseFormReturnType<RoleFormValues>;
 }> = ({ group, form }) => {
+    const [openDependencyScopes, setOpenDependencyScopes] = useState<
+        Set<string>
+    >(new Set());
     const selectedScopes = Object.entries(form.values.scopes || {})
         .filter(([_, isSelected]) => isSelected)
         .map(([scope]) => scope);
@@ -81,23 +108,66 @@ const ScopePanel: FC<{
     );
 
     const handleGroupToggle = () => {
-        const newScopesArray = toggleGroupScopes(
-            group.scopes,
-            selectedScopes,
-            !isFullySelected,
-        );
-
         const toggledScopes = { ...form.values.scopes };
+        const shouldSelectGroup = !isFullySelected;
 
         group.scopes.forEach((scope) => {
             toggledScopes[scope.name] = false;
         });
 
-        newScopesArray.forEach((scopeName) => {
-            toggledScopes[scopeName] = true;
-        });
+        if (shouldSelectGroup) {
+            const groupScopesWithDependencies = group.scopes.flatMap((scope) =>
+                getScopeNamesWithDependencies(scope.name),
+            );
+
+            groupScopesWithDependencies.forEach((scopeName) => {
+                toggledScopes[scopeName] = true;
+            });
+        }
 
         form.setFieldValue('scopes', toggledScopes);
+    };
+
+    const toggleDependencyScope = (scopeName: string) => {
+        setOpenDependencyScopes((previous) => {
+            const next = new Set(previous);
+
+            if (next.has(scopeName)) {
+                next.delete(scopeName);
+            } else {
+                next.add(scopeName);
+            }
+
+            return next;
+        });
+    };
+
+    const setScopeSelected = (scopeName: string, isSelected: boolean) => {
+        form.setFieldValue('scopes', {
+            ...form.values.scopes,
+            [scopeName]: isSelected,
+        });
+    };
+
+    const setScopeAndDependenciesSelected = (
+        scopeName: string,
+        isSelected: boolean,
+    ) => {
+        const dependencySelections = isSelected
+            ? getScopeDependencies(scopeName).reduce<Record<string, boolean>>(
+                  (acc, dependency) => ({
+                      ...acc,
+                      [dependency.name]: true,
+                  }),
+                  {},
+              )
+            : {};
+
+        form.setFieldValue('scopes', {
+            ...form.values.scopes,
+            [scopeName]: isSelected,
+            ...dependencySelections,
+        });
     };
 
     return (
@@ -118,38 +188,193 @@ const ScopePanel: FC<{
 
             <ScrollArea.Autosize mah="100%" flex={1}>
                 <Stack gap="0">
-                    {group.scopes.map((scope) => (
-                        <Box
-                            key={scope.name}
-                            p="xs"
-                            className={styles.scopeItem}
-                        >
-                            <Group gap="xs" align="flex-start">
-                                <Checkbox
-                                    mt={2}
-                                    {...form.getInputProps(
-                                        `scopes.${scope.name}`,
-                                        { type: 'checkbox' },
-                                    )}
-                                />
-                                <Stack
-                                    className={styles.scopeContent}
-                                    gap="two"
-                                >
-                                    <Text fw={500} fz={13}>
-                                        {formatScopeName(scope.name)}
-                                    </Text>
-                                    <Text
-                                        fz="xs"
-                                        c="dimmed"
-                                        className={styles.scopeDescription}
+                    {group.scopes.map((scope) => {
+                        const dependencies = getScopeDependencies(scope.name);
+                        const selectedDependencyCount = dependencies.filter(
+                            (dependency) =>
+                                form.values.scopes?.[dependency.name],
+                        ).length;
+                        const dependencyStatus = getDependencyStatusIcon(
+                            selectedDependencyCount,
+                            dependencies.length,
+                        );
+                        const isDependencyListOpen = openDependencyScopes.has(
+                            scope.name,
+                        );
+                        const isSelected =
+                            form.values.scopes?.[scope.name] ?? false;
+
+                        return (
+                            <Box
+                                key={scope.name}
+                                p="xs"
+                                className={styles.scopeItem}
+                            >
+                                <Group gap="xs" align="flex-start">
+                                    <Checkbox
+                                        mt={2}
+                                        checked={isSelected}
+                                        onChange={(event) =>
+                                            setScopeAndDependenciesSelected(
+                                                scope.name,
+                                                event.currentTarget.checked,
+                                            )
+                                        }
+                                    />
+                                    <Stack
+                                        className={styles.scopeContent}
+                                        gap="two"
                                     >
-                                        {scope.description}
-                                    </Text>
-                                </Stack>
-                            </Group>
-                        </Box>
-                    ))}
+                                        <Text fw={500} fz={13}>
+                                            {formatScopeName(scope.name)}
+                                        </Text>
+                                        <Text
+                                            fz="xs"
+                                            c="dimmed"
+                                            className={styles.scopeDescription}
+                                        >
+                                            {scope.description}
+                                        </Text>
+                                        {dependencies.length > 0 ? (
+                                            <Stack gap="xs">
+                                                <Group gap="xs">
+                                                    <UnstyledButton
+                                                        onClick={() =>
+                                                            toggleDependencyScope(
+                                                                scope.name,
+                                                            )
+                                                        }
+                                                    >
+                                                        <Group gap={4}>
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconChevronDown
+                                                                }
+                                                                size="sm"
+                                                                className={
+                                                                    styles.dependencyToggleIcon
+                                                                }
+                                                                data-open={
+                                                                    isDependencyListOpen
+                                                                }
+                                                            />
+                                                            <Text
+                                                                fz={11}
+                                                                c="dimmed"
+                                                                fw={500}
+                                                            >
+                                                                {
+                                                                    selectedDependencyCount
+                                                                }{' '}
+                                                                /{' '}
+                                                                {
+                                                                    dependencies.length
+                                                                }{' '}
+                                                                dependencies
+                                                            </Text>
+                                                            {isSelected ? (
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        dependencyStatus.icon
+                                                                    }
+                                                                    size={11}
+                                                                    color={
+                                                                        dependencyStatus.color
+                                                                    }
+                                                                />
+                                                            ) : null}
+                                                        </Group>
+                                                    </UnstyledButton>
+                                                </Group>
+                                                <Collapse
+                                                    in={isDependencyListOpen}
+                                                >
+                                                    <Stack gap="xs">
+                                                        {dependencies.map(
+                                                            (dependency) => (
+                                                                <Box
+                                                                    key={
+                                                                        dependency.name
+                                                                    }
+                                                                    className={
+                                                                        styles.dependencyItem
+                                                                    }
+                                                                >
+                                                                    <Group
+                                                                        gap="xs"
+                                                                        align="flex-start"
+                                                                    >
+                                                                        <Checkbox
+                                                                            size="xs"
+                                                                            mt={
+                                                                                1
+                                                                            }
+                                                                            checked={
+                                                                                form
+                                                                                    .values
+                                                                                    .scopes?.[
+                                                                                    dependency
+                                                                                        .name
+                                                                                ] ??
+                                                                                false
+                                                                            }
+                                                                            onChange={(
+                                                                                event,
+                                                                            ) =>
+                                                                                setScopeSelected(
+                                                                                    dependency.name,
+                                                                                    event
+                                                                                        .currentTarget
+                                                                                        .checked,
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                        <Stack
+                                                                            gap={
+                                                                                0
+                                                                            }
+                                                                            className={
+                                                                                styles.dependencyContent
+                                                                            }
+                                                                        >
+                                                                            <Text
+                                                                                fz={
+                                                                                    11
+                                                                                }
+                                                                                fw={
+                                                                                    500
+                                                                                }
+                                                                            >
+                                                                                {formatScopeName(
+                                                                                    dependency.name,
+                                                                                )}
+                                                                            </Text>
+                                                                            {dependency.description ? (
+                                                                                <Text
+                                                                                    fz={
+                                                                                        11
+                                                                                    }
+                                                                                    c="dimmed"
+                                                                                >
+                                                                                    {
+                                                                                        dependency.description
+                                                                                    }
+                                                                                </Text>
+                                                                            ) : null}
+                                                                        </Stack>
+                                                                    </Group>
+                                                                </Box>
+                                                            ),
+                                                        )}
+                                                    </Stack>
+                                                </Collapse>
+                                            </Stack>
+                                        ) : null}
+                                    </Stack>
+                                </Group>
+                            </Box>
+                        );
+                    })}
                 </Stack>
             </ScrollArea.Autosize>
         </Stack>
@@ -208,10 +433,16 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
     ).length;
 
     const handleClickClearScopes = () => {
+        const scopesToClear = new Set<string>(
+            allGroupedScopes.flatMap((group) =>
+                group.scopes.map((scope) => scope.name),
+            ),
+        );
+
         const clearedScopes = Object.keys(form.values.scopes || {}).reduce(
             (acc, scope) => ({
                 ...acc,
-                [scope]: visibleScopeNames.has(scope)
+                [scope]: scopesToClear.has(scope)
                     ? false
                     : form.values.scopes[scope],
             }),

--- a/packages/frontend/src/ee/features/customRoles/utils/scopeUtils.test.ts
+++ b/packages/frontend/src/ee/features/customRoles/utils/scopeUtils.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getScopeDependencyStatusCounts,
+    getScopeDependencies,
+    getScopeNamesWithDependencies,
+} from './scopeUtils';
+
+describe('getScopeDependencies', () => {
+    it('returns direct and indirect scope dependencies with descriptions once', () => {
+        expect(getScopeDependencies('manage:Dashboard')).toEqual([
+            {
+                name: 'view:Project',
+                description: 'View project details',
+            },
+            {
+                name: 'view:SavedChart',
+                description: 'Load chart tiles while editing dashboards',
+            },
+            {
+                name: 'view:Space',
+                description: 'Create a dashboard without picking a space',
+            },
+        ]);
+    });
+
+    it('returns an empty list when a scope has no dependencies', () => {
+        expect(getScopeDependencies('view:Project')).toEqual([]);
+    });
+});
+
+describe('getScopeNamesWithDependencies', () => {
+    it('returns the selected scope and its direct and indirect dependencies once', () => {
+        expect(getScopeNamesWithDependencies('manage:Dashboard')).toEqual([
+            'manage:Dashboard',
+            'view:Project',
+            'view:SavedChart',
+            'view:Space',
+        ]);
+    });
+});
+
+describe('getScopeDependencyStatusCounts', () => {
+    it('counts selected scopes with all dependencies selected as full', () => {
+        expect(
+            getScopeDependencyStatusCounts({
+                level: 'project',
+                scopes: {
+                    'create:Job': true,
+                    'view:Project': true,
+                    'manage:CompileProject': true,
+                    'manage:SqlRunner': true,
+                },
+            }),
+        ).toEqual({
+            full: 4,
+            partial: 0,
+            empty: 0,
+        });
+    });
+
+    it('counts selected scopes with no dependencies as full', () => {
+        expect(
+            getScopeDependencyStatusCounts({
+                level: 'project',
+                scopes: {
+                    'view:Project': true,
+                },
+            }),
+        ).toEqual({
+            full: 1,
+            partial: 0,
+            empty: 0,
+        });
+    });
+
+    it('counts selected scopes with some or no dependencies selected separately', () => {
+        expect(
+            getScopeDependencyStatusCounts({
+                level: 'project',
+                scopes: {
+                    'create:Job': true,
+                    'manage:Dashboard': true,
+                    'view:Project': true,
+                },
+            }),
+        ).toEqual({
+            full: 1,
+            partial: 2,
+            empty: 0,
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/customRoles/utils/scopeUtils.ts
+++ b/packages/frontend/src/ee/features/customRoles/utils/scopeUtils.ts
@@ -23,6 +23,15 @@ export type GroupedScopes = {
     scopes: Scope[];
 };
 
+export type ScopeDependency = {
+    description?: string;
+    name: Scope['name'];
+};
+
+export type DependencyStatus = 'full' | 'partial' | 'empty';
+
+export type DependencyStatusCounts = Record<DependencyStatus, number>;
+
 export const getScopesByGroup = (
     isEnterprise = false,
     level?: RoleLevel,
@@ -58,6 +67,94 @@ export const getScopesByGroup = (
  */
 export const formatScopeName = (scopeName: string): string => {
     return startCase(scopeName.replace(':', ' '));
+};
+
+export const getScopeDependencies = (scopeName: string): ScopeDependency[] => {
+    const scopeMap = Object.fromEntries(
+        getScopes({ isEnterprise: true }).map((scope) => [scope.name, scope]),
+    ) as Record<string, Scope>;
+    const rootScope = scopeMap[scopeName];
+
+    if (!rootScope) {
+        return [];
+    }
+
+    const visited = new Set<string>([scopeName]);
+    const dependencies: ScopeDependency[] = [];
+    const queue = [rootScope];
+    let queueIndex = 0;
+
+    while (queueIndex < queue.length) {
+        const currentScope = queue[queueIndex];
+        queueIndex += 1;
+
+        currentScope.dependencies.forEach((dependency) => {
+            const dependencyScope = scopeMap[dependency.name];
+
+            if (!dependencyScope || visited.has(dependency.name)) {
+                return;
+            }
+
+            visited.add(dependency.name);
+            dependencies.push({
+                name: dependency.name,
+                description:
+                    dependency.description ?? dependencyScope.description,
+            });
+            queue.push(dependencyScope);
+        });
+    }
+
+    return dependencies;
+};
+
+export const getScopeNamesWithDependencies = (scopeName: string): string[] => [
+    scopeName,
+    ...getScopeDependencies(scopeName).map((dependency) => dependency.name),
+];
+
+export const getScopeDependencyStatusCounts = ({
+    isEnterprise = true,
+    level,
+    scopes,
+}: {
+    isEnterprise?: boolean;
+    level?: RoleLevel;
+    scopes: Record<string, boolean>;
+}): DependencyStatusCounts => {
+    const selectedScopeNames = new Set(
+        Object.entries(scopes)
+            .filter(([_, isSelected]) => isSelected)
+            .map(([scopeName]) => scopeName),
+    );
+
+    return getScopesByGroup(isEnterprise, level)
+        .flatMap((group) => group.scopes)
+        .filter((scope) => selectedScopeNames.has(scope.name))
+        .reduce<DependencyStatusCounts>(
+            (acc, scope) => {
+                const dependencies = getScopeDependencies(scope.name);
+
+                if (dependencies.length === 0) {
+                    return { ...acc, full: acc.full + 1 };
+                }
+
+                const selectedDependencyCount = dependencies.filter(
+                    (dependency) => scopes[dependency.name],
+                ).length;
+
+                if (selectedDependencyCount === dependencies.length) {
+                    return { ...acc, full: acc.full + 1 };
+                }
+
+                if (selectedDependencyCount === 0) {
+                    return { ...acc, empty: acc.empty + 1 };
+                }
+
+                return { ...acc, partial: acc.partial + 1 };
+            },
+            { full: 0, partial: 0, empty: 0 },
+        );
 };
 
 /**
@@ -120,22 +217,4 @@ export const isGroupPartiallySelected = (
         selectedScopes.includes(scope.name),
     ).length;
     return selectedCount > 0 && selectedCount < groupScopes.length;
-};
-
-export const toggleGroupScopes = (
-    groupScopes: Scope[],
-    selectedScopes: string[],
-    isSelected: boolean,
-): string[] => {
-    const groupScopeNames = groupScopes.map((scope) => scope.name as string);
-
-    if (isSelected) {
-        // Add all group scopes
-        return Array.from(new Set([...selectedScopes, ...groupScopeNames]));
-    } else {
-        // Remove all group scopes
-        return selectedScopes.filter(
-            (scope) => !groupScopeNames.includes(scope),
-        );
-    }
 };


### PR DESCRIPTION
Closes: n/a

## Summary

Custom role builders now show scope dependencies inline, let admins inspect and adjust dependency scopes directly, and summarize dependency health in the footer before saving.

### Permissions selector

- Dependency counts now appear under scopes with dependencies.
- Dependency rows expand into a compact checklist with the dependency label and dependency-specific description.
- Selecting a scope selects its dependencies by default.
- Unselecting a scope leaves dependency rows as explicit user-controlled selections.
- Group-level Select all applies the same dependency auto-selection as individual scope selection.

### Footer dependency summary

The footer shows the status of every selected scope, so the icon counts always add up to the selected scope count.

```text
selected scopes: 4

full      ✓ 4  all dependencies selected, or no dependencies required
partial   ! 0  some dependencies selected
empty     x 0  no dependencies selected
```

## Regression analysis

- **Custom role submit** — submits exactly the checked scopes, including dependency rows the admin explicitly toggled.
- **Level changes** — still filter selected scopes by assignability for the new role level.
- **Existing scope grouping/search** — still uses the same group and filter utilities.
- No backend/API surface touched.

## Test plan

- [x] `pnpm -F frontend test src/ee/features/customRoles/utils/scopeUtils.test.ts`
- [x] `pnpm -F frontend typecheck:fast`
- [x] `pnpm -F frontend linter src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx src/ee/features/customRoles/utils/scopeUtils.ts src/ee/features/customRoles/utils/scopeUtils.test.ts`
