### PR TITLE
fix: keep OAuth MCP client setup reusable

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -222,6 +222,9 @@ export type AiMcpOAuthCredentialPayload = {
     };
     clientInformation?: Record<string, unknown>;
     clientMetadata?: Record<string, unknown>;
+    clientRegistration?: {
+        initialAccessToken?: string;
+    };
     codeVerifier?: string;
     state?: string;
     authorizationServerUrl?: string;
@@ -938,6 +941,7 @@ export class AiAgentModel {
     private static serializeMcpCredentialPayload(
         authType: ApiCreateAiMcpServer['authType'],
         credentials: ApiCreateAiMcpServer['credentials'],
+        credentialScope: AiMcpCredentialScope,
     ): AiMcpCredentialPayload | null {
         switch (authType) {
             case 'none':
@@ -954,7 +958,38 @@ export class AiAgentModel {
                     bearerToken: credentials.bearerToken,
                 };
             case 'oauth':
-                return null;
+                if (
+                    !credentials?.oauthClientInformation &&
+                    !credentials?.oauthClientRegistration?.initialAccessToken
+                ) {
+                    return null;
+                }
+
+                return {
+                    type: 'oauth',
+                    credentialScope,
+                    connectionStatus: 'not_connected',
+                    clientInformation: credentials.oauthClientInformation
+                        ? {
+                              client_id:
+                                  credentials.oauthClientInformation.clientId,
+                              client_secret:
+                                  credentials.oauthClientInformation
+                                      .clientSecret,
+                              token_endpoint_auth_method:
+                                  credentials.oauthClientInformation
+                                      .tokenEndpointAuthMethod,
+                          }
+                        : undefined,
+                    clientRegistration: credentials.oauthClientRegistration
+                        ?.initialAccessToken
+                        ? {
+                              initialAccessToken:
+                                  credentials.oauthClientRegistration
+                                      .initialAccessToken,
+                          }
+                        : undefined,
+                };
             default:
                 return assertUnreachable(
                     authType,
@@ -1633,6 +1668,7 @@ export class AiAgentModel {
                 AiAgentModel.serializeMcpCredentialPayload(
                     args.authType,
                     args.credentials,
+                    credentialScope,
                 );
 
             const credential =

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -597,6 +597,165 @@ describe('AiAgentService MCP support', () => {
         ).resolves.toBeUndefined();
     });
 
+    it('stores OAuth MCP client registration credentials during server creation', async () => {
+        const services = getServices(context.app);
+        const models = getModels(context.app);
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const clientId = `client-${suffix}`;
+
+        const mcpServer = await services.aiAgentService.createMcpServer(
+            context.testUser,
+            SEED_PROJECT.project_uuid,
+            {
+                name: `OAuth DCR MCP ${suffix}`,
+                url: mcpServerUrl,
+                authType: 'oauth',
+                credentials: {
+                    oauthClientInformation: {
+                        clientId,
+                        clientSecret: 'client-secret',
+                        tokenEndpointAuthMethod: 'client_secret_post',
+                    },
+                    oauthClientRegistration: {
+                        initialAccessToken: 'dcr-token',
+                    },
+                },
+            },
+        );
+
+        expect(mcpServer.hasCredentials).toBe(true);
+        expect(mcpServer.credentialScope).toBe('shared');
+        expect(mcpServer.connectionStatus).toBe('not_connected');
+
+        await expect(
+            models.aiAgentModel.getCredential(mcpServer.uuid, 'shared'),
+        ).resolves.toMatchObject({
+            credentials: {
+                type: 'oauth',
+                credentialScope: 'shared',
+                connectionStatus: 'not_connected',
+                clientInformation: {
+                    client_id: clientId,
+                    client_secret: 'client-secret',
+                    token_endpoint_auth_method: 'client_secret_post',
+                },
+                clientRegistration: {
+                    initialAccessToken: 'dcr-token',
+                },
+            },
+        });
+    });
+
+    it('rejects confidential OAuth MCP client authentication without a client secret', async () => {
+        const services = getServices(context.app);
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const invalidOAuthClientInformation = [
+            {
+                clientId: `client-basic-${suffix}`,
+                tokenEndpointAuthMethod: 'client_secret_basic',
+            },
+            {
+                clientId: `client-post-${suffix}`,
+                clientSecret: '   ',
+                tokenEndpointAuthMethod: 'client_secret_post',
+            },
+        ] as const;
+
+        await Promise.all(
+            invalidOAuthClientInformation.map((oauthClientInformation, index) =>
+                expect(
+                    services.aiAgentService.createMcpServer(
+                        context.testUser,
+                        SEED_PROJECT.project_uuid,
+                        {
+                            name: `Invalid Confidential OAuth ${suffix}-${index}`,
+                            url: mcpServerUrl,
+                            authType: 'oauth',
+                            credentials: {
+                                oauthClientInformation,
+                            },
+                        },
+                    ),
+                ).rejects.toThrow(
+                    'OAuth client secret is required when OAuth token endpoint authentication method uses a client secret',
+                ),
+            ),
+        );
+    });
+
+    it('seeds personal OAuth connections with shared client registration setup', async () => {
+        const services = getServices(context.app);
+        const models = getModels(context.app);
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const clientId = `client-${suffix}`;
+
+        const mcpServer = await services.aiAgentService.createMcpServer(
+            context.testUser,
+            SEED_PROJECT.project_uuid,
+            {
+                name: `Personal OAuth DCR MCP ${suffix}`,
+                url: mcpServerUrl,
+                authType: 'oauth',
+                credentials: {
+                    oauthClientInformation: {
+                        clientId,
+                        clientSecret: 'client-secret',
+                        tokenEndpointAuthMethod: 'client_secret_post',
+                    },
+                    oauthClientRegistration: {
+                        initialAccessToken: 'dcr-token',
+                    },
+                },
+            },
+        );
+
+        const runtimeClient = Reflect.get(
+            services.aiAgentService,
+            'aiAgentMcpRuntimeClient',
+        ) as RuntimeClientSpies;
+        const startOAuthConnectionSpy = vi
+            .spyOn(runtimeClient, 'startOAuthConnection')
+            .mockResolvedValue('https://example.com/oauth');
+
+        await expect(
+            services.aiAgentService.startMcpOAuthConnection(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                mcpServer.uuid,
+            ),
+        ).resolves.toBe('https://example.com/oauth');
+
+        expect(startOAuthConnectionSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                mcpServerUuid: mcpServer.uuid,
+                credentialScope: 'user',
+                userUuid: context.testUser.userUuid,
+            }),
+        );
+
+        await expect(
+            models.aiAgentModel.getCredential(mcpServer.uuid, 'user', {
+                userUuid: context.testUser.userUuid,
+            }),
+        ).resolves.toMatchObject({
+            credentials: {
+                type: 'oauth',
+                credentialScope: 'user',
+                connectionStatus: 'not_connected',
+                clientInformation: {
+                    client_id: clientId,
+                    client_secret: 'client-secret',
+                    token_endpoint_auth_method: 'client_secret_post',
+                },
+                clientRegistration: {
+                    initialAccessToken: 'dcr-token',
+                },
+            },
+        });
+
+        startOAuthConnectionSpy.mockRestore();
+    });
+
     it('does not let non-managers enable shared OAuth credentials during server creation', async () => {
         const services = getServices(context.app);
         const editorUser = getProjectUser(context, {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -208,6 +208,7 @@ import {
     type AiAgentMcpServerToolPermissionSetting,
     type AiAgentMcpServerToolPermissionSettingUpdate,
     type AiMcpCredential,
+    type AiMcpOAuthCredentialPayload,
     type AiMcpServerWithSensitiveData,
 } from '../../models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
@@ -3181,6 +3182,41 @@ export class AiAgentService extends BaseService {
             .then((tools) => tools.map(AiAgentService.toApiAgentMcpServerTool));
     }
 
+    private static normalizeOAuthMcpCredentials(
+        credentials: ApiCreateAiMcpServer['credentials'],
+    ): ApiCreateAiMcpServer['credentials'] {
+        const clientId =
+            credentials?.oauthClientInformation?.clientId?.trim() || undefined;
+        const clientSecret =
+            credentials?.oauthClientInformation?.clientSecret?.trim() ||
+            undefined;
+        const tokenEndpointAuthMethod =
+            credentials?.oauthClientInformation?.tokenEndpointAuthMethod;
+        const initialAccessToken =
+            credentials?.oauthClientRegistration?.initialAccessToken?.trim() ||
+            undefined;
+
+        const oauthClientInformation = clientId
+            ? {
+                  clientId,
+                  clientSecret,
+                  tokenEndpointAuthMethod,
+              }
+            : undefined;
+        const oauthClientRegistration = initialAccessToken
+            ? {
+                  initialAccessToken,
+              }
+            : undefined;
+
+        return oauthClientInformation || oauthClientRegistration
+            ? {
+                  oauthClientInformation,
+                  oauthClientRegistration,
+              }
+            : null;
+    }
+
     public async createMcpServer(
         user: SessionUser,
         projectUuid: string,
@@ -3211,9 +3247,18 @@ export class AiAgentService extends BaseService {
 
         switch (body.authType) {
             case 'none':
-                if (body.credentials?.bearerToken) {
+                if (body.credentials?.bearerToken?.trim()) {
                     throw new ParameterError(
                         'Credentials are not allowed for auth type "none"',
+                    );
+                }
+                if (
+                    AiAgentService.normalizeOAuthMcpCredentials(
+                        body.credentials,
+                    )
+                ) {
+                    throw new ParameterError(
+                        'OAuth client credentials are only allowed for auth type "oauth"',
                     );
                 }
                 if (body.credentialScope !== undefined) {
@@ -3228,9 +3273,18 @@ export class AiAgentService extends BaseService {
                 }
                 break;
             case 'bearer':
-                if (!body.credentials?.bearerToken.trim()) {
+                if (!body.credentials?.bearerToken?.trim()) {
                     throw new ParameterError(
                         'Bearer MCP servers require a bearer token',
+                    );
+                }
+                if (
+                    AiAgentService.normalizeOAuthMcpCredentials(
+                        body.credentials,
+                    )
+                ) {
+                    throw new ParameterError(
+                        'OAuth client credentials are only allowed for auth type "oauth"',
                     );
                 }
                 if (allowOAuthCredentialSharing) {
@@ -3239,10 +3293,44 @@ export class AiAgentService extends BaseService {
                     );
                 }
                 break;
-            case 'oauth':
+            case 'oauth': {
                 if (body.credentials?.bearerToken) {
                     throw new ParameterError(
                         'Bearer credentials are not allowed for auth type "oauth"',
+                    );
+                }
+                const oauthClientInformation =
+                    body.credentials?.oauthClientInformation;
+                if (
+                    oauthClientInformation?.tokenEndpointAuthMethod &&
+                    ![
+                        'none',
+                        'client_secret_basic',
+                        'client_secret_post',
+                    ].includes(oauthClientInformation.tokenEndpointAuthMethod)
+                ) {
+                    throw new ParameterError(
+                        'Unsupported OAuth token endpoint authentication method',
+                    );
+                }
+                if (
+                    (oauthClientInformation?.clientSecret?.trim() ||
+                        oauthClientInformation?.tokenEndpointAuthMethod) &&
+                    !oauthClientInformation.clientId?.trim()
+                ) {
+                    throw new ParameterError(
+                        'OAuth client ID is required when OAuth client secret or token endpoint authentication method is provided',
+                    );
+                }
+                if (
+                    oauthClientInformation?.tokenEndpointAuthMethod &&
+                    ['client_secret_basic', 'client_secret_post'].includes(
+                        oauthClientInformation.tokenEndpointAuthMethod,
+                    ) &&
+                    !oauthClientInformation.clientSecret?.trim()
+                ) {
+                    throw new ParameterError(
+                        'OAuth client secret is required when OAuth token endpoint authentication method uses a client secret',
                     );
                 }
                 if (body.credentialScope !== undefined) {
@@ -3251,6 +3339,7 @@ export class AiAgentService extends BaseService {
                     );
                 }
                 break;
+            }
             default:
                 assertUnreachable(
                     body.authType,
@@ -3258,12 +3347,16 @@ export class AiAgentService extends BaseService {
                 );
         }
 
-        const credentials =
-            body.authType === 'bearer'
-                ? {
-                      bearerToken: body.credentials!.bearerToken.trim(),
-                  }
-                : null;
+        let credentials: ApiCreateAiMcpServer['credentials'] = null;
+        if (body.authType === 'bearer') {
+            credentials = {
+                bearerToken: body.credentials!.bearerToken!.trim(),
+            };
+        } else if (body.authType === 'oauth') {
+            credentials = AiAgentService.normalizeOAuthMcpCredentials(
+                body.credentials,
+            );
+        }
 
         let mcpConnectionMetadata: { iconUrl: string | null } | null = null;
 
@@ -3548,6 +3641,71 @@ export class AiAgentService extends BaseService {
         );
     }
 
+    private async seedUserMcpOAuthClientSetup(args: {
+        mcpServerUuid: string;
+        userUuid: string;
+        actorUserUuid: string;
+    }): Promise<void> {
+        const sharedCredential = await this.aiAgentModel.getCredential(
+            args.mcpServerUuid,
+            'shared',
+        );
+
+        if (sharedCredential?.credentials.type !== 'oauth') {
+            return;
+        }
+
+        const { clientInformation, clientMetadata, clientRegistration } =
+            sharedCredential.credentials;
+
+        if (!clientInformation && !clientRegistration) {
+            return;
+        }
+
+        const userCredential = await this.aiAgentModel.getCredential(
+            args.mcpServerUuid,
+            'user',
+            {
+                userUuid: args.userUuid,
+            },
+        );
+        const userPayload: AiMcpOAuthCredentialPayload =
+            userCredential?.credentials.type === 'oauth'
+                ? userCredential.credentials
+                : {
+                      type: 'oauth',
+                      credentialScope: 'user',
+                      connectionStatus: 'not_connected',
+                  };
+        const nextClientInformation =
+            userPayload.clientInformation ?? clientInformation;
+        const nextClientMetadata = userPayload.clientMetadata ?? clientMetadata;
+        const nextClientRegistration =
+            userPayload.clientRegistration ?? clientRegistration;
+
+        if (
+            nextClientInformation === userPayload.clientInformation &&
+            nextClientMetadata === userPayload.clientMetadata &&
+            nextClientRegistration === userPayload.clientRegistration
+        ) {
+            return;
+        }
+
+        await this.aiAgentModel.upsertCredential({
+            serverUuid: args.mcpServerUuid,
+            scope: 'user',
+            userUuid: args.userUuid,
+            credentials: {
+                ...userPayload,
+                credentialScope: 'user',
+                clientInformation: nextClientInformation,
+                clientMetadata: nextClientMetadata,
+                clientRegistration: nextClientRegistration,
+            },
+            actorUserUuid: args.actorUserUuid,
+        });
+    }
+
     public async startMcpOAuthConnection(
         user: SessionUser,
         projectUuid: string,
@@ -3578,6 +3736,14 @@ export class AiAgentService extends BaseService {
             await this.assertCanManageMcpServers(user, projectUuid);
         } else {
             await this.assertCanUsePersonalMcpCredentials(user, projectUuid);
+        }
+
+        if (credentialScope === 'user') {
+            await this.seedUserMcpOAuthClientSetup({
+                mcpServerUuid,
+                userUuid: user.userUuid,
+                actorUserUuid: user.userUuid,
+            });
         }
 
         return this.aiAgentMcpRuntimeClient.startOAuthConnection({

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -1,7 +1,11 @@
 import * as mcpSdk from '@ai-sdk/mcp';
 import type { MCPClient } from '@ai-sdk/mcp';
 import type { LightdashConfig } from '../../../config/parseConfig';
-import type { AiAgentModel } from '../../models/AiAgentModel';
+import type {
+    AiAgentModel,
+    AiMcpCredential,
+    AiMcpOAuthCredentialPayload,
+} from '../../models/AiAgentModel';
 import {
     AiAgentMcpRuntimeClient,
     createHttpMcpClient,
@@ -13,6 +17,13 @@ import type { AiAgentMcpServer } from './types/aiAgent';
 vi.mock('@ai-sdk/mcp', async () => ({
     ...(await vi.importActual<typeof import('@ai-sdk/mcp')>('@ai-sdk/mcp')),
     createMCPClient: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@modelcontextprotocol/sdk/client/auth.js', () => ({
+    auth: authMock,
+    UnauthorizedError: class UnauthorizedError extends Error {},
 }));
 
 const getMcpServer = (
@@ -435,5 +446,327 @@ describe('createHttpMcpClient', () => {
         } finally {
             fetchSpy.mockRestore();
         }
+    });
+});
+
+const getOAuthCredential = (
+    payload: AiMcpOAuthCredentialPayload,
+    overrides: Partial<AiMcpCredential> = {},
+): AiMcpCredential => ({
+    uuid: 'credential-uuid',
+    mcpServerUuid: 'mcp-server-uuid',
+    credentialScope: payload.credentialScope,
+    userUuid: payload.credentialScope === 'user' ? 'user-uuid' : null,
+    createdByUserUuid: 'user-uuid',
+    updatedByUserUuid: 'user-uuid',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    credentials: payload,
+    ...overrides,
+});
+
+const getOAuthRuntimeClient = (payload: AiMcpOAuthCredentialPayload) => {
+    let storedPayload = payload;
+    const aiAgentModel = {
+        getCredential: vi.fn(async () => getOAuthCredential(storedPayload)),
+        upsertCredential: vi.fn(async (args) => {
+            storedPayload = args.credentials;
+            return getOAuthCredential(storedPayload, {
+                mcpServerUuid: args.serverUuid,
+                credentialScope: args.scope,
+                userUuid: args.userUuid ?? null,
+                createdByUserUuid: args.actorUserUuid ?? null,
+                updatedByUserUuid: args.actorUserUuid ?? null,
+            });
+        }),
+    };
+
+    return new AiAgentMcpRuntimeClient({
+        aiAgentModel: aiAgentModel as unknown as AiAgentModel,
+        lightdashConfig: {
+            siteUrl: 'https://lightdash.example.com',
+        } as LightdashConfig,
+    });
+};
+
+describe('startOAuthConnection', () => {
+    beforeEach(() => {
+        authMock.mockReset();
+        vi.unstubAllGlobals();
+    });
+
+    it('adds the initial access token to dynamic client registration requests', async () => {
+        let registrationAuthorizationHeader: string | null = null;
+        const fetchMock = vi.fn(async (input, init) => {
+            const url = input instanceof Request ? input.url : input.toString();
+
+            if (url === 'https://auth.example.com/.well-known/oauth') {
+                return new Response(
+                    JSON.stringify({
+                        registration_endpoint:
+                            'https://auth.example.com/dcr/register',
+                    }),
+                    {
+                        headers: {
+                            'content-type': 'application/json',
+                        },
+                    },
+                );
+            }
+
+            if (url === 'https://auth.example.com/dcr/register') {
+                registrationAuthorizationHeader = new Headers(
+                    init?.headers,
+                ).get('Authorization');
+                return new Response(
+                    JSON.stringify({
+                        client_id: 'registered-client-id',
+                    }),
+                    {
+                        headers: {
+                            'content-type': 'application/json',
+                        },
+                    },
+                );
+            }
+
+            return new Response('{}');
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        authMock.mockImplementation(async (provider, options) => {
+            expect(options.fetchFn).toEqual(expect.any(Function));
+            await options.fetchFn('https://auth.example.com/.well-known/oauth');
+            await options.fetchFn('https://auth.example.com/dcr/register', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: '{}',
+            });
+            await provider.redirectToAuthorization(
+                new URL('https://auth.example.com/authorize'),
+            );
+        });
+
+        const runtimeClient = getOAuthRuntimeClient({
+            type: 'oauth',
+            credentialScope: 'shared',
+            connectionStatus: 'not_connected',
+            clientRegistration: {
+                initialAccessToken: 'dcr-token',
+            },
+        });
+
+        await expect(
+            runtimeClient.startOAuthConnection({
+                projectUuid: 'project-uuid',
+                mcpServerUuid: 'mcp-server-uuid',
+                credentialScope: 'shared',
+                serverUrl: 'https://mcp.example.com',
+                actorUserUuid: 'user-uuid',
+            }),
+        ).resolves.toBe('https://auth.example.com/authorize');
+
+        expect(registrationAuthorizationHeader).toBe('Bearer dcr-token');
+    });
+
+    it('persists user dynamic client registrations back to shared setup', async () => {
+        const credentials = new Map<string, AiMcpOAuthCredentialPayload>([
+            [
+                'shared:',
+                {
+                    type: 'oauth',
+                    credentialScope: 'shared',
+                    connectionStatus: 'not_connected',
+                    clientRegistration: {
+                        initialAccessToken: 'dcr-token',
+                    },
+                },
+            ],
+            [
+                'user:user-uuid',
+                {
+                    type: 'oauth',
+                    credentialScope: 'user',
+                    connectionStatus: 'not_connected',
+                    clientRegistration: {
+                        initialAccessToken: 'dcr-token',
+                    },
+                },
+            ],
+        ]);
+        const getKey = (scope: string, userUuid?: string | null) =>
+            `${scope}:${scope === 'user' ? (userUuid ?? '') : ''}`;
+        const aiAgentModel = {
+            getCredential: vi.fn(async (_serverUuid, scope, options) => {
+                const storedPayload = credentials.get(
+                    getKey(scope, options?.userUuid),
+                );
+
+                return storedPayload
+                    ? getOAuthCredential(storedPayload, {
+                          credentialScope: scope,
+                          userUuid:
+                              scope === 'user'
+                                  ? (options?.userUuid ?? null)
+                                  : null,
+                      })
+                    : undefined;
+            }),
+            upsertCredential: vi.fn(async (args) => {
+                credentials.set(
+                    getKey(args.scope, args.userUuid),
+                    args.credentials,
+                );
+                return getOAuthCredential(args.credentials, {
+                    mcpServerUuid: args.serverUuid,
+                    credentialScope: args.scope,
+                    userUuid: args.userUuid ?? null,
+                    createdByUserUuid: args.actorUserUuid ?? null,
+                    updatedByUserUuid: args.actorUserUuid ?? null,
+                });
+            }),
+        };
+        const runtimeClient = new AiAgentMcpRuntimeClient({
+            aiAgentModel: aiAgentModel as unknown as AiAgentModel,
+            lightdashConfig: {
+                siteUrl: 'https://lightdash.example.com',
+            } as LightdashConfig,
+        });
+
+        authMock.mockImplementation(async (provider) => {
+            await provider.saveClientInformation({
+                client_id: 'registered-client-id',
+                client_secret: 'registered-client-secret',
+            });
+            await provider.redirectToAuthorization(
+                new URL('https://auth.example.com/authorize'),
+            );
+        });
+
+        await expect(
+            runtimeClient.startOAuthConnection({
+                projectUuid: 'project-uuid',
+                mcpServerUuid: 'mcp-server-uuid',
+                credentialScope: 'user',
+                userUuid: 'user-uuid',
+                serverUrl: 'https://mcp.example.com',
+                actorUserUuid: 'user-uuid',
+            }),
+        ).resolves.toBe('https://auth.example.com/authorize');
+
+        expect(credentials.get('shared:')).toMatchObject({
+            credentialScope: 'shared',
+            connectionStatus: 'not_connected',
+            clientInformation: {
+                client_id: 'registered-client-id',
+                client_secret: 'registered-client-secret',
+            },
+            clientRegistration: {
+                initialAccessToken: 'dcr-token',
+            },
+        });
+    });
+
+    it('uses seeded client information without installing a DCR fetch hook', async () => {
+        authMock.mockImplementation(async (provider, options) => {
+            await expect(provider.clientInformation()).resolves.toMatchObject({
+                client_id: 'client-id',
+                client_secret: 'client-secret',
+            });
+            expect(options.fetchFn).toBeUndefined();
+            await provider.redirectToAuthorization(
+                new URL('https://auth.example.com/authorize'),
+            );
+        });
+
+        const runtimeClient = getOAuthRuntimeClient({
+            type: 'oauth',
+            credentialScope: 'shared',
+            connectionStatus: 'not_connected',
+            clientInformation: {
+                client_id: 'client-id',
+                client_secret: 'client-secret',
+            },
+        });
+
+        await expect(
+            runtimeClient.startOAuthConnection({
+                projectUuid: 'project-uuid',
+                mcpServerUuid: 'mcp-server-uuid',
+                credentialScope: 'shared',
+                serverUrl: 'https://mcp.example.com',
+                actorUserUuid: 'user-uuid',
+            }),
+        ).resolves.toBe('https://auth.example.com/authorize');
+    });
+});
+
+describe('disconnectOAuthConnection', () => {
+    it('preserves OAuth client setup while clearing connection state', async () => {
+        const existingPayload: AiMcpOAuthCredentialPayload = {
+            type: 'oauth',
+            credentialScope: 'shared',
+            connectionStatus: 'connected',
+            tokens: {
+                accessToken: 'access-token',
+                refreshToken: 'refresh-token',
+                tokenType: 'Bearer',
+            },
+            clientInformation: {
+                client_id: 'static-client-id',
+                client_secret: 'static-client-secret',
+                token_endpoint_auth_method: 'client_secret_post',
+            },
+            clientMetadata: {
+                redirect_uris: ['https://lightdash.example.com/callback'],
+            },
+            clientRegistration: {
+                initialAccessToken: 'dcr-token',
+            },
+            codeVerifier: 'code-verifier',
+            state: 'oauth-state',
+        };
+        const aiAgentModel = {
+            getCredential: vi.fn(async () =>
+                getOAuthCredential(existingPayload),
+            ),
+            upsertCredential: vi.fn(async (args) =>
+                getOAuthCredential(args.credentials, {
+                    mcpServerUuid: args.serverUuid,
+                    credentialScope: args.scope,
+                    userUuid: args.userUuid ?? null,
+                    updatedByUserUuid: args.actorUserUuid ?? null,
+                }),
+            ),
+        };
+        const runtimeClient = new AiAgentMcpRuntimeClient({
+            aiAgentModel: aiAgentModel as unknown as AiAgentModel,
+            lightdashConfig: {
+                siteUrl: 'https://lightdash.example.com',
+            } as LightdashConfig,
+        });
+
+        await runtimeClient.disconnectOAuthConnection({
+            mcpServerUuid: 'mcp-server-uuid',
+            credentialScope: 'shared',
+            actorUserUuid: 'user-uuid',
+        });
+
+        expect(aiAgentModel.upsertCredential).toHaveBeenCalledWith({
+            serverUuid: 'mcp-server-uuid',
+            scope: 'shared',
+            credentials: {
+                type: 'oauth',
+                credentialScope: 'shared',
+                connectionStatus: 'not_connected',
+                clientInformation: existingPayload.clientInformation,
+                clientMetadata: existingPayload.clientMetadata,
+                clientRegistration: existingPayload.clientRegistration,
+            },
+            userUuid: undefined,
+            actorUserUuid: 'user-uuid',
+        });
     });
 });

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -64,6 +64,8 @@ type McpServerInfoWithIcons = Configuration & {
     websiteUrl?: string;
 };
 
+type OAuthFetchFn = typeof fetch;
+
 const buildDefaultClientMetadata = (
     redirectUrl: string,
 ): OAuthClientMetadata => ({
@@ -254,6 +256,21 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         return payload.clientInformation as
             | OAuthClientInformationMixed
             | undefined;
+    }
+
+    async clientRegistrationInitialAccessToken(): Promise<string | undefined> {
+        const payload = await this.loadPayload();
+        return payload.clientRegistration?.initialAccessToken;
+    }
+
+    async clientRegistrationEndpoint(): Promise<string | undefined> {
+        const payload = await this.loadPayload();
+        const registrationEndpoint =
+            payload.authorizationServerMetadata?.registration_endpoint;
+
+        return typeof registrationEndpoint === 'string'
+            ? registrationEndpoint
+            : undefined;
     }
 
     async saveClientInformation(
@@ -710,6 +727,40 @@ export class AiAgentMcpRuntimeClient {
         ).toString();
     }
 
+    private async persistSharedOAuthClientInformation(args: {
+        mcpServerUuid: string;
+        clientInformation: Record<string, unknown>;
+        clientMetadata?: Record<string, unknown>;
+        actorUserUuid?: string | null;
+    }): Promise<void> {
+        const sharedCredential = await this.aiAgentModel.getCredential(
+            args.mcpServerUuid,
+            'shared',
+        );
+        const sharedPayload = sharedCredential?.credentials;
+
+        if (
+            sharedPayload?.type !== 'oauth' ||
+            sharedPayload.clientInformation ||
+            !sharedPayload.clientRegistration
+        ) {
+            return;
+        }
+
+        await this.aiAgentModel.upsertCredential({
+            serverUuid: args.mcpServerUuid,
+            scope: 'shared',
+            credentials: {
+                ...sharedPayload,
+                credentialScope: 'shared',
+                clientInformation: args.clientInformation,
+                clientMetadata:
+                    sharedPayload.clientMetadata ?? args.clientMetadata,
+            },
+            actorUserUuid: args.actorUserUuid ?? null,
+        });
+    }
+
     private createMcpOAuthProvider(args: {
         projectUuid: string;
         mcpServerUuid: string;
@@ -742,6 +793,18 @@ export class AiAgentMcpRuntimeClient {
                     userUuid: args.userUuid,
                     actorUserUuid: args.actorUserUuid ?? null,
                 });
+                if (
+                    args.credentialScope === 'user' &&
+                    payload.clientInformation &&
+                    payload.clientRegistration
+                ) {
+                    await this.persistSharedOAuthClientInformation({
+                        mcpServerUuid: args.mcpServerUuid,
+                        clientInformation: payload.clientInformation,
+                        clientMetadata: payload.clientMetadata,
+                        actorUserUuid: args.actorUserUuid,
+                    });
+                }
             },
             onAuthorizationUrl: args.onAuthorizationUrl,
             forceReauth: args.forceReauth,
@@ -789,6 +852,73 @@ export class AiAgentMcpRuntimeClient {
         );
     }
 
+    private static async buildOAuthFetchFn(
+        provider: PersistentMcpOAuthClientProvider,
+    ): Promise<OAuthFetchFn | undefined> {
+        const initialAccessToken =
+            await provider.clientRegistrationInitialAccessToken();
+
+        if (!initialAccessToken) {
+            return undefined;
+        }
+
+        let registrationEndpoint = await provider.clientRegistrationEndpoint();
+
+        return async (input, init) => {
+            const requestUrl =
+                input instanceof Request ? input.url : input.toString();
+            const method = (
+                init?.method ??
+                (input instanceof Request ? input.method : 'GET')
+            ).toUpperCase();
+            const shouldAuthorizeClientRegistration =
+                method === 'POST' &&
+                registrationEndpoint !== undefined &&
+                requestUrl === new URL(registrationEndpoint).toString();
+            const requestInit = shouldAuthorizeClientRegistration
+                ? {
+                      ...init,
+                      headers: new Headers(
+                          init?.headers ??
+                              (input instanceof Request
+                                  ? input.headers
+                                  : undefined),
+                      ),
+                  }
+                : init;
+
+            if (shouldAuthorizeClientRegistration) {
+                (requestInit!.headers as Headers).set(
+                    'Authorization',
+                    `Bearer ${initialAccessToken}`,
+                );
+            }
+
+            const response = await fetch(input, requestInit);
+            const responseContentType =
+                response.headers.get('content-type') ?? '';
+
+            if (
+                !registrationEndpoint &&
+                response.ok &&
+                responseContentType.includes('application/json')
+            ) {
+                try {
+                    const body = await response.clone().json();
+                    if (typeof body?.registration_endpoint === 'string') {
+                        registrationEndpoint = new URL(
+                            body.registration_endpoint,
+                        ).toString();
+                    }
+                } catch {
+                    // Ignore non-JSON discovery responses.
+                }
+            }
+
+            return response;
+        };
+    }
+
     async startOAuthConnection(args: {
         projectUuid: string;
         mcpServerUuid: string;
@@ -812,9 +942,12 @@ export class AiAgentMcpRuntimeClient {
                 authorizationUrl = url;
             },
         });
+        const fetchFn =
+            await AiAgentMcpRuntimeClient.buildOAuthFetchFn(provider);
 
         await auth(provider, {
             serverUrl: args.serverUrl,
+            ...(fetchFn ? { fetchFn } : {}),
         });
 
         if (!authorizationUrl) {
@@ -883,6 +1016,18 @@ export class AiAgentMcpRuntimeClient {
         userUuid?: string;
         actorUserUuid: string;
     }): Promise<void> {
+        const existingCredential = await this.aiAgentModel.getCredential(
+            args.mcpServerUuid,
+            args.credentialScope,
+            {
+                userUuid: args.userUuid,
+            },
+        );
+        const existingPayload =
+            existingCredential?.credentials.type === 'oauth'
+                ? existingCredential.credentials
+                : undefined;
+
         await this.aiAgentModel.upsertCredential({
             serverUuid: args.mcpServerUuid,
             scope: args.credentialScope,
@@ -890,6 +1035,9 @@ export class AiAgentMcpRuntimeClient {
                 type: 'oauth',
                 credentialScope: args.credentialScope,
                 connectionStatus: 'not_connected',
+                clientInformation: existingPayload?.clientInformation,
+                clientMetadata: existingPayload?.clientMetadata,
+                clientRegistration: existingPayload?.clientRegistration,
             },
             userUuid: args.userUuid,
             actorUserUuid: args.actorUserUuid,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12437,8 +12437,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -12683,6 +12683,19 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiMcpServer_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiMcpOAuthTokenEndpointAuthMethod: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['none'] },
+                { dataType: 'enum', enums: ['client_secret_basic'] },
+                { dataType: 'enum', enums: ['client_secret_post'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCreateAiMcpServer: {
         dataType: 'refAlias',
         type: {
@@ -12694,10 +12707,42 @@ const models: TsoaRoute.Models = {
                         {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
-                                bearerToken: {
-                                    dataType: 'string',
-                                    required: true,
+                                oauthClientRegistration: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                initialAccessToken: {
+                                                    dataType: 'string',
+                                                },
+                                            },
+                                        },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
                                 },
+                                oauthClientInformation: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                tokenEndpointAuthMethod: {
+                                                    ref: 'AiMcpOAuthTokenEndpointAuthMethod',
+                                                },
+                                                clientSecret: {
+                                                    dataType: 'string',
+                                                },
+                                                clientId: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                },
+                                bearerToken: { dataType: 'string' },
                             },
                         },
                         { dataType: 'enum', enums: [null] },
@@ -13086,8 +13131,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -14970,11 +15015,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -15032,11 +15077,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -15073,11 +15118,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15092,11 +15137,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15111,11 +15156,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15130,11 +15175,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15293,6 +15338,12 @@ const models: TsoaRoute.Models = {
                                                                                                                             'nestedObjectLiteral',
                                                                                                                         nestedProperties:
                                                                                                                             {
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 settings:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15317,12 +15368,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15443,11 +15488,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15514,46 +15559,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
-                                                                                status: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'success',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'error',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 results:
                                                                                     {
                                                                                         dataType:
@@ -15658,10 +15663,50 @@ const models: TsoaRoute.Models = {
                                                                                         },
                                                                                         required: true,
                                                                                     },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
+                                                                                },
+                                                                                status: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'error',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'success',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
                                                                                 },
                                                                             },
                                                                     },
@@ -15680,11 +15725,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15699,11 +15744,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15718,11 +15763,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15765,10 +15810,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -15776,6 +15817,10 @@ const models: TsoaRoute.Models = {
                                                             enums: [
                                                                 'not_found',
                                                             ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15835,59 +15880,6 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15908,6 +15900,54 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -15918,19 +15958,24 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'metric',
+                                                                                                        'dimension',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'dimension',
+                                                                                                        'metric',
                                                                                                     ],
                                                                                                 },
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 label: {
                                                                                     dataType:
                                                                                         'string',
@@ -15970,6 +16015,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'nestedObjectLiteral',
                                                                                                     nestedProperties:
                                                                                                         {
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             settings:
                                                                                                                 {
                                                                                                                     dataType:
@@ -15994,12 +16045,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16033,12 +16078,6 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -16047,6 +16086,12 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -16225,15 +16270,15 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16252,11 +16297,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16271,11 +16316,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16290,11 +16335,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16309,11 +16354,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16333,6 +16378,11 @@ const models: TsoaRoute.Models = {
                                                                     'nestedObjectLiteral',
                                                                 nestedProperties:
                                                                     {
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
                                                                         kind: {
                                                                             dataType:
                                                                                 'union',
@@ -16342,7 +16392,7 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'read',
+                                                                                            'compile',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -16356,14 +16406,14 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'search',
+                                                                                            'read',
                                                                                         ],
                                                                                     },
                                                                                     {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'compile',
+                                                                                            'search',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -16374,11 +16424,6 @@ const models: TsoaRoute.Models = {
                                                                                         ],
                                                                                     },
                                                                                 ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
                                                                             required: true,
                                                                         },
                                                                     },
@@ -16497,7 +16542,9 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['unknown'],
+                                                            enums: [
+                                                                'git_write_permission',
+                                                            ],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16514,19 +16561,17 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'pull_request_not_open',
                                                             ],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['unknown'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: [
-                                                                'git_write_permission',
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16554,11 +16599,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16582,11 +16627,11 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
+                                                name: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16619,11 +16664,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16638,11 +16683,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16655,10 +16700,6 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'union',
                                                     subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
@@ -16666,6 +16707,10 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16684,11 +16729,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16705,25 +16750,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16813,6 +16839,13 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
+                                                                                    'dimension',
+                                                                                ],
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
                                                                                     'metric',
                                                                                 ],
                                                                             },
@@ -16820,8 +16853,20 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    null,
                                                                                 ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                             },
                                                                             {
                                                                                 dataType:
@@ -16846,11 +16891,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16865,11 +16910,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16884,11 +16929,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16903,11 +16948,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16922,11 +16967,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -33310,7 +33355,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33320,7 +33365,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33330,7 +33375,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -33343,7 +33388,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14045,7 +14045,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -14301,15 +14301,43 @@
             "ApiAiMcpServerResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiMcpServer_"
             },
+            "AiMcpOAuthTokenEndpointAuthMethod": {
+                "type": "string",
+                "enum": ["none", "client_secret_basic", "client_secret_post"]
+            },
             "ApiCreateAiMcpServer": {
                 "properties": {
                     "credentials": {
                         "properties": {
+                            "oauthClientRegistration": {
+                                "properties": {
+                                    "initialAccessToken": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "nullable": true
+                            },
+                            "oauthClientInformation": {
+                                "properties": {
+                                    "tokenEndpointAuthMethod": {
+                                        "$ref": "#/components/schemas/AiMcpOAuthTokenEndpointAuthMethod"
+                                    },
+                                    "clientSecret": {
+                                        "type": "string"
+                                    },
+                                    "clientId": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["clientId"],
+                                "type": "object",
+                                "nullable": true
+                            },
                             "bearerToken": {
                                 "type": "string"
                             }
                         },
-                        "required": ["bearerToken"],
                         "type": "object",
                         "nullable": true
                     },
@@ -14675,7 +14703,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16579,8 +16607,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16638,8 +16666,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16673,8 +16701,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16732,13 +16760,13 @@
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "required": {
+                                                                                        "type": "boolean"
+                                                                                    },
                                                                                     "settings": {},
                                                                                     "values": {
                                                                                         "items": {},
                                                                                         "type": "array"
-                                                                                    },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
                                                                                     },
                                                                                     "operator": {
                                                                                         "type": "string"
@@ -16803,8 +16831,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16844,16 +16872,6 @@
                                                                                 "page"
                                                                             ],
                                                                             "type": "object"
-                                                                        },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "status": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "success",
-                                                                                "error"
-                                                                            ]
                                                                         },
                                                                         "results": {
                                                                             "items": {
@@ -16896,8 +16914,18 @@
                                                                             },
                                                                             "type": "array"
                                                                         },
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "label": {
                                                                             "type": "string"
+                                                                        },
+                                                                        "status": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "error",
+                                                                                "success"
+                                                                            ]
                                                                         }
                                                                     },
                                                                     "required": [
@@ -16917,8 +16945,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16952,9 +16980,9 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
-                                                            "not_found"
+                                                            "not_found",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16987,36 +17015,36 @@
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "false",
+                                                                                        "not_applicable",
+                                                                                        "true"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
+                                                                                        "dimension",
+                                                                                        "metric"
                                                                                     ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
@@ -17029,13 +17057,13 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "fieldValueType",
-                                                                                "caseSensitiveFilters",
-                                                                                "isFromJoinedTable",
-                                                                                "fieldFilterType",
-                                                                                "table",
                                                                                 "description",
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldFilterType",
+                                                                                "fieldValueType",
                                                                                 "fieldType",
+                                                                                "table",
                                                                                 "label",
                                                                                 "name",
                                                                                 "fieldId"
@@ -17049,13 +17077,13 @@
                                                                             "requiredFilters": {
                                                                                 "items": {
                                                                                     "properties": {
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
                                                                                         "settings": {},
                                                                                         "values": {
                                                                                             "items": {},
                                                                                             "type": "array"
-                                                                                        },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
                                                                                         },
                                                                                         "operator": {
                                                                                             "type": "string"
@@ -17081,14 +17109,14 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -17098,8 +17126,8 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
@@ -17224,13 +17252,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "uuid": {
                                                         "type": "string"
                                                     },
                                                     "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -17243,9 +17271,9 @@
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "slug",
                                                     "uuid",
                                                     "name",
+                                                    "slug",
                                                     "status"
                                                 ],
                                                 "type": "object"
@@ -17255,23 +17283,23 @@
                                                     "steps": {
                                                         "items": {
                                                             "properties": {
+                                                                "label": {
+                                                                    "type": "string"
+                                                                },
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
-                                                                        "read",
-                                                                        "edit",
-                                                                        "search",
                                                                         "compile",
+                                                                        "edit",
+                                                                        "read",
+                                                                        "search",
                                                                         "stage"
                                                                     ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
                                                                 }
                                                             },
                                                             "required": [
-                                                                "kind",
-                                                                "label"
+                                                                "label",
+                                                                "kind"
                                                             ],
                                                             "type": "object"
                                                         },
@@ -17323,12 +17351,12 @@
                                                     "errorCode": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "unknown",
+                                                            "git_write_permission",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
-                                                            "git_write_permission",
+                                                            "unknown",
+                                                            "unsupported_source_control",
                                                             null
                                                         ],
                                                         "nullable": true
@@ -17347,10 +17375,10 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
+                                                    "name": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
+                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -17361,8 +17389,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "name",
+                                                    "slug",
                                                     "status"
                                                 ],
                                                 "type": "object"
@@ -17376,8 +17404,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -17389,9 +17417,9 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -17403,10 +17431,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17446,25 +17470,29 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
+                                                                "nullable": true
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
-                                                            "type"
+                                                            "type",
+                                                            "searchQuery"
                                                         ],
                                                         "type": "object"
                                                     },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -33807,22 +33835,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -43969,7 +43997,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3333.0",
+        "version": "0.3334.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -47,6 +47,10 @@ export * from './validators';
 
 export type AiMcpServerAuthType = 'none' | 'bearer' | 'oauth';
 export type AiMcpCredentialScope = 'shared' | 'user';
+export type AiMcpOAuthTokenEndpointAuthMethod =
+    | 'none'
+    | 'client_secret_basic'
+    | 'client_secret_post';
 export type AiMcpServerConnectionStatus =
     | 'not_connected'
     | 'connecting'
@@ -395,7 +399,15 @@ export type ApiCreateAiMcpServer = {
     allowOAuthCredentialSharing?: boolean;
     credentialScope?: AiMcpCredentialScope;
     credentials?: {
-        bearerToken: string;
+        bearerToken?: string;
+        oauthClientInformation?: {
+            clientId: string;
+            clientSecret?: string;
+            tokenEndpointAuthMethod?: AiMcpOAuthTokenEndpointAuthMethod;
+        } | null;
+        oauthClientRegistration?: {
+            initialAccessToken?: string;
+        } | null;
     } | null;
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -21,6 +21,7 @@ import {
     Paper,
     PasswordInput,
     SegmentedControl,
+    Select,
     Stack,
     Text,
     TextInput,
@@ -69,6 +70,15 @@ const createMcpServerFormSchema = z
         authType: z.enum(['none', 'bearer', 'oauth']),
         bearerToken: z.string(),
         allowOAuthCredentialSharing: z.boolean(),
+        oauthClientId: z.string(),
+        oauthClientSecret: z.string(),
+        oauthTokenEndpointAuthMethod: z.enum([
+            '',
+            'none',
+            'client_secret_basic',
+            'client_secret_post',
+        ]),
+        oauthClientRegistrationAccessToken: z.string(),
     })
     .superRefine((values, ctx) => {
         if (
@@ -79,6 +89,18 @@ const createMcpServerFormSchema = z
                 code: z.ZodIssueCode.custom,
                 message: 'Bearer token is required',
                 path: ['bearerToken'],
+            });
+        }
+        if (
+            values.authType === 'oauth' &&
+            (values.oauthClientSecret.trim().length > 0 ||
+                values.oauthTokenEndpointAuthMethod.length > 0) &&
+            values.oauthClientId.trim().length === 0
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'OAuth client ID is required',
+                path: ['oauthClientId'],
             });
         }
     });
@@ -236,6 +258,10 @@ const CreateMcpServerModal = ({
             authType: 'none',
             bearerToken: '',
             allowOAuthCredentialSharing: false,
+            oauthClientId: '',
+            oauthClientSecret: '',
+            oauthTokenEndpointAuthMethod: '',
+            oauthClientRegistrationAccessToken: '',
         },
         validate: zodResolver(createMcpServerFormSchema),
     });
@@ -251,6 +277,11 @@ const CreateMcpServerModal = ({
         form.reset();
         closeOauthOptions();
     });
+    const hasOAuthCredentialOptions =
+        form.values.oauthClientId.trim().length > 0 ||
+        form.values.oauthClientSecret.trim().length > 0 ||
+        form.values.oauthTokenEndpointAuthMethod.length > 0 ||
+        form.values.oauthClientRegistrationAccessToken.trim().length > 0;
 
     return (
         <MantineModal
@@ -330,7 +361,8 @@ const CreateMcpServerModal = ({
                                             icon={
                                                 oauthOptionsOpened ||
                                                 form.values
-                                                    .allowOAuthCredentialSharing
+                                                    .allowOAuthCredentialSharing ||
+                                                hasOAuthCredentialOptions
                                                     ? IconChevronDown
                                                     : IconChevronRight
                                             }
@@ -344,10 +376,12 @@ const CreateMcpServerModal = ({
                                 <Collapse
                                     in={
                                         oauthOptionsOpened ||
-                                        form.values.allowOAuthCredentialSharing
+                                        form.values
+                                            .allowOAuthCredentialSharing ||
+                                        hasOAuthCredentialOptions
                                     }
                                 >
-                                    <Box pt="xs">
+                                    <Stack pt="xs" gap="sm">
                                         <Checkbox
                                             label="Allow shared project credentials for this MCP"
                                             description="Optional. Agent managers can connect a shared project account for this MCP."
@@ -359,7 +393,70 @@ const CreateMcpServerModal = ({
                                                 },
                                             )}
                                         />
-                                    </Box>
+                                        <Divider />
+                                        <TextInput
+                                            variant="subtle"
+                                            label="OAuth client ID"
+                                            disabled={isLoading}
+                                            autoComplete="off"
+                                            {...form.getInputProps(
+                                                'oauthClientId',
+                                            )}
+                                        />
+                                        <PasswordInput
+                                            variant="subtle"
+                                            label="OAuth client secret"
+                                            disabled={isLoading}
+                                            autoComplete="off"
+                                            {...form.getInputProps(
+                                                'oauthClientSecret',
+                                            )}
+                                        />
+                                        <Select
+                                            variant="subtle"
+                                            label="Token endpoint auth method"
+                                            disabled={isLoading}
+                                            data={[
+                                                {
+                                                    label: 'Automatic',
+                                                    value: '',
+                                                },
+                                                {
+                                                    label: 'None',
+                                                    value: 'none',
+                                                },
+                                                {
+                                                    label: 'Client secret basic',
+                                                    value: 'client_secret_basic',
+                                                },
+                                                {
+                                                    label: 'Client secret post',
+                                                    value: 'client_secret_post',
+                                                },
+                                            ]}
+                                            value={
+                                                form.values
+                                                    .oauthTokenEndpointAuthMethod
+                                            }
+                                            onChange={(value) =>
+                                                form.setFieldValue(
+                                                    'oauthTokenEndpointAuthMethod',
+                                                    (value ?? '') as z.infer<
+                                                        typeof createMcpServerFormSchema
+                                                    >['oauthTokenEndpointAuthMethod'],
+                                                )
+                                            }
+                                        />
+                                        <PasswordInput
+                                            variant="subtle"
+                                            label="DCR initial access token"
+                                            disabled={isLoading}
+                                            autoComplete="off"
+                                            {...form.getInputProps(
+                                                'oauthClientRegistrationAccessToken',
+                                            )}
+                                        />
+                                    </Stack>
                                 </Collapse>
                             </Box>
                         </Stack>
@@ -752,6 +849,35 @@ export const AiAgentMcpServersInput = ({
 
     const handleCreateMcpServer = useCallback(
         async (values: z.infer<typeof createMcpServerFormSchema>) => {
+            const oauthClientInformation = values.oauthClientId.trim()
+                ? {
+                      clientId: values.oauthClientId.trim(),
+                      clientSecret:
+                          values.oauthClientSecret.trim() || undefined,
+                      tokenEndpointAuthMethod:
+                          values.oauthTokenEndpointAuthMethod || undefined,
+                  }
+                : undefined;
+            const oauthClientRegistration =
+                values.oauthClientRegistrationAccessToken.trim()
+                    ? {
+                          initialAccessToken:
+                              values.oauthClientRegistrationAccessToken.trim(),
+                      }
+                    : undefined;
+            const credentials =
+                values.authType === 'bearer'
+                    ? {
+                          bearerToken: values.bearerToken.trim(),
+                      }
+                    : values.authType === 'oauth' &&
+                        (oauthClientInformation || oauthClientRegistration)
+                      ? {
+                            oauthClientInformation,
+                            oauthClientRegistration,
+                        }
+                      : null;
+
             const popupWindow =
                 values.authType === 'oauth'
                     ? window.open('', 'mcp-oauth-popup', 'width=600,height=700')
@@ -767,12 +893,7 @@ export const AiAgentMcpServersInput = ({
                         values.authType === 'oauth'
                             ? values.allowOAuthCredentialSharing
                             : undefined,
-                    credentials:
-                        values.authType === 'bearer'
-                            ? {
-                                  bearerToken: values.bearerToken.trim(),
-                              }
-                            : null,
+                    credentials,
                 });
             } catch (error) {
                 popupWindow?.close();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/25275

### Description:

Fixes OAuth MCP client setup persistence so reconnects and personal OAuth flows can reuse configured or dynamically registered clients.

- Stores OAuth client information/registration setup when OAuth MCP servers are created.
- Seeds personal OAuth connections from shared client setup without enabling shared OAuth token fallback.
- Persists DCR-registered client information back to the shared setup record so limited initial access tokens are not reused for later users or reconnects.
- Preserves static/DCR OAuth client setup when disconnecting, while clearing connection state and tokens.
- Updates the MCP OAuth frontend inputs and generated API metadata for the new OAuth client setup fields.

Validation:

- `pnpm exec vitest run --config vitest.config.ts src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts`
- `pnpm -F backend typecheck:fast`
- Targeted backend ESLint
- Targeted `oxfmt --check`
- Pre-commit hook: `git-secrets`, lint-staged, frontend unused exports

No screenshots: backend/API credential lifecycle change.