### PR TITLE
fix(pivot): never freeze pivoted data columns, keep scroll working

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -70,11 +70,18 @@ type ColumnConfigurationProps = {
      * When provided, the freeze toggle controls all listed fieldIds together.
      */
     syncFreezeWith?: string[];
+
+    /**
+     * Hides the freeze toggle for fields that can't be meaningfully frozen,
+     * e.g. metrics in a pivoted table with metrics as columns.
+     */
+    hideFreezeToggle?: boolean;
 };
 
 const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     fieldId,
     syncFreezeWith,
+    hideFreezeToggle = false,
 }) => {
     const { pivotDimensions, visualizationConfig, resultsData } =
         useVisualizationContext();
@@ -108,7 +115,7 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     );
 
     // Pivoted dimensions become column headers and can't be frozen.
-    const shouldShowFreezeToggle = !isPivotingDimension;
+    const shouldShowFreezeToggle = !isPivotingDimension && !hideFreezeToggle;
 
     // When syncFreezeWith is set, the lock visually reflects "any sibling
     // frozen" and clicking flips the entire group in lockstep.

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -238,6 +238,12 @@ const GeneralSettings: FC = () => {
                         // metricsAsRows: there's one shared label column for
                         // all metrics, so freeze lock icons should sync.
                         syncFreezeWith={metricsAsRows ? metrics : undefined}
+                        // Pivoted with metrics as columns: the pivoted data
+                        // columns can't be frozen, so the toggle would do
+                        // nothing.
+                        hideFreezeToggle={
+                            !!isPivotTableEnabled && !metricsAsRows
+                        }
                     />
                 ))}
             </Config.Section>

--- a/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts
@@ -133,7 +133,9 @@ describe('getFrozenColumnLayout', () => {
         });
     });
 
-    it('uses underlyingId/baseId as the freeze key for data columns', () => {
+    it('never freezes data columns, even when their base field is frozen', () => {
+        // All data columns share the same base field — freezing them would pin
+        // the entire data area and break horizontal scrolling.
         const layout = getFrozenColumnLayout({
             pivotColumnInfo: [
                 indexCol('orders_category'),
@@ -141,21 +143,18 @@ describe('getFrozenColumnLayout', () => {
                 dataCol('total_count__pivot_1', 'total_count'),
             ],
             columnProperties: {
+                orders_category: { frozen: true, width: 120 },
                 total_count: { frozen: true, width: 90 },
             },
             rowNumberWidth: 0,
             defaultColumnWidth: 100,
         });
-        // Both pivot slices of the same metric become sticky because the freeze
-        // key resolves to the metric's baseId.
-        expect(layout.get('total_count__pivot_0')).toEqual({
+        expect(layout.get('orders_category')).toEqual({
             left: 0,
-            isLast: false,
-        });
-        expect(layout.get('total_count__pivot_1')).toEqual({
-            left: 90,
             isLast: true,
         });
+        expect(layout.has('total_count__pivot_0')).toBe(false);
+        expect(layout.has('total_count__pivot_1')).toBe(false);
     });
 
     it('freezes the label column when labelColumnFrozen is true', () => {
@@ -190,7 +189,9 @@ describe('getFrozenColumnLayout', () => {
         expect(layout.size).toBe(0);
     });
 
-    it('prefers underlyingId over baseId as the freeze key for data columns', () => {
+    it('ignores frozen underlyingId and baseId fields on data columns', () => {
+        // A stale frozen flag on the pivoted dimension (baseId) or the metric
+        // (underlyingId) must not freeze the pivoted data columns.
         const layout = getFrozenColumnLayout({
             pivotColumnInfo: [
                 {
@@ -202,16 +203,37 @@ describe('getFrozenColumnLayout', () => {
             ],
             columnProperties: {
                 orders_total_count: { frozen: true, width: 90 },
-                // baseId match would also resolve to frozen, but underlyingId
-                // takes priority — this property has frozen: false to prove it.
-                orders_shipping_method: { frozen: false },
+                orders_shipping_method: { frozen: true },
             },
             rowNumberWidth: 0,
             defaultColumnWidth: 100,
         });
-        expect(layout.get('orders_total_count__pivot_0')).toEqual({
-            left: 0,
-            isLast: true,
+        expect(layout.size).toBe(0);
+    });
+
+    it('does not freeze rowTotal or passthrough columns', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                {
+                    fieldId: 'row-total-0',
+                    baseId: 'orders_total_count',
+                    underlyingId: undefined,
+                    columnType: 'rowTotal',
+                },
+                {
+                    fieldId: 'orders_status',
+                    baseId: 'orders_status',
+                    underlyingId: undefined,
+                    columnType: 'passthrough',
+                },
+            ],
+            columnProperties: {
+                orders_total_count: { frozen: true },
+                orders_status: { frozen: true },
+            },
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
         });
+        expect(layout.size).toBe(0);
     });
 });

--- a/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
+++ b/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
@@ -29,10 +29,13 @@ type Args = {
 };
 
 const getFreezeKey = (col: PivotColumn): string | undefined => {
+    // Only row-index and label columns are freezable. Data-value columns all
+    // share one underlying field, so honoring its frozen flag would pin the
+    // entire data area and break horizontal scrolling.
     if (col.columnType === 'indexValue' || col.columnType === 'label') {
         return col.fieldId;
     }
-    return col.underlyingId ?? col.baseId;
+    return undefined;
 };
 
 const getColumnWidth = (


### PR DESCRIPTION
### Description

In a pivoted table chart, a `frozen: true` flag on the field underlying the pivot data columns pinned **every** data column as sticky at its natural offset, which made horizontal scrolling look broken: data columns never moved, the non-frozen index/label columns scrolled away underneath, and only the trailing edge shifted at the end of the scroll range.

Two ways into that state:
- **Metrics as columns**: freezing a metric via the config panel froze all of its pivoted value columns (the freeze key resolved to `underlyingId`).
- **Metrics as rows**: a stale `frozen: true` on a dimension that was later pivoted froze all data columns (the freeze key resolved to `baseId`, which is the pivot dimension in that mode), with no way to unfreeze since the toggle is hidden for pivoting dimensions.

### Fix

- `getFrozenColumnLayout` now only honors `frozen` for `indexValue` and `label` columns and ignores it on data-value columns (also `rowTotal`/`passthrough`). This heals existing saved charts without any config migration.
- The config panel hides the freeze toggle for metrics while the table is pivoted with metrics as columns, since it can no longer do anything there. In metrics-as-rows mode the metric toggle still drives the shared label column via `syncFreezeWith`.

### How was it tested

- Unit tests: rewrote the two tests that asserted the old data-column freeze behavior and added coverage for stale frozen `baseId`/`underlyingId` fields and `rowTotal`/`passthrough` columns.
- Verified in the local app for both variants: data columns scroll normally again, a frozen index dimension still pins correctly, and the label-column freeze in metrics-as-rows mode still works.

**Before**

https://github.com/user-attachments/assets/ad365a5e-8ed0-4943-8cac-19f3fe245d5f


**After**

https://github.com/user-attachments/assets/7db9f89b-e356-4432-adfb-0a67aa100000



Closes: PROD-8744
Closes: #25283
