### PR TITLE
fix(ai-agents): guard null launcher agent uuid when opening panel from dock

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
@@ -75,7 +75,8 @@ export const LauncherDock: FC<Props> = ({
     };
 
     const handleNewThread = () => {
-        if (!selectedAgent) return;
+        const agentUuid = getLauncherAgentUuid(selectedAgent);
+        if (!agentUuid) return;
         const pendingContext =
             currentDashboard?.projectUuid === projectUuid
                 ? {
@@ -85,7 +86,7 @@ export const LauncherDock: FC<Props> = ({
         dispatch(
             openPanel({
                 threadId: null,
-                agentUuid: getLauncherAgentUuid(selectedAgent),
+                agentUuid,
                 pendingContext,
             }),
         );


### PR DESCRIPTION
Fixes a frontend typecheck error on main: `LauncherDock.tsx` passes `getLauncherAgentUuid(selectedAgent)` (`string | null`) to `openPanel`, which requires a non-null `agentUuid`. This is a semantic conflict between #25240 and later launcher changes — each PR passed CI individually, but their combination on main fails `typecheck:fast`, which now breaks CI for any PR rebased onto latest main (first seen on #25281).

The fix resolves the uuid first and returns early when null, matching the existing guard pattern in `AiAgentsLauncher.tsx`.

Relates: #25240

🤖 Generated with [Claude Code](https://claude.com/claude-code)