### PR TITLE
fix(ai-agents): stop "Ask AI Agent" from shifting the dashboard menu

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
@@ -4,8 +4,7 @@ import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
 import { store as aiAgentStore } from '../../store';
-import { openPanel } from '../../store/aiAgentLauncherSlice';
-import { getLauncherAgentUuid } from '../Launcher/launcherAgentSelection';
+import { openDefaultAgentPanel } from '../../store/aiAgentLauncherSlice';
 import { useDefaultAiAgent } from '../Launcher/useDefaultAiAgent';
 
 type Args = {
@@ -28,14 +27,14 @@ export const useAskAiAgentAction = ({
     clickedFrom,
 }: Args) => {
     const isVisible = useAiAgentButtonVisibility();
-    const { selectedAgent } = useDefaultAiAgent(projectUuid);
+    const { agents } = useDefaultAiAgent(projectUuid);
     const { user } = useApp();
     const { track } = useTracking();
 
-    const canAsk = isVisible && !!selectedAgent;
+    const canAsk = isVisible && agents.length > 0;
 
     const handleClick = () => {
-        if (!selectedAgent) return;
+        if (agents.length === 0) return;
         track({
             name: EventName.AI_AGENT_ASK_CLICKED,
             properties: {
@@ -47,13 +46,7 @@ export const useAskAiAgentAction = ({
         });
         const pendingContext =
             chartUuid || dashboardUuid ? { chartUuid, dashboardUuid } : null;
-        aiAgentStore.dispatch(
-            openPanel({
-                threadId: null,
-                agentUuid: getLauncherAgentUuid(selectedAgent),
-                pendingContext,
-            }),
-        );
+        aiAgentStore.dispatch(openDefaultAgentPanel({ pendingContext }));
     };
 
     return { canAsk, handleClick };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -4,7 +4,10 @@ import { useEffect, useRef, type FC } from 'react';
 import { useMatches } from 'react-router';
 import { useActiveProjectUuid } from '../../../../../hooks/useActiveProject';
 import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
-import { resetActivePanel } from '../../store/aiAgentLauncherSlice';
+import {
+    resetActivePanel,
+    setActiveAgent,
+} from '../../store/aiAgentLauncherSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -12,6 +15,7 @@ import {
 import { AiSavedChartPreviewPanel } from '../ChatElements/AiSavedChartPreviewPanel';
 import styles from './AiAgentsLauncher.module.css';
 import {
+    getLauncherAgentUuid,
     getLauncherPanelAgent,
     isLauncherAgentAvailable,
 } from './launcherAgentSelection';
@@ -44,7 +48,8 @@ const AiAgentsLauncherInner: FC = () => {
 
     const isAiAgentEnabled = useAiAgentButtonVisibility();
 
-    const { agents, selectedAgent } = useDefaultAiAgent(activeProjectUuid);
+    const { agents, selectedAgent, isResolving } =
+        useDefaultAiAgent(activeProjectUuid);
 
     const dispatch = useAiAgentStoreDispatch();
     const mode = useAiAgentStoreSelector((state) => state.aiAgentLauncher.mode);
@@ -84,6 +89,29 @@ const AiAgentsLauncherInner: FC = () => {
             dispatch(resetActivePanel());
         }
     }, [activeAgentUuid, agents, dispatch, selectedAgent]);
+
+    useEffect(() => {
+        if (
+            mode !== 'panel-open' ||
+            activeAgentUuid !== null ||
+            activeThreadId !== null ||
+            isResolving ||
+            !selectedAgent
+        ) {
+            return;
+        }
+        const resolvedAgentUuid = getLauncherAgentUuid(selectedAgent);
+        if (resolvedAgentUuid) {
+            dispatch(setActiveAgent(resolvedAgentUuid));
+        }
+    }, [
+        mode,
+        activeAgentUuid,
+        activeThreadId,
+        isResolving,
+        selectedAgent,
+        dispatch,
+    ]);
 
     const isAllowed =
         Boolean(activeProjectUuid) && isAiAgentEnabled && agents.length > 0;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts
@@ -10,7 +10,7 @@ import {
 
 export const useDefaultAiAgent = (projectUuid: string | undefined) => {
     const aiOrganizationSettingsQuery = useAiOrganizationSettings();
-    const { data: agents } = useProjectAiAgents({
+    const agentsQuery = useProjectAiAgents({
         projectUuid,
         options: {
             enabled:
@@ -21,7 +21,9 @@ export const useDefaultAiAgent = (projectUuid: string | undefined) => {
         },
         redirectOnUnauthorized: false,
     });
-    const { data: preferences } = useGetUserAgentPreferences(projectUuid);
+    const agents = agentsQuery.data;
+    const preferencesQuery = useGetUserAgentPreferences(projectUuid);
+    const preferences = preferencesQuery.data;
     const aiRouterConfigQuery = useAiRouterConfig();
 
     const selectedAgent = useMemo(
@@ -40,9 +42,15 @@ export const useDefaultAiAgent = (projectUuid: string | undefined) => {
         ],
     );
 
+    const isResolving =
+        agentsQuery.isLoading ||
+        preferencesQuery.isLoading ||
+        aiRouterConfigQuery.isLoading;
+
     return {
         agent: getConcreteLauncherAgent(selectedAgent),
         selectedAgent,
         agents: agents ?? [],
+        isResolving,
     };
 };

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -53,7 +53,7 @@ export const aiAgentLauncherSlice = createSlice({
             state,
             action: PayloadAction<{
                 threadId: string | null;
-                agentUuid: LauncherActiveAgentUuid | null;
+                agentUuid: LauncherActiveAgentUuid;
                 pendingContext?: LauncherPendingContext | null;
             }>,
         ) => {
@@ -61,6 +61,23 @@ export const aiAgentLauncherSlice = createSlice({
             state.activeThreadId = action.payload.threadId;
             state.activeAgentUuid = action.payload.agentUuid;
             state.pendingContext = action.payload.pendingContext ?? null;
+        },
+        openDefaultAgentPanel: (
+            state,
+            action: PayloadAction<{
+                pendingContext?: LauncherPendingContext | null;
+            }>,
+        ) => {
+            state.mode = 'panel-open';
+            state.activeThreadId = null;
+            state.activeAgentUuid = null;
+            state.pendingContext = action.payload.pendingContext ?? null;
+        },
+        setActiveAgent: (
+            state,
+            action: PayloadAction<LauncherActiveAgentUuid>,
+        ) => {
+            state.activeAgentUuid = action.payload;
         },
         closePanel: (state) => {
             state.mode = 'collapsed';
@@ -108,6 +125,8 @@ export const aiAgentLauncherSlice = createSlice({
 
 export const {
     openPanel,
+    openDefaultAgentPanel,
+    setActiveAgent,
     closePanel,
     resetActivePanel,
     dockItemRemoved,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8734/dashboard-context-menu-shifts-when-ask-ai-agent-loads-causing-wrong

### Description:
The menu item was hidden until the AI router config / user preferences resolved, so it appeared after the kebab menu had opened and pushed the items below it down, causing misclicks for fast users.

Visibility now depends only on whether an agent is available, so the item is present from the first frame and never reflows the menu. The launcher resolves which agent to open once the default has fully settled, so a click during resolution waits and opens the user's actual default rather than an arbitrary first agent.


### Testing:
Added a 4s delay to the relevant endpoint just to repro the issue better.

Before:

https://github.com/user-attachments/assets/7dcb146e-c9c6-42e3-bda1-16d3d6a8d8c5


After:

https://github.com/user-attachments/assets/ec8e51db-ef56-40fe-b99b-19637e88deac

