### PR TITLE
fix(cli): download warnings no longer overwrite the active spinner

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -926,7 +926,7 @@ export const downloadHandler = async (
         // Download regular charts and SQL charts
         if (!options.skipCharts) {
             if (hasFilters && options.charts.length === 0) {
-                console.info(
+                GlobalState.log(
                     styles.warning(`No charts filters provided, skipping`),
                 );
             } else {
@@ -978,7 +978,7 @@ export const downloadHandler = async (
         // Download dashboards
         if (!options.skipDashboards) {
             if (hasFilters && options.dashboards.length === 0) {
-                console.info(
+                GlobalState.log(
                     styles.warning(`No dashboards filters provided, skipping`),
                 );
             } else {


### PR DESCRIPTION
### Description:
The "No charts/dashboards filters provided, skipping" warnings used raw console.info, which writes on top of the live ora spinner and concatenates onto its line (e.g. "Downloading content from projectNo charts filters provided, skipping"). Switch to GlobalState.log, which stops the spinner, logs, and restarts it — matching every other warning in this file.

Before:
<img width="722" height="224" alt="Screenshot 2026-07-08 at 11 01 25" src="https://github.com/user-attachments/assets/cc58e8e6-fe7c-400b-a569-4635b83bd052" />

After:
<img width="722" height="224" alt="Screenshot 2026-07-08 at 11 07 09" src="https://github.com/user-attachments/assets/8880003c-988b-4ad5-b504-37afd3b569cf" />
