### PR TITLE
fix(roles): return 409 instead of 500 when a role name already exists

### DIFF
--- a/packages/backend/src/models/RolesModel.test.ts
+++ b/packages/backend/src/models/RolesModel.test.ts
@@ -1,0 +1,99 @@
+import { AlreadyExistsError, NotFoundError } from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { DatabaseError } from 'pg';
+import { RolesTableName } from '../database/entities/roles';
+import { RolesModel } from './RolesModel';
+
+const databaseError = (code: string): DatabaseError => {
+    const error = new DatabaseError(`database error ${code}`, 0, 'error');
+    error.code = code;
+    return error;
+};
+
+const uniqueViolation = () => databaseError('23505');
+
+describe('RolesModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new RolesModel(database);
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    describe('createRole', () => {
+        const roleData = {
+            name: 'Copy of: Editor',
+            description: null,
+            level: 'organization' as const,
+            created_by: 'user-uuid',
+        };
+
+        it('translates a unique-name violation into AlreadyExistsError', async () => {
+            tracker.on
+                .insert(RolesTableName)
+                .simulateErrorOnce(uniqueViolation());
+
+            await expect(
+                model.createRole('org-uuid', roleData),
+            ).rejects.toThrow(AlreadyExistsError);
+        });
+
+        it('names the conflicting role in the error message', async () => {
+            tracker.on
+                .insert(RolesTableName)
+                .simulateErrorOnce(uniqueViolation());
+
+            await expect(
+                model.createRole('org-uuid', roleData),
+            ).rejects.toThrow('A role named "Copy of: Editor" already exists');
+        });
+
+        it('rethrows non-unique database errors unchanged', async () => {
+            const foreignKeyViolation = databaseError('23503');
+            tracker.on
+                .insert(RolesTableName)
+                .simulateErrorOnce(foreignKeyViolation);
+
+            await expect(model.createRole('org-uuid', roleData)).rejects.toBe(
+                foreignKeyViolation,
+            );
+        });
+    });
+
+    describe('updateRole', () => {
+        it('translates a unique-name violation into AlreadyExistsError', async () => {
+            tracker.on
+                .update(RolesTableName)
+                .simulateErrorOnce(uniqueViolation());
+
+            await expect(
+                model.updateRole('role-uuid', { name: 'Copy of: Editor' }),
+            ).rejects.toThrow(AlreadyExistsError);
+        });
+
+        it('rethrows non-unique database errors unchanged', async () => {
+            const foreignKeyViolation = databaseError('23503');
+            tracker.on
+                .update(RolesTableName)
+                .simulateErrorOnce(foreignKeyViolation);
+
+            await expect(
+                model.updateRole('role-uuid', { name: 'Copy of: Editor' }),
+            ).rejects.toBe(foreignKeyViolation);
+        });
+
+        it('throws NotFoundError when the role does not exist', async () => {
+            tracker.on.update(RolesTableName).responseOnce([]);
+
+            await expect(
+                model.updateRole('missing-uuid', { description: 'x' }),
+            ).rejects.toThrow(NotFoundError);
+        });
+    });
+});

--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -1,4 +1,5 @@
 import {
+    AlreadyExistsError,
     getSystemRoles,
     GroupProjectAccess,
     isOrganizationMemberRole,
@@ -32,6 +33,7 @@ import {
     ScopedRolesTableName,
 } from '../database/entities/roles';
 import { UserTableName } from '../database/entities/users';
+import { isUniqueConstraintViolation } from '../database/errors';
 
 type DbRoleWithScopes = DbRole & {
     scopes: string;
@@ -248,17 +250,26 @@ export class RolesModel {
         roleData: Omit<DbRoleInsert, 'organization_uuid'>,
         tx?: Knex.Transaction,
     ): Promise<Role> {
-        const [role] = await (tx || this.database)(RolesTableName)
-            .insert({
-                name: roleData.name,
-                description: roleData.description,
-                level: roleData.level,
-                organization_uuid: organizationUuid,
-                created_by: roleData.created_by,
-            })
-            .returning('*');
+        try {
+            const [role] = await (tx || this.database)(RolesTableName)
+                .insert({
+                    name: roleData.name,
+                    description: roleData.description,
+                    level: roleData.level,
+                    organization_uuid: organizationUuid,
+                    created_by: roleData.created_by,
+                })
+                .returning('*');
 
-        return RolesModel.mapDbRoleToRole(role);
+            return RolesModel.mapDbRoleToRole(role);
+        } catch (error) {
+            if (isUniqueConstraintViolation(error)) {
+                throw new AlreadyExistsError(
+                    `A role named "${roleData.name}" already exists in this organization`,
+                );
+            }
+            throw error;
+        }
     }
 
     async updateRole(
@@ -266,13 +277,25 @@ export class RolesModel {
         updateData: Omit<DbRoleUpdate, 'updated_at'>,
         tx?: Knex.Transaction,
     ): Promise<Role> {
-        const [updatedRole] = await (tx || this.database)(RolesTableName)
-            .where('role_uuid', roleUuid)
-            .update({
-                ...updateData,
-                updated_at: new Date(),
-            })
-            .returning('*');
+        let updatedRole: DbRole | undefined;
+        try {
+            [updatedRole] = await (tx || this.database)(RolesTableName)
+                .where('role_uuid', roleUuid)
+                .update({
+                    ...updateData,
+                    updated_at: new Date(),
+                })
+                .returning('*');
+        } catch (error) {
+            if (isUniqueConstraintViolation(error)) {
+                throw new AlreadyExistsError(
+                    updateData.name
+                        ? `A role named "${updateData.name}" already exists in this organization`
+                        : `A role with this name already exists in this organization`,
+                );
+            }
+            throw error;
+        }
 
         if (!updatedRole) {
             throw new NotFoundError(`Role with uuid ${roleUuid} not found`);


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8735

## Summary

Creating, duplicating, or renaming a custom role to a name that already exists in the organization returned a generic `500 Something went wrong` instead of a clear validation error. The duplicate-role page defaults copied roles to names like `Copy of: Editor`, so repeating the flow reliably hit it.

Affects all three write paths that set `roles.name` — create, duplicate, and rename. No behaviour change for unique names.

## Root cause

`roles` has a unique constraint `(name, organization_uuid)` (`roles_name_organization_uuid_unique`). `RolesModel.createRole` / `updateRole` inserted/updated the row with no handling for a collision, so Postgres `23505` propagated uncaught and was wrapped as `UnexpectedServerError` → HTTP 500.

```ts
// RolesModel.createRole — before
const [role] = await (tx || this.database)(RolesTableName)
    .insert({ name: roleData.name, /* ... */ })
    .returning('*'); // 23505 on a duplicate name → uncaught → 500
```

`RolesService.duplicateRole` funnels through the same `createRole`, and the frontend duplicate form pre-fills `Copy of: ${sourceRole.name}`, so duplicating a role twice submits an identical name and trips the constraint.

## Fix

Translate the unique-constraint violation into `AlreadyExistsError` (HTTP 409) at the model layer, mirroring the existing `GroupsModel` pattern. One catch covers create, duplicate, and rename.

- `packages/backend/src/models/RolesModel.ts` — wrap the `createRole` insert and `updateRole` update in try/catch; on `isUniqueConstraintViolation` throw `AlreadyExistsError` with a message naming the role, else rethrow.
- `packages/backend/src/models/RolesModel.test.ts` — new unit test (knex-mock-client): 23505 → `AlreadyExistsError` on both paths, message includes the name, non-unique errors rethrown unchanged, and the `updateRole` not-found path.
- No frontend change: the create/duplicate form already surfaces the API error via `showToastApiError`, so the clear 409 message flows through automatically.
- Out of scope: auto-incrementing the frontend default name (`Copy of: Editor 2`) to avoid the collision up front — deferred as a follow-up.

## Before / After

Second `POST /api/v2/orgs/{org}/roles` with an existing name:

```
Before:  HTTP 500  {"name":"UnexpectedServerError","message":"Something went wrong."}
After:   HTTP 409  {"name":"AlreadyExistsError",
                    "message":"A role named \"Copy of: Editor\" already exists in this organization"}
Unique name (unchanged):  HTTP 201
```

## Test plan

- [x] `pnpm -F backend typecheck:fast` + `eslint RolesModel.ts RolesModel.test.ts` — clean
- [x] `vitest RolesModel.test` — 6 tests pass (create/update 23505→409, message, non-unique rethrow, not-found); full backend suite green (3795 pass)
- [x] Manual (dev instance): duplicate-name create → 409, rename-to-existing → 409, unique-name create → 201
