### PR TITLE
fix: allow viewing ai router config

### DIFF
--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -138,6 +138,22 @@ describe('AiRouterService', () => {
         });
     });
 
+    it('allows users with AI agent view permission to read router config', async () => {
+        const { service, aiRouterModel } = makeService({ candidates: [] });
+        (ability.cannot as import('vitest').Mock).mockImplementation(
+            (action, resource) =>
+                action === 'manage' &&
+                resource?.__caslSubjectType__ === 'OrganizationAiAgent',
+        );
+
+        const result = await service.getConfig(account);
+
+        expect(result.enabled).toBe(true);
+        expect(aiRouterModel.findByOrganization).toHaveBeenCalledWith(
+            organizationUuid,
+        );
+    });
+
     it('uses the latest routing instructions and accessible candidates', async () => {
         const candidates = [
             createCandidate({ uuid: 'agent-1', name: 'General' }),

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -203,7 +203,7 @@ export class AiRouterService extends BaseService {
 
     async getConfig(account: RegisteredAccount): Promise<AiRouter> {
         const organizationUuid = AiRouterService.organizationUuidOf(account);
-        this.assertManageAiAgent(account, organizationUuid);
+        this.assertViewAiAgent(account, organizationUuid);
         const router =
             await this.aiRouterModel.findByOrganization(organizationUuid);
         if (!router) {


### PR DESCRIPTION
## Summary
- Allow users with AI agent view permission to read AI router config
- Keep dashboard/chart Ask AI using the Auto router for non-admin users
- Add regression coverage for view-level router config access

## Validation
- CI=true direnv exec . pnpm -F backend test src/ee/services/AiRouterService/AiRouterService.test.ts
- CI=true direnv exec . pnpm -F backend typecheck:fast
- Browser: dashboard Ask AI opened Auto after the router config endpoint allowed view access

Relates: PROD-8455