### PR TITLE
feat(permissions): add view:ContentVerification scope for read-only discovery

### DIFF
--- a/packages/backend/src/services/ContentVerificationService.test.ts
+++ b/packages/backend/src/services/ContentVerificationService.test.ts
@@ -51,6 +51,15 @@ const editorUser: SessionUser = {
     ]),
 };
 
+const viewOnlyUser: SessionUser = {
+    ...adminUser,
+    userUuid: 'view-only-uuid',
+    role: OrganizationMemberRole.INTERACTIVE_VIEWER,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'ContentVerification', action: 'view' },
+    ]),
+};
+
 const mockVerifiedItems: VerifiedContentListItem[] = [
     {
         uuid: 'cv-uuid-1',
@@ -93,7 +102,7 @@ describe('ContentVerificationService', () => {
     });
 
     describe('listVerifiedContent', () => {
-        it('should throw ForbiddenError when user lacks manage:ContentVerification', async () => {
+        it('should throw ForbiddenError when user lacks view:ContentVerification', async () => {
             await expect(
                 service.listVerifiedContent(editorUser, 'project-uuid'),
             ).rejects.toThrow(ForbiddenError);
@@ -101,6 +110,18 @@ describe('ContentVerificationService', () => {
             expect(
                 contentVerificationModel.getAllForProject,
             ).not.toHaveBeenCalled();
+        });
+
+        it('should return verified content when user has view:ContentVerification', async () => {
+            const result = await service.listVerifiedContent(
+                viewOnlyUser,
+                'project-uuid',
+            );
+
+            expect(result).toEqual(mockVerifiedItems);
+            expect(
+                contentVerificationModel.getAllForProject,
+            ).toHaveBeenCalledWith('project-uuid');
         });
 
         it('should return verified content when user is admin', async () => {

--- a/packages/backend/src/services/ContentVerificationService.test.ts
+++ b/packages/backend/src/services/ContentVerificationService.test.ts
@@ -11,6 +11,7 @@ import {
 import { ContentVerificationModel } from '../models/ContentVerificationModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
 import { ContentVerificationService } from './ContentVerificationService';
+import { SpacePermissionService } from './SpaceService/SpacePermissionService';
 
 const projectSummary = {
     organizationUuid: 'org-uuid',
@@ -90,11 +91,17 @@ const contentVerificationModel = {
     getAllForProject: vi.fn(async () => mockVerifiedItems),
 };
 
+const spacePermissionService = {
+    getAccessibleSpaceUuids: vi.fn(async () => ['space-uuid']),
+};
+
 describe('ContentVerificationService', () => {
     const service = new ContentVerificationService({
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
         projectModel: projectModel as unknown as ProjectModel,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
     });
 
     afterEach(() => {
@@ -124,7 +131,7 @@ describe('ContentVerificationService', () => {
             ).toHaveBeenCalledWith('project-uuid');
         });
 
-        it('should return verified content when user is admin', async () => {
+        it('should return verified content the user can access', async () => {
             const result = await service.listVerifiedContent(
                 adminUser,
                 'project-uuid',
@@ -134,6 +141,22 @@ describe('ContentVerificationService', () => {
             expect(
                 contentVerificationModel.getAllForProject,
             ).toHaveBeenCalledWith('project-uuid');
+            expect(
+                spacePermissionService.getAccessibleSpaceUuids,
+            ).toHaveBeenCalledWith('view', adminUser, ['space-uuid']);
+        });
+
+        it('should filter out verified content in spaces the user cannot access', async () => {
+            spacePermissionService.getAccessibleSpaceUuids.mockResolvedValueOnce(
+                [],
+            );
+
+            const result = await service.listVerifiedContent(
+                adminUser,
+                'project-uuid',
+            );
+
+            expect(result).toEqual([]);
         });
     });
 });

--- a/packages/backend/src/services/ContentVerificationService.ts
+++ b/packages/backend/src/services/ContentVerificationService.ts
@@ -9,10 +9,12 @@ import { logAuditEvent } from '../logging/winston';
 import { ContentVerificationModel } from '../models/ContentVerificationModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
 import { BaseService } from './BaseService';
+import { SpacePermissionService } from './SpaceService/SpacePermissionService';
 
 type ContentVerificationServiceArguments = {
     contentVerificationModel: ContentVerificationModel;
     projectModel: ProjectModel;
+    spacePermissionService: SpacePermissionService;
 };
 
 export class ContentVerificationService extends BaseService {
@@ -20,13 +22,17 @@ export class ContentVerificationService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly spacePermissionService: SpacePermissionService;
+
     constructor({
         contentVerificationModel,
         projectModel,
+        spacePermissionService,
     }: ContentVerificationServiceArguments) {
         super({ serviceName: 'ContentVerificationService' });
         this.contentVerificationModel = contentVerificationModel;
         this.projectModel = projectModel;
+        this.spacePermissionService = spacePermissionService;
     }
 
     async listVerifiedContent(
@@ -54,6 +60,17 @@ export class ContentVerificationService extends BaseService {
             );
         }
 
-        return this.contentVerificationModel.getAllForProject(projectUuid);
+        const items =
+            await this.contentVerificationModel.getAllForProject(projectUuid);
+
+        const accessibleSpaceUuids = new Set(
+            await this.spacePermissionService.getAccessibleSpaceUuids(
+                'view',
+                user,
+                [...new Set(items.map((item) => item.spaceUuid))],
+            ),
+        );
+
+        return items.filter((item) => accessibleSpaceUuids.has(item.spaceUuid));
     }
 }

--- a/packages/backend/src/services/ContentVerificationService.ts
+++ b/packages/backend/src/services/ContentVerificationService.ts
@@ -41,7 +41,7 @@ export class ContentVerificationService extends BaseService {
 
         if (
             auditedAbility.cannot(
-                'manage',
+                'view',
                 subject('ContentVerification', {
                     organizationUuid: project.organizationUuid,
                     projectUuid,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1287,6 +1287,7 @@ export class ServiceRepository
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
                     projectModel: this.models.getProjectModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -248,6 +248,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('create', 'AiAgentThread', {
             organizationUuid: member.organizationUuid,
         });
+        can('view', 'ContentVerification', {
+            organizationUuid: member.organizationUuid,
+        });
     },
     editor(member, { can }) {
         applyOrganizationMemberStaticAbilities.interactive_viewer(member, {

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -206,6 +206,9 @@ export const projectMemberAbilities: Record<
         can('create', 'AiAgentThread', {
             projectUuid: member.projectUuid,
         });
+        can('view', 'ContentVerification', {
+            projectUuid: member.projectUuid,
+        });
     },
     editor(member, { can }) {
         projectMemberAbilities.interactive_viewer(member, { can });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -72,6 +72,7 @@ const BASE_ROLE_SCOPES = {
         'view:DataApp@self', // Own personal apps
         'manage:DataApp@self', // Own personal apps
         'view:ExternalConnection', // Select/link connections in the app builder (manage stays admin-only)
+        'view:ContentVerification', // Read-only discovery of verified content (manage stays developer-level)
     ],
 
     [ProjectMemberRole.EDITOR]: [

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -408,6 +408,14 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'view:ContentVerification',
+        description: 'View verified charts and dashboards',
+        isEnterprise: false,
+        group: ScopeGroup.CONTENT,
+        dependencies: [{ name: 'view:Project' }],
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:ContentVerification',
         description: 'Verify and unverify charts and dashboards',
         isEnterprise: false,

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -187,6 +187,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('view', 'OrganizationDesign', {
             organizationUuid,
         });
+        can('view', 'ContentVerification', {
+            organizationUuid,
+        });
     },
     [ServiceAccountScope.ORG_EDIT]: ({
         organizationUuid,


### PR DESCRIPTION
Closes: #25284

## Problem

`list_verified_content` (and `ContentVerificationService.listVerifiedContent()`) required `manage:ContentVerification` — a Developer-level scope that also grants verify/unverify. Admins had no way to give a service account or AI agent read-only access to discover verified content without also handing over verification management rights.

Separately, `listVerifiedContent()` returned **every** verified chart/dashboard in the project with no space-access filtering — leaking name/description/space/explore/owner metadata for content in private spaces the caller can't open. Widening the read path to interactive viewers and read-only service accounts makes that leak materially worse, so both are fixed together here.

## Approach

**1. Split the read path off the write scope**

- Add a new `view:ContentVerification` scope ("View verified charts and dashboards") in the Content group.
- Grant it to `interactive_viewer` (project + org abilities) and the `org:read` service account role, so Editor-level/interactive-viewer custom roles and read-only service accounts can discover verified content.
- `listVerifiedContent()` now checks `view` instead of `manage`.
- `manage:ContentVerification` still gates the actual verify/unverify write actions (unchanged), and `manage` implies `view` so Developers/Admins keep access.

This is a purely additive scope, so no `scoped_roles` migration is required. The custom role editor surfaces the new scope automatically since it's data-driven from `scopes.ts`.

**2. Filter the verified list by the caller's space access**

- `listVerifiedContent()` now post-filters results through `SpacePermissionService.getAccessibleSpaceUuids('view', user, spaceUuids)` — the same primitive `ContentService` / `SearchService` use — so callers only see verified content in spaces they can actually access (public/shared, private-with-membership, and nested-inherited all handled by the existing chain resolver).

## Testing

- `packages/common` authorization suite (incl. role↔scope parity) passes.
- `ContentVerificationService.test.ts` updated: a view-only user can now list, an Editor without the scope is still forbidden, admins still succeed, and content in a space the caller can't access is filtered out.

### Manual verification (local, Jaffle shop)

Scope boundary — `GET /api/v1/projects/{uuid}/content-verification`:

| Principal | Scope | Result |
|-----------|-------|--------|
| Admin | `manage` (⊇ `view`) | 200 |
| Editor | `view` (via `interactive_viewer`) | 200 |
| Viewer | none | 403 |

Space-access filter — verified a chart in a private, admin-only space, then listed as each user:

| Principal | Accessible spaces resolved | Verified items returned |
|-----------|---------------------------|-------------------------|
| Admin | `[private, shared]` | 2 (incl. the admin-only chart) |
| Editor | `[shared]` only | 1 (private-space chart **filtered out**) |

Confirmed the filter does not over-restrict: content the editor legitimately accesses still passes through (cross-checked against the same access resolution used by `/spaces` and v2 `/content`).