### PR TITLE
fix: add hrefs to list content output

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -1131,6 +1131,7 @@ export class AiAgentToolsService extends BaseService {
 
                 if (spaceSlug === null) {
                     return this.getRootSpacesForAgent(
+                        context,
                         context.user,
                         context.projectUuid,
                         agentSpaceAccess,
@@ -1140,6 +1141,7 @@ export class AiAgentToolsService extends BaseService {
                 }
 
                 return this.getSpaceContentsForAgent(
+                    context,
                     context.user,
                     context.projectUuid,
                     spaceSlug,
@@ -1164,6 +1166,20 @@ export class AiAgentToolsService extends BaseService {
             default:
                 return assertUnreachable(type, 'Invalid content type');
         }
+    }
+
+    private static getSpaceUrl(
+        context: AiAgentToolsRuntimeContext,
+        uuid: string,
+    ) {
+        return `/projects/${context.projectUuid}/spaces/${uuid}`;
+    }
+
+    private static getDataAppUrl(
+        context: AiAgentToolsRuntimeContext,
+        uuid: string,
+    ) {
+        return `/projects/${context.projectUuid}/apps/${uuid}`;
     }
 
     private static getContentTypeLabel(type: ContentAsCodeType) {
@@ -2308,6 +2324,7 @@ export class AiAgentToolsService extends BaseService {
     }
 
     private async getRootSpacesForAgent(
+        context: AiAgentToolsRuntimeContext,
         user: SessionUser,
         projectUuid: string,
         agentSpaceAccess: Set<string> | null,
@@ -2334,6 +2351,7 @@ export class AiAgentToolsService extends BaseService {
                     contentType: ContentType.SPACE,
                     name: space.name,
                     slug: getContentAsCodePathFromLtreePath(space.path),
+                    href: AiAgentToolsService.getSpaceUrl(context, space.uuid),
                     chartCount: space.chartCount,
                     dashboardCount: space.dashboardCount,
                     childSpaceCount: space.childSpaceCount,
@@ -2346,6 +2364,7 @@ export class AiAgentToolsService extends BaseService {
     }
 
     private async getSpaceContentsForAgent(
+        context: AiAgentToolsRuntimeContext,
         user: SessionUser,
         projectUuid: string,
         spaceSlug: string,
@@ -2400,6 +2419,10 @@ export class AiAgentToolsService extends BaseService {
                             contentType: ContentType.SPACE,
                             name: item.name,
                             slug: getContentAsCodePathFromLtreePath(item.path),
+                            href: AiAgentToolsService.getSpaceUrl(
+                                context,
+                                item.uuid,
+                            ),
                             chartCount: item.chartCount,
                             dashboardCount: item.dashboardCount,
                             childSpaceCount: item.childSpaceCount,
@@ -2408,11 +2431,45 @@ export class AiAgentToolsService extends BaseService {
                         };
                     }
 
-                    return {
-                        contentType: item.contentType,
-                        name: item.name,
-                        slug: item.slug,
-                    };
+                    switch (item.contentType) {
+                        case ContentType.DASHBOARD:
+                            return {
+                                contentType: item.contentType,
+                                name: item.name,
+                                slug: item.slug,
+                                href: AiAgentToolsService.getContentUrl(
+                                    context,
+                                    'dashboard',
+                                    item.uuid,
+                                ),
+                            };
+                        case ContentType.CHART:
+                            return {
+                                contentType: item.contentType,
+                                name: item.name,
+                                slug: item.slug,
+                                href: AiAgentToolsService.getContentUrl(
+                                    context,
+                                    'chart',
+                                    item.uuid,
+                                ),
+                            };
+                        case ContentType.DATA_APP:
+                            return {
+                                contentType: item.contentType,
+                                name: item.name,
+                                slug: item.slug,
+                                href: AiAgentToolsService.getDataAppUrl(
+                                    context,
+                                    item.uuid,
+                                ),
+                            };
+                        default:
+                            return assertUnreachable(
+                                item,
+                                'Invalid content type',
+                            );
+                    }
                 }),
             pagination: results.pagination,
         };

--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -90,6 +90,7 @@ type TestSpace = {
 type TestContentItem =
     | {
           contentType: 'chart' | 'dashboard' | 'data_app';
+          uuid: string;
           name: string;
           slug: string;
       }
@@ -165,6 +166,23 @@ const makeMcpService = ({
 
     const toSpaceSlug = (path: string) =>
         path.replace(/\./g, '/').replace(/_/g, '-');
+    const getContentHref = (
+        item: Extract<
+            TestContentItem,
+            { contentType: 'chart' | 'dashboard' | 'data_app' }
+        >,
+    ) => {
+        switch (item.contentType) {
+            case 'dashboard':
+                return `/projects/${projectUuid}/dashboards/${item.uuid}/view#dashboard-link`;
+            case 'chart':
+                return `/projects/${projectUuid}/saved/${item.uuid}/view#chart-link`;
+            case 'data_app':
+                return `/projects/${projectUuid}/apps/${item.uuid}`;
+            default:
+                throw new Error(`Unsupported content type`);
+        }
+    };
     const aiAgentToolsService = {
         createRuntime: vi.fn((runtimeContext: TestRuntimeContext) => ({
             listContent: vi.fn(async ({ spaceSlug, page }) => {
@@ -180,6 +198,7 @@ const makeMcpService = ({
                             contentType: 'space',
                             name: space.name,
                             slug: toSpaceSlug(space.path),
+                            href: `/projects/${projectUuid}/spaces/${space.uuid}`,
                             chartCount: space.chartCount,
                             dashboardCount: space.dashboardCount,
                             childSpaceCount: space.childSpaceCount,
@@ -204,6 +223,7 @@ const makeMcpService = ({
                                   contentType: 'space',
                                   name: item.name,
                                   slug: toSpaceSlug(item.path),
+                                  href: `/projects/${projectUuid}/spaces/${item.uuid}`,
                                   chartCount: item.chartCount,
                                   dashboardCount: item.dashboardCount,
                                   childSpaceCount: item.childSpaceCount,
@@ -211,7 +231,10 @@ const makeMcpService = ({
                                   directAccess:
                                       item.access?.includes(userUuid) === true,
                               }
-                            : item,
+                            : {
+                                  ...item,
+                                  href: getContentHref(item),
+                              },
                     ),
                     pagination: contentResults.pagination,
                 };
@@ -335,6 +358,9 @@ describe('MCP list_content', () => {
         expect(text).toContain('contentType="space"');
         expect(text).toContain('name="Allowed Space"');
         expect(text).toContain('slug="allowed-space"');
+        expect(text).toContain(
+            `href="/projects/${projectUuid}/spaces/${allowedSpaceUuid}"`,
+        );
         expect(text).toContain('chartCount="2"');
         expect(text).not.toContain('Blocked Space');
     });
@@ -358,6 +384,7 @@ describe('MCP list_content', () => {
                 data: [
                     {
                         contentType: 'chart',
+                        uuid: 'revenue-chart-uuid',
                         name: 'Revenue Chart',
                         slug: 'revenue-chart',
                     },
@@ -391,7 +418,13 @@ describe('MCP list_content', () => {
         expect(text).toContain('spaceSlug="allowed-space"');
         expect(text).toContain('name="Revenue Chart"');
         expect(text).toContain('slug="revenue-chart"');
+        expect(text).toContain(
+            `href="/projects/${projectUuid}/saved/revenue-chart-uuid/view#chart-link"`,
+        );
         expect(text).toContain('name="Child Space"');
         expect(text).toContain('slug="allowed-space/child-space"');
+        expect(text).toContain(
+            `href="/projects/${projectUuid}/spaces/child-space-uuid"`,
+        );
     });
 });

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -731,7 +731,7 @@ Usage tips:
 - By default, lists root-level spaces.
 - Pass a spaceSlug to list direct children and content inside that space.
 - Use page for pagination. Page starts at 1.
-- Results include names, slugs, content types, and space content counts.",
+- Results include names, slugs, content types, URLs, and space content counts.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3341,7 +3341,7 @@ Usage tips:
 - By default, lists root-level spaces.
 - Pass a spaceSlug to list direct children and content inside that space.
 - Use page for pagination. Page starts at 1.
-- Results include names, slugs, content types, and space content counts.",
+- Results include names, slugs, content types, URLs, and space content counts.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,

--- a/packages/backend/src/ee/services/ai/tools/listContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/listContent.tsx
@@ -25,6 +25,7 @@ const renderContent = (content: Awaited<ReturnType<ListContentFn>>) => (
                     contentType={item.contentType}
                     name={item.name}
                     slug={item.slug}
+                    href={item.href}
                     chartCount={item.chartCount}
                     dashboardCount={item.dashboardCount}
                     childSpaceCount={item.childSpaceCount}
@@ -36,6 +37,7 @@ const renderContent = (content: Awaited<ReturnType<ListContentFn>>) => (
                     contentType={item.contentType}
                     name={item.name}
                     slug={item.slug}
+                    href={item.href}
                 />
             ),
         )}

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -219,11 +219,13 @@ export type ListContentFn = (args: {
               contentType: 'chart' | 'dashboard' | 'data_app';
               name: string;
               slug: string;
+              href: string;
           }
         | {
               contentType: 'space';
               name: string;
               slug: string;
+              href: string;
               chartCount: number;
               dashboardCount: number;
               childSpaceCount: number;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolListContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolListContentArgs.ts
@@ -10,7 +10,7 @@ Usage tips:
 - By default, lists root-level spaces.
 - Pass a spaceSlug to list direct children and content inside that space.
 - Use page for pagination. Page starts at 1.
-- Results include names, slugs, content types, and space content counts.`;
+- Results include names, slugs, content types, URLs, and space content counts.`;
 
 export const toolListContentArgsSchema = createToolSchema()
     .extend({


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Adds `href` fields to content items returned by the `listContent` tool, giving the AI agent direct URLs to navigate to spaces, dashboards, charts, and data apps.

- Spaces link to `/projects/{projectUuid}/spaces/{uuid}`
- Dashboards link to `/projects/{projectUuid}/dashboards/{uuid}/view`
- Charts link to `/projects/{projectUuid}/saved/{uuid}/view`
- Data apps link to `/projects/{projectUuid}/apps/{uuid}`

The tool description has also been updated to mention that results now include URLs alongside names, slugs, content types, and space content counts.