### PR TITLE
fix(ai): don't require admin ability to resolve org default model in Slack

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8302,16 +8302,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                   agentUuid: data.agentUuid,
               })
             : undefined;
-        const aiOrganizationSettings =
+        const orgDefaultModelConfig =
             data.modelConfig || agent?.modelConfig
-                ? undefined
-                : await this.aiOrganizationSettingsService.getSettings(
-                      user as SessionUser,
+                ? null
+                : await this.aiOrganizationSettingsService.getDefaultModelConfig(
+                      user.organizationUuid,
                   );
         const modelConfig =
             data.modelConfig ??
             agent?.modelConfig ??
-            aiOrganizationSettings?.defaultAiAgentModelConfig ??
+            orgDefaultModelConfig ??
             undefined;
 
         if (!threadUuid) {

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -9,6 +9,7 @@ import {
     ParameterError,
     UpdateAiOrganizationSettings,
     UpdateAiProviderApiKeys,
+    type AiAgentModelConfig,
     type AiModelOption,
     type ByoAiProvider,
     type SessionUser,
@@ -167,6 +168,22 @@ export class AiOrganizationSettingsService extends BaseService {
         } catch (error) {
             return false;
         }
+    }
+
+    /**
+     * The org-level default model config, without the admin-gated key-hint
+     * masking that getSettings applies. Callers that only need to resolve a
+     * model (e.g. the Slack prompt flow) use this instead of getSettings so
+     * they don't require a SessionUser ability or `manage` permission.
+     */
+    async getDefaultModelConfig(
+        organizationUuid: string,
+    ): Promise<AiAgentModelConfig | null> {
+        const settings =
+            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+                organizationUuid,
+            );
+        return settings?.defaultAiAgentModelConfig ?? null;
     }
 
     async getSettings(


### PR DESCRIPTION
## Problem

Every Slack `@mention` of an AI agent that **falls back to the org default model** crashes with:

```
TypeError: Cannot read properties of undefined (reading 'can')
    at CaslAuditWrapper.can (caslAuditWrapper.ts:293)
    at AiOrganizationSettingsService.canManageAiAgent
    at AiOrganizationSettingsService.getSettings
    at AiAgentService.createSlackPrompt
    at AiAgentService.handleAppMention
```

`createSlackPrompt` resolves the default model by calling `AiOrganizationSettingsService.getSettings`, passing a user built from `userModel.getUserDetailsByUuid` — a `LightdashUser`, which has **no CASL `ability`** — cast as `SessionUser`. The `as SessionUser` cast hid the mismatch.

`getSettings` gained a permission check in #25194 (`canManageAiAgent` → `createAuditedAbility(user)`), which dereferences `user.ability`. On the ability-less Slack user that is `undefined`, so `wrappedAbility.can(...)` throws.

## Fix

The Slack path only needs the **non-secret** model selection (`{ modelName, modelProvider, reasoning }`) — it does not need the admin-facing settings payload or its provider-key-hint masking. So this separates the two concerns:

- **Use** the org's configured model → new `getDefaultModelConfig(organizationUuid)`, **ungated** (no ability, no `manage` permission). The Slack flow uses this.
- **See / change** the provider key → `getSettings` keeps its admin-gated `maskProviderKeyExposure(…, canManage)`; `upsertSettings` keeps `checkManageAiAgentAccess`.

This also removes the `as SessionUser` lie — the internal flow no longer masquerades as an interactive user.

The model config carries **no secret** (the API key lives in `providerApiKeys`, resolved server-side), so exposing it ungated is safe: anyone can *use* the admin's key via the agent; only admins can *see/change* it.

## Regression analysis

- **Affected (crashing before this fix):** Slack `@mention` where the agent uses the org default model — i.e. neither the request (`data.modelConfig`) nor the agent (`agent.modelConfig`) pins a model. Introduced by #25194 (merged the same day).
- **Not affected:** agents/requests with an explicit `modelConfig` (they skip the settings read entirely); the web-app prompt path and MCP path, which pass a real `SessionUser` with a populated `ability`.

## Test plan

- [x] `pnpm -F backend typecheck:fast`
- [x] `AiOrganizationSettingsService.test.ts` passes (7/7)
- [x] `pnpm -F backend lint` clean on changed files
- [ ] Manual: `@mention` an agent (no per-agent/per-request model) in Slack and confirm it responds instead of crashing

## Notes

- Root cause is #25194, not the base PR of this stack (#25256).
- Stacked on #25256.

Relates: #25194