### PR TITLE
feat: postgres wire protocol endpoint for the semantic layer

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -172,6 +172,7 @@
         "passport-strategy": "1.0.0",
         "pg": "8.13.1",
         "pg-connection-string": "2.7.0",
+        "pgsql-ast-parser": "12.0.2",
         "playwright": "1.56.1",
         "prom-client": "15.1.2",
         "qs": "6.15.2",

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -68,6 +68,11 @@ import {
 import { sessionAccountMiddleware } from './middlewares/accountMiddleware';
 import { jwtAuthMiddleware } from './middlewares/jwtAuthMiddleware';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
+import {
+    createLightdashPgWireHandlers,
+    type LightdashPgWireSession,
+} from './postgresWire/lightdashHandlers';
+import { PostgresWireServer } from './postgresWire/PostgresWireServer';
 import PrometheusMetrics from './prometheus/PrometheusMetrics';
 import { apiV1Router } from './routers/apiV1Router';
 import { createAppPreviewRouter } from './routers/appPreviewRouter';
@@ -171,6 +176,10 @@ export default class App {
     private readonly environment: 'production' | 'development';
 
     private schedulerWorker: SchedulerWorker | undefined;
+
+    private pgWireServer:
+        | PostgresWireServer<LightdashPgWireSession>
+        | undefined;
 
     private readonly clients: ClientRepository;
 
@@ -302,6 +311,20 @@ export default class App {
 
         // Load Lightdash middleware/routes last
         await this.initExpress(expressApp);
+
+        // Postgres wire protocol endpoint for the semantic layer (experimental)
+        const pgWirePort = process.env.PGWIRE_PORT
+            ? parseInt(process.env.PGWIRE_PORT, 10)
+            : undefined;
+        if (pgWirePort) {
+            this.pgWireServer = new PostgresWireServer(
+                createLightdashPgWireHandlers(this.serviceRepository),
+            );
+            await this.pgWireServer.listen(pgWirePort);
+            Logger.info(
+                `Postgres wire protocol server listening on port ${pgWirePort}`,
+            );
+        }
 
         if (this.lightdashConfig.scheduler?.enabled) {
             this.initSchedulerWorker();
@@ -1003,6 +1026,10 @@ export default class App {
     }
 
     async stop() {
+        if (this.pgWireServer) {
+            await this.pgWireServer.close();
+            Logger.info('Stopped Postgres wire protocol server');
+        }
         if (this.eventStreamWriter) {
             await this.eventStreamWriter.close();
             Logger.info('Flushed usage event stream writer');

--- a/packages/backend/src/postgresWire/PostgresWireServer.ts
+++ b/packages/backend/src/postgresWire/PostgresWireServer.ts
@@ -1,0 +1,420 @@
+import * as net from 'net';
+import Logger from '../logging/logger';
+
+/**
+ * A minimal implementation of the Postgres wire protocol (v3) frontend/backend
+ * message flow, supporting cleartext password authentication and the simple
+ * query protocol. Enough for psql, node-postgres and most drivers that don't
+ * force the extended protocol for parameterless queries.
+ *
+ * Protocol reference: https://www.postgresql.org/docs/current/protocol-message-formats.html
+ */
+
+const PROTOCOL_VERSION = 196608; // 3.0
+const SSL_REQUEST_CODE = 80877103;
+const GSSENC_REQUEST_CODE = 80877104;
+const CANCEL_REQUEST_CODE = 80877102;
+const MAX_MESSAGE_LENGTH = 1024 * 1024; // 1MB
+
+export class PgWireServerError extends Error {
+    constructor(
+        message: string,
+        public readonly code: string = 'XX000',
+        public readonly hint?: string,
+    ) {
+        super(message);
+        this.name = 'PgWireServerError';
+    }
+}
+
+export type PgWireResultField = {
+    name: string;
+    /** Postgres type OID (e.g. 25 text, 701 float8) */
+    oid: number;
+};
+
+export type PgWireQueryResult =
+    | {
+          type: 'rows';
+          fields: PgWireResultField[];
+          /** row values pre-serialized to Postgres text format; null for SQL NULL */
+          rows: (string | null)[][];
+          commandTag: string;
+      }
+    | { type: 'command'; commandTag: string };
+
+export type PgWireHandlers<TSession> = {
+    /** Throw PgWireServerError to reject the connection */
+    authenticate: (params: {
+        user: string;
+        database: string;
+        password: string;
+    }) => Promise<TSession>;
+    /** Throw PgWireServerError to return an error to the client */
+    query: (session: TSession, sql: string) => Promise<PgWireQueryResult>;
+};
+
+// --- message encoding helpers ---
+
+const cstring = (s: string): Buffer =>
+    Buffer.concat([Buffer.from(s, 'utf8'), Buffer.from([0])]);
+
+const int16 = (n: number): Buffer => {
+    const b = Buffer.alloc(2);
+    b.writeInt16BE(n);
+    return b;
+};
+
+const int32 = (n: number): Buffer => {
+    const b = Buffer.alloc(4);
+    b.writeInt32BE(n);
+    return b;
+};
+
+const message = (type: string, ...parts: Buffer[]): Buffer => {
+    const body = Buffer.concat(parts);
+    return Buffer.concat([Buffer.from(type), int32(body.length + 4), body]);
+};
+
+const authenticationCleartextPassword = () => message('R', int32(3));
+const authenticationOk = () => message('R', int32(0));
+const parameterStatus = (name: string, value: string) =>
+    message('S', cstring(name), cstring(value));
+const backendKeyData = (pid: number, secret: number) =>
+    message('K', int32(pid), int32(secret));
+const readyForQuery = () => message('Z', Buffer.from('I'));
+const commandComplete = (tag: string) => message('C', cstring(tag));
+const emptyQueryResponse = () => message('I');
+
+const errorResponse = (error: PgWireServerError): Buffer => {
+    const parts: Buffer[] = [
+        Buffer.from('S'),
+        cstring('ERROR'),
+        Buffer.from('V'),
+        cstring('ERROR'),
+        Buffer.from('C'),
+        cstring(error.code),
+        Buffer.from('M'),
+        cstring(error.message),
+    ];
+    if (error.hint) {
+        parts.push(Buffer.from('H'), cstring(error.hint));
+    }
+    parts.push(Buffer.from([0]));
+    return message('E', ...parts);
+};
+
+const rowDescription = (fields: PgWireResultField[]): Buffer => {
+    const parts: Buffer[] = [int16(fields.length)];
+    for (const field of fields) {
+        parts.push(
+            cstring(field.name),
+            int32(0), // table oid
+            int16(0), // attribute number
+            int32(field.oid),
+            int16(-1), // type length (variable)
+            int32(-1), // type modifier
+            int16(0), // text format
+        );
+    }
+    return message('T', ...parts);
+};
+
+const dataRow = (values: (string | null)[]): Buffer => {
+    const parts: Buffer[] = [int16(values.length)];
+    for (const value of values) {
+        if (value === null) {
+            parts.push(int32(-1));
+        } else {
+            const bytes = Buffer.from(value, 'utf8');
+            parts.push(int32(bytes.length), bytes);
+        }
+    }
+    return message('D', ...parts);
+};
+
+const toServerError = (e: unknown): PgWireServerError => {
+    if (e instanceof PgWireServerError) return e;
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    return new PgWireServerError(errorMessage);
+};
+
+type ConnectionPhase = 'startup' | 'password' | 'ready';
+
+/** State machine for a single client connection */
+class PgWireConnection<TSession> {
+    private buffer: Buffer = Buffer.alloc(0);
+
+    private phase: ConnectionPhase = 'startup';
+
+    private startupParams: Record<string, string> = {};
+
+    private session: TSession | null = null;
+
+    /** serializes async message handling for this connection */
+    private chain: Promise<void> = Promise.resolve();
+
+    constructor(
+        private socket: net.Socket,
+        private handlers: PgWireHandlers<TSession>,
+    ) {
+        socket.on('data', (chunk) => {
+            try {
+                this.buffer = Buffer.concat([this.buffer, chunk]);
+                this.drainBuffer();
+            } catch (e) {
+                Logger.warn(
+                    `pgwire: closing connection after protocol error: ${
+                        e instanceof Error ? e.message : e
+                    }`,
+                );
+                socket.destroy();
+            }
+        });
+        socket.on('error', (e) => {
+            Logger.debug(`pgwire: socket error: ${e.message}`);
+        });
+    }
+
+    /** Extract complete frontend messages from the buffer and queue them */
+    private drainBuffer(): void {
+        for (;;) {
+            if (this.phase === 'startup') {
+                // untyped startup packet: int32 length, int32 code
+                if (this.buffer.length < 8) return;
+                const length = this.buffer.readInt32BE(0);
+                if (length > MAX_MESSAGE_LENGTH || length < 8) {
+                    throw new Error(`invalid startup packet length ${length}`);
+                }
+                if (this.buffer.length < length) return;
+                const code = this.buffer.readInt32BE(4);
+                const payload = this.buffer.subarray(8, length);
+                this.buffer = this.buffer.subarray(length);
+                if (code === SSL_REQUEST_CODE || code === GSSENC_REQUEST_CODE) {
+                    // SSL/GSS not supported: client falls back to plaintext
+                    this.socket.write('N');
+                } else if (code === CANCEL_REQUEST_CODE) {
+                    this.socket.end();
+                    return;
+                } else if (code === PROTOCOL_VERSION) {
+                    this.handleStartup(payload);
+                } else {
+                    throw new Error(`unsupported protocol version ${code}`);
+                }
+            } else {
+                // typed message: byte type, int32 length (includes itself)
+                if (this.buffer.length < 5) return;
+                const type = String.fromCharCode(this.buffer[0]);
+                const length = this.buffer.readInt32BE(1);
+                if (length > MAX_MESSAGE_LENGTH || length < 4) {
+                    throw new Error(`invalid message length ${length}`);
+                }
+                if (this.buffer.length < length + 1) return;
+                const payload = Buffer.from(
+                    this.buffer.subarray(5, length + 1),
+                );
+                this.buffer = this.buffer.subarray(length + 1);
+                this.enqueue(type, payload);
+            }
+        }
+    }
+
+    private handleStartup(payload: Buffer): void {
+        const params: Record<string, string> = {};
+        let offset = 0;
+        while (offset < payload.length) {
+            const keyEnd = payload.indexOf(0, offset);
+            if (keyEnd === -1 || keyEnd === offset) break;
+            const key = payload.toString('utf8', offset, keyEnd);
+            const valueEnd = payload.indexOf(0, keyEnd + 1);
+            if (valueEnd === -1) break;
+            params[key] = payload.toString('utf8', keyEnd + 1, valueEnd);
+            offset = valueEnd + 1;
+        }
+        this.startupParams = params;
+        this.phase = 'password';
+        this.socket.write(authenticationCleartextPassword());
+    }
+
+    private enqueue(type: string, payload: Buffer): void {
+        this.chain = this.chain
+            .then(() => this.handleMessage(type, payload))
+            .catch((e) => {
+                Logger.error(
+                    `pgwire: unexpected error handling message: ${
+                        e instanceof Error ? e.stack : e
+                    }`,
+                );
+                this.socket.destroy();
+            });
+    }
+
+    private async handleMessage(type: string, payload: Buffer): Promise<void> {
+        if (this.socket.destroyed) return;
+        switch (type) {
+            case 'p': {
+                if (this.phase !== 'password') return;
+                const end = payload.indexOf(0);
+                const password = payload.toString(
+                    'utf8',
+                    0,
+                    end === -1 ? payload.length : end,
+                );
+                await this.authenticate(password);
+                return;
+            }
+            case 'Q': {
+                if (this.phase !== 'ready') {
+                    this.socket.write(
+                        errorResponse(
+                            new PgWireServerError(
+                                'connection not authenticated',
+                                '08P01',
+                            ),
+                        ),
+                    );
+                    this.socket.end();
+                    return;
+                }
+                const end = payload.indexOf(0);
+                const sql = payload.toString(
+                    'utf8',
+                    0,
+                    end === -1 ? payload.length : end,
+                );
+                await this.runQuery(sql);
+                return;
+            }
+            case 'X': // Terminate
+                this.socket.end();
+                return;
+            case 'P': // extended query protocol not supported
+            case 'B':
+            case 'D':
+            case 'E':
+            case 'C':
+            case 'H':
+            case 'S': {
+                this.socket.write(
+                    errorResponse(
+                        new PgWireServerError(
+                            'the extended query protocol is not supported',
+                            '0A000',
+                            'Use simple queries without bind parameters',
+                        ),
+                    ),
+                );
+                // Sync: let the client recover
+                if (type === 'S') this.socket.write(readyForQuery());
+                return;
+            }
+            default:
+                this.socket.write(
+                    errorResponse(
+                        new PgWireServerError(
+                            `unsupported message type "${type}"`,
+                            '08P01',
+                        ),
+                    ),
+                );
+        }
+    }
+
+    private async authenticate(password: string): Promise<void> {
+        const user = this.startupParams.user ?? '';
+        const database = this.startupParams.database ?? user;
+        try {
+            this.session = await this.handlers.authenticate({
+                user,
+                database,
+                password,
+            });
+        } catch (e) {
+            const error =
+                e instanceof PgWireServerError
+                    ? e
+                    : new PgWireServerError(
+                          e instanceof Error ? e.message : String(e),
+                          '28P01',
+                      );
+            this.socket.write(errorResponse(error));
+            this.socket.end();
+            return;
+        }
+        this.phase = 'ready';
+        this.socket.write(
+            Buffer.concat([
+                authenticationOk(),
+                parameterStatus('server_version', '16.3 (Lightdash)'),
+                parameterStatus('server_encoding', 'UTF8'),
+                parameterStatus('client_encoding', 'UTF8'),
+                parameterStatus('DateStyle', 'ISO, MDY'),
+                parameterStatus('TimeZone', 'UTC'),
+                parameterStatus('integer_datetimes', 'on'),
+                parameterStatus('standard_conforming_strings', 'on'),
+                backendKeyData(
+                    process.pid,
+                    Math.floor(Math.random() * 2 ** 31),
+                ),
+                readyForQuery(),
+            ]),
+        );
+    }
+
+    private async runQuery(sql: string): Promise<void> {
+        if (sql.trim().length === 0) {
+            this.socket.write(
+                Buffer.concat([emptyQueryResponse(), readyForQuery()]),
+            );
+            return;
+        }
+        try {
+            const result = await this.handlers.query(
+                this.session as TSession,
+                sql,
+            );
+            const buffers: Buffer[] = [];
+            if (result.type === 'rows') {
+                buffers.push(rowDescription(result.fields));
+                for (const row of result.rows) {
+                    buffers.push(dataRow(row));
+                }
+            }
+            buffers.push(commandComplete(result.commandTag), readyForQuery());
+            this.socket.write(Buffer.concat(buffers));
+        } catch (e) {
+            this.socket.write(
+                Buffer.concat([
+                    errorResponse(toServerError(e)),
+                    readyForQuery(),
+                ]),
+            );
+        }
+    }
+}
+
+export class PostgresWireServer<TSession> {
+    private server: net.Server;
+
+    constructor(handlers: PgWireHandlers<TSession>) {
+        this.server = net.createServer(
+            (socket) => new PgWireConnection(socket, handlers),
+        );
+    }
+
+    async listen(port: number, host?: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.server.once('error', reject);
+            this.server.listen(port, host, () => {
+                this.server.removeListener('error', reject);
+                resolve();
+            });
+        });
+    }
+
+    async close(): Promise<void> {
+        return new Promise((resolve) => {
+            this.server.close(() => resolve());
+        });
+    }
+}

--- a/packages/backend/src/postgresWire/informationSchema.ts
+++ b/packages/backend/src/postgresWire/informationSchema.ts
@@ -1,0 +1,299 @@
+import {
+    type Expr,
+    type ExprRef,
+    type SelectFromStatement,
+    type Statement,
+} from 'pgsql-ast-parser';
+import {
+    PgWireServerError,
+    type PgWireQueryResult,
+} from './PostgresWireServer';
+import { type PgWireTable } from './types';
+
+/**
+ * Virtual information_schema.tables / information_schema.columns tables so
+ * clients can discover explores and their dimensions/metrics with standard
+ * catalog queries. Supports projection, simple WHERE predicates (=, !=, LIKE,
+ * ILIKE, IN, AND, OR), ORDER BY and LIMIT.
+ */
+
+type VirtualValue = string | number | null;
+type VirtualRow = Record<string, VirtualValue>;
+
+const TEXT_OID = 25;
+const INT8_OID = 20;
+
+const VIRTUAL_TABLES: Record<string, string[]> = {
+    tables: ['table_catalog', 'table_schema', 'table_name', 'table_type'],
+    columns: [
+        'table_catalog',
+        'table_schema',
+        'table_name',
+        'column_name',
+        'ordinal_position',
+        'data_type',
+        'is_nullable',
+        'field_type',
+    ],
+};
+
+/** DimensionType / MetricType value -> information_schema data_type name */
+const DATA_TYPE_NAMES: Record<string, string> = {
+    string: 'text',
+    number: 'double precision',
+    boolean: 'boolean',
+    date: 'date',
+    timestamp: 'timestamp without time zone',
+    count: 'bigint',
+    count_distinct: 'bigint',
+    sum: 'double precision',
+    average: 'double precision',
+    median: 'double precision',
+    percentile: 'double precision',
+    min: 'double precision',
+    max: 'double precision',
+};
+
+const buildRows = (
+    virtualTable: string,
+    catalog: PgWireTable[],
+    projectUuid: string,
+): VirtualRow[] => {
+    if (virtualTable === 'tables') {
+        return catalog.map((table) => ({
+            table_catalog: projectUuid,
+            table_schema: 'public',
+            table_name: table.name,
+            table_type: 'BASE TABLE',
+        }));
+    }
+    return catalog.flatMap((table) =>
+        table.fields.map((field, index) => ({
+            table_catalog: projectUuid,
+            table_schema: 'public',
+            table_name: table.name,
+            column_name: field.fieldId,
+            ordinal_position: index + 1,
+            data_type: DATA_TYPE_NAMES[field.type] ?? 'text',
+            is_nullable: 'YES',
+            field_type: field.kind,
+        })),
+    );
+};
+
+const literalOf = (expr: Expr): VirtualValue => {
+    switch (expr.type) {
+        case 'string':
+            return expr.value;
+        case 'integer':
+        case 'numeric':
+            return expr.value;
+        case 'null':
+            return null;
+        default:
+            throw new PgWireServerError(
+                'information_schema filters only support literal values',
+                '0A000',
+            );
+    }
+};
+
+const likeToRegex = (pattern: string, caseInsensitive: boolean): RegExp => {
+    const escaped = pattern
+        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        .replace(/%/g, '.*')
+        .replace(/_/g, '.');
+    return new RegExp(`^${escaped}$`, caseInsensitive ? 'i' : undefined);
+};
+
+const columnValue = (
+    row: VirtualRow,
+    ref: ExprRef,
+    availableColumns: string[],
+): VirtualValue => {
+    if (!availableColumns.includes(ref.name)) {
+        throw new PgWireServerError(
+            `Column "${ref.name}" does not exist in information_schema`,
+            '42703',
+            `Available columns: ${availableColumns.join(', ')}`,
+        );
+    }
+    return row[ref.name] ?? null;
+};
+
+const evalPredicate = (
+    expr: Expr,
+    row: VirtualRow,
+    availableColumns: string[],
+): boolean => {
+    switch (expr.type) {
+        case 'binary': {
+            const { op } = expr;
+            if (op === 'AND') {
+                return (
+                    evalPredicate(expr.left, row, availableColumns) &&
+                    evalPredicate(expr.right, row, availableColumns)
+                );
+            }
+            if (op === 'OR') {
+                return (
+                    evalPredicate(expr.left, row, availableColumns) ||
+                    evalPredicate(expr.right, row, availableColumns)
+                );
+            }
+            if (expr.left.type !== 'ref') {
+                throw new PgWireServerError(
+                    'information_schema filters must have a column on the left side',
+                    '0A000',
+                );
+            }
+            const value = columnValue(row, expr.left, availableColumns);
+            if (op === 'IN' || op === 'NOT IN') {
+                const list =
+                    expr.right.type === 'list'
+                        ? expr.right.expressions
+                        : [expr.right];
+                const matches = list.some(
+                    (item) => String(literalOf(item)) === String(value),
+                );
+                return op === 'IN' ? matches : !matches;
+            }
+            if (
+                op === 'LIKE' ||
+                op === 'ILIKE' ||
+                op === 'NOT LIKE' ||
+                op === 'NOT ILIKE'
+            ) {
+                const pattern = literalOf(expr.right);
+                if (typeof pattern !== 'string') {
+                    throw new PgWireServerError(
+                        'LIKE patterns must be strings',
+                        '22023',
+                    );
+                }
+                const matches =
+                    value !== null &&
+                    likeToRegex(pattern, op.includes('ILIKE')).test(
+                        String(value),
+                    );
+                return op.startsWith('NOT') ? !matches : matches;
+            }
+            if (op === '=' || op === '!=') {
+                const literal = literalOf(expr.right);
+                const matches = String(value) === String(literal);
+                return op === '=' ? matches : !matches;
+            }
+            throw new PgWireServerError(
+                `Operator "${op}" is not supported on information_schema`,
+                '0A000',
+            );
+        }
+        default:
+            throw new PgWireServerError(
+                'Unsupported filter on information_schema',
+                '0A000',
+                'Supported: =, !=, LIKE, ILIKE, IN, AND, OR',
+            );
+    }
+};
+
+/**
+ * Serve SELECTs against information_schema.tables / information_schema.columns
+ * from the session catalog. Returns null when the statement targets something
+ * else (regular compilation should proceed).
+ */
+export const tryHandleInformationSchema = (
+    statements: Statement[],
+    catalog: PgWireTable[],
+    projectUuid: string,
+): PgWireQueryResult | null => {
+    if (statements.length !== 1) return null;
+    const [statement] = statements;
+    if (statement.type !== 'select') return null;
+    const select = statement as SelectFromStatement;
+    if (!select.from || select.from.length !== 1) return null;
+    const [from] = select.from;
+    if (from.type !== 'table') return null;
+    if (from.name.schema !== 'information_schema') return null;
+
+    const virtualTable = from.name.name;
+    const availableColumns = VIRTUAL_TABLES[virtualTable];
+    if (!availableColumns) {
+        throw new PgWireServerError(
+            `information_schema.${virtualTable} is not supported`,
+            '42P01',
+            'Available: information_schema.tables, information_schema.columns',
+        );
+    }
+
+    let rows = buildRows(virtualTable, catalog, projectUuid);
+
+    if (select.where) {
+        rows = rows.filter((row) =>
+            evalPredicate(select.where as Expr, row, availableColumns),
+        );
+    }
+
+    for (const orderBy of [...(select.orderBy ?? [])].reverse()) {
+        if (orderBy.by.type !== 'ref') {
+            throw new PgWireServerError(
+                'ORDER BY on information_schema only supports column names',
+                '0A000',
+            );
+        }
+        const { name } = orderBy.by;
+        const direction = orderBy.order === 'DESC' ? -1 : 1;
+        rows = [...rows].sort((a, b) => {
+            const left = a[name];
+            const right = b[name];
+            if (typeof left === 'number' && typeof right === 'number') {
+                return (left - right) * direction;
+            }
+            return String(left).localeCompare(String(right)) * direction;
+        });
+    }
+
+    if (select.limit?.limit?.type === 'integer') {
+        rows = rows.slice(0, select.limit.limit.value);
+    }
+
+    // projection: * or column refs (with optional aliases)
+    const projected: Array<{ name: string; column: string }> = [];
+    for (const col of select.columns ?? []) {
+        if (col.expr.type === 'ref' && col.expr.name === '*') {
+            availableColumns.forEach((column) =>
+                projected.push({ name: column, column }),
+            );
+        } else if (col.expr.type === 'ref') {
+            const { name } = col.expr;
+            if (!availableColumns.includes(name)) {
+                throw new PgWireServerError(
+                    `Column "${name}" does not exist in information_schema.${virtualTable}`,
+                    '42703',
+                    `Available columns: ${availableColumns.join(', ')}`,
+                );
+            }
+            projected.push({ name: col.alias?.name ?? name, column: name });
+        } else {
+            throw new PgWireServerError(
+                'Only plain columns can be selected from information_schema',
+                '0A000',
+            );
+        }
+    }
+
+    return {
+        type: 'rows',
+        fields: projected.map((p) => ({
+            name: p.name,
+            oid: p.column === 'ordinal_position' ? INT8_OID : TEXT_OID,
+        })),
+        rows: rows.map((row) =>
+            projected.map((p) => {
+                const value = row[p.column];
+                return value === null ? null : String(value);
+            }),
+        ),
+        commandTag: `SELECT ${rows.length}`,
+    };
+};

--- a/packages/backend/src/postgresWire/lightdashHandlers.ts
+++ b/packages/backend/src/postgresWire/lightdashHandlers.ts
@@ -1,0 +1,427 @@
+import {
+    generateSlug,
+    getDimensions,
+    getItemId,
+    getMetrics,
+    QueryExecutionContext,
+    type Account,
+    type ResultRow,
+} from '@lightdash/common';
+import { parse } from 'pgsql-ast-parser';
+import { fromApiKey } from '../auth/account/account';
+import Logger from '../logging/logger';
+import type { ServiceRepository } from '../services/ServiceRepository';
+import { tryHandleInformationSchema } from './informationSchema';
+import {
+    PgWireServerError,
+    type PgWireHandlers,
+    type PgWireQueryResult,
+    type PgWireResultField,
+} from './PostgresWireServer';
+import { compileSqlToMetricQuery, SqlCompileError } from './sqlToMetricQuery';
+import { type PgWireColumn, type PgWireField, type PgWireTable } from './types';
+
+export type LightdashPgWireSession = {
+    account: Account;
+    projectUuid: string;
+    catalog: PgWireTable[];
+};
+
+const VERSION_STRING =
+    'PostgreSQL 16.3 (Lightdash semantic layer, wire protocol)';
+
+const TEXT_OID = 25;
+const BOOL_OID = 16;
+const INT8_OID = 20;
+const FLOAT8_OID = 701;
+const DATE_OID = 1082;
+const TIMESTAMP_OID = 1114;
+
+/** DimensionType / MetricType value -> Postgres type OID */
+const TYPE_OIDS: Record<string, number> = {
+    string: TEXT_OID,
+    number: FLOAT8_OID,
+    boolean: BOOL_OID,
+    date: DATE_OID,
+    timestamp: TIMESTAMP_OID,
+    count: INT8_OID,
+    count_distinct: INT8_OID,
+    sum: FLOAT8_OID,
+    average: FLOAT8_OID,
+    median: FLOAT8_OID,
+    percentile: FLOAT8_OID,
+    min: FLOAT8_OID,
+    max: FLOAT8_OID,
+};
+
+const oidForColumn = (column: PgWireColumn): number =>
+    (column.type && TYPE_OIDS[column.type]) || TEXT_OID;
+
+const ISO_DATETIME_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+
+/** Serialize a raw result value to Postgres text format */
+const toTextValue = (raw: unknown, type: string | null): string | null => {
+    if (raw === null || raw === undefined) return null;
+    if (raw instanceof Date) {
+        if (type === 'date') return raw.toISOString().slice(0, 10);
+        return raw.toISOString().replace('T', ' ').replace('Z', '+00');
+    }
+    if (typeof raw === 'boolean') return raw ? 't' : 'f';
+    if (typeof raw === 'string' && ISO_DATETIME_PATTERN.test(raw)) {
+        if (type === 'date') return raw.slice(0, 10);
+        if (type === 'timestamp')
+            return raw.replace('T', ' ').replace('Z', '+00');
+    }
+    if (typeof raw === 'object') return JSON.stringify(raw);
+    return String(raw);
+};
+
+const compileErrorToServerError = (e: SqlCompileError): PgWireServerError => {
+    let code = '42601'; // syntax_error
+    if (e.message.includes('does not exist in table')) code = '42703'; // undefined_column
+    if (e.message.includes('does not exist') && e.message.includes('Table'))
+        code = '42P01'; // undefined_table
+    return new PgWireServerError(e.message, code, e.hint);
+};
+
+/** SHOW <param> responses for common client compatibility probes */
+const SHOW_PARAMETERS: Record<string, string> = {
+    server_version: '16.3 (Lightdash)',
+    server_encoding: 'UTF8',
+    client_encoding: 'UTF8',
+    transaction_isolation: 'read committed',
+    standard_conforming_strings: 'on',
+    timezone: 'UTC',
+    datestyle: 'ISO, MDY',
+    search_path: 'public',
+};
+
+/**
+ * Handle transaction/session statements that BI tools and drivers send but
+ * that have no meaning against the semantic layer. Returns null when the
+ * statement should be compiled as a real query.
+ */
+const tryHandleSessionStatement = (sql: string): PgWireQueryResult | null => {
+    const trimmed = sql.trim().replace(/;\s*$/, '');
+    const firstWord = trimmed.split(/\s+/)[0]?.toUpperCase() ?? '';
+    switch (firstWord) {
+        case 'BEGIN':
+        case 'START':
+            return { type: 'command', commandTag: 'BEGIN' };
+        case 'COMMIT':
+        case 'END':
+            return { type: 'command', commandTag: 'COMMIT' };
+        case 'ROLLBACK':
+        case 'ABORT':
+            return { type: 'command', commandTag: 'ROLLBACK' };
+        case 'SET':
+            return { type: 'command', commandTag: 'SET' };
+        case 'RESET':
+            return { type: 'command', commandTag: 'RESET' };
+        case 'DISCARD':
+            return { type: 'command', commandTag: 'DISCARD ALL' };
+        case 'DEALLOCATE':
+            return { type: 'command', commandTag: 'DEALLOCATE' };
+        case 'SHOW': {
+            const param = trimmed.split(/\s+/)[1]?.toLowerCase() ?? '';
+            const value = SHOW_PARAMETERS[param];
+            if (value === undefined) {
+                throw new PgWireServerError(
+                    `unrecognized configuration parameter "${param}"`,
+                    '42704',
+                );
+            }
+            return {
+                type: 'rows',
+                fields: [{ name: param, oid: TEXT_OID }],
+                rows: [[value]],
+                commandTag: 'SHOW',
+            };
+        }
+        default:
+            return null;
+    }
+};
+
+/**
+ * Evaluate SELECTs without a FROM clause (SELECT 1, SELECT version(), ...)
+ * used by clients as connection tests. Returns null when the statement is
+ * not a FROM-less select.
+ */
+const tryHandleConstantSelect = (
+    sql: string,
+    session: LightdashPgWireSession,
+): PgWireQueryResult | null => {
+    let statements;
+    try {
+        statements = parse(sql);
+    } catch {
+        return null; // let the compiler produce the error message
+    }
+    if (statements.length !== 1) return null;
+    const [statement] = statements;
+    if (statement.type !== 'select') return null;
+    if (statement.from && statement.from.length > 0) return null;
+
+    const fields: PgWireResultField[] = [];
+    const row: (string | null)[] = [];
+    for (const col of statement.columns ?? []) {
+        const { expr } = col;
+        let name = col.alias?.name ?? '?column?';
+        let oid = TEXT_OID;
+        let value: string | null;
+        switch (expr.type) {
+            case 'string':
+                value = expr.value;
+                break;
+            case 'integer':
+                oid = INT8_OID;
+                value = String(expr.value);
+                break;
+            case 'numeric':
+                oid = FLOAT8_OID;
+                value = String(expr.value);
+                break;
+            case 'boolean':
+                oid = BOOL_OID;
+                value = expr.value ? 't' : 'f';
+                break;
+            case 'null':
+                value = null;
+                break;
+            case 'call': {
+                const fn = expr.function.name.toLowerCase();
+                if (!col.alias) name = fn;
+                if (fn === 'version') value = VERSION_STRING;
+                else if (fn === 'current_database') value = session.projectUuid;
+                else if (fn === 'current_schema') value = 'public';
+                else if (fn === 'now' || fn === 'current_timestamp') {
+                    oid = TIMESTAMP_OID;
+                    value = new Date()
+                        .toISOString()
+                        .replace('T', ' ')
+                        .replace('Z', '+00');
+                } else return null;
+                break;
+            }
+            case 'keyword': {
+                if (!col.alias) name = expr.keyword;
+                if (
+                    expr.keyword === 'current_user' ||
+                    expr.keyword === 'session_user' ||
+                    expr.keyword === 'user'
+                ) {
+                    value = session.account.user?.email ?? 'lightdash';
+                } else if (expr.keyword === 'current_catalog') {
+                    value = session.projectUuid;
+                } else if (expr.keyword === 'current_schema') {
+                    value = 'public';
+                } else return null;
+                break;
+            }
+            default:
+                return null;
+        }
+        fields.push({ name, oid });
+        row.push(value);
+    }
+    return { type: 'rows', fields, rows: [row], commandTag: 'SELECT 1' };
+};
+
+const UUID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const createLightdashPgWireHandlers = (
+    serviceRepository: ServiceRepository,
+): PgWireHandlers<LightdashPgWireSession> => {
+    /**
+     * The database name can be a project UUID or a slugified project name
+     * (e.g. "jaffle-shop"). Projects have no stored slug, so slugs are derived
+     * from names at connect time and may be ambiguous - UUIDs always work.
+     */
+    const resolveProjectUuid = async (
+        account: Account,
+        database: string,
+    ): Promise<string> => {
+        if (UUID_PATTERN.test(database)) return database;
+        const projects = await serviceRepository
+            .getOrganizationService()
+            .getProjects(account);
+        const wanted = database.toLowerCase();
+        const matches = projects.filter(
+            (p) =>
+                generateSlug(p.name) === wanted ||
+                p.name.toLowerCase() === wanted,
+        );
+        if (matches.length === 1) return matches[0].projectUuid;
+        if (matches.length > 1) {
+            throw new PgWireServerError(
+                `database "${database}" is ambiguous: ${matches.length} projects share that name`,
+                '3D000',
+                `Use the project UUID instead: ${matches
+                    .map((p) => p.projectUuid)
+                    .join(', ')}`,
+            );
+        }
+        throw new PgWireServerError(
+            `database "${database}" does not exist`,
+            '3D000',
+            `Use a project UUID or one of: ${projects
+                .map((p) => generateSlug(p.name))
+                .join(', ')}`,
+        );
+    };
+    const buildCatalog = async (
+        account: Account,
+        projectUuid: string,
+    ): Promise<PgWireTable[]> => {
+        const projectService = serviceRepository.getProjectService();
+        const summaries = await projectService.getAllExploresSummary(
+            account,
+            projectUuid,
+            true,
+            false,
+        );
+        const tables = await Promise.all(
+            summaries.map(async (summary): Promise<PgWireTable | null> => {
+                try {
+                    const explore = await projectService.getExplore(
+                        account,
+                        projectUuid,
+                        summary.name,
+                    );
+                    const fields: PgWireField[] = [
+                        ...getDimensions(explore)
+                            .filter((d) => !d.hidden)
+                            .map((d) => ({
+                                fieldId: getItemId(d),
+                                kind: 'dimension' as const,
+                                type: d.type,
+                            })),
+                        ...getMetrics(explore)
+                            .filter((m) => !m.hidden)
+                            .map((m) => ({
+                                fieldId: getItemId(m),
+                                kind: 'metric' as const,
+                                type: m.type,
+                            })),
+                    ];
+                    return { name: explore.name, fields };
+                } catch (e) {
+                    Logger.debug(
+                        `pgwire: skipping explore ${summary.name}: ${
+                            e instanceof Error ? e.message : e
+                        }`,
+                    );
+                    return null;
+                }
+            }),
+        );
+        return tables.filter((t): t is PgWireTable => t !== null);
+    };
+
+    return {
+        authenticate: async ({ user, database, password }) => {
+            if (!password) {
+                throw new PgWireServerError(
+                    'password authentication failed: provide a Lightdash personal access token as the password',
+                    '28P01',
+                );
+            }
+            let sessionUser;
+            try {
+                sessionUser = await serviceRepository
+                    .getUserService()
+                    .loginWithPersonalAccessToken(password);
+            } catch (e) {
+                Logger.info(
+                    `pgwire: PAT authentication failed for user "${user}"`,
+                );
+                throw new PgWireServerError(
+                    'password authentication failed: invalid personal access token',
+                    '28P01',
+                    'Create a token in Lightdash under Settings > Personal access tokens and use it as the password',
+                );
+            }
+            const account = fromApiKey(sessionUser, 'pgwire');
+            const projectUuid = await resolveProjectUuid(account, database);
+            let catalog: PgWireTable[];
+            try {
+                catalog = await buildCatalog(account, projectUuid);
+            } catch (e) {
+                throw new PgWireServerError(
+                    `cannot access project "${projectUuid}": ${
+                        e instanceof Error ? e.message : e
+                    }`,
+                    '3D000',
+                    'Use the Lightdash project UUID as the database name',
+                );
+            }
+            Logger.info(
+                `pgwire: ${sessionUser.email} connected to project ${projectUuid} (${catalog.length} explores)`,
+            );
+            return { account, projectUuid, catalog };
+        },
+
+        query: async (session, sql) => {
+            const sessionResult = tryHandleSessionStatement(sql);
+            if (sessionResult) return sessionResult;
+
+            const constantResult = tryHandleConstantSelect(sql, session);
+            if (constantResult) return constantResult;
+
+            // catalog discovery via information_schema.tables / .columns
+            try {
+                const infoResult = tryHandleInformationSchema(
+                    parse(sql),
+                    session.catalog,
+                    session.projectUuid,
+                );
+                if (infoResult) return infoResult;
+            } catch (e) {
+                if (e instanceof PgWireServerError) throw e;
+                // parse errors fall through to the compiler for consistent messages
+            }
+
+            let compiled;
+            try {
+                compiled = compileSqlToMetricQuery(sql, session.catalog);
+            } catch (e) {
+                if (e instanceof SqlCompileError) {
+                    throw compileErrorToServerError(e);
+                }
+                throw e;
+            }
+
+            const results = await serviceRepository
+                .getProjectService()
+                .runExploreQuery(
+                    session.account,
+                    compiled.metricQuery,
+                    session.projectUuid,
+                    compiled.metricQuery.exploreName,
+                    undefined, // csvLimit: undefined = respect metricQuery.limit
+                    undefined,
+                    QueryExecutionContext.API,
+                );
+
+            const fields: PgWireResultField[] = compiled.columns.map(
+                (column) => ({
+                    name: column.name,
+                    oid: oidForColumn(column),
+                }),
+            );
+            const rows = results.rows.map((row: ResultRow) =>
+                compiled.columns.map((column) =>
+                    toTextValue(row[column.source]?.value?.raw, column.type),
+                ),
+            );
+            return {
+                type: 'rows',
+                fields,
+                rows,
+                commandTag: `SELECT ${rows.length}`,
+            };
+        },
+    };
+};

--- a/packages/backend/src/postgresWire/sqlToMetricQuery.test.ts
+++ b/packages/backend/src/postgresWire/sqlToMetricQuery.test.ts
@@ -1,0 +1,1405 @@
+import { FilterOperator, type Filters } from '@lightdash/common';
+import {
+    compileSqlToMetricQuery,
+    PGWIRE_DEFAULT_LIMIT,
+    SqlCompileError,
+} from './sqlToMetricQuery';
+import { type PgWireTable } from './types';
+
+const ORDERS: PgWireTable = {
+    name: 'orders',
+    fields: [
+        { fieldId: 'orders_status', kind: 'dimension', type: 'string' },
+        { fieldId: 'orders_order_date', kind: 'dimension', type: 'date' },
+        { fieldId: 'orders_is_completed', kind: 'dimension', type: 'boolean' },
+        { fieldId: 'orders_amount', kind: 'dimension', type: 'number' },
+        // fields from a joined table in the explore
+        {
+            fieldId: 'customers_first_name',
+            kind: 'dimension',
+            type: 'string',
+        },
+        {
+            fieldId: 'orders_total_order_amount',
+            kind: 'metric',
+            type: 'sum',
+        },
+        {
+            fieldId: 'orders_unique_order_count',
+            kind: 'metric',
+            type: 'count_distinct',
+        },
+        { fieldId: 'orders_avg_amount', kind: 'metric', type: 'average' },
+    ],
+};
+
+const CUSTOMERS: PgWireTable = {
+    name: 'customers',
+    fields: [
+        { fieldId: 'customers_customer_id', kind: 'dimension', type: 'number' },
+        {
+            fieldId: 'customers_days_since_last_order',
+            kind: 'metric',
+            type: 'min',
+        },
+    ],
+};
+
+const CATALOG = [ORDERS, CUSTOMERS];
+
+const compile = (sql: string) => compileSqlToMetricQuery(sql, CATALOG);
+
+/** Strip generated filter rule/group ids so tests compare structure only */
+const stripIds = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(stripIds);
+    if (value !== null && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>)
+                .filter(([key]) => key !== 'id')
+                .map(([key, v]) => [key, stripIds(v)]),
+        );
+    }
+    return value;
+};
+
+const filtersOf = (sql: string) => stripIds(compile(sql).metricQuery.filters);
+
+describe('compileSqlToMetricQuery', () => {
+    describe('basic selection', () => {
+        it('compiles a single dimension', () => {
+            const result = compile('SELECT orders_status FROM orders');
+            expect(result.metricQuery).toEqual({
+                exploreName: 'orders',
+                dimensions: ['orders_status'],
+                metrics: [],
+                filters: {},
+                sorts: [],
+                limit: PGWIRE_DEFAULT_LIMIT,
+                tableCalculations: [],
+            });
+            expect(result.columns).toEqual([
+                {
+                    name: 'orders_status',
+                    source: 'orders_status',
+                    kind: 'dimension',
+                    type: 'string',
+                },
+            ]);
+        });
+
+        it('compiles dimensions and metrics', () => {
+            const result = compile(
+                'SELECT orders_status, orders_total_order_amount, orders_unique_order_count FROM orders',
+            );
+            expect(result.metricQuery.dimensions).toEqual(['orders_status']);
+            expect(result.metricQuery.metrics).toEqual([
+                'orders_total_order_amount',
+                'orders_unique_order_count',
+            ]);
+        });
+
+        it('selects fields from joined explore tables', () => {
+            const result = compile(
+                'SELECT customers_first_name, orders_total_order_amount FROM orders',
+            );
+            expect(result.metricQuery.dimensions).toEqual([
+                'customers_first_name',
+            ]);
+        });
+
+        it('deduplicates repeated fields but keeps both output columns', () => {
+            const result = compile(
+                'SELECT orders_status, orders_status AS again FROM orders',
+            );
+            expect(result.metricQuery.dimensions).toEqual(['orders_status']);
+            expect(result.columns).toHaveLength(2);
+            expect(result.columns[1].name).toBe('again');
+            expect(result.columns[1].source).toBe('orders_status');
+        });
+
+        it('expands SELECT * to all fields in catalog order', () => {
+            const result = compile('SELECT * FROM orders');
+            expect(result.metricQuery.dimensions).toEqual([
+                'orders_status',
+                'orders_order_date',
+                'orders_is_completed',
+                'orders_amount',
+                'customers_first_name',
+            ]);
+            expect(result.metricQuery.metrics).toEqual([
+                'orders_total_order_amount',
+                'orders_unique_order_count',
+                'orders_avg_amount',
+            ]);
+            expect(result.columns).toHaveLength(ORDERS.fields.length);
+        });
+
+        it('expands table-qualified star', () => {
+            const result = compile('SELECT orders.* FROM orders');
+            expect(result.columns).toHaveLength(ORDERS.fields.length);
+        });
+
+        it('resolves table-qualified column names', () => {
+            const result = compile(
+                'SELECT orders.status, customers.first_name FROM orders',
+            );
+            expect(result.metricQuery.dimensions).toEqual([
+                'orders_status',
+                'customers_first_name',
+            ]);
+        });
+
+        it('resolves columns qualified by the FROM alias', () => {
+            const result = compile(
+                'SELECT o.orders_status, o.status FROM orders o',
+            );
+            expect(result.metricQuery.dimensions).toEqual(['orders_status']);
+        });
+
+        it('uses the alias as the output column name', () => {
+            const result = compile(
+                'SELECT orders_status AS status FROM orders',
+            );
+            expect(result.columns[0].name).toBe('status');
+            expect(result.columns[0].source).toBe('orders_status');
+        });
+
+        it('targets the requested explore from the catalog', () => {
+            const result = compile(
+                'SELECT customers_customer_id FROM customers',
+            );
+            expect(result.metricQuery.exploreName).toBe('customers');
+            expect(result.table.name).toBe('customers');
+        });
+
+        it('throws on unknown table with available tables hint', () => {
+            expect(() => compile('SELECT x FROM nope')).toThrow(
+                /Table "nope" does not exist/,
+            );
+            try {
+                compile('SELECT x FROM nope');
+            } catch (e) {
+                expect((e as SqlCompileError).hint).toContain('orders');
+            }
+        });
+
+        it('throws on unknown column with available columns hint', () => {
+            expect(() => compile('SELECT nope FROM orders')).toThrow(
+                /Column "nope" does not exist/,
+            );
+        });
+
+        it('throws on unknown qualified column', () => {
+            expect(() => compile('SELECT payments.amount FROM orders')).toThrow(
+                /Column "payments.amount" does not exist/,
+            );
+        });
+
+        it('throws when only table calculations are selected', () => {
+            expect(() => compile('SELECT 1 + 1 AS two FROM orders')).toThrow(
+                /at least one dimension or metric/,
+            );
+        });
+    });
+
+    describe('WHERE filters on dimensions', () => {
+        it('compiles equals', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status FROM orders WHERE orders_status = 'completed'",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed'],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles not equals with != and <>', () => {
+            for (const op of ['!=', '<>']) {
+                expect(
+                    filtersOf(
+                        `SELECT orders_status FROM orders WHERE orders_status ${op} 'completed'`,
+                    ),
+                ).toEqual({
+                    dimensions: {
+                        and: [
+                            {
+                                target: { fieldId: 'orders_status' },
+                                operator: FilterOperator.NOT_EQUALS,
+                                values: ['completed'],
+                            },
+                        ],
+                    },
+                });
+            }
+        });
+
+        it('compiles numeric comparisons', () => {
+            const cases: Array<[string, FilterOperator]> = [
+                ['<', FilterOperator.LESS_THAN],
+                ['<=', FilterOperator.LESS_THAN_OR_EQUAL],
+                ['>', FilterOperator.GREATER_THAN],
+                ['>=', FilterOperator.GREATER_THAN_OR_EQUAL],
+            ];
+            for (const [op, operator] of cases) {
+                expect(
+                    filtersOf(
+                        `SELECT orders_amount FROM orders WHERE orders_amount ${op} 100`,
+                    ),
+                ).toEqual({
+                    dimensions: {
+                        and: [
+                            {
+                                target: { fieldId: 'orders_amount' },
+                                operator,
+                                values: [100],
+                            },
+                        ],
+                    },
+                });
+            }
+        });
+
+        it('flips the operator when the literal is on the left', () => {
+            expect(
+                filtersOf(
+                    'SELECT orders_amount FROM orders WHERE 100 < orders_amount',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_amount' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [100],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles negative and decimal numbers', () => {
+            expect(
+                filtersOf(
+                    'SELECT orders_amount FROM orders WHERE orders_amount > -1.5',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_amount' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [-1.5],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles IN to equals with multiple values', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status FROM orders WHERE orders_status IN ('completed', 'shipped')",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed', 'shipped'],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles single-element IN lists', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status FROM orders WHERE orders_status NOT IN ('returned')",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.NOT_EQUALS,
+                            values: ['returned'],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles NOT IN to notEquals with multiple values', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status FROM orders WHERE orders_status NOT IN ('returned', 'refunded')",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.NOT_EQUALS,
+                            values: ['returned', 'refunded'],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles LIKE patterns to string operators', () => {
+            const cases: Array<[string, FilterOperator, string]> = [
+                ["'%ship%'", FilterOperator.INCLUDE, 'ship'],
+                ["'ship%'", FilterOperator.STARTS_WITH, 'ship'],
+                ["'%ship'", FilterOperator.ENDS_WITH, 'ship'],
+                ["'ship'", FilterOperator.EQUALS, 'ship'],
+            ];
+            for (const [pattern, operator, value] of cases) {
+                expect(
+                    filtersOf(
+                        `SELECT orders_status FROM orders WHERE orders_status LIKE ${pattern}`,
+                    ),
+                ).toEqual({
+                    dimensions: {
+                        and: [
+                            {
+                                target: { fieldId: 'orders_status' },
+                                operator,
+                                values: [value],
+                            },
+                        ],
+                    },
+                });
+            }
+        });
+
+        it('treats ILIKE like LIKE', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status FROM orders WHERE orders_status ILIKE '%ship%'",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.INCLUDE,
+                            values: ['ship'],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles NOT LIKE %value% to doesNotInclude', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status FROM orders WHERE orders_status NOT LIKE '%ship%'",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.NOT_INCLUDE,
+                            values: ['ship'],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('rejects unsupported LIKE patterns', () => {
+            expect(() =>
+                compile(
+                    "SELECT orders_status FROM orders WHERE orders_status LIKE 'a%b'",
+                ),
+            ).toThrow(/Unsupported LIKE pattern/);
+            expect(() =>
+                compile(
+                    "SELECT orders_status FROM orders WHERE orders_status LIKE 'a_b'",
+                ),
+            ).toThrow(/Unsupported LIKE pattern/);
+            expect(() =>
+                compile(
+                    "SELECT orders_status FROM orders WHERE orders_status NOT LIKE 'ship%'",
+                ),
+            ).toThrow(/NOT LIKE with pattern/);
+        });
+
+        it('compiles IS NULL and IS NOT NULL', () => {
+            expect(
+                filtersOf(
+                    'SELECT orders_status FROM orders WHERE orders_status IS NULL',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.NULL,
+                        },
+                    ],
+                },
+            });
+            expect(
+                filtersOf(
+                    'SELECT orders_status FROM orders WHERE orders_status IS NOT NULL',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.NOT_NULL,
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles boolean column filters', () => {
+            expect(
+                filtersOf(
+                    'SELECT orders_is_completed FROM orders WHERE orders_is_completed',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_is_completed' },
+                            operator: FilterOperator.EQUALS,
+                            values: [true],
+                        },
+                    ],
+                },
+            });
+            expect(
+                filtersOf(
+                    'SELECT orders_is_completed FROM orders WHERE NOT orders_is_completed',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_is_completed' },
+                            operator: FilterOperator.EQUALS,
+                            values: [false],
+                        },
+                    ],
+                },
+            });
+            expect(
+                filtersOf(
+                    'SELECT orders_is_completed FROM orders WHERE orders_is_completed IS TRUE',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_is_completed' },
+                            operator: FilterOperator.EQUALS,
+                            values: [true],
+                        },
+                    ],
+                },
+            });
+            expect(
+                filtersOf(
+                    'SELECT orders_is_completed FROM orders WHERE orders_is_completed = true',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_is_completed' },
+                            operator: FilterOperator.EQUALS,
+                            values: [true],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles BETWEEN to a >= and <= group', () => {
+            expect(
+                filtersOf(
+                    'SELECT orders_amount FROM orders WHERE orders_amount BETWEEN 10 AND 20',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            and: [
+                                {
+                                    target: { fieldId: 'orders_amount' },
+                                    operator:
+                                        FilterOperator.GREATER_THAN_OR_EQUAL,
+                                    values: [10],
+                                },
+                                {
+                                    target: { fieldId: 'orders_amount' },
+                                    operator: FilterOperator.LESS_THAN_OR_EQUAL,
+                                    values: [20],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles NOT BETWEEN to a < or > group', () => {
+            expect(
+                filtersOf(
+                    'SELECT orders_amount FROM orders WHERE orders_amount NOT BETWEEN 10 AND 20',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            or: [
+                                {
+                                    target: { fieldId: 'orders_amount' },
+                                    operator: FilterOperator.LESS_THAN,
+                                    values: [10],
+                                },
+                                {
+                                    target: { fieldId: 'orders_amount' },
+                                    operator: FilterOperator.GREATER_THAN,
+                                    values: [20],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('unwraps casts in filter values', () => {
+            for (const literal of [
+                "'2024-01-01'::date",
+                "DATE '2024-01-01'",
+                "CAST('2024-01-01' AS date)",
+            ]) {
+                expect(
+                    filtersOf(
+                        `SELECT orders_order_date FROM orders WHERE orders_order_date >= ${literal}`,
+                    ),
+                ).toEqual({
+                    dimensions: {
+                        and: [
+                            {
+                                target: { fieldId: 'orders_order_date' },
+                                operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+                                values: ['2024-01-01'],
+                            },
+                        ],
+                    },
+                });
+            }
+        });
+
+        it('combines top-level AND conjuncts into one dimensions group', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status, orders_amount FROM orders WHERE orders_status = 'completed' AND orders_amount > 10",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed'],
+                        },
+                        {
+                            target: { fieldId: 'orders_amount' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [10],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles OR groups', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status FROM orders WHERE orders_status = 'completed' OR orders_status = 'shipped'",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            or: [
+                                {
+                                    target: { fieldId: 'orders_status' },
+                                    operator: FilterOperator.EQUALS,
+                                    values: ['completed'],
+                                },
+                                {
+                                    target: { fieldId: 'orders_status' },
+                                    operator: FilterOperator.EQUALS,
+                                    values: ['shipped'],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles nested AND/OR groups', () => {
+            expect(
+                filtersOf(
+                    `SELECT orders_status, orders_amount FROM orders
+                     WHERE orders_amount > 0 AND (orders_status = 'completed' OR orders_status = 'shipped')`,
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_amount' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [0],
+                        },
+                        {
+                            or: [
+                                {
+                                    target: { fieldId: 'orders_status' },
+                                    operator: FilterOperator.EQUALS,
+                                    values: ['completed'],
+                                },
+                                {
+                                    target: { fieldId: 'orders_status' },
+                                    operator: FilterOperator.EQUALS,
+                                    values: ['shipped'],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('negates simple comparisons with NOT', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status FROM orders WHERE NOT (orders_status = 'completed')",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.NOT_EQUALS,
+                            values: ['completed'],
+                        },
+                    ],
+                },
+            });
+            expect(
+                filtersOf(
+                    'SELECT orders_amount FROM orders WHERE NOT (orders_amount < 10)',
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_amount' },
+                            operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+                            values: [10],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('allows filtering on fields that are not selected', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_amount FROM orders WHERE orders_status = 'completed'",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed'],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('allows filtering via select-list aliases', () => {
+            expect(
+                filtersOf(
+                    "SELECT orders_status AS status FROM orders WHERE status = 'completed'",
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed'],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('skips tautologies like WHERE TRUE and 1=1', () => {
+            expect(
+                filtersOf('SELECT orders_status FROM orders WHERE TRUE'),
+            ).toEqual({});
+            expect(
+                filtersOf('SELECT orders_status FROM orders WHERE 1 = 1'),
+            ).toEqual({});
+        });
+
+        it('rejects comparison to NULL', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status FROM orders WHERE orders_status = NULL',
+                ),
+            ).toThrow(/Cannot compare to NULL/);
+        });
+
+        it('rejects NULL inside IN lists', () => {
+            expect(() =>
+                compile(
+                    "SELECT orders_status FROM orders WHERE orders_status IN ('a', NULL)",
+                ),
+            ).toThrow(/NULL is not supported inside IN/);
+        });
+
+        it('rejects column-to-column comparisons', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status FROM orders WHERE orders_amount > orders_total_order_amount',
+                ),
+            ).toThrow(/Unsupported filter/);
+        });
+
+        it('rejects subqueries in IN', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status FROM orders WHERE orders_status IN (SELECT x FROM y)',
+                ),
+            ).toThrow(SqlCompileError);
+        });
+
+        it('rejects NOT over AND/OR groups', () => {
+            expect(() =>
+                compile(
+                    "SELECT orders_status FROM orders WHERE NOT (orders_status = 'a' AND orders_amount > 1)",
+                ),
+            ).toThrow(/NOT over AND\/OR/);
+        });
+    });
+
+    describe('metric filters', () => {
+        it('routes WHERE conditions on metrics to metric filters', () => {
+            expect(
+                filtersOf(
+                    'SELECT orders_status, orders_total_order_amount FROM orders WHERE orders_total_order_amount > 1000',
+                ),
+            ).toEqual({
+                metrics: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_total_order_amount' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [1000],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('splits mixed dimension and metric conjuncts', () => {
+            expect(
+                filtersOf(
+                    `SELECT orders_status, orders_total_order_amount FROM orders
+                     WHERE orders_status = 'completed' AND orders_total_order_amount > 1000`,
+                ),
+            ).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed'],
+                        },
+                    ],
+                },
+                metrics: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_total_order_amount' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [1000],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('compiles HAVING to metric filters', () => {
+            expect(
+                filtersOf(
+                    `SELECT orders_status, orders_total_order_amount FROM orders
+                     GROUP BY orders_status HAVING orders_total_order_amount > 1000`,
+                ),
+            ).toEqual({
+                metrics: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_total_order_amount' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [1000],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('merges WHERE metric filters and HAVING filters', () => {
+            const filters = filtersOf(
+                `SELECT orders_status, orders_total_order_amount, orders_unique_order_count FROM orders
+                 WHERE orders_total_order_amount > 1000
+                 GROUP BY orders_status
+                 HAVING orders_unique_order_count > 5`,
+            ) as Filters;
+            const metricGroup = filters.metrics as { and: unknown[] };
+            expect(metricGroup.and).toHaveLength(2);
+        });
+
+        it('supports OR groups of metric filters', () => {
+            expect(
+                filtersOf(
+                    `SELECT orders_status, orders_total_order_amount FROM orders
+                     WHERE orders_total_order_amount > 1000 OR orders_total_order_amount < 10`,
+                ),
+            ).toEqual({
+                metrics: {
+                    and: [
+                        {
+                            or: [
+                                {
+                                    target: {
+                                        fieldId: 'orders_total_order_amount',
+                                    },
+                                    operator: FilterOperator.GREATER_THAN,
+                                    values: [1000],
+                                },
+                                {
+                                    target: {
+                                        fieldId: 'orders_total_order_amount',
+                                    },
+                                    operator: FilterOperator.LESS_THAN,
+                                    values: [10],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('rejects OR conditions mixing dimensions and metrics', () => {
+            expect(() =>
+                compile(
+                    `SELECT orders_status, orders_total_order_amount FROM orders
+                     WHERE orders_status = 'completed' OR orders_total_order_amount > 1000`,
+                ),
+            ).toThrow(/cannot mix dimensions, metrics/);
+        });
+
+        it('rejects dimension filters in HAVING', () => {
+            expect(() =>
+                compile(
+                    `SELECT orders_status, orders_total_order_amount FROM orders
+                     GROUP BY orders_status HAVING orders_status = 'completed'`,
+                ),
+            ).toThrow(/HAVING can only filter on metrics/);
+        });
+    });
+
+    describe('table calculations', () => {
+        it('compiles arithmetic expressions to table calculations', () => {
+            const result = compile(
+                `SELECT orders_status, orders_total_order_amount, orders_unique_order_count,
+                        orders_total_order_amount / orders_unique_order_count AS aov
+                 FROM orders`,
+            );
+            expect(result.metricQuery.tableCalculations).toEqual([
+                {
+                    name: 'aov',
+                    displayName: 'aov',
+                    sql: '(${orders_total_order_amount} / ${orders_unique_order_count})',
+                },
+            ]);
+            expect(result.columns[3]).toEqual({
+                name: 'aov',
+                source: 'aov',
+                kind: 'table_calculation',
+                type: null,
+            });
+        });
+
+        it('compiles function calls in table calculations', () => {
+            const result = compile(
+                `SELECT orders_status, orders_avg_amount,
+                        round(orders_avg_amount, 2) AS rounded
+                 FROM orders`,
+            );
+            expect(result.metricQuery.tableCalculations[0].name).toBe(
+                'rounded',
+            );
+            const calc = result.metricQuery.tableCalculations[0];
+            expect('sql' in calc && calc.sql).toContain('${orders_avg_amount}');
+        });
+
+        it('compiles CASE expressions', () => {
+            const result = compile(
+                `SELECT orders_status, orders_amount,
+                        CASE WHEN orders_amount > 100 THEN 'big' ELSE 'small' END AS size
+                 FROM orders`,
+            );
+            const calc = result.metricQuery.tableCalculations[0];
+            expect('sql' in calc && calc.sql).toMatch(
+                /CASE\s+WHEN \(\$\{orders_amount\} > \(100\)\) THEN \('big'\) ELSE \('small'\) END/,
+            );
+        });
+
+        it('allows window functions and rewrites refs inside OVER', () => {
+            const result = compile(
+                `SELECT orders_status, orders_total_order_amount,
+                        sum(orders_total_order_amount) OVER (PARTITION BY orders_status ORDER BY orders_status) AS running
+                 FROM orders`,
+            );
+            const calc = result.metricQuery.tableCalculations[0];
+            const sql = 'sql' in calc ? calc.sql : '';
+            expect(sql).toContain('over');
+            // refs inside the OVER clause must also be rewritten
+            expect(sql).toMatch(/PARTITION BY \$\{orders_status\}/);
+            expect(sql).toMatch(/ORDER BY \$\{orders_status\}/);
+        });
+
+        it('allows referencing other table calculations', () => {
+            const result = compile(
+                `SELECT orders_status, orders_total_order_amount,
+                        orders_total_order_amount * 2 AS doubled,
+                        doubled + 1 AS doubled_plus_one
+                 FROM orders`,
+            );
+            expect(result.metricQuery.tableCalculations).toHaveLength(2);
+            const second = result.metricQuery.tableCalculations[1];
+            expect('sql' in second && second.sql).toContain('${doubled}');
+        });
+
+        it('compiles string concatenation', () => {
+            const result = compile(
+                `SELECT orders_status, customers_first_name,
+                        customers_first_name || ' - ' || orders_status AS label
+                 FROM orders`,
+            );
+            const calc = result.metricQuery.tableCalculations[0];
+            expect('sql' in calc && calc.sql).toBe(
+                "((${customers_first_name} || (' - ')) || ${orders_status})",
+            );
+        });
+
+        it('rejects expressions without an alias', () => {
+            expect(() =>
+                compile('SELECT orders_status, orders_amount * 2 FROM orders'),
+            ).toThrow(/must have an alias/);
+        });
+
+        it('rejects plain aggregate functions with a helpful hint', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status, sum(orders_amount) AS total FROM orders',
+                ),
+            ).toThrow(/Aggregate function "sum" is not supported/);
+            expect(() =>
+                compile('SELECT orders_status, count(*) AS n FROM orders'),
+            ).toThrow(SqlCompileError);
+        });
+
+        it('rejects references to fields not in the SELECT list', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status, orders_amount * 2 AS doubled FROM orders',
+                ),
+            ).toThrow(/not in the SELECT list/);
+        });
+
+        it('rejects aliases that conflict with column names', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status, orders_amount, orders_amount * 2 AS orders_status FROM orders',
+                ),
+            ).toThrow(/conflicts with an existing column/);
+        });
+
+        it('rejects duplicate aliases', () => {
+            expect(() =>
+                compile(
+                    `SELECT orders_status, orders_amount,
+                            orders_amount * 2 AS x, orders_amount * 3 AS x
+                     FROM orders`,
+                ),
+            ).toThrow(/Duplicate alias/);
+        });
+
+        it('supports filtering on table calculations', () => {
+            const result = compile(
+                `SELECT orders_status, orders_total_order_amount,
+                        orders_total_order_amount * 2 AS doubled
+                 FROM orders WHERE doubled > 100`,
+            );
+            expect(stripIds(result.metricQuery.filters)).toEqual({
+                tableCalculations: {
+                    and: [
+                        {
+                            target: { fieldId: 'doubled' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [100],
+                        },
+                    ],
+                },
+            });
+        });
+    });
+
+    describe('GROUP BY', () => {
+        it('accepts GROUP BY listing all selected dimensions', () => {
+            expect(() =>
+                compile(
+                    `SELECT orders_status, orders_order_date, orders_total_order_amount
+                     FROM orders GROUP BY orders_status, orders_order_date`,
+                ),
+            ).not.toThrow();
+        });
+
+        it('accepts GROUP BY with ordinals', () => {
+            expect(() =>
+                compile(
+                    `SELECT orders_status, orders_order_date, orders_total_order_amount
+                     FROM orders GROUP BY 1, 2`,
+                ),
+            ).not.toThrow();
+        });
+
+        it('accepts queries without GROUP BY (grouping is implicit)', () => {
+            const result = compile(
+                'SELECT orders_status, orders_total_order_amount FROM orders',
+            );
+            expect(result.metricQuery.dimensions).toEqual(['orders_status']);
+        });
+
+        it('rejects GROUP BY missing a selected dimension', () => {
+            expect(() =>
+                compile(
+                    `SELECT orders_status, orders_order_date, orders_total_order_amount
+                     FROM orders GROUP BY orders_status`,
+                ),
+            ).toThrow(/must appear in GROUP BY: orders_order_date/);
+        });
+
+        it('rejects GROUP BY on metrics', () => {
+            expect(() =>
+                compile(
+                    `SELECT orders_status, orders_total_order_amount
+                     FROM orders GROUP BY orders_status, orders_total_order_amount`,
+                ),
+            ).toThrow(/only dimensions can be grouped/);
+        });
+
+        it('rejects GROUP BY on columns not selected', () => {
+            expect(() =>
+                compile(
+                    `SELECT orders_status, orders_total_order_amount
+                     FROM orders GROUP BY orders_order_date, orders_status`,
+                ),
+            ).toThrow(/must be in the SELECT list/);
+        });
+
+        it('rejects out-of-range GROUP BY ordinals', () => {
+            expect(() =>
+                compile('SELECT orders_status FROM orders GROUP BY 5'),
+            ).toThrow(/position 5/);
+        });
+    });
+
+    describe('ORDER BY', () => {
+        it('compiles ascending and descending sorts', () => {
+            const result = compile(
+                `SELECT orders_status, orders_total_order_amount FROM orders
+                 ORDER BY orders_total_order_amount DESC, orders_status`,
+            );
+            expect(result.metricQuery.sorts).toEqual([
+                { fieldId: 'orders_total_order_amount', descending: true },
+                { fieldId: 'orders_status', descending: false },
+            ]);
+        });
+
+        it('compiles sorts by ordinal', () => {
+            const result = compile(
+                `SELECT orders_status, orders_total_order_amount FROM orders ORDER BY 2 DESC`,
+            );
+            expect(result.metricQuery.sorts).toEqual([
+                { fieldId: 'orders_total_order_amount', descending: true },
+            ]);
+        });
+
+        it('compiles sorts by alias', () => {
+            const result = compile(
+                `SELECT orders_status AS status FROM orders ORDER BY status DESC`,
+            );
+            expect(result.metricQuery.sorts).toEqual([
+                { fieldId: 'orders_status', descending: true },
+            ]);
+        });
+
+        it('compiles sorts on table calculations', () => {
+            const result = compile(
+                `SELECT orders_status, orders_total_order_amount,
+                        orders_total_order_amount * 2 AS doubled
+                 FROM orders ORDER BY doubled DESC`,
+            );
+            expect(result.metricQuery.sorts).toEqual([
+                { fieldId: 'doubled', descending: true },
+            ]);
+        });
+
+        it('compiles NULLS FIRST / NULLS LAST', () => {
+            const result = compile(
+                `SELECT orders_status FROM orders
+                 ORDER BY orders_status ASC NULLS FIRST`,
+            );
+            expect(result.metricQuery.sorts).toEqual([
+                {
+                    fieldId: 'orders_status',
+                    descending: false,
+                    nullsFirst: true,
+                },
+            ]);
+        });
+
+        it('rejects sorts on columns not in the SELECT list', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status FROM orders ORDER BY orders_amount',
+                ),
+            ).toThrow(/must be in the SELECT list/);
+        });
+
+        it('rejects out-of-range ORDER BY ordinals', () => {
+            expect(() =>
+                compile('SELECT orders_status FROM orders ORDER BY 3'),
+            ).toThrow(/position 3/);
+        });
+    });
+
+    describe('LIMIT and OFFSET', () => {
+        it('applies the default limit when none is given', () => {
+            expect(
+                compile('SELECT orders_status FROM orders').metricQuery.limit,
+            ).toBe(PGWIRE_DEFAULT_LIMIT);
+        });
+
+        it('compiles LIMIT', () => {
+            expect(
+                compile('SELECT orders_status FROM orders LIMIT 42').metricQuery
+                    .limit,
+            ).toBe(42);
+        });
+
+        it('allows OFFSET 0', () => {
+            expect(
+                compile('SELECT orders_status FROM orders LIMIT 10 OFFSET 0')
+                    .metricQuery.limit,
+            ).toBe(10);
+        });
+
+        it('rejects non-zero OFFSET', () => {
+            expect(() =>
+                compile('SELECT orders_status FROM orders LIMIT 10 OFFSET 5'),
+            ).toThrow(/OFFSET is not supported/);
+        });
+    });
+
+    describe('unsupported statements', () => {
+        it.each([
+            ['INSERT', 'INSERT INTO orders (a) VALUES (1)'],
+            ['UPDATE', 'UPDATE orders SET a = 1'],
+            ['DELETE', 'DELETE FROM orders'],
+        ])('rejects %s statements', (_, sql) => {
+            expect(() => compile(sql)).toThrow(/not supported/);
+        });
+
+        it('rejects multiple statements', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status FROM orders; SELECT orders_status FROM orders',
+                ),
+            ).toThrow(/Exactly one SQL statement/);
+        });
+
+        it('rejects UNION', () => {
+            expect(() =>
+                compile(
+                    'SELECT orders_status FROM orders UNION SELECT orders_status FROM orders',
+                ),
+            ).toThrow(/not supported/);
+        });
+
+        it('rejects CTEs', () => {
+            expect(() =>
+                compile(
+                    'WITH x AS (SELECT orders_status FROM orders) SELECT * FROM x',
+                ),
+            ).toThrow(/not supported/);
+        });
+
+        it('rejects JOINs with a helpful hint', () => {
+            try {
+                compile(
+                    'SELECT orders_status FROM orders JOIN customers ON true',
+                );
+                throw new Error('should have thrown');
+            } catch (e) {
+                expect(e).toBeInstanceOf(SqlCompileError);
+                expect((e as SqlCompileError).message).toMatch(
+                    /JOINs are not supported/,
+                );
+                expect((e as SqlCompileError).hint).toMatch(/explore/);
+            }
+        });
+
+        it('rejects subqueries in FROM', () => {
+            expect(() =>
+                compile(
+                    'SELECT x FROM (SELECT orders_status AS x FROM orders) sub',
+                ),
+            ).toThrow(/FROM must reference an explore/);
+        });
+
+        it('rejects SELECT DISTINCT', () => {
+            expect(() =>
+                compile('SELECT DISTINCT orders_status FROM orders'),
+            ).toThrow(/DISTINCT is not supported/);
+        });
+
+        it('rejects queries without FROM', () => {
+            expect(() => compile('SELECT orders_status')).toThrow(
+                /Missing FROM clause/,
+            );
+        });
+
+        it('rejects multiple tables in FROM', () => {
+            expect(() =>
+                compile('SELECT orders_status FROM orders, customers'),
+            ).toThrow(/Only one table/);
+        });
+
+        it('wraps syntax errors', () => {
+            expect(() => compile('SELECT FROM WHERE')).toThrow(
+                /SQL syntax error/,
+            );
+        });
+    });
+
+    describe('end-to-end shapes', () => {
+        it('compiles a realistic analytics query', () => {
+            const result = compile(
+                `SELECT
+                    orders_status AS status,
+                    orders_order_date,
+                    orders_total_order_amount,
+                    orders_unique_order_count,
+                    orders_total_order_amount / orders_unique_order_count AS aov
+                 FROM orders
+                 WHERE orders_order_date >= '2024-01-01'::date
+                   AND orders_status IN ('completed', 'shipped')
+                   AND orders_total_order_amount > 100
+                 GROUP BY 1, 2
+                 HAVING orders_unique_order_count > 2
+                 ORDER BY orders_total_order_amount DESC NULLS LAST
+                 LIMIT 25`,
+            );
+            expect(result.metricQuery.exploreName).toBe('orders');
+            expect(result.metricQuery.dimensions).toEqual([
+                'orders_status',
+                'orders_order_date',
+            ]);
+            expect(result.metricQuery.metrics).toEqual([
+                'orders_total_order_amount',
+                'orders_unique_order_count',
+            ]);
+            expect(result.metricQuery.limit).toBe(25);
+            expect(result.metricQuery.sorts).toEqual([
+                {
+                    fieldId: 'orders_total_order_amount',
+                    descending: true,
+                    nullsFirst: false,
+                },
+            ]);
+            expect(result.metricQuery.tableCalculations).toHaveLength(1);
+            expect(stripIds(result.metricQuery.filters)).toEqual({
+                dimensions: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_order_date' },
+                            operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+                            values: ['2024-01-01'],
+                        },
+                        {
+                            target: { fieldId: 'orders_status' },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed', 'shipped'],
+                        },
+                    ],
+                },
+                metrics: {
+                    and: [
+                        {
+                            target: { fieldId: 'orders_total_order_amount' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [100],
+                        },
+                        {
+                            target: { fieldId: 'orders_unique_order_count' },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [2],
+                        },
+                    ],
+                },
+            });
+            expect(result.columns.map((c) => c.name)).toEqual([
+                'status',
+                'orders_order_date',
+                'orders_total_order_amount',
+                'orders_unique_order_count',
+                'aov',
+            ]);
+        });
+    });
+});

--- a/packages/backend/src/postgresWire/sqlToMetricQuery.ts
+++ b/packages/backend/src/postgresWire/sqlToMetricQuery.ts
@@ -1,0 +1,1009 @@
+import {
+    FilterOperator,
+    type FilterGroup,
+    type FilterGroupItem,
+    type FilterRule,
+    type Filters,
+    type MetricQuery,
+    type SortField,
+    type TableCalculation,
+} from '@lightdash/common';
+import {
+    astMapper,
+    parse,
+    toSql,
+    type Expr,
+    type ExprRef,
+    type SelectedColumn,
+    type SelectFromStatement,
+    type Statement,
+} from 'pgsql-ast-parser';
+import {
+    type PgWireColumn,
+    type PgWireCompiledQuery,
+    type PgWireField,
+    type PgWireTable,
+} from './types';
+
+export const PGWIRE_DEFAULT_LIMIT = 500;
+
+export class SqlCompileError extends Error {
+    public readonly hint: string | undefined;
+
+    constructor(message: string, hint?: string) {
+        super(message);
+        this.name = 'SqlCompileError';
+        this.hint = hint;
+    }
+}
+
+type ColumnKind = 'dimension' | 'metric' | 'table_calculation';
+
+type ResolvedColumn = {
+    /** fieldId or table calculation name */
+    source: string;
+    kind: ColumnKind;
+    type: string | null;
+};
+
+type CompilerContext = {
+    table: PgWireTable;
+    fieldMap: Map<string, PgWireField>;
+    /** names that qualify a column as belonging to the FROM table (table name + alias) */
+    fromNames: Set<string>;
+    /** output alias -> resolved column (fields and table calculations) */
+    aliasMap: Map<string, ResolvedColumn>;
+    /** table calculation names defined so far */
+    tableCalcNames: Set<string>;
+    nextFilterId: () => string;
+};
+
+const AGGREGATE_FUNCTIONS = new Set([
+    'sum',
+    'count',
+    'avg',
+    'min',
+    'max',
+    'median',
+    'array_agg',
+    'string_agg',
+    'bool_and',
+    'bool_or',
+    'percentile_cont',
+    'percentile_disc',
+    'stddev',
+    'stddev_pop',
+    'stddev_samp',
+    'variance',
+    'var_pop',
+    'var_samp',
+]);
+
+const isLiteralExpr = (expr: Expr): boolean => {
+    switch (expr.type) {
+        case 'string':
+        case 'integer':
+        case 'numeric':
+        case 'boolean':
+        case 'null':
+        case 'constant':
+            return true;
+        case 'cast':
+            return isLiteralExpr(expr.operand);
+        case 'unary':
+            return (
+                (expr.op === '-' || expr.op === '+') &&
+                isLiteralExpr(expr.operand)
+            );
+        default:
+            return false;
+    }
+};
+
+type LiteralValue = string | number | boolean | null;
+
+/** Extract a literal filter value, unwrapping casts (e.g. '2024-01-01'::date) */
+const literalValue = (expr: Expr): LiteralValue => {
+    switch (expr.type) {
+        case 'string':
+            return expr.value;
+        case 'integer':
+        case 'numeric':
+            return expr.value;
+        case 'boolean':
+            return expr.value;
+        case 'null':
+            return null;
+        case 'constant':
+            return expr.value as LiteralValue;
+        case 'cast':
+            return literalValue(expr.operand);
+        case 'unary': {
+            if (expr.op === '-' || expr.op === '+') {
+                const inner = literalValue(expr.operand);
+                if (typeof inner !== 'number') {
+                    throw new SqlCompileError(
+                        `Cannot apply unary ${expr.op} to a non-numeric value`,
+                    );
+                }
+                return expr.op === '-' ? -inner : inner;
+            }
+            throw new SqlCompileError(
+                `Unsupported operator "${expr.op}" in filter value`,
+            );
+        }
+        default:
+            throw new SqlCompileError(
+                `Expected a literal value in filter but found ${expr.type}`,
+                'Only constant values (strings, numbers, booleans, dates) are supported in filters',
+            );
+    }
+};
+
+const resolveRef = (
+    ctx: CompilerContext,
+    ref: ExprRef,
+): ResolvedColumn | undefined => {
+    const candidates: string[] = [];
+    if (ref.table) {
+        if (ctx.fromNames.has(ref.table.name)) {
+            candidates.push(ref.name, `${ctx.table.name}_${ref.name}`);
+        } else {
+            // qualified reference to a joined table in the explore, e.g. customers.first_name
+            candidates.push(`${ref.table.name}_${ref.name}`);
+        }
+    } else {
+        candidates.push(ref.name);
+    }
+    for (const candidate of candidates) {
+        const field = ctx.fieldMap.get(candidate);
+        if (field) {
+            return {
+                source: field.fieldId,
+                kind: field.kind,
+                type: field.type,
+            };
+        }
+    }
+    // unqualified names can also refer to select-list aliases (incl. table calculations)
+    if (!ref.table) {
+        const aliased = ctx.aliasMap.get(ref.name);
+        if (aliased) return aliased;
+    }
+    return undefined;
+};
+
+const unknownColumnError = (ctx: CompilerContext, ref: ExprRef) => {
+    const name = ref.table ? `${ref.table.name}.${ref.name}` : ref.name;
+    return new SqlCompileError(
+        `Column "${name}" does not exist in table "${ctx.table.name}"`,
+        `Available columns: ${ctx.table.fields
+            .map((f) => f.fieldId)
+            .slice(0, 30)
+            .join(', ')}`,
+    );
+};
+
+const resolveRefOrThrow = (
+    ctx: CompilerContext,
+    ref: ExprRef,
+): ResolvedColumn => {
+    const resolved = resolveRef(ctx, ref);
+    if (!resolved) throw unknownColumnError(ctx, ref);
+    return resolved;
+};
+
+/**
+ * Convert a SQL expression to a Lightdash table calculation SQL string, replacing
+ * column references with ${fieldId} placeholders. References must be selected fields
+ * or previously defined table calculations.
+ */
+const exprToTableCalcSql = (
+    ctx: CompilerContext,
+    expr: Expr,
+    selectedSources: Set<string>,
+): string => {
+    const mapper = astMapper((map) => ({
+        ref: (ref: ExprRef): ExprRef => {
+            if (ref.name === '*') {
+                throw new SqlCompileError(
+                    'Cannot use * inside an expression',
+                    'Aggregate functions like count(*) are not supported; select a pre-defined metric instead',
+                );
+            }
+            const resolved = resolveRefOrThrow(ctx, ref);
+            if (
+                !selectedSources.has(resolved.source) &&
+                !ctx.tableCalcNames.has(resolved.source)
+            ) {
+                throw new SqlCompileError(
+                    `Expression references "${resolved.source}" which is not in the SELECT list`,
+                    'Table calculations can only reference selected dimensions, metrics, or previous expressions',
+                );
+            }
+            return {
+                type: 'ref',
+                name: `__ldref__${resolved.source}__ferdl__`,
+            };
+        },
+        call: (call) => {
+            const fnName = call.function.name.toLowerCase();
+            if (AGGREGATE_FUNCTIONS.has(fnName) && !call.over) {
+                throw new SqlCompileError(
+                    `Aggregate function "${fnName}" is not supported`,
+                    'Metrics are already aggregated - select a pre-defined metric instead. Window functions (with OVER) are allowed.',
+                );
+            }
+            const mapped = map.super().call(call);
+            // astMapper does not descend into OVER clauses; rewrite refs there too
+            if (mapped && 'over' in mapped && mapped.over) {
+                return {
+                    ...mapped,
+                    over: {
+                        ...mapped.over,
+                        partitionBy: mapped.over.partitionBy?.map(
+                            (e) => map.expr(e) ?? e,
+                        ),
+                        orderBy: mapped.over.orderBy?.map((ob) => ({
+                            ...ob,
+                            by: map.expr(ob.by) ?? ob.by,
+                        })),
+                    },
+                };
+            }
+            return mapped;
+        },
+    }));
+    const mapped = mapper.expr(expr);
+    if (!mapped) {
+        throw new SqlCompileError('Unsupported expression in SELECT');
+    }
+    const sql = toSql.expr(mapped);
+    return sql.replace(
+        /"?__ldref__([A-Za-z0-9_]+?)__ferdl__"?/g,
+        (_, fieldId) => `\${${fieldId}}`,
+    );
+};
+
+/** Map a supported binary comparison operator to a FilterOperator, optionally flipped */
+const comparisonOperator = (
+    op: string,
+    flipped: boolean,
+): FilterOperator | undefined => {
+    switch (op) {
+        case '=':
+            return FilterOperator.EQUALS;
+        case '!=':
+            return FilterOperator.NOT_EQUALS;
+        case '<':
+            return flipped
+                ? FilterOperator.GREATER_THAN
+                : FilterOperator.LESS_THAN;
+        case '<=':
+            return flipped
+                ? FilterOperator.GREATER_THAN_OR_EQUAL
+                : FilterOperator.LESS_THAN_OR_EQUAL;
+        case '>':
+            return flipped
+                ? FilterOperator.LESS_THAN
+                : FilterOperator.GREATER_THAN;
+        case '>=':
+            return flipped
+                ? FilterOperator.LESS_THAN_OR_EQUAL
+                : FilterOperator.GREATER_THAN_OR_EQUAL;
+        default:
+            return undefined;
+    }
+};
+
+/** Parse a LIKE/ILIKE pattern into a Lightdash string operator */
+const likeToOperator = (
+    pattern: string,
+    negated: boolean,
+): { operator: FilterOperator; value: string } => {
+    const inner = pattern.replace(/^%|%$/g, '');
+    if (inner.includes('%') || inner.includes('_')) {
+        throw new SqlCompileError(
+            `Unsupported LIKE pattern "${pattern}"`,
+            "Only patterns of the form '%value%', 'value%', '%value' or 'value' are supported",
+        );
+    }
+    const startsWithWildcard = pattern.startsWith('%');
+    const endsWithWildcard = pattern.endsWith('%');
+    if (startsWithWildcard && endsWithWildcard) {
+        return {
+            operator: negated
+                ? FilterOperator.NOT_INCLUDE
+                : FilterOperator.INCLUDE,
+            value: inner,
+        };
+    }
+    if (negated) {
+        throw new SqlCompileError(
+            `NOT LIKE with pattern "${pattern}" is not supported`,
+            "Only NOT LIKE '%value%' (does not include) is supported",
+        );
+    }
+    if (endsWithWildcard) {
+        return { operator: FilterOperator.STARTS_WITH, value: inner };
+    }
+    if (startsWithWildcard) {
+        return { operator: FilterOperator.ENDS_WITH, value: inner };
+    }
+    return { operator: FilterOperator.EQUALS, value: inner };
+};
+
+const NEGATED_OPERATORS: Partial<Record<FilterOperator, FilterOperator>> = {
+    [FilterOperator.EQUALS]: FilterOperator.NOT_EQUALS,
+    [FilterOperator.NOT_EQUALS]: FilterOperator.EQUALS,
+    [FilterOperator.INCLUDE]: FilterOperator.NOT_INCLUDE,
+    [FilterOperator.NOT_INCLUDE]: FilterOperator.INCLUDE,
+    [FilterOperator.NULL]: FilterOperator.NOT_NULL,
+    [FilterOperator.NOT_NULL]: FilterOperator.NULL,
+    [FilterOperator.LESS_THAN]: FilterOperator.GREATER_THAN_OR_EQUAL,
+    [FilterOperator.LESS_THAN_OR_EQUAL]: FilterOperator.GREATER_THAN,
+    [FilterOperator.GREATER_THAN]: FilterOperator.LESS_THAN_OR_EQUAL,
+    [FilterOperator.GREATER_THAN_OR_EQUAL]: FilterOperator.LESS_THAN,
+};
+
+type CompiledFilter = {
+    item: FilterGroupItem;
+    kinds: Set<ColumnKind>;
+};
+
+const isTautology = (expr: Expr): boolean => {
+    if (expr.type === 'boolean' && expr.value === true) return true;
+    if (
+        expr.type === 'binary' &&
+        expr.op === '=' &&
+        isLiteralExpr(expr.left) &&
+        isLiteralExpr(expr.right)
+    ) {
+        return literalValue(expr.left) === literalValue(expr.right);
+    }
+    return false;
+};
+
+const compileFilterExpr = (
+    ctx: CompilerContext,
+    expr: Expr,
+): CompiledFilter => {
+    const rule = (
+        target: ResolvedColumn,
+        operator: FilterOperator,
+        values?: LiteralValue[],
+    ): CompiledFilter => {
+        const filterRule: FilterRule = {
+            id: ctx.nextFilterId(),
+            target: { fieldId: target.source },
+            operator,
+            ...(values !== undefined ? { values } : {}),
+        };
+        return { item: filterRule, kinds: new Set([target.kind]) };
+    };
+
+    switch (expr.type) {
+        case 'binary': {
+            const { op } = expr;
+            if (op === 'AND' || op === 'OR') {
+                const children = [
+                    compileFilterExpr(ctx, expr.left),
+                    compileFilterExpr(ctx, expr.right),
+                ];
+                const kinds = new Set(
+                    children.flatMap((c) => Array.from(c.kinds)),
+                );
+                const group: FilterGroup =
+                    op === 'AND'
+                        ? {
+                              id: ctx.nextFilterId(),
+                              and: children.map((c) => c.item),
+                          }
+                        : {
+                              id: ctx.nextFilterId(),
+                              or: children.map((c) => c.item),
+                          };
+                return { item: group, kinds };
+            }
+            if (op === 'IN' || op === 'NOT IN') {
+                if (expr.left.type !== 'ref') {
+                    throw new SqlCompileError(
+                        'IN filters must have a column on the left side',
+                    );
+                }
+                if (
+                    expr.right.type === 'select' ||
+                    expr.right.type === 'union' ||
+                    expr.right.type === 'union all' ||
+                    expr.right.type === 'with'
+                ) {
+                    throw new SqlCompileError(
+                        'IN filters must use a list of literal values',
+                        'Subqueries are not supported',
+                    );
+                }
+                const target = resolveRefOrThrow(ctx, expr.left);
+                // single-element IN ('x') parses as a parenthesized literal, not a list
+                const valueExprs =
+                    expr.right.type === 'list'
+                        ? expr.right.expressions
+                        : [expr.right];
+                const values = valueExprs.map(literalValue);
+                if (values.some((v) => v === null)) {
+                    throw new SqlCompileError(
+                        'NULL is not supported inside IN lists',
+                        'Use IS NULL instead',
+                    );
+                }
+                return rule(
+                    target,
+                    op === 'IN'
+                        ? FilterOperator.EQUALS
+                        : FilterOperator.NOT_EQUALS,
+                    values,
+                );
+            }
+            if (
+                op === 'LIKE' ||
+                op === 'ILIKE' ||
+                op === 'NOT LIKE' ||
+                op === 'NOT ILIKE'
+            ) {
+                if (expr.left.type !== 'ref') {
+                    throw new SqlCompileError(
+                        'LIKE filters must have a column on the left side',
+                    );
+                }
+                const target = resolveRefOrThrow(ctx, expr.left);
+                const pattern = literalValue(expr.right);
+                if (typeof pattern !== 'string') {
+                    throw new SqlCompileError(
+                        'LIKE patterns must be string literals',
+                    );
+                }
+                const negated = op.startsWith('NOT');
+                const { operator, value } = likeToOperator(pattern, negated);
+                return rule(target, operator, [value]);
+            }
+            // plain comparison: one side must be a column ref, the other a literal
+            const leftIsRef = expr.left.type === 'ref';
+            const rightIsRef = expr.right.type === 'ref';
+            let refSide: ExprRef | undefined;
+            if (leftIsRef) refSide = expr.left as ExprRef;
+            else if (rightIsRef) refSide = expr.right as ExprRef;
+            const valueSide = leftIsRef ? expr.right : expr.left;
+            if (!refSide || (leftIsRef && rightIsRef)) {
+                throw new SqlCompileError(
+                    `Unsupported filter: ${toSql.expr(expr)}`,
+                    'Filters must compare a column to a literal value',
+                );
+            }
+            const operator = comparisonOperator(op, !leftIsRef);
+            if (!operator) {
+                throw new SqlCompileError(
+                    `Unsupported operator "${op}" in filter`,
+                );
+            }
+            const target = resolveRefOrThrow(ctx, refSide);
+            const value = literalValue(valueSide);
+            if (value === null) {
+                throw new SqlCompileError(
+                    'Cannot compare to NULL with = or !=',
+                    'Use IS NULL or IS NOT NULL instead',
+                );
+            }
+            return rule(target, operator, [value]);
+        }
+        case 'unary': {
+            switch (expr.op) {
+                case 'IS NULL':
+                case 'IS NOT NULL': {
+                    if (expr.operand.type !== 'ref') {
+                        throw new SqlCompileError(
+                            'IS NULL must be applied to a column',
+                        );
+                    }
+                    const target = resolveRefOrThrow(ctx, expr.operand);
+                    return rule(
+                        target,
+                        expr.op === 'IS NULL'
+                            ? FilterOperator.NULL
+                            : FilterOperator.NOT_NULL,
+                    );
+                }
+                case 'IS TRUE':
+                case 'IS FALSE':
+                case 'IS NOT TRUE':
+                case 'IS NOT FALSE': {
+                    if (expr.operand.type !== 'ref') {
+                        throw new SqlCompileError(
+                            `${expr.op} must be applied to a column`,
+                        );
+                    }
+                    const target = resolveRefOrThrow(ctx, expr.operand);
+                    const isNegated = expr.op.includes('NOT');
+                    const boolValue = expr.op.endsWith('TRUE');
+                    return rule(
+                        target,
+                        isNegated
+                            ? FilterOperator.NOT_EQUALS
+                            : FilterOperator.EQUALS,
+                        [boolValue],
+                    );
+                }
+                case 'NOT': {
+                    // bare boolean column: NOT my_bool_col
+                    if (expr.operand.type === 'ref') {
+                        const target = resolveRefOrThrow(ctx, expr.operand);
+                        return rule(target, FilterOperator.EQUALS, [false]);
+                    }
+                    const inner = compileFilterExpr(ctx, expr.operand);
+                    if ('and' in inner.item || 'or' in inner.item) {
+                        throw new SqlCompileError(
+                            'NOT over AND/OR groups is not supported',
+                            'Rewrite the filter without NOT, e.g. using != or NOT IN',
+                        );
+                    }
+                    const innerRule = inner.item as FilterRule;
+                    const negatedOp = NEGATED_OPERATORS[innerRule.operator];
+                    if (!negatedOp) {
+                        throw new SqlCompileError(
+                            `Cannot negate operator "${innerRule.operator}"`,
+                        );
+                    }
+                    return {
+                        item: { ...innerRule, operator: negatedOp },
+                        kinds: inner.kinds,
+                    };
+                }
+                default:
+                    throw new SqlCompileError(
+                        `Unsupported operator "${expr.op}" in filter`,
+                    );
+            }
+        }
+        case 'ternary': {
+            if (expr.value.type !== 'ref') {
+                throw new SqlCompileError(
+                    'BETWEEN must be applied to a column',
+                );
+            }
+            const target = resolveRefOrThrow(ctx, expr.value);
+            const lo = literalValue(expr.lo);
+            const hi = literalValue(expr.hi);
+            if (expr.op === 'BETWEEN') {
+                const group: FilterGroup = {
+                    id: ctx.nextFilterId(),
+                    and: [
+                        {
+                            id: ctx.nextFilterId(),
+                            target: { fieldId: target.source },
+                            operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+                            values: [lo],
+                        },
+                        {
+                            id: ctx.nextFilterId(),
+                            target: { fieldId: target.source },
+                            operator: FilterOperator.LESS_THAN_OR_EQUAL,
+                            values: [hi],
+                        },
+                    ],
+                };
+                return { item: group, kinds: new Set([target.kind]) };
+            }
+            const group: FilterGroup = {
+                id: ctx.nextFilterId(),
+                or: [
+                    {
+                        id: ctx.nextFilterId(),
+                        target: { fieldId: target.source },
+                        operator: FilterOperator.LESS_THAN,
+                        values: [lo],
+                    },
+                    {
+                        id: ctx.nextFilterId(),
+                        target: { fieldId: target.source },
+                        operator: FilterOperator.GREATER_THAN,
+                        values: [hi],
+                    },
+                ],
+            };
+            return { item: group, kinds: new Set([target.kind]) };
+        }
+        case 'ref': {
+            // bare boolean column: WHERE my_bool_col
+            const target = resolveRefOrThrow(ctx, expr);
+            return rule(target, FilterOperator.EQUALS, [true]);
+        }
+        default:
+            throw new SqlCompileError(
+                `Unsupported filter expression: ${toSql.expr(expr)}`,
+                'Supported filters: =, !=, <, <=, >, >=, IN, NOT IN, LIKE, ILIKE, BETWEEN, IS NULL, IS NOT NULL, AND, OR, NOT',
+            );
+    }
+};
+
+/** Flatten nested ANDs into a list of conjuncts */
+const flattenAnd = (expr: Expr): Expr[] => {
+    if (expr.type === 'binary' && expr.op === 'AND') {
+        return [...flattenAnd(expr.left), ...flattenAnd(expr.right)];
+    }
+    return [expr];
+};
+
+const groupItems = (
+    ctx: CompilerContext,
+    items: FilterGroupItem[],
+): FilterGroup | undefined => {
+    if (items.length === 0) return undefined;
+    return { id: ctx.nextFilterId(), and: items };
+};
+
+const asSingleKind = (
+    filter: CompiledFilter,
+    context: 'WHERE' | 'HAVING',
+): ColumnKind => {
+    if (filter.kinds.size !== 1) {
+        throw new SqlCompileError(
+            `A single ${context} condition cannot mix dimensions, metrics and table calculations with OR`,
+            'Split the condition into separate AND-ed conditions per field type',
+        );
+    }
+    return filter.kinds.values().next().value as ColumnKind;
+};
+
+const parseStatement = (sql: string): Statement[] => {
+    try {
+        return parse(sql);
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        throw new SqlCompileError(`SQL syntax error: ${message}`);
+    }
+};
+
+/**
+ * Compile a Postgres SELECT statement into a Lightdash MetricQuery against
+ * one of the explores in the catalog.
+ */
+export const compileSqlToMetricQuery = (
+    sql: string,
+    catalog: PgWireTable[],
+): PgWireCompiledQuery => {
+    const statements = parseStatement(sql);
+    if (statements.length !== 1) {
+        throw new SqlCompileError(
+            'Exactly one SQL statement is supported per query',
+        );
+    }
+    const [statement] = statements;
+    if (statement.type !== 'select') {
+        throw new SqlCompileError(
+            `${statement.type.toUpperCase()} statements are not supported`,
+            'Only SELECT queries can be run against the Lightdash semantic layer',
+        );
+    }
+    const select = statement as SelectFromStatement;
+
+    if (select.distinct) {
+        throw new SqlCompileError(
+            'SELECT DISTINCT is not supported',
+            'Results are already grouped by the selected dimensions',
+        );
+    }
+
+    // FROM: exactly one explore, no joins
+    if (!select.from || select.from.length === 0) {
+        throw new SqlCompileError(
+            'Missing FROM clause',
+            'Query an explore, e.g. SELECT ... FROM orders',
+        );
+    }
+    if (select.from.some((f) => f.join)) {
+        throw new SqlCompileError(
+            'JOINs are not supported',
+            'Joins are defined in the Lightdash explore itself - joined table fields are available as columns',
+        );
+    }
+    if (select.from.length > 1) {
+        throw new SqlCompileError(
+            'Only one table is supported in FROM',
+            'Joins are defined in the Lightdash explore itself',
+        );
+    }
+    const [from] = select.from;
+    if (from.type !== 'table') {
+        throw new SqlCompileError(
+            'FROM must reference an explore by name',
+            'Subqueries and function calls in FROM are not supported',
+        );
+    }
+    const tableName = from.name.name;
+    const table = catalog.find((t) => t.name === tableName);
+    if (!table) {
+        throw new SqlCompileError(
+            `Table "${tableName}" does not exist`,
+            `Available tables: ${catalog.map((t) => t.name).join(', ')}`,
+        );
+    }
+
+    let filterIdCounter = 0;
+    const ctx: CompilerContext = {
+        table,
+        fieldMap: new Map(table.fields.map((f) => [f.fieldId, f])),
+        fromNames: new Set(
+            from.name.alias ? [tableName, from.name.alias] : [tableName],
+        ),
+        aliasMap: new Map(),
+        tableCalcNames: new Set(),
+        nextFilterId: () => {
+            filterIdCounter += 1;
+            return `pgwire_${filterIdCounter}`;
+        },
+    };
+
+    // SELECT list
+    const dimensions: string[] = [];
+    const metrics: string[] = [];
+    const tableCalculations: TableCalculation[] = [];
+    const columns: PgWireColumn[] = [];
+    const selectedSources = new Set<string>();
+
+    const addField = (resolved: ResolvedColumn, outputName: string) => {
+        if (resolved.kind === 'dimension') {
+            if (!dimensions.includes(resolved.source)) {
+                dimensions.push(resolved.source);
+            }
+        } else if (resolved.kind === 'metric') {
+            if (!metrics.includes(resolved.source)) {
+                metrics.push(resolved.source);
+            }
+        }
+        selectedSources.add(resolved.source);
+        columns.push({
+            name: outputName,
+            source: resolved.source,
+            kind: resolved.kind,
+            type: resolved.type,
+        });
+    };
+
+    const selectColumns: SelectedColumn[] = select.columns ?? [];
+    if (selectColumns.length === 0) {
+        throw new SqlCompileError('SELECT list cannot be empty');
+    }
+
+    const handleSelectedColumn = (col: SelectedColumn): void => {
+        const { expr } = col;
+        // SELECT * or SELECT table.*
+        if (expr.type === 'ref' && expr.name === '*') {
+            if (expr.table && !ctx.fromNames.has(expr.table.name)) {
+                throw new SqlCompileError(
+                    `Unknown table "${expr.table.name}" in select list`,
+                );
+            }
+            for (const field of table.fields) {
+                addField(
+                    {
+                        source: field.fieldId,
+                        kind: field.kind,
+                        type: field.type,
+                    },
+                    field.fieldId,
+                );
+            }
+            return;
+        }
+        if (expr.type === 'ref') {
+            const resolved = resolveRefOrThrow(ctx, expr);
+            if (resolved.kind === 'table_calculation') {
+                throw new SqlCompileError(
+                    `"${expr.name}" is already defined in this SELECT list`,
+                );
+            }
+            const outputName = col.alias?.name ?? resolved.source;
+            addField(resolved, outputName);
+            if (col.alias) {
+                ctx.aliasMap.set(col.alias.name, resolved);
+            }
+            return;
+        }
+        // any other expression becomes a table calculation and requires an alias
+        if (!col.alias) {
+            throw new SqlCompileError(
+                `Expressions in SELECT must have an alias: ${toSql.expr(expr)}`,
+                'Add "AS name" after the expression',
+            );
+        }
+        const calcName = col.alias.name;
+        if (ctx.fieldMap.has(calcName)) {
+            throw new SqlCompileError(
+                `Alias "${calcName}" conflicts with an existing column name`,
+                'Choose a different alias',
+            );
+        }
+        if (ctx.tableCalcNames.has(calcName) || ctx.aliasMap.has(calcName)) {
+            throw new SqlCompileError(
+                `Duplicate alias "${calcName}" in SELECT list`,
+            );
+        }
+        const calcSql = exprToTableCalcSql(ctx, expr, selectedSources);
+        tableCalculations.push({
+            name: calcName,
+            displayName: calcName,
+            sql: calcSql,
+        });
+        ctx.tableCalcNames.add(calcName);
+        const resolved: ResolvedColumn = {
+            source: calcName,
+            kind: 'table_calculation',
+            type: null,
+        };
+        ctx.aliasMap.set(calcName, resolved);
+        columns.push({
+            name: calcName,
+            source: calcName,
+            kind: 'table_calculation',
+            type: null,
+        });
+    };
+    selectColumns.forEach(handleSelectedColumn);
+
+    if (dimensions.length === 0 && metrics.length === 0) {
+        throw new SqlCompileError(
+            'Select at least one dimension or metric',
+            'Table calculations must be combined with at least one field',
+        );
+    }
+
+    // WHERE: split conjuncts into dimension / metric / table calculation filters
+    const dimensionFilters: FilterGroupItem[] = [];
+    const metricFilters: FilterGroupItem[] = [];
+    const tableCalcFilters: FilterGroupItem[] = [];
+
+    if (select.where) {
+        for (const conjunct of flattenAnd(select.where)) {
+            if (!isTautology(conjunct)) {
+                const compiled = compileFilterExpr(ctx, conjunct);
+                const kind = asSingleKind(compiled, 'WHERE');
+                if (kind === 'dimension') dimensionFilters.push(compiled.item);
+                else if (kind === 'metric') metricFilters.push(compiled.item);
+                else tableCalcFilters.push(compiled.item);
+            }
+        }
+    }
+
+    // HAVING: metric filters only
+    if (select.having) {
+        for (const conjunct of flattenAnd(select.having)) {
+            if (!isTautology(conjunct)) {
+                const compiled = compileFilterExpr(ctx, conjunct);
+                const kind = asSingleKind(compiled, 'HAVING');
+                if (kind !== 'metric') {
+                    throw new SqlCompileError(
+                        'HAVING can only filter on metrics',
+                        'Move dimension filters to the WHERE clause',
+                    );
+                }
+                metricFilters.push(compiled.item);
+            }
+        }
+    }
+
+    const filters: Filters = {};
+    const dimensionGroup = groupItems(ctx, dimensionFilters);
+    if (dimensionGroup) filters.dimensions = dimensionGroup;
+    const metricGroup = groupItems(ctx, metricFilters);
+    if (metricGroup) filters.metrics = metricGroup;
+    const tableCalcGroup = groupItems(ctx, tableCalcFilters);
+    if (tableCalcGroup) filters.tableCalculations = tableCalcGroup;
+
+    // GROUP BY: validate it matches the selected dimensions (grouping is implicit)
+    if (select.groupBy && select.groupBy.length > 0) {
+        const grouped = new Set<string>();
+        for (const groupExpr of select.groupBy) {
+            let resolved: ResolvedColumn;
+            if (groupExpr.type === 'integer') {
+                const ordinal = groupExpr.value;
+                if (ordinal < 1 || ordinal > columns.length) {
+                    throw new SqlCompileError(
+                        `GROUP BY position ${ordinal} is not in the select list`,
+                    );
+                }
+                const column = columns[ordinal - 1];
+                resolved = {
+                    source: column.source,
+                    kind: column.kind,
+                    type: column.type,
+                };
+            } else if (groupExpr.type === 'ref') {
+                resolved = resolveRefOrThrow(ctx, groupExpr);
+            } else {
+                throw new SqlCompileError(
+                    'GROUP BY only supports column names or positions',
+                );
+            }
+            if (resolved.kind !== 'dimension') {
+                throw new SqlCompileError(
+                    `Cannot GROUP BY "${resolved.source}" - only dimensions can be grouped`,
+                );
+            }
+            if (!dimensions.includes(resolved.source)) {
+                throw new SqlCompileError(
+                    `GROUP BY column "${resolved.source}" must be in the SELECT list`,
+                );
+            }
+            grouped.add(resolved.source);
+        }
+        const missing = dimensions.filter((d) => !grouped.has(d));
+        if (missing.length > 0) {
+            throw new SqlCompileError(
+                `Selected dimensions must appear in GROUP BY: ${missing.join(', ')}`,
+                'Lightdash always groups by all selected dimensions; either list them all or omit GROUP BY entirely',
+            );
+        }
+    }
+
+    // ORDER BY
+    const sorts: SortField[] = [];
+    for (const orderBy of select.orderBy ?? []) {
+        let source: string;
+        if (orderBy.by.type === 'integer') {
+            const ordinal = orderBy.by.value;
+            if (ordinal < 1 || ordinal > columns.length) {
+                throw new SqlCompileError(
+                    `ORDER BY position ${ordinal} is not in the select list`,
+                );
+            }
+            source = columns[ordinal - 1].source;
+        } else if (orderBy.by.type === 'ref') {
+            const resolved = resolveRefOrThrow(ctx, orderBy.by);
+            source = resolved.source;
+        } else {
+            throw new SqlCompileError(
+                'ORDER BY only supports column names or positions',
+            );
+        }
+        if (!selectedSources.has(source) && !ctx.tableCalcNames.has(source)) {
+            throw new SqlCompileError(
+                `ORDER BY column "${source}" must be in the SELECT list`,
+            );
+        }
+        sorts.push({
+            fieldId: source,
+            descending: orderBy.order === 'DESC',
+            ...(orderBy.nulls ? { nullsFirst: orderBy.nulls === 'FIRST' } : {}),
+        });
+    }
+
+    // LIMIT / OFFSET
+    let limit = PGWIRE_DEFAULT_LIMIT;
+    if (select.limit) {
+        if (select.limit.offset) {
+            const offsetValue =
+                select.limit.offset.type === 'integer'
+                    ? select.limit.offset.value
+                    : undefined;
+            if (offsetValue !== 0) {
+                throw new SqlCompileError('OFFSET is not supported');
+            }
+        }
+        if (select.limit.limit) {
+            if (select.limit.limit.type !== 'integer') {
+                throw new SqlCompileError('LIMIT must be an integer literal');
+            }
+            limit = select.limit.limit.value;
+        }
+    }
+
+    const metricQuery: MetricQuery = {
+        exploreName: table.name,
+        dimensions,
+        metrics,
+        filters,
+        sorts,
+        limit,
+        tableCalculations,
+    };
+
+    return { table, metricQuery, columns };
+};

--- a/packages/backend/src/postgresWire/types.ts
+++ b/packages/backend/src/postgresWire/types.ts
@@ -1,0 +1,36 @@
+import { type MetricQuery } from '@lightdash/common';
+
+export type PgWireFieldKind = 'dimension' | 'metric';
+
+export type PgWireField = {
+    /** Lightdash field id, exposed to clients as the column name (e.g. `orders_status`) */
+    fieldId: string;
+    kind: PgWireFieldKind;
+    /** DimensionType or MetricType value, used to pick a Postgres type OID */
+    type: string;
+};
+
+/** One explore exposed as a Postgres table */
+export type PgWireTable = {
+    name: string;
+    fields: PgWireField[];
+};
+
+export type PgWireColumnKind = PgWireFieldKind | 'table_calculation';
+
+/** One output column of the compiled query, in SELECT order */
+export type PgWireColumn = {
+    /** Column name presented to the client (alias if given) */
+    name: string;
+    /** Key into result rows: a fieldId or a table calculation name */
+    source: string;
+    kind: PgWireColumnKind;
+    /** DimensionType/MetricType value for OID mapping; null when unknown */
+    type: string | null;
+};
+
+export type PgWireCompiledQuery = {
+    table: PgWireTable;
+    metricQuery: MetricQuery;
+    columns: PgWireColumn[];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,7 +278,7 @@ importers:
         version: 2.8.0(@opentelemetry/api@1.9.0)
       '@rudderstack/rudder-sdk-node':
         specifier: 2.1.1
-        version: 2.1.1(tslib@2.8.1)
+        version: 2.1.1(tslib@2.6.2)
       '@sentry/core':
         specifier: 9.31.0
         version: 9.31.0
@@ -522,6 +522,9 @@ importers:
       pg-connection-string:
         specifier: 2.7.0
         version: 2.7.0
+      pgsql-ast-parser:
+        specifier: 12.0.2
+        version: 12.0.2
       playwright:
         specifier: 1.56.1
         version: 1.56.1
@@ -563,7 +566,7 @@ importers:
         version: 11.1.1
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
       winston:
         specifier: 3.13.0
         version: 3.13.0
@@ -678,7 +681,7 @@ importers:
         version: 3.1.9
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@22.13.1)(@typescript/typescript6@6.0.1)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(@typescript/typescript6@6.0.1)
       typescript:
         specifier: npm:@typescript/typescript6@6.0.1
         version: '@typescript/typescript6@6.0.1'
@@ -763,7 +766,7 @@ importers:
         version: 9.15.1(encoding@0.1.13)
       inquirer:
         specifier: 8.2.7
-        version: 8.2.7(@types/node@22.13.1)
+        version: 8.2.7(@types/node@24.3.1)
       js-yaml:
         specifier: 4.2.0
         version: 4.2.0
@@ -830,7 +833,7 @@ importers:
         version: 2.4.1
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@22.13.1)(@typescript/typescript6@6.0.1)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(@typescript/typescript6@6.0.1)
       typescript:
         specifier: npm:@typescript/typescript6@6.0.1
         version: '@typescript/typescript6@6.0.1'
@@ -839,7 +842,7 @@ importers:
         version: typescript@7.0.1-rc
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(jsdom@26.1.0(canvas@3.2.1))(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@26.1.0(canvas@3.2.1))(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
 
   packages/common:
     dependencies:
@@ -14053,6 +14056,9 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
+  pgsql-ast-parser@12.0.2:
+    resolution: {integrity: sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -16329,6 +16335,9 @@ packages:
 
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
+  tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -20751,12 +20760,12 @@ snapshots:
   '@img/sharp-win32-x64@0.35.2':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.13.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.3.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 22.13.1
+      '@types/node': 24.3.1
 
   '@ioredis/commands@1.2.0':
     optional: true
@@ -22857,7 +22866,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
-  '@rudderstack/rudder-sdk-node@2.1.1(tslib@2.8.1)':
+  '@rudderstack/rudder-sdk-node@2.1.1(tslib@2.6.2)':
     dependencies:
       axios: 1.16.0
       axios-retry: 4.5.0(axios@1.16.0)
@@ -22869,7 +22878,7 @@ snapshots:
       ms: 2.1.3
       remove-trailing-slash: 0.1.1
       serialize-javascript: 6.0.2
-      tslib: 2.8.1
+      tslib: 2.6.2
       uuid: 11.0.2
     optionalDependencies:
       bull: 4.16.4
@@ -24828,7 +24837,6 @@ snapshots:
   '@types/node@24.3.1':
     dependencies:
       undici-types: 7.10.0
-    optional: true
 
   '@types/nodemailer@7.0.9':
     dependencies:
@@ -25494,14 +25502,6 @@ snapshots:
       '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.6(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.6(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))':
     dependencies:
@@ -29865,9 +29865,9 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
 
-  inquirer@8.2.7(@types/node@22.13.1):
+  inquirer@8.2.7(@types/node@24.3.1):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@22.13.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.3.1)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -32873,6 +32873,11 @@ snapshots:
     dependencies:
       split2: 4.1.0
 
+  pgsql-ast-parser@12.0.2:
+    dependencies:
+      moo: 0.5.2
+      nearley: 2.20.1
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -35645,26 +35650,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@swc/core@1.13.5)(@types/node@22.13.1)(@typescript/typescript6@6.0.1):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 22.13.1
-      acorn: 8.16.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: '@typescript/typescript6@6.0.1'
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.13.5
-
   ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(@typescript/typescript6@6.0.1):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -35684,7 +35669,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.5
-    optional: true
 
   ts-unused-exports@9.0.4(@typescript/typescript6@6.0.1):
     dependencies:
@@ -35708,6 +35692,8 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.3.0: {}
+
+  tslib@2.6.2: {}
 
   tslib@2.8.1: {}
 
@@ -35890,8 +35876,7 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici-types@7.10.0:
-    optional: true
+  undici-types@7.10.0: {}
 
   undici@6.27.0: {}
 
@@ -36511,24 +36496,6 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.13.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.32.0
-      sugarss: 5.0.1(postcss@8.5.10)
-      terser: 5.46.1
-      tsx: 4.19.4
-      yaml: 2.8.3
-
   vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
@@ -36567,10 +36534,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
+  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.6(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -36587,41 +36554,12 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
+      vite: 7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 22.13.1
+      '@types/node': 24.3.1
       jsdom: 24.0.0(canvas@3.2.1)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(jsdom@26.1.0(canvas@3.2.1))(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 22.13.1
-      jsdom: 26.1.0(canvas@3.2.1)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Description

Experimental **Postgres wire protocol (v3) endpoint for the semantic layer**: any standard Postgres client (psql, node-postgres, psycopg, …) can connect to Lightdash, authenticate with a personal access token, and query explores with plain SQL. The SQL is compiled into a `MetricQuery` and executed through the standard query path (`ProjectService.runExploreQuery`), so CASL permissions, explore joins, metric definitions, and result formatting behave exactly like the explorer.

Disabled by default — enabled by setting `PGWIRE_PORT` (no listener is started otherwise).

```bash
psql -h localhost -p 5433 -U you@example.com -d jaffle-shop   # password = personal access token
```

- **database** = project UUID or slugified project name (resolved at connect time, ambiguity errors)
- **tables** = explores, **columns** = fieldIds (`orders_status`, `orders_total_order_amount`), including joined-table fields
- **user** = ignored (any value)

### What's supported

- `SELECT` of dimensions and metrics, `SELECT *`, aliases, table/alias-qualified names
- `WHERE`: `=`, `!=`, `<`, `<=`, `>`, `>=`, `IN`/`NOT IN`, `LIKE`/`ILIKE` (→ include/startsWith/endsWith), `BETWEEN`, `IS NULL`, boolean columns, nested `AND`/`OR`; conditions on metrics are routed to metric filters automatically
- `HAVING` → metric filters; `GROUP BY` optional and validated (grouping is implicit); `ORDER BY` (fields, ordinals, aliases, table calcs, `NULLS FIRST/LAST`); `LIMIT`
- **Table calculations** from SELECT expressions: arithmetic, functions, `CASE`, window functions, references to other calcs — compiled to `${fieldId}` SQL
- **Catalog discovery** via virtual `information_schema.tables` / `information_schema.columns` (with a `field_type` column marking dimension vs metric)
- Session shims for client compatibility: `BEGIN`/`COMMIT`/`SET`/`SHOW`, `SELECT version()`, FROM-less selects
- Unsupported SQL fails with Postgres-style errors + hints (unknown columns list available fields, `count(*)` suggests selecting a metric, JOINs point at the explore, etc.)

### Not supported (by design / for now)

- Extended query protocol (bind parameters) — clear `0A000` error; psql and parameterless driver queries use the simple protocol
- `pg_catalog` emulation — GUI schema browsers (DBeaver etc.) won't populate; `information_schema` works
- Explicit JOINs, subqueries, CTEs, DML, custom metrics, period-over-period

### Implementation

| File | What |
|---|---|
| `postgresWire/sqlToMetricQuery.ts` | Pure SQL→MetricQuery compiler (pgsql-ast-parser) |
| `postgresWire/sqlToMetricQuery.test.ts` | 93 unit tests for the compiler |
| `postgresWire/PostgresWireServer.ts` | Hand-rolled wire protocol: cleartext-password auth, simple query flow, typed OIDs |
| `postgresWire/lightdashHandlers.ts` | PAT auth → `Account`, project resolution, catalog, query execution |
| `postgresWire/informationSchema.ts` | Virtual catalog tables served from the explore cache |
| `App.ts` | Env-gated startup/shutdown of the listener |

### Testing

- 93 unit tests covering the compiler (selection, filters, group by, sorts, limits, table calcs, error cases)
- Verified end-to-end locally against the seeded demo project with **psql** and **node-postgres**; wire results byte-identical to the same MetricQuery via `POST /runQuery`
- Auth failure paths verified (bad PAT → `28P01`, unknown/ambiguous database → `3D000`)

> Note: `pnpm-lock.yaml` includes a small one-time peer-resolution correction (`@types/node@22 → 24` suffixes within the backend importer) — main's lockfile was stale relative to backend's `package.json` and re-resolves when backend's dependency set changes.

Closes: PROD-8731
