### PR TITLE
fix(cli): never count the pinned query-sdk as a custom app dependency

### DIFF
--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
     appFolderName,
+    applySdkMirrorToTemplateDeps,
     attachDependenciesToCode,
     buildDepsWarningLines,
     buildImportBody,
@@ -392,5 +393,37 @@ describe('attachDependenciesToCode', () => {
         );
         expect(result.manifest).toBe(baseCode.manifest);
         expect(result.files).toBe(baseCode.files);
+    });
+});
+
+describe('applySdkMirrorToTemplateDeps', () => {
+    const template = {
+        '@lightdash/query-sdk': '0.3326.1',
+        react: '19.2.5',
+    };
+
+    it('mirrors the declared SDK spec so an older pin never counts as custom', () => {
+        const result = applySdkMirrorToTemplateDeps(
+            template,
+            JSON.stringify({
+                dependencies: { '@lightdash/query-sdk': '0.3315.3' },
+            }),
+        );
+        expect(result['@lightdash/query-sdk']).toBe('0.3315.3');
+        expect(result.react).toBe('19.2.5');
+    });
+
+    it('leaves the baseline untouched when the SDK is not declared', () => {
+        const result = applySdkMirrorToTemplateDeps(
+            template,
+            JSON.stringify({ dependencies: { react: '19.2.5' } }),
+        );
+        expect(result).toEqual(template);
+    });
+
+    it('leaves the baseline untouched for unparseable packageJson', () => {
+        expect(applySdkMirrorToTemplateDeps(template, 'not-json')).toEqual(
+            template,
+        );
     });
 });

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -222,6 +222,33 @@ export const buildDepsWarningLines = (
     });
 
 /**
+ * Mirrors the server's baseline rule: the declared `@lightdash/query-sdk` spec
+ * is copied into the template baseline so the SDK never counts as custom. The
+ * scaffold pins the SDK per release, so a folder scaffolded under an older CLI
+ * would otherwise flag the SDK as an override after every CLI upgrade.
+ */
+export const applySdkMirrorToTemplateDeps = (
+    templateDependencies: Record<string, string>,
+    packageJson: string,
+): Record<string, string> => {
+    try {
+        const parsed = JSON.parse(packageJson) as {
+            dependencies?: Record<string, unknown>;
+        };
+        const sdkSpec = parsed.dependencies?.['@lightdash/query-sdk'];
+        if (typeof sdkSpec === 'string') {
+            return {
+                ...templateDependencies,
+                '@lightdash/query-sdk': sdkSpec,
+            };
+        }
+    } catch {
+        // Unparseable packageJson — validateDataAppDependencies reports it.
+    }
+    return templateDependencies;
+};
+
+/**
  * Returns a new DataAppCode with `dependencies` attached when the custom set
  * is non-empty, or the original code object unchanged when there are no custom
  * deps (payload stays identical to today's format).

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -41,6 +41,7 @@ import GlobalState from '../globalState';
 import * as styles from '../styles';
 import {
     appFolderName,
+    applySdkMirrorToTemplateDeps,
     attachDependenciesToCode,
     buildDepsWarningLines,
     buildImportBody,
@@ -2011,8 +2012,10 @@ export const uploadHandler = async (
                     let codeToUpload = code;
 
                     if (rawDeps !== null) {
-                        const templateDeps =
-                            loadTemplateDependencies(CLI_VERSION);
+                        const templateDeps = applySdkMirrorToTemplateDeps(
+                            loadTemplateDependencies(CLI_VERSION),
+                            rawDeps.packageJson,
+                        );
                         let customDeps: Record<string, string>;
                         try {
                             ({ customDeps } = validateDataAppDependencies(


### PR DESCRIPTION
The CLI's dependency diff compared against the vendored template with `workspace:*` rewritten to the CLI's own version — so any app folder scaffolded under an older release flagged `@lightdash/query-sdk` as a custom override after every CLI upgrade (warning noise + a pointless deps payload the server then ignores).

The server already mirrors the declared SDK spec into its baseline (`buildTemplateBaseline`); this applies the same rule client-side via `applySdkMirrorToTemplateDeps` before the diff.

Before: `+ @lightdash/query-sdk@0.3315.3 (overrides template 0.3326.1)` on every upload of an older scaffold.
After: only genuinely custom packages are listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)