### PR TITLE
feat(mcp): quieter MCP activity table and redesigned tool call drawer

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDetail.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDetail.module.css
@@ -1,0 +1,3 @@
+.row + .row {
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDetail.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDetail.tsx
@@ -1,110 +1,125 @@
 import { type McpActivityItem } from '@lightdash/common';
 import {
-    Badge,
     Code,
-    Divider,
     Group,
+    Paper,
     ScrollArea,
     Stack,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
-import { type FC } from 'react';
+import { type FC, type ReactNode } from 'react';
 import Callout from '../../../../../components/common/Callout';
+import classes from './McpActivityDetail.module.css';
+import { ToolCallStatusIndicator, ToolNamePill } from './McpActivityDisplay';
+import {
+    formatToolCallDuration,
+    formatToolCallTime,
+    formatToolCallTimeFull,
+} from './mcpActivityFormat';
 
-const DetailRow: FC<{ label: string; children: React.ReactNode }> = ({
-    label,
-    children,
+export const McpActivityDetailTitle: FC<{ toolCall: McpActivityItem }> = ({
+    toolCall,
 }) => (
-    <Group justify="space-between" wrap="nowrap" gap="md">
-        <Text fz="sm" c="ldGray.6" fw={500} style={{ whiteSpace: 'nowrap' }}>
-            {label}
-        </Text>
-        {children}
+    <Group gap="xs" wrap="nowrap">
+        <Text fw={600}>Tool call</Text>
+        <ToolNamePill name={toolCall.toolName} />
+        <ToolCallStatusIndicator status={toolCall.status} />
     </Group>
 );
+
+const SectionLabel: FC<{ children: ReactNode }> = ({ children }) => (
+    <Text fz="xs" fw={600} c="ldGray.5" tt="uppercase" lts="0.05em">
+        {children}
+    </Text>
+);
+
+const serializeArgs = (toolArgs: McpActivityItem['toolArgs']): string => {
+    const compact = JSON.stringify(toolArgs);
+    return compact.length <= 80 ? compact : JSON.stringify(toolArgs, null, 2);
+};
 
 export const McpActivityDetail: FC<{ toolCall: McpActivityItem }> = ({
     toolCall,
 }) => {
-    const durationLabel =
-        toolCall.durationMs >= 1000
-            ? `${(toolCall.durationMs / 1000).toFixed(1)}s`
-            : `${toolCall.durationMs}ms`;
+    const rows: { label: string; value: ReactNode }[] = [
+        {
+            label: 'Time',
+            value: (
+                <Tooltip
+                    withinPortal
+                    variant="xs"
+                    label={formatToolCallTimeFull(toolCall.createdAt)}
+                >
+                    <Text fz="sm" display="inline-block">
+                        {formatToolCallTime(toolCall.createdAt)}
+                    </Text>
+                </Tooltip>
+            ),
+        },
+        {
+            label: 'User',
+            value: `${toolCall.user.name}${
+                toolCall.user.email ? ` (${toolCall.user.email})` : ''
+            }`,
+        },
+        { label: 'Project', value: toolCall.project?.name ?? '—' },
+        { label: 'Agent', value: toolCall.agent?.name ?? '—' },
+        {
+            label: 'Duration',
+            value: formatToolCallDuration(toolCall.durationMs),
+        },
+        {
+            label: 'Client',
+            value: toolCall.clientName
+                ? `${toolCall.clientName}${
+                      toolCall.clientVersion ? ` ${toolCall.clientVersion}` : ''
+                  }`
+                : '—',
+        },
+        { label: 'User agent', value: toolCall.userAgent ?? '—' },
+        { label: 'Auth', value: toolCall.authType },
+        { label: 'Protocol', value: toolCall.protocolVersion ?? '—' },
+    ];
 
     return (
-        <Stack gap="sm" p="md">
-            <Group gap="xs">
-                <Badge variant="light" color="indigo" tt="none">
-                    {toolCall.toolName}
-                </Badge>
-                <Badge
-                    variant="light"
-                    color={toolCall.status === 'error' ? 'red' : 'green'}
-                >
-                    {toolCall.status}
-                </Badge>
-            </Group>
-
+        <Stack gap="md" p="md">
             {toolCall.errorMessage && (
                 <Callout variant="danger" title="Error">
                     {toolCall.errorMessage}
                 </Callout>
             )}
 
-            <Stack gap="xs">
-                <DetailRow label="Time">
-                    <Text fz="sm">
-                        {new Date(toolCall.createdAt).toLocaleString()}
-                    </Text>
-                </DetailRow>
-                <DetailRow label="User">
-                    <Text fz="sm" truncate>
-                        {toolCall.user.name}
-                        {toolCall.user.email ? ` (${toolCall.user.email})` : ''}
-                    </Text>
-                </DetailRow>
-                <DetailRow label="Project">
-                    <Text fz="sm">{toolCall.project?.name ?? '—'}</Text>
-                </DetailRow>
-                <DetailRow label="Agent">
-                    <Text fz="sm">{toolCall.agent?.name ?? '—'}</Text>
-                </DetailRow>
-                <DetailRow label="Duration">
-                    <Text fz="sm">{durationLabel}</Text>
-                </DetailRow>
-                <DetailRow label="Client">
-                    <Text fz="sm" truncate>
-                        {toolCall.clientName
-                            ? `${toolCall.clientName}${
-                                  toolCall.clientVersion
-                                      ? ` ${toolCall.clientVersion}`
-                                      : ''
-                              }`
-                            : '—'}
-                    </Text>
-                </DetailRow>
-                <DetailRow label="User agent">
-                    <Text fz="sm" truncate>
-                        {toolCall.userAgent ?? '—'}
-                    </Text>
-                </DetailRow>
-                <DetailRow label="Auth">
-                    <Text fz="sm">{toolCall.authType}</Text>
-                </DetailRow>
-                <DetailRow label="Protocol">
-                    <Text fz="sm">{toolCall.protocolVersion ?? '—'}</Text>
-                </DetailRow>
-            </Stack>
-
-            <Divider />
+            <Paper>
+                {rows.map((row) => (
+                    <Group
+                        key={row.label}
+                        className={classes.row}
+                        justify="space-between"
+                        wrap="nowrap"
+                        gap="md"
+                        px="md"
+                        py="sm"
+                    >
+                        <Text fz="sm" c="ldGray.6" flex="0 0 auto">
+                            {row.label}
+                        </Text>
+                        {typeof row.value === 'string' ? (
+                            <Text fz="sm" ta="right" truncate>
+                                {row.value}
+                            </Text>
+                        ) : (
+                            row.value
+                        )}
+                    </Group>
+                ))}
+            </Paper>
 
             <Stack gap="xs">
-                <Text fz="sm" fw={500} c="ldGray.7">
-                    Arguments
-                </Text>
+                <SectionLabel>Arguments</SectionLabel>
                 <ScrollArea.Autosize mah={400}>
                     <Code block fz="xs">
-                        {JSON.stringify(toolCall.toolArgs, null, 2)}
+                        {serializeArgs(toolCall.toolArgs)}
                     </Code>
                 </ScrollArea.Autosize>
             </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDisplay.tsx
@@ -1,0 +1,31 @@
+import { type McpActivityStatus } from '@lightdash/common';
+import { Box, Group, Paper, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+
+export const ToolNamePill: FC<{ name: string }> = ({ name }) => (
+    <Paper px="xs" maw="100%" display="inline-block">
+        <Text fz="xs" ff="monospace" c="ldGray.8" truncate>
+            {name}
+        </Text>
+    </Paper>
+);
+
+const StatusDot: FC<{ status: McpActivityStatus }> = ({ status }) => (
+    <Box
+        w={6}
+        h={6}
+        bg={status === 'error' ? 'red.6' : 'green.6'}
+        style={{ borderRadius: '50%', flexShrink: 0 }}
+    />
+);
+
+export const ToolCallStatusIndicator: FC<{ status: McpActivityStatus }> = ({
+    status,
+}) => (
+    <Group gap={6} wrap="nowrap">
+        <StatusDot status={status} />
+        <Text fz="sm" c="ldGray.7">
+            {status}
+        </Text>
+    </Group>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTable.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTable.module.css
@@ -1,0 +1,3 @@
+.durationHeadCell button {
+    justify-content: flex-end;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTable.tsx
@@ -2,14 +2,7 @@ import {
     type McpActivityItem,
     type McpActivitySortField,
 } from '@lightdash/common';
-import {
-    Badge,
-    Box,
-    Group,
-    Text,
-    Tooltip,
-    useMantineTheme,
-} from '@mantine-8/core';
+import { Box, Group, Text, Tooltip, useMantineTheme } from '@mantine-8/core';
 import {
     IconArrowDown,
     IconArrowsSort,
@@ -43,6 +36,13 @@ import { useIsTruncated } from '../../../../../hooks/useIsTruncated';
 import { useInfiniteMcpActivity } from '../../hooks/useMcpActivity';
 import { useMcpActivityFilters } from '../../hooks/useMcpActivityFilters';
 import { AgentNamePill } from '../AgentNamePill';
+import { ToolCallStatusIndicator, ToolNamePill } from './McpActivityDisplay';
+import {
+    formatToolCallDuration,
+    formatToolCallTime,
+    formatToolCallTimeFull,
+} from './mcpActivityFormat';
+import styles from './McpActivityTable.module.css';
 import { McpActivityTopToolbar } from './McpActivityTopToolbar';
 
 type McpActivityTableProps = {
@@ -168,9 +168,20 @@ const McpActivityTable = ({
                 </Group>
             ),
             Cell: ({ row }) => (
-                <Text fz="sm" c="ldGray.7">
-                    {new Date(row.original.createdAt).toLocaleString()}
-                </Text>
+                <Tooltip
+                    withinPortal
+                    variant="xs"
+                    label={formatToolCallTimeFull(row.original.createdAt)}
+                >
+                    <Text
+                        fz="xs"
+                        ff="monospace"
+                        c="ldGray.7"
+                        display="inline-block"
+                    >
+                        {formatToolCallTime(row.original.createdAt)}
+                    </Text>
+                </Tooltip>
             ),
         },
         {
@@ -185,11 +196,7 @@ const McpActivityTable = ({
                     {column.columnDef.header}
                 </Group>
             ),
-            Cell: ({ row }) => (
-                <Badge variant="light" color="indigo" tt="none">
-                    {row.original.toolName}
-                </Badge>
-            ),
+            Cell: ({ row }) => <ToolNamePill name={row.original.toolName} />,
         },
         {
             accessorKey: 'user.name',
@@ -308,12 +315,7 @@ const McpActivityTable = ({
                 </Group>
             ),
             Cell: ({ row }) => (
-                <Badge
-                    variant="light"
-                    color={row.original.status === 'error' ? 'red' : 'green'}
-                >
-                    {row.original.status}
-                </Badge>
+                <ToolCallStatusIndicator status={row.original.status} />
             ),
         },
         {
@@ -322,6 +324,10 @@ const McpActivityTable = ({
             enableSorting: true,
             enableEditing: false,
             size: 120,
+            mantineTableHeadCellProps: {
+                className: styles.durationHeadCell,
+            },
+            mantineTableBodyCellProps: { ta: 'right' },
             Header: ({ column }) => (
                 <Group gap="two">
                     <MantineIcon icon={IconHourglass} color="ldGray.6" />
@@ -330,13 +336,15 @@ const McpActivityTable = ({
             ),
             Cell: ({ row }) => {
                 const { durationMs } = row.original;
-                const label =
-                    durationMs >= 1000
-                        ? `${(durationMs / 1000).toFixed(1)}s`
-                        : `${durationMs}ms`;
+                const isSlow = durationMs >= 1000;
                 return (
-                    <Text fz="sm" c="ldGray.7">
-                        {label}
+                    <Text
+                        fz="xs"
+                        ff="monospace"
+                        fw={isSlow ? 600 : 400}
+                        c={isSlow ? 'ldGray.9' : 'ldGray.7'}
+                    >
+                        {formatToolCallDuration(durationMs)}
                     </Text>
                 );
             },

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/mcpActivityFormat.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/mcpActivityFormat.ts
@@ -1,0 +1,57 @@
+// Browser-locale formatters (undefined locale) so date/time and decimal
+// separators follow the user's settings, including 12/24h clocks.
+const timeOnlyFormat = new Intl.DateTimeFormat(undefined, {
+    timeStyle: 'medium',
+});
+const sameYearFormat = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+});
+const otherYearFormat = new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+});
+const fullFormat = new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+});
+const millisecondsFormat = new Intl.NumberFormat(undefined, {
+    style: 'unit',
+    unit: 'millisecond',
+    unitDisplay: 'narrow',
+    maximumFractionDigits: 0,
+});
+const secondsFormat = new Intl.NumberFormat(undefined, {
+    style: 'unit',
+    unit: 'second',
+    unitDisplay: 'narrow',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+});
+
+export const formatToolCallTime = (timestamp: string | Date): string => {
+    const date = new Date(timestamp);
+    const now = new Date();
+    if (date.toDateString() === now.toDateString()) {
+        return timeOnlyFormat.format(date);
+    }
+    if (date.getFullYear() === now.getFullYear()) {
+        return sameYearFormat.format(date);
+    }
+    return otherYearFormat.format(date);
+};
+
+export const formatToolCallTimeFull = (timestamp: string | Date): string =>
+    fullFormat.format(new Date(timestamp));
+
+export const formatToolCallDuration = (durationMs: number): string =>
+    durationMs >= 1000
+        ? secondsFormat.format(durationMs / 1000)
+        : millisecondsFormat.format(durationMs);

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage.tsx
@@ -4,7 +4,10 @@ import { useState } from 'react';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
-import { McpActivityDetail } from '../McpActivityDetail';
+import {
+    McpActivityDetail,
+    McpActivityDetailTitle,
+} from '../McpActivityDetail';
 import McpActivityTable from '../McpActivityTable';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
 import drawerClasses from './ThreadPreviewDrawer.module.css';
@@ -42,7 +45,11 @@ export const McpActivitySettingsPage = () => {
                 onClose={() => setSelectedCall(null)}
                 position="right"
                 size="lg"
-                title="Tool call details"
+                title={
+                    selectedCall && (
+                        <McpActivityDetailTitle toolCall={selectedCall} />
+                    )
+                }
                 classNames={{
                     inner: drawerClasses.inner,
                     overlay: drawerClasses.overlay,


### PR DESCRIPTION
Design polish on top of #25237: quieter MCP activity table (tool pills, status dots, localized time/duration formatting) and a redesigned tool call drawer to match.

Relates: PROD-6844

🤖 Generated with [Claude Code](https://claude.com/claude-code)