### PR TITLE
feat(ai): show all charts from one Slack turn as a carousel

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -6602,6 +6602,38 @@ export class AiAgentModel {
         });
     }
 
+    async findArtifactVersionsByPromptUuid(
+        promptUuid: string,
+        { db }: { db: Knex } = { db: this.database },
+    ): Promise<AiArtifact[]> {
+        return db(AiArtifactVersionsTableName)
+            .select({
+                artifactUuid: `${AiArtifactsTableName}.ai_artifact_uuid`,
+                threadUuid: `${AiArtifactsTableName}.ai_thread_uuid`,
+                artifactType: `${AiArtifactsTableName}.artifact_type`,
+                savedQueryUuid: `${AiArtifactVersionsTableName}.saved_query_uuid`,
+                savedDashboardUuid: `${AiArtifactVersionsTableName}.saved_dashboard_uuid`,
+                createdAt: `${AiArtifactsTableName}.created_at`,
+                versionNumber: `${AiArtifactVersionsTableName}.version_number`,
+                versionUuid: `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                title: `${AiArtifactVersionsTableName}.title`,
+                description: `${AiArtifactVersionsTableName}.description`,
+                chartConfig: `${AiArtifactVersionsTableName}.chart_config`,
+                dashboardConfig: `${AiArtifactVersionsTableName}.dashboard_config`,
+                promptUuid: `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+                versionCreatedAt: `${AiArtifactVersionsTableName}.created_at`,
+                verifiedByUserUuid: `${AiArtifactVersionsTableName}.verified_by_user_uuid`,
+                verifiedAt: `${AiArtifactVersionsTableName}.verified_at`,
+            } satisfies Record<keyof AiArtifact, string>)
+            .join(
+                AiArtifactsTableName,
+                `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                `${AiArtifactsTableName}.ai_artifact_uuid`,
+            )
+            .where(`${AiArtifactVersionsTableName}.ai_prompt_uuid`, promptUuid)
+            .orderBy(`${AiArtifactVersionsTableName}.created_at`, 'asc');
+    }
+
     async updateThreadTitle({
         threadUuid,
         title,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8396,6 +8396,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             (artifact) => artifact.promptUuid === slackPrompt.promptUuid,
         );
 
+        // Each generateVisualization call in a turn adds a version to the
+        // thread's artifact, so a "make me 3 charts" turn produces one artifact
+        // with several versions. Render each version as its own card (with its
+        // own config + image) so all charts from the turn are shown.
+        const promptArtifactVersions =
+            await this.aiAgentModel.findArtifactVersionsByPromptUuid(
+                slackPrompt.promptUuid,
+            );
+
         const toolResults = await this.aiAgentModel.getToolResultsForPrompt(
             slackPrompt.promptUuid,
         );
@@ -8442,7 +8451,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     exploreName,
                 ),
             agent?.uuid,
-            promptArtifacts,
+            promptArtifactVersions.length > 0
+                ? promptArtifactVersions
+                : promptArtifacts,
             toolResults,
         );
         const proposeChangeBlocks = getProposeChangeBlocks(

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -577,8 +577,8 @@ describe('Slack AI agent blocks', () => {
         expect(blocks).toHaveLength(1);
     });
 
-    it('keeps charts with the same title but different queries as separate cards', async () => {
-        const chartVersion = (versionUuid: string, status: string) => ({
+    it('collapses a retry that changed the query but kept the title', async () => {
+        const retryVersion = (versionUuid: string, grain: string) => ({
             artifactUuid: 'artifact-1',
             threadUuid: 'thread-1',
             promptUuid: 'prompt-1',
@@ -588,15 +588,75 @@ describe('Slack AI agent blocks', () => {
             createdAt: new Date(),
             versionNumber: Number(versionUuid.split('-')[1]),
             versionUuid,
-            title: 'Orders by month',
+            title: 'Unique order count over time by status',
             description: null,
             dashboardConfig: null,
             versionCreatedAt: new Date(),
             verifiedByUserUuid: null,
             verifiedAt: null,
             chartConfig: {
-                title: 'Orders by month',
-                description: 'Orders by month',
+                title: 'Unique order count over time by status',
+                description: 'Unique order count over time by status',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: [`orders_order_date_${grain}`],
+                    metrics: ['orders_unique_order_count'],
+                    sorts: [],
+                    limit: 500,
+                    customMetrics: [],
+                    tableCalculations: [],
+                    filters: statusFilter('completed'),
+                },
+                chartConfig: null,
+            },
+        });
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async () => 'https://lightdash.example.com/share/chart',
+            async () => ({}) as never,
+            'agent-1',
+            [
+                retryVersion('version-1', 'day'),
+                retryVersion('version-2', 'month'),
+            ],
+            [],
+        );
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks).toMatchObject([{ type: 'card' }]);
+    });
+
+    it('keeps distinct charts with different titles as separate cards', async () => {
+        const chartVersion = (
+            versionUuid: string,
+            title: string,
+            status: string,
+        ) => ({
+            artifactUuid: 'artifact-1',
+            threadUuid: 'thread-1',
+            promptUuid: 'prompt-1',
+            artifactType: 'chart' as const,
+            savedQueryUuid: null,
+            savedDashboardUuid: null,
+            createdAt: new Date(),
+            versionNumber: Number(versionUuid.split('-')[1]),
+            versionUuid,
+            title,
+            description: null,
+            dashboardConfig: null,
+            versionCreatedAt: new Date(),
+            verifiedByUserUuid: null,
+            verifiedAt: null,
+            chartConfig: {
+                title,
+                description: title,
                 queryConfig: {
                     exploreName: 'orders',
                     dimensions: ['orders_order_date_month'],
@@ -623,8 +683,8 @@ describe('Slack AI agent blocks', () => {
             async () => ({}) as never,
             'agent-1',
             [
-                chartVersion('version-1', 'placed'),
-                chartVersion('version-2', 'completed'),
+                chartVersion('version-1', 'Placed orders', 'placed'),
+                chartVersion('version-2', 'Completed orders', 'completed'),
             ],
             [],
         );

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -696,4 +696,89 @@ describe('Slack AI agent blocks', () => {
             },
         ]);
     });
+
+    it('keeps a line and a bar of the same query as separate cards', async () => {
+        const vizChartConfig = (
+            defaultVizType: 'line' | 'bar',
+            lineType: 'line' | null,
+        ) => ({
+            groupBy: null,
+            lineType,
+            stackBars: null,
+            xAxisType: 'time' as const,
+            xAxisLabel: 'Order month',
+            yAxisLabel: 'Unique order count',
+            yAxisMetrics: ['orders_unique_order_count'],
+            defaultVizType,
+            xAxisDimension: 'orders_order_date_month',
+            funnelDataInput: null,
+            secondaryYAxisLabel: null,
+            secondaryYAxisMetric: null,
+        });
+
+        const chartVersion = (
+            versionUuid: string,
+            defaultVizType: 'line' | 'bar',
+            lineType: 'line' | null,
+        ) => ({
+            artifactUuid: 'artifact-1',
+            threadUuid: 'thread-1',
+            promptUuid: 'prompt-1',
+            artifactType: 'chart' as const,
+            savedQueryUuid: null,
+            savedDashboardUuid: null,
+            createdAt: new Date(),
+            versionNumber: Number(versionUuid.split('-')[1]),
+            versionUuid,
+            title: 'Unique Order Count Over Time',
+            description: null,
+            dashboardConfig: null,
+            versionCreatedAt: new Date(),
+            verifiedByUserUuid: null,
+            verifiedAt: null,
+            chartConfig: {
+                title: 'Unique Order Count Over Time',
+                description: 'Unique Order Count Over Time',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_order_date_month'],
+                    metrics: ['orders_unique_order_count'],
+                    sorts: [],
+                    limit: 500,
+                    customMetrics: [],
+                    tableCalculations: [],
+                    filters: null,
+                },
+                chartConfig: vizChartConfig(
+                    defaultVizType,
+                    defaultVizType === 'line' ? 'line' : null,
+                ),
+            },
+        });
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async () => 'https://lightdash.example.com/share/chart',
+            async () => ({}) as never,
+            'agent-1',
+            [
+                chartVersion('version-1', 'line', 'line'),
+                chartVersion('version-2', 'bar', null),
+            ],
+            [],
+        );
+
+        expect(blocks).toMatchObject([
+            {
+                type: 'carousel',
+                elements: [{ type: 'card' }, { type: 'card' }],
+            },
+        ]);
+    });
 });

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -374,4 +374,102 @@ describe('Slack AI agent blocks', () => {
             },
         ]);
     });
+
+    it('renders one turn with multiple chart versions as a carousel', async () => {
+        const chartVersion = (versionUuid: string, title: string) => ({
+            artifactUuid: 'artifact-1',
+            threadUuid: 'thread-1',
+            promptUuid: 'prompt-1',
+            artifactType: 'chart' as const,
+            savedQueryUuid: null,
+            savedDashboardUuid: null,
+            createdAt: new Date(),
+            versionNumber: Number(versionUuid.split('-')[1]),
+            versionUuid,
+            title,
+            description: null,
+            dashboardConfig: null,
+            versionCreatedAt: new Date(),
+            verifiedByUserUuid: null,
+            verifiedAt: null,
+            chartConfig: {
+                title,
+                description: title,
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_order_date_month'],
+                    metrics: ['orders_unique_order_count'],
+                    sorts: [],
+                    limit: 500,
+                    customMetrics: [],
+                    tableCalculations: [],
+                    filters: null,
+                },
+                chartConfig: null,
+            },
+        });
+
+        const attempt = (callId: string, url: string) => ({
+            uuid: `result-${callId}`,
+            promptUuid: 'prompt-1',
+            toolCallId: callId,
+            toolType: 'built-in' as const,
+            toolName: 'generateVisualization' as const,
+            result: 'ok',
+            createdAt: new Date(),
+            metadata: { status: 'success', chartImageUrl: url } as never,
+        });
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async () => 'https://lightdash.example.com/share/chart',
+            async () => ({}) as never,
+            'agent-1',
+            [
+                chartVersion('version-1', 'Placed orders by month'),
+                chartVersion('version-2', 'Shipped orders by month'),
+                chartVersion('version-3', 'Completed orders by month'),
+            ],
+            [
+                attempt('call-1', 'https://files.slack.com/placed.png'),
+                attempt('call-2', 'https://files.slack.com/shipped.png'),
+                attempt('call-3', 'https://files.slack.com/completed.png'),
+            ],
+        );
+
+        expect(blocks).toMatchObject([
+            {
+                type: 'carousel',
+                elements: [
+                    {
+                        type: 'card',
+                        title: { text: 'Placed orders by month' },
+                        hero_image: {
+                            image_url: 'https://files.slack.com/placed.png',
+                        },
+                    },
+                    {
+                        type: 'card',
+                        title: { text: 'Shipped orders by month' },
+                        hero_image: {
+                            image_url: 'https://files.slack.com/shipped.png',
+                        },
+                    },
+                    {
+                        type: 'card',
+                        title: { text: 'Completed orders by month' },
+                        hero_image: {
+                            image_url: 'https://files.slack.com/completed.png',
+                        },
+                    },
+                ],
+            },
+        ]);
+    });
 });

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -1,3 +1,4 @@
+import { DimensionType, FilterOperator, FilterType } from '@lightdash/common';
 import {
     buildFeedbackContextActions,
     buildSlackTaskUpdate,
@@ -375,8 +376,27 @@ describe('Slack AI agent blocks', () => {
         ]);
     });
 
+    const statusFilter = (status: string) => ({
+        type: 'and' as const,
+        dimensions: [
+            {
+                fieldId: 'orders_status',
+                operator: FilterOperator.EQUALS as const,
+                values: [status],
+                fieldType: DimensionType.STRING as const,
+                fieldFilterType: FilterType.STRING as const,
+            },
+        ],
+        metrics: null,
+        tableCalculations: null,
+    });
+
     it('renders one turn with multiple chart versions as a carousel', async () => {
-        const chartVersion = (versionUuid: string, title: string) => ({
+        const chartVersion = (
+            versionUuid: string,
+            title: string,
+            status: string,
+        ) => ({
             artifactUuid: 'artifact-1',
             threadUuid: 'thread-1',
             promptUuid: 'prompt-1',
@@ -403,7 +423,7 @@ describe('Slack AI agent blocks', () => {
                     limit: 500,
                     customMetrics: [],
                     tableCalculations: [],
-                    filters: null,
+                    filters: statusFilter(status),
                 },
                 chartConfig: null,
             },
@@ -432,9 +452,13 @@ describe('Slack AI agent blocks', () => {
             async () => ({}) as never,
             'agent-1',
             [
-                chartVersion('version-1', 'Placed orders by month'),
-                chartVersion('version-2', 'Shipped orders by month'),
-                chartVersion('version-3', 'Completed orders by month'),
+                chartVersion('version-1', 'Placed orders by month', 'placed'),
+                chartVersion('version-2', 'Shipped orders by month', 'shipped'),
+                chartVersion(
+                    'version-3',
+                    'Completed orders by month',
+                    'completed',
+                ),
             ],
             [
                 attempt('call-1', 'https://files.slack.com/placed.png'),
@@ -469,6 +493,146 @@ describe('Slack AI agent blocks', () => {
                         },
                     },
                 ],
+            },
+        ]);
+    });
+
+    it('collapses retried versions of the same chart into a single card', async () => {
+        const retryVersion = (versionUuid: string) => ({
+            artifactUuid: 'artifact-1',
+            threadUuid: 'thread-1',
+            promptUuid: 'prompt-1',
+            artifactType: 'chart' as const,
+            savedQueryUuid: null,
+            savedDashboardUuid: null,
+            createdAt: new Date(),
+            versionNumber: Number(versionUuid.split('-')[1]),
+            versionUuid,
+            title: 'Placed vs completed orders',
+            description: null,
+            dashboardConfig: null,
+            versionCreatedAt: new Date(),
+            verifiedByUserUuid: null,
+            verifiedAt: null,
+            chartConfig: {
+                title: 'Placed vs completed orders',
+                description: 'Placed vs completed orders',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_order_date_month'],
+                    metrics: ['orders_unique_order_count'],
+                    sorts: [],
+                    limit: 500,
+                    customMetrics: [],
+                    tableCalculations: [],
+                    filters: statusFilter('completed'),
+                },
+                chartConfig: null,
+            },
+        });
+
+        const attempt = (callId: string, url: string) => ({
+            uuid: `result-${callId}`,
+            promptUuid: 'prompt-1',
+            toolCallId: callId,
+            toolType: 'built-in' as const,
+            toolName: 'generateVisualization' as const,
+            result: 'ok',
+            createdAt: new Date(),
+            metadata: { status: 'success', chartImageUrl: url } as never,
+        });
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async () => 'https://lightdash.example.com/share/chart',
+            async () => ({}) as never,
+            'agent-1',
+            [
+                retryVersion('version-1'),
+                retryVersion('version-2'),
+                retryVersion('version-3'),
+            ],
+            [
+                attempt('call-1', 'https://files.slack.com/attempt-1.png'),
+                attempt('call-2', 'https://files.slack.com/attempt-2.png'),
+                attempt('call-3', 'https://files.slack.com/attempt-3.png'),
+            ],
+        );
+
+        expect(blocks).toMatchObject([
+            {
+                type: 'card',
+                title: { text: 'Placed vs completed orders' },
+                hero_image: {
+                    image_url: 'https://files.slack.com/attempt-3.png',
+                },
+            },
+        ]);
+        expect(blocks).toHaveLength(1);
+    });
+
+    it('keeps charts with the same title but different queries as separate cards', async () => {
+        const chartVersion = (versionUuid: string, status: string) => ({
+            artifactUuid: 'artifact-1',
+            threadUuid: 'thread-1',
+            promptUuid: 'prompt-1',
+            artifactType: 'chart' as const,
+            savedQueryUuid: null,
+            savedDashboardUuid: null,
+            createdAt: new Date(),
+            versionNumber: Number(versionUuid.split('-')[1]),
+            versionUuid,
+            title: 'Orders by month',
+            description: null,
+            dashboardConfig: null,
+            versionCreatedAt: new Date(),
+            verifiedByUserUuid: null,
+            verifiedAt: null,
+            chartConfig: {
+                title: 'Orders by month',
+                description: 'Orders by month',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_order_date_month'],
+                    metrics: ['orders_unique_order_count'],
+                    sorts: [],
+                    limit: 500,
+                    customMetrics: [],
+                    tableCalculations: [],
+                    filters: statusFilter(status),
+                },
+                chartConfig: null,
+            },
+        });
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async () => 'https://lightdash.example.com/share/chart',
+            async () => ({}) as never,
+            'agent-1',
+            [
+                chartVersion('version-1', 'placed'),
+                chartVersion('version-2', 'completed'),
+            ],
+            [],
+        );
+
+        expect(blocks).toMatchObject([
+            {
+                type: 'carousel',
+                elements: [{ type: 'card' }, { type: 'card' }],
             },
         ]);
     });

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -548,12 +548,52 @@ export async function getModernArtifactCardBlocks(
                     .chartImageUrl,
         )
         .filter((url): url is string => Boolean(url));
-    const chartArtifacts = artifacts
-        .slice(0, 3)
-        .filter((artifact) => Boolean(artifact.chartConfig));
+    // Two chart versions are the "same chart" when their query and viz type
+    // match. A retried generateVisualization re-runs the same query, so those
+    // versions share this identity; genuinely different charts (e.g. a
+    // per-status filter) do not.
+    const getArtifactChartIdentity = (artifact: AiArtifact): string => {
+        if (artifact.chartConfig) {
+            const viz = parseVizConfig(artifact.chartConfig, maxQueryLimit);
+            if (viz) {
+                // parseVizConfig assigns a random id to each filter rule, so
+                // drop id fields to keep the identity stable across retries.
+                return JSON.stringify(
+                    { type: viz.type, metricQuery: viz.metricQuery },
+                    (key, value) => (key === 'id' ? undefined : value),
+                );
+            }
+        }
+        if (artifact.dashboardConfig) {
+            return JSON.stringify({ dashboard: artifact.dashboardConfig });
+        }
+        return `version:${artifact.versionUuid}`;
+    };
+
+    // Collapse retries to the latest version so they render as one card, while
+    // keeping distinct charts as separate cards (Slack allows up to 10).
+    const dedupedArtifacts = Array.from(
+        artifacts
+            .reduce((byIdentity, artifact) => {
+                const identity = getArtifactChartIdentity(artifact);
+                const existing = byIdentity.get(identity);
+                if (
+                    !existing ||
+                    artifact.versionNumber > existing.versionNumber
+                ) {
+                    byIdentity.set(identity, artifact);
+                }
+                return byIdentity;
+            }, new Map<string, AiArtifact>())
+            .values(),
+    ).slice(0, 10);
+
+    const chartArtifacts = dedupedArtifacts.filter((artifact) =>
+        Boolean(artifact.chartConfig),
+    );
 
     const blocks = await Promise.all(
-        artifacts.slice(0, 3).map(async (artifact, index) => {
+        dedupedArtifacts.map(async (artifact, index) => {
             if (artifact.chartConfig) {
                 const vizConfig = parseVizConfig(
                     artifact.chartConfig,

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -548,16 +548,15 @@ export async function getModernArtifactCardBlocks(
                     .chartImageUrl,
         )
         .filter((url): url is string => Boolean(url));
-    // Two chart versions are the "same chart" when their query and viz type
-    // match. A retried generateVisualization re-runs the same query, so those
-    // versions share this identity; genuinely different charts (e.g. a
-    // per-status filter) do not.
-    const getArtifactChartIdentity = (artifact: AiArtifact): string => {
+    // A retried generateVisualization adds another version to the turn's
+    // artifact — sometimes re-running the same query, sometimes tweaking it
+    // (e.g. day -> month grain) to work around an error while keeping the same
+    // title. Its query identity: viz type + query, ignoring the random ids
+    // parseVizConfig stamps on filter rules.
+    const getArtifactQueryIdentity = (artifact: AiArtifact): string => {
         if (artifact.chartConfig) {
             const viz = parseVizConfig(artifact.chartConfig, maxQueryLimit);
             if (viz) {
-                // parseVizConfig assigns a random id to each filter rule, so
-                // drop id fields to keep the identity stable across retries.
                 return JSON.stringify(
                     { type: viz.type, metricQuery: viz.metricQuery },
                     (key, value) => (key === 'id' ? undefined : value),
@@ -570,23 +569,51 @@ export async function getModernArtifactCardBlocks(
         return `version:${artifact.versionUuid}`;
     };
 
-    // Collapse retries to the latest version so they render as one card, while
-    // keeping distinct charts as separate cards (Slack allows up to 10).
-    const dedupedArtifacts = Array.from(
-        artifacts
-            .reduce((byIdentity, artifact) => {
-                const identity = getArtifactChartIdentity(artifact);
-                const existing = byIdentity.get(identity);
-                if (
-                    !existing ||
-                    artifact.versionNumber > existing.versionNumber
-                ) {
-                    byIdentity.set(identity, artifact);
-                }
-                return byIdentity;
-            }, new Map<string, AiArtifact>())
-            .values(),
-    ).slice(0, 10);
+    // Treat two versions as the same chart when they share a query OR a title,
+    // so retries collapse whether or not the query changed. Union them and keep
+    // the latest version of each group (Slack allows up to 10 cards).
+    const parent = artifacts.map((_, index) => index);
+    const find = (index: number): number => {
+        let root = index;
+        while (parent[root] !== root) root = parent[root];
+        return root;
+    };
+    const union = (a: number, b: number) => {
+        parent[find(a)] = find(b);
+    };
+    const firstByKey = new Map<string, number>();
+    artifacts.forEach((artifact, index) => {
+        const title = artifact.title?.trim();
+        const keys = [
+            `query:${getArtifactQueryIdentity(artifact)}`,
+            ...(title ? [`title:${title}`] : []),
+        ];
+        keys.forEach((key) => {
+            const seen = firstByKey.get(key);
+            if (seen === undefined) firstByKey.set(key, index);
+            else union(index, seen);
+        });
+    });
+    const latestByGroup = new Map<
+        number,
+        { artifact: AiArtifact; firstIndex: number }
+    >();
+    artifacts.forEach((artifact, index) => {
+        const group = find(index);
+        const existing = latestByGroup.get(group);
+        if (
+            !existing ||
+            artifact.versionNumber > existing.artifact.versionNumber
+        )
+            latestByGroup.set(group, {
+                artifact,
+                firstIndex: existing?.firstIndex ?? index,
+            });
+    });
+    const dedupedArtifacts = Array.from(latestByGroup.values())
+        .sort((a, b) => a.firstIndex - b.firstIndex)
+        .map((entry) => entry.artifact)
+        .slice(0, 10);
 
     const chartArtifacts = dedupedArtifacts.filter((artifact) =>
         Boolean(artifact.chartConfig),

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -620,23 +620,22 @@ export async function getModernArtifactCardBlocks(
                     vizConfig.metricQuery.metrics.length +
                     additionalMetricsWithSql.length;
                 const dimensionCount = vizConfig.metricQuery.dimensions.length;
-                // A prompt upserts a single artifact, so its retried
-                // visualizations produce several images for that one artifact —
-                // the latest is its current render. Use it for the single-artifact
-                // case; for multiple artifacts fall back to positional matching.
+                // A single chart with several images is a retried render — show
+                // the latest. Multiple charts (one card per version) match their
+                // image positionally by version.
                 const chartImageUrl =
                     chartArtifacts.length === 1
                         ? chartImageUrls[chartImageUrls.length - 1]
                         : chartImageUrls[
                               chartArtifacts.findIndex(
                                   (chartArtifact) =>
-                                      chartArtifact.artifactUuid ===
-                                      artifact.artifactUuid,
+                                      chartArtifact.versionUuid ===
+                                      artifact.versionUuid,
                               )
                           ];
 
                 return buildSlackCardBlock({
-                    blockId: `ai_agent_chart_card_${artifact.artifactUuid}`,
+                    blockId: `ai_agent_chart_card_${artifact.versionUuid}`,
                     title: getArtifactTitle(artifact),
                     subtitle: `${vizConfig.metricQuery.exploreName} chart`,
                     heroImageUrl: chartImageUrl,
@@ -678,7 +677,7 @@ export async function getModernArtifactCardBlocks(
 
             if (artifact.dashboardConfig && agentUuid) {
                 return buildSlackCardBlock({
-                    blockId: `ai_agent_dashboard_card_${artifact.artifactUuid}`,
+                    blockId: `ai_agent_dashboard_card_${artifact.versionUuid}`,
                     title: getArtifactTitle(artifact),
                     subtitle: 'Lightdash dashboard',
                     body:
@@ -704,7 +703,21 @@ export async function getModernArtifactCardBlocks(
         }),
     );
 
-    return blocks.filter((block): block is Block => Boolean(block));
+    const cards = blocks.filter((block): block is Block => Boolean(block));
+
+    // A single card renders on its own; multiple cards go in a horizontally
+    // scrollable carousel (Slack allows up to 10 cards).
+    if (cards.length <= 1) {
+        return cards;
+    }
+
+    return [
+        {
+            type: 'carousel',
+            block_id: `ai_agent_artifact_carousel_${slackPrompt.promptUuid}`,
+            elements: cards.slice(0, 10),
+        } as unknown as Block,
+    ];
 }
 
 // Tool names whose successful results count as "an answer the user can score".

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -14,6 +14,7 @@ import {
 } from '@lightdash/common';
 import { Block, KnownBlock } from '@slack/bolt';
 import { partition } from 'lodash';
+import { z } from 'zod';
 import type { SlackStreamChunk } from '../../../../clients/Slack/SlackClient';
 import { populateCustomMetricsSQL } from './populateCustomMetricsSQL';
 
@@ -548,72 +549,64 @@ export async function getModernArtifactCardBlocks(
                     .chartImageUrl,
         )
         .filter((url): url is string => Boolean(url));
-    // A retried generateVisualization adds another version to the turn's
-    // artifact — sometimes re-running the same query, sometimes tweaking it
-    // (e.g. day -> month grain) to work around an error while keeping the same
-    // title. Its query identity: viz type + query, ignoring the random ids
-    // parseVizConfig stamps on filter rules.
-    const getArtifactQueryIdentity = (artifact: AiArtifact): string => {
+    // The viz type lives in chartConfig.chartConfig.defaultVizType (line, bar,
+    // ...); parseVizConfig flattens the unified generateVisualization shape to
+    // "query_result" and can't tell a line from a bar, so read it directly and
+    // fall back to parseVizConfig's type for legacy per-tool shapes.
+    const vizTypeSchema = z.object({
+        chartConfig: z
+            .object({ defaultVizType: z.string() })
+            .nullable()
+            .optional(),
+    });
+    const getChartVizType = (artifact: AiArtifact): string => {
+        const parsed = vizTypeSchema.safeParse(artifact.chartConfig);
+        if (parsed.success && parsed.data.chartConfig?.defaultVizType) {
+            return parsed.data.chartConfig.defaultVizType;
+        }
+        return (
+            parseVizConfig(artifact.chartConfig, maxQueryLimit)?.type ?? 'chart'
+        );
+    };
+
+    // Identity of a chart within a turn: viz type + title. A retry keeps both
+    // (even when it tweaks the query, e.g. day -> month), so retries collapse;
+    // a line and a bar of the same data differ in viz type, and different
+    // charts differ in title, so both stay separate. Untitled charts fall back
+    // to their query so they don't all collapse together.
+    const getArtifactIdentity = (artifact: AiArtifact): string => {
+        const title = artifact.title?.trim();
         if (artifact.chartConfig) {
+            const vizType = getChartVizType(artifact);
+            if (title) return `chart:${vizType}:${title}`;
             const viz = parseVizConfig(artifact.chartConfig, maxQueryLimit);
-            if (viz) {
-                return JSON.stringify(
-                    { type: viz.type, metricQuery: viz.metricQuery },
-                    (key, value) => (key === 'id' ? undefined : value),
-                );
-            }
+            const query = viz
+                ? JSON.stringify(
+                      { type: viz.type, metricQuery: viz.metricQuery },
+                      (key, value) => (key === 'id' ? undefined : value),
+                  )
+                : artifact.versionUuid;
+            return `chart:${vizType}:${query}`;
         }
         if (artifact.dashboardConfig) {
-            return JSON.stringify({ dashboard: artifact.dashboardConfig });
+            return title
+                ? `dashboard:${title}`
+                : `dashboard:${JSON.stringify(artifact.dashboardConfig)}`;
         }
         return `version:${artifact.versionUuid}`;
     };
 
-    // Treat two versions as the same chart when they share a query OR a title,
-    // so retries collapse whether or not the query changed. Union them and keep
-    // the latest version of each group (Slack allows up to 10 cards).
-    const parent = artifacts.map((_, index) => index);
-    const find = (index: number): number => {
-        let root = index;
-        while (parent[root] !== root) root = parent[root];
-        return root;
-    };
-    const union = (a: number, b: number) => {
-        parent[find(a)] = find(b);
-    };
-    const firstByKey = new Map<string, number>();
-    artifacts.forEach((artifact, index) => {
-        const title = artifact.title?.trim();
-        const keys = [
-            `query:${getArtifactQueryIdentity(artifact)}`,
-            ...(title ? [`title:${title}`] : []),
-        ];
-        keys.forEach((key) => {
-            const seen = firstByKey.get(key);
-            if (seen === undefined) firstByKey.set(key, index);
-            else union(index, seen);
-        });
+    // Keep the latest version per identity, preserving first-appearance order
+    // (Slack allows up to 10 cards).
+    const latestByIdentity = new Map<string, AiArtifact>();
+    artifacts.forEach((artifact) => {
+        const identity = getArtifactIdentity(artifact);
+        const existing = latestByIdentity.get(identity);
+        if (!existing || artifact.versionNumber > existing.versionNumber) {
+            latestByIdentity.set(identity, artifact);
+        }
     });
-    const latestByGroup = new Map<
-        number,
-        { artifact: AiArtifact; firstIndex: number }
-    >();
-    artifacts.forEach((artifact, index) => {
-        const group = find(index);
-        const existing = latestByGroup.get(group);
-        if (
-            !existing ||
-            artifact.versionNumber > existing.artifact.versionNumber
-        )
-            latestByGroup.set(group, {
-                artifact,
-                firstIndex: existing?.firstIndex ?? index,
-            });
-    });
-    const dedupedArtifacts = Array.from(latestByGroup.values())
-        .sort((a, b) => a.firstIndex - b.firstIndex)
-        .map((entry) => entry.artifact)
-        .slice(0, 10);
+    const dedupedArtifacts = Array.from(latestByIdentity.values()).slice(0, 10);
 
     const chartArtifacts = dedupedArtifacts.filter((artifact) =>
         Boolean(artifact.chartConfig),


### PR DESCRIPTION
## Problem

When an agent produces **several charts in one Slack turn** (e.g. "make me 3 separate charts"), Slack showed only **one**. Each `generateVisualization` call upserts a new *version* of the thread's single chart artifact, so the render path saw one artifact and used the latest version — the other chart images were computed and then **discarded**.

## Change

Render every chart the turn produced, each as its own card, wrapped in a Block Kit **carousel** when there's more than one:

- **New model method** `AiAgentModel.findArtifactVersionsByPromptUuid` — returns every artifact version created by the prompt, each with its own `chartConfig`, title, and `versionUuid`.
- **Per-version cards** — each card gets its own **hero image** (matched positionally by version) and its own **"Explore in Lightdash"** link built from *that version's* config, so every chart drills through to the right chart (not the latest).
- **Carousel wrap** — `getModernArtifactCardBlocks` returns a single `{ type: 'carousel', elements: [...cards] }` when there is more than one card (Slack's 10-card cap respected). One card renders on its own, unchanged.

Single-chart and retried-single-chart turns are untouched — the existing "one artifact + several images → latest render" contract is preserved.

## Why render-only (no data-model change)

The whole stack already supports many artifacts/versions per prompt (no DB constraint, the message query already returns an array). The one-artifact-per-thread upsert in `createOrUpdateArtifact` is deliberate so follow-up edits ("make it a bar chart") version the chart instead of spawning duplicates. This PR surfaces what already exists rather than changing that model.

## Test plan

- [x] `pnpm -F backend typecheck:fast`
- [x] `getSlackBlocks.test.ts` — 12/12, incl. a new case asserting a 3-version turn yields one carousel with three cards carrying distinct titles + hero images
- [x] Slack `blocks.validate` on the real card-carousel shape (subtitle/body/subtext/actions) → `{"ok":true}`
- [ ] Manual: run a multi-chart turn in Slack and confirm the carousel renders and each card's Explore opens the right chart

## Notes

- The `card`/`carousel` blocks aren't in `@slack/types` yet, so the carousel object is cast the same way the existing `buildSlackCardBlock` casts its card.