### PR TITLE
feat(roles): allow project scopes in org custom roles

### DIFF
--- a/packages/common/src/authorization/scopes.level.test.ts
+++ b/packages/common/src/authorization/scopes.level.test.ts
@@ -1,13 +1,14 @@
 import {
-    getOrgAssignableScopes,
+    getOrganizationOnlyScopes,
     getScopes,
-    isOrgAssignableScope,
+    isOrganizationOnlyScope,
+    isScopeAssignableAtLevel,
 } from './scopes';
 
-// Deliberate golden copy of the org-assignable set. Do NOT replace this with a
-// call to getOrgAssignableScopes() — the point is to fail loudly when a scope's
-// `level` is changed to/from 'organization' without a conscious test update.
-const ORG_ASSIGNABLE_SCOPE_NAMES = [
+// Deliberate golden copy of the org-only set. Do NOT replace this with
+// getOrganizationOnlyScopes(); the point is to fail loudly when a scope's
+// `level` changes to/from 'organization' without a conscious test update.
+const ORG_ONLY_SCOPE_NAMES = [
     'view:Organization',
     'manage:Organization',
     'view:OrganizationMemberProfile',
@@ -26,36 +27,55 @@ const ORG_ASSIGNABLE_SCOPE_NAMES = [
 ];
 
 describe('scope levels', () => {
-    it('classifies the org-assignable scope set and treats every other scope as project-level', () => {
-        expect(getOrgAssignableScopes()).toEqual(
-            expect.arrayContaining(ORG_ASSIGNABLE_SCOPE_NAMES),
+    it('classifies the org-only scope set and treats every other scope as project-level', () => {
+        expect(getOrganizationOnlyScopes()).toEqual(
+            expect.arrayContaining(ORG_ONLY_SCOPE_NAMES),
         );
-        expect(getOrgAssignableScopes()).toHaveLength(
-            ORG_ASSIGNABLE_SCOPE_NAMES.length,
+        expect(getOrganizationOnlyScopes()).toHaveLength(
+            ORG_ONLY_SCOPE_NAMES.length,
         );
 
-        ORG_ASSIGNABLE_SCOPE_NAMES.forEach((scopeName) => {
-            expect(isOrgAssignableScope(scopeName)).toBe(true);
+        ORG_ONLY_SCOPE_NAMES.forEach((scopeName) => {
+            expect(isOrganizationOnlyScope(scopeName)).toBe(true);
         });
 
-        expect(isOrgAssignableScope('delete:Project')).toBe(false);
-        expect(isOrgAssignableScope('create:Project@preview')).toBe(false);
-        expect(isOrgAssignableScope('manage:SpotlightTableConfig')).toBe(false);
-        expect(isOrgAssignableScope('manage:ContentAsCode')).toBe(false);
-        expect(isOrgAssignableScope('manage:ExternalConnection')).toBe(false);
+        expect(isOrganizationOnlyScope('delete:Project')).toBe(false);
+        expect(isOrganizationOnlyScope('create:Project@preview')).toBe(false);
+        expect(isOrganizationOnlyScope('manage:SpotlightTableConfig')).toBe(
+            false,
+        );
+        expect(isOrganizationOnlyScope('manage:ContentAsCode')).toBe(false);
+        expect(isOrganizationOnlyScope('manage:ExternalConnection')).toBe(
+            false,
+        );
         // The project-level AI agent scopes stay project-assignable; only the
         // dedicated OrganizationAiAgent scopes are org-assignable.
-        expect(isOrgAssignableScope('view:AiAgent')).toBe(false);
-        expect(isOrgAssignableScope('manage:AiAgent')).toBe(false);
+        expect(isOrganizationOnlyScope('view:AiAgent')).toBe(false);
+        expect(isOrganizationOnlyScope('manage:AiAgent')).toBe(false);
     });
 
-    it('keeps every org-assignable scope name backed by a real scope definition', () => {
+    it('keeps every organization-only scope name backed by a real scope definition', () => {
         const scopeNames = new Set(
             getScopes({ isEnterprise: true }).map((scope) => scope.name),
         );
 
-        getOrgAssignableScopes().forEach((scopeName) => {
+        getOrganizationOnlyScopes().forEach((scopeName) => {
             expect(scopeNames.has(scopeName)).toBe(true);
         });
+    });
+
+    it('allows organization roles to include project scopes while keeping organization scopes out of project roles', () => {
+        expect(
+            isScopeAssignableAtLevel('view:Organization', 'organization'),
+        ).toBe(true);
+        expect(isScopeAssignableAtLevel('view:Dashboard', 'organization')).toBe(
+            true,
+        );
+        expect(isScopeAssignableAtLevel('view:Dashboard', 'project')).toBe(
+            true,
+        );
+        expect(isScopeAssignableAtLevel('view:Organization', 'project')).toBe(
+            false,
+        );
     });
 });

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1429,26 +1429,27 @@ const scopes: Scope[] = [
     },
 ] as const;
 
-const isOrgAssignableScopeDefinition = (scope: Scope): boolean =>
+const isOrganizationOnlyScopeDefinition = (scope: Scope): boolean =>
     scope.level === 'organization';
 
-const ORG_ASSIGNABLE_SCOPE_NAMES = new Set<string>(
-    scopes.filter(isOrgAssignableScopeDefinition).map((scope) => scope.name),
+const ORGANIZATION_ONLY_SCOPE_NAMES = new Set<string>(
+    scopes.filter(isOrganizationOnlyScopeDefinition).map((scope) => scope.name),
 );
 
-export const getOrgAssignableScopes = (): ScopeName[] =>
-    scopes.filter(isOrgAssignableScopeDefinition).map((scope) => scope.name);
+export const getOrganizationOnlyScopes = (): ScopeName[] =>
+    scopes.filter(isOrganizationOnlyScopeDefinition).map((scope) => scope.name);
 
-export const isOrgAssignableScope = (scopeName: string): boolean =>
-    ORG_ASSIGNABLE_SCOPE_NAMES.has(scopeName);
+export const isOrganizationOnlyScope = (scopeName: string): boolean =>
+    ORGANIZATION_ONLY_SCOPE_NAMES.has(scopeName);
+
+export const getOrgAssignableScopes = getOrganizationOnlyScopes;
+
+export const isOrgAssignableScope = isOrganizationOnlyScope;
 
 export const isScopeAssignableAtLevel = (
     scopeName: string,
     level: RoleLevel,
-): boolean =>
-    level === 'organization'
-        ? isOrgAssignableScope(scopeName)
-        : !isOrgAssignableScope(scopeName);
+): boolean => level === 'organization' || !isOrganizationOnlyScope(scopeName);
 
 const getNonEnterpriseScopes = (): Scope[] =>
     scopes.filter((scope) => !scope.isEnterprise);

--- a/packages/common/src/types/scopes.ts
+++ b/packages/common/src/types/scopes.ts
@@ -104,8 +104,9 @@ export type Scope = {
      */
     dependencies: ScopeDependency[];
     /**
-     * The level at which this scope can be granted by a custom role.
-     * Defaults to 'project'. Single source of truth for level classification.
+     * Organization-only scopes are unavailable to project roles.
+     * Scopes without a level are project scopes; organization roles may grant
+     * them across all projects.
      */
     level?: RoleLevel;
     /**


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8621/add-project-scopes-to-the-org-custom-role-builder

## Description:

Allows organization custom roles to include project scopes, so org-level custom roles can mirror system org roles and apply project permissions across every project. Project custom roles still exclude organization-only scopes.

```text
Project custom role      -> project scopes only
Organization custom role -> organization-only scopes + project scopes
```

## Test plan

- `pnpm -F common test -- scopes.level.test.ts`
- `pnpm -F common typecheck:fast`
- `pnpm -F common lint`
- `pnpm -F common build`
- `pnpm -F frontend typecheck:fast`
- `pnpm -F backend typecheck:fast`
- `git diff --check`