### PR TITLE
fix(frontend): clarify route chunk load errors

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -34,6 +34,7 @@ import ProjectSwitcher from './components/NavBar/ProjectSwitcher';
 import { ThemeSwitcher } from './components/NavBar/ThemeSwitcher';
 import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
+import { loadLazyRouteDefault } from './features/chunkErrorHandler';
 import { useActiveProjectUuid } from './hooks/useActiveProject';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
 import { getMantineThemeOverride } from './mantineTheme';
@@ -202,15 +203,20 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/auth/popup/:status',
         lazy: async () => {
-            const { default: AuthPopupResult } =
-                await import('./pages/AuthPopupResult');
+            const AuthPopupResult = await loadLazyRouteDefault(
+                './pages/AuthPopupResult',
+                () => import('./pages/AuthPopupResult'),
+            );
             return { Component: AuthPopupResult };
         },
     },
     {
         path: '/login',
         lazy: async () => {
-            const { default: Login } = await import('./pages/Login');
+            const Login = await loadLazyRouteDefault(
+                './pages/Login',
+                () => import('./pages/Login'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.LOGIN}>
@@ -228,8 +234,10 @@ const PUBLIC_ROUTES: RouteObject[] = [
         // Autoclose popup after github installation
         path: '/generalSettings/integrations',
         lazy: async () => {
-            const { default: SuccessAuthPopupResult } =
-                await import('./pages/SuccessAuthPopupResult');
+            const SuccessAuthPopupResult = await loadLazyRouteDefault(
+                './pages/SuccessAuthPopupResult',
+                () => import('./pages/SuccessAuthPopupResult'),
+            );
             return { Component: SuccessAuthPopupResult };
         },
     },
@@ -246,8 +254,10 @@ const MINIMAL_ROUTES: RouteObject[] = [
             {
                 path: '/minimal/projects/:projectUuid/saved/:savedQueryUuid',
                 lazy: async () => {
-                    const { default: MinimalSavedExplorer } =
-                        await import('./pages/MinimalSavedExplorer');
+                    const MinimalSavedExplorer = await loadLazyRouteDefault(
+                        './pages/MinimalSavedExplorer',
+                        () => import('./pages/MinimalSavedExplorer'),
+                    );
                     return {
                         Component: () => (
                             <Stack p="lg" h="90vh">
@@ -260,24 +270,30 @@ const MINIMAL_ROUTES: RouteObject[] = [
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid',
                 lazy: async () => {
-                    const { default: MinimalDashboard } =
-                        await import('./pages/MinimalDashboard');
+                    const MinimalDashboard = await loadLazyRouteDefault(
+                        './pages/MinimalDashboard',
+                        () => import('./pages/MinimalDashboard'),
+                    );
                     return { Component: MinimalDashboard };
                 },
             },
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid/view/tabs/:tabUuid',
                 lazy: async () => {
-                    const { default: MinimalDashboard } =
-                        await import('./pages/MinimalDashboard');
+                    const MinimalDashboard = await loadLazyRouteDefault(
+                        './pages/MinimalDashboard',
+                        () => import('./pages/MinimalDashboard'),
+                    );
                     return { Component: MinimalDashboard };
                 },
             },
             {
                 path: '/minimal/projects/:projectUuid/sql-runner/:savedSqlUuid',
                 lazy: async () => {
-                    const { default: MinimalSqlChart } =
-                        await import('./pages/MinimalSqlChart');
+                    const MinimalSqlChart = await loadLazyRouteDefault(
+                        './pages/MinimalSqlChart',
+                        () => import('./pages/MinimalSqlChart'),
+                    );
                     return {
                         Component: () => (
                             <Stack p="lg" h="90vh">
@@ -303,8 +319,10 @@ const APP_ROUTES: RouteObject[] = [
             {
                 path: '/projects',
                 lazy: async () => {
-                    const { default: Projects } =
-                        await import('./pages/Projects');
+                    const Projects = await loadLazyRouteDefault(
+                        './pages/Projects',
+                        () => import('./pages/Projects'),
+                    );
                     return { Component: Projects };
                 },
             },
@@ -320,8 +338,10 @@ const APP_ROUTES: RouteObject[] = [
                     {
                         path: '/projects/:projectUuid/home',
                         lazy: async () => {
-                            const { default: MobileHome } =
-                                await import('./pages/MobileHome');
+                            const MobileHome = await loadLazyRouteDefault(
+                                './pages/MobileHome',
+                                () => import('./pages/MobileHome'),
+                            );
                             return {
                                 Component: () => (
                                     <TrackPage name={PageName.HOME}>
@@ -342,8 +362,10 @@ const APP_ROUTES: RouteObject[] = [
                     {
                         path: '/projects/:projectUuid/saved',
                         lazy: async () => {
-                            const { default: MobileCharts } =
-                                await import('./pages/MobileCharts');
+                            const MobileCharts = await loadLazyRouteDefault(
+                                './pages/MobileCharts',
+                                () => import('./pages/MobileCharts'),
+                            );
                             return {
                                 Component: () => (
                                     <TrackPage name={PageName.SAVED_QUERIES}>
@@ -356,8 +378,10 @@ const APP_ROUTES: RouteObject[] = [
                     {
                         path: '/projects/:projectUuid/dashboards',
                         lazy: async () => {
-                            const { default: MobileDashboards } =
-                                await import('./pages/MobileDashboards');
+                            const MobileDashboards = await loadLazyRouteDefault(
+                                './pages/MobileDashboards',
+                                () => import('./pages/MobileDashboards'),
+                            );
                             return {
                                 Component: () => (
                                     <TrackPage name={PageName.SAVED_DASHBOARDS}>
@@ -370,8 +394,10 @@ const APP_ROUTES: RouteObject[] = [
                     {
                         path: '/projects/:projectUuid/spaces/:spaceUuid',
                         lazy: async () => {
-                            const { default: MobileSpace } =
-                                await import('./pages/MobileSpace');
+                            const MobileSpace = await loadLazyRouteDefault(
+                                './pages/MobileSpace',
+                                () => import('./pages/MobileSpace'),
+                            );
                             return {
                                 Component: () => (
                                     <TrackPage name={PageName.SPACE}>
@@ -384,8 +410,10 @@ const APP_ROUTES: RouteObject[] = [
                     {
                         path: '/projects/:projectUuid/spaces',
                         lazy: async () => {
-                            const { default: MobileSpaces } =
-                                await import('./pages/MobileSpaces');
+                            const MobileSpaces = await loadLazyRouteDefault(
+                                './pages/MobileSpaces',
+                                () => import('./pages/MobileSpaces'),
+                            );
                             return {
                                 Component: () => (
                                     <TrackPage name={PageName.SPACES}>
@@ -398,16 +426,20 @@ const APP_ROUTES: RouteObject[] = [
                     {
                         path: '/projects/:projectUuid/apps/:appUuid/preview',
                         lazy: async () => {
-                            const { default: AppPreviewTest } =
-                                await import('./pages/AppPreviewTest');
+                            const AppPreviewTest = await loadLazyRouteDefault(
+                                './pages/AppPreviewTest',
+                                () => import('./pages/AppPreviewTest'),
+                            );
                             return { Component: AppPreviewTest };
                         },
                     },
                     {
                         path: '/projects/:projectUuid/apps/:appUuid/versions/:version/preview',
                         lazy: async () => {
-                            const { default: AppPreviewTest } =
-                                await import('./pages/AppPreviewTest');
+                            const AppPreviewTest = await loadLazyRouteDefault(
+                                './pages/AppPreviewTest',
+                                () => import('./pages/AppPreviewTest'),
+                            );
                             return { Component: AppPreviewTest };
                         },
                     },
@@ -460,8 +492,10 @@ const PRIVATE_ROUTES: RouteObject[] = [
             {
                 path: '/share/:shareNanoid',
                 lazy: async () => {
-                    const { default: ShareRedirect } =
-                        await import('./pages/ShareRedirect');
+                    const ShareRedirect = await loadLazyRouteDefault(
+                        './pages/ShareRedirect',
+                        () => import('./pages/ShareRedirect'),
+                    );
                     return {
                         Component: () => (
                             <TrackPage name={PageName.SHARE}>

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -10,6 +10,7 @@ import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
 import CreateProjectSettings from './components/Settings/CreateProjectSettings';
 import UserCompletionModal from './components/UserCompletionModal';
+import { loadLazyRouteDefault } from './features/chunkErrorHandler';
 import { MetricCatalogView } from './features/metricsCatalog/types';
 import { TrackPage } from './providers/Tracking/TrackingProvider';
 import { PageName } from './types/Events';
@@ -23,15 +24,20 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/auth/popup/:status',
         lazy: async () => {
-            const { default: AuthPopupResult } =
-                await import('./pages/AuthPopupResult');
+            const AuthPopupResult = await loadLazyRouteDefault(
+                './pages/AuthPopupResult',
+                () => import('./pages/AuthPopupResult'),
+            );
             return { Component: AuthPopupResult };
         },
     },
     {
         path: '/register',
         lazy: async () => {
-            const { default: Register } = await import('./pages/Register');
+            const Register = await loadLazyRouteDefault(
+                './pages/Register',
+                () => import('./pages/Register'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.REGISTER}>
@@ -44,7 +50,10 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/login',
         lazy: async () => {
-            const { default: Login } = await import('./pages/Login');
+            const Login = await loadLazyRouteDefault(
+                './pages/Login',
+                () => import('./pages/Login'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.LOGIN}>
@@ -57,8 +66,10 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/recover-password',
         lazy: async () => {
-            const { default: PasswordRecovery } =
-                await import('./pages/PasswordRecovery');
+            const PasswordRecovery = await loadLazyRouteDefault(
+                './pages/PasswordRecovery',
+                () => import('./pages/PasswordRecovery'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.PASSWORD_RECOVERY}>
@@ -71,8 +82,10 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/reset-password/:code',
         lazy: async () => {
-            const { default: PasswordReset } =
-                await import('./pages/PasswordReset');
+            const PasswordReset = await loadLazyRouteDefault(
+                './pages/PasswordReset',
+                () => import('./pages/PasswordReset'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.PASSWORD_RESET}>
@@ -85,7 +98,10 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/invite/:inviteCode',
         lazy: async () => {
-            const { default: Invite } = await import('./pages/Invite');
+            const Invite = await loadLazyRouteDefault(
+                './pages/Invite',
+                () => import('./pages/Invite'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.SIGNUP}>
@@ -98,8 +114,10 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/verify-email',
         lazy: async () => {
-            const { default: VerifyEmailPage } =
-                await import('./pages/VerifyEmail');
+            const VerifyEmailPage = await loadLazyRouteDefault(
+                './pages/VerifyEmail',
+                () => import('./pages/VerifyEmail'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.VERIFY_EMAIL}>
@@ -112,8 +130,10 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/join-organization',
         lazy: async () => {
-            const { default: JoinOrganization } =
-                await import('./pages/JoinOrganization');
+            const JoinOrganization = await loadLazyRouteDefault(
+                './pages/JoinOrganization',
+                () => import('./pages/JoinOrganization'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.JOIN_ORGANIZATION}>
@@ -133,8 +153,10 @@ const MINIMAL_ROUTES: RouteObject[] = [
             {
                 path: '/minimal/projects/:projectUuid/saved/:savedQueryUuid',
                 lazy: async () => {
-                    const { default: MinimalSavedExplorer } =
-                        await import('./pages/MinimalSavedExplorer');
+                    const MinimalSavedExplorer = await loadLazyRouteDefault(
+                        './pages/MinimalSavedExplorer',
+                        () => import('./pages/MinimalSavedExplorer'),
+                    );
                     return {
                         Component: () => (
                             <Stack p="lg" h="100vh">
@@ -147,24 +169,30 @@ const MINIMAL_ROUTES: RouteObject[] = [
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid',
                 lazy: async () => {
-                    const { default: MinimalDashboard } =
-                        await import('./pages/MinimalDashboard');
+                    const MinimalDashboard = await loadLazyRouteDefault(
+                        './pages/MinimalDashboard',
+                        () => import('./pages/MinimalDashboard'),
+                    );
                     return { Component: MinimalDashboard };
                 },
             },
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid/view/tabs/:tabUuid',
                 lazy: async () => {
-                    const { default: MinimalDashboard } =
-                        await import('./pages/MinimalDashboard');
+                    const MinimalDashboard = await loadLazyRouteDefault(
+                        './pages/MinimalDashboard',
+                        () => import('./pages/MinimalDashboard'),
+                    );
                     return { Component: MinimalDashboard };
                 },
             },
             {
                 path: '/minimal/projects/:projectUuid/sql-runner/:savedSqlUuid',
                 lazy: async () => {
-                    const { default: MinimalSqlChart } =
-                        await import('./pages/MinimalSqlChart');
+                    const MinimalSqlChart = await loadLazyRouteDefault(
+                        './pages/MinimalSqlChart',
+                        () => import('./pages/MinimalSqlChart'),
+                    );
                     return {
                         Component: () => (
                             <Stack p="lg" h="100vh">
@@ -177,8 +205,10 @@ const MINIMAL_ROUTES: RouteObject[] = [
             {
                 path: '/minimal/projects/:projectUuid/apps/:appUuid',
                 lazy: async () => {
-                    const { default: MinimalApp } =
-                        await import('./pages/MinimalApp');
+                    const MinimalApp = await loadLazyRouteDefault(
+                        './pages/MinimalApp',
+                        () => import('./pages/MinimalApp'),
+                    );
                     return { Component: MinimalApp };
                 },
             },
@@ -190,8 +220,10 @@ const CHART_ROUTES: RouteObject[] = [
     {
         path: 'saved',
         lazy: async () => {
-            const { default: SavedQueries } =
-                await import('./pages/SavedQueries');
+            const SavedQueries = await loadLazyRouteDefault(
+                './pages/SavedQueries',
+                () => import('./pages/SavedQueries'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.SAVED_QUERIES}>
@@ -208,8 +240,10 @@ const CHART_ROUTES: RouteObject[] = [
             {
                 path: 'history',
                 lazy: async () => {
-                    const { default: ChartHistory } =
-                        await import('./pages/ChartHistory');
+                    const ChartHistory = await loadLazyRouteDefault(
+                        './pages/ChartHistory',
+                        () => import('./pages/ChartHistory'),
+                    );
                     return {
                         Component: () => (
                             <TrackPage name={PageName.CHART_HISTORY}>
@@ -223,8 +257,10 @@ const CHART_ROUTES: RouteObject[] = [
                 path: ':mode?',
                 index: false,
                 lazy: async () => {
-                    const { default: SavedExplorer } =
-                        await import('./pages/SavedExplorer');
+                    const SavedExplorer = await loadLazyRouteDefault(
+                        './pages/SavedExplorer',
+                        () => import('./pages/SavedExplorer'),
+                    );
                     return {
                         Component: () => (
                             <TrackPage name={PageName.SAVED_QUERY_EXPLORER}>
@@ -243,8 +279,10 @@ const DASHBOARD_LIST_ROUTES: RouteObject[] = [
     {
         path: 'dashboards',
         lazy: async () => {
-            const { default: SavedDashboards } =
-                await import('./pages/SavedDashboards');
+            const SavedDashboards = await loadLazyRouteDefault(
+                './pages/SavedDashboards',
+                () => import('./pages/SavedDashboards'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.SAVED_DASHBOARDS}>
@@ -257,8 +295,10 @@ const DASHBOARD_LIST_ROUTES: RouteObject[] = [
     {
         path: 'dashboards/:dashboardUuid/history',
         lazy: async () => {
-            const { default: DashboardHistory } =
-                await import('./pages/DashboardHistory');
+            const DashboardHistory = await loadLazyRouteDefault(
+                './pages/DashboardHistory',
+                () => import('./pages/DashboardHistory'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.DASHBOARD_HISTORY}>
@@ -278,7 +318,10 @@ const DASHBOARD_LIST_ROUTES: RouteObject[] = [
 let DashboardRouteComponent: FC | undefined;
 const loadDashboardRoute = async () => {
     if (!DashboardRouteComponent) {
-        const { default: Dashboard } = await import('./pages/Dashboard');
+        const Dashboard = await loadLazyRouteDefault(
+            './pages/Dashboard',
+            () => import('./pages/Dashboard'),
+        );
         DashboardRouteComponent = () => (
             <TrackPage name={PageName.DASHBOARD}>
                 <Dashboard />
@@ -314,24 +357,30 @@ const SQL_RUNNER_ROUTES: RouteObject[] = [
             {
                 index: true,
                 lazy: async () => {
-                    const { default: SqlRunner } =
-                        await import('./pages/SqlRunner');
+                    const SqlRunner = await loadLazyRouteDefault(
+                        './pages/SqlRunner',
+                        () => import('./pages/SqlRunner'),
+                    );
                     return { Component: SqlRunner };
                 },
             },
             {
                 path: ':slug',
                 lazy: async () => {
-                    const { default: ViewSqlChart } =
-                        await import('./pages/ViewSqlChart');
+                    const ViewSqlChart = await loadLazyRouteDefault(
+                        './pages/ViewSqlChart',
+                        () => import('./pages/ViewSqlChart'),
+                    );
                     return { Component: ViewSqlChart };
                 },
             },
             {
                 path: ':slug/edit',
                 lazy: async () => {
-                    const { default: SqlRunner } =
-                        await import('./pages/SqlRunner');
+                    const SqlRunner = await loadLazyRouteDefault(
+                        './pages/SqlRunner',
+                        () => import('./pages/SqlRunner'),
+                    );
                     return { Component: () => <SqlRunner isEditMode /> };
                 },
             },
@@ -344,8 +393,10 @@ const SOURCE_CODE_ROUTES: RouteObject[] = [
         // Redirect old source-code route to project home with editor drawer open
         path: 'source-code',
         lazy: async () => {
-            const { default: SourceCodeEditorRedirect } =
-                await import('./pages/SourceCodeEditorRedirect');
+            const SourceCodeEditorRedirect = await loadLazyRouteDefault(
+                './pages/SourceCodeEditorRedirect',
+                () => import('./pages/SourceCodeEditorRedirect'),
+            );
             return { Component: SourceCodeEditorRedirect };
         },
     },
@@ -355,7 +406,10 @@ const TABLES_ROUTES: RouteObject[] = [
     {
         path: 'tables',
         lazy: async () => {
-            const { default: Explorer } = await import('./pages/Explorer');
+            const Explorer = await loadLazyRouteDefault(
+                './pages/Explorer',
+                () => import('./pages/Explorer'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.EXPLORE_TABLES}>
@@ -368,7 +422,10 @@ const TABLES_ROUTES: RouteObject[] = [
     {
         path: 'tables/:tableId',
         lazy: async () => {
-            const { default: Explorer } = await import('./pages/Explorer');
+            const Explorer = await loadLazyRouteDefault(
+                './pages/Explorer',
+                () => import('./pages/Explorer'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.EXPLORER}>
@@ -384,7 +441,10 @@ const SPACES_ROUTES: RouteObject[] = [
     {
         path: 'spaces',
         lazy: async () => {
-            const { default: Spaces } = await import('./pages/Spaces');
+            const Spaces = await loadLazyRouteDefault(
+                './pages/Spaces',
+                () => import('./pages/Spaces'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.SPACES}>
@@ -397,7 +457,10 @@ const SPACES_ROUTES: RouteObject[] = [
     {
         path: 'spaces/:spaceUuid',
         lazy: async () => {
-            const { default: Space } = await import('./pages/Space');
+            const Space = await loadLazyRouteDefault(
+                './pages/Space',
+                () => import('./pages/Space'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.SPACE}>
@@ -413,8 +476,10 @@ const METRICS_ROUTES: RouteObject[] = [
     {
         path: 'metrics',
         lazy: async () => {
-            const { default: MetricsCatalog } =
-                await import('./pages/MetricsCatalog');
+            const MetricsCatalog = await loadLazyRouteDefault(
+                './pages/MetricsCatalog',
+                () => import('./pages/MetricsCatalog'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.METRICS_CATALOG}>
@@ -427,8 +492,10 @@ const METRICS_ROUTES: RouteObject[] = [
     {
         path: 'metrics/peek/:tableName/:metricName',
         lazy: async () => {
-            const { default: MetricsCatalog } =
-                await import('./pages/MetricsCatalog');
+            const MetricsCatalog = await loadLazyRouteDefault(
+                './pages/MetricsCatalog',
+                () => import('./pages/MetricsCatalog'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.METRICS_CATALOG}>
@@ -441,8 +508,10 @@ const METRICS_ROUTES: RouteObject[] = [
     {
         path: 'metrics/canvas',
         lazy: async () => {
-            const { default: MetricsCatalog } =
-                await import('./pages/MetricsCatalog');
+            const MetricsCatalog = await loadLazyRouteDefault(
+                './pages/MetricsCatalog',
+                () => import('./pages/MetricsCatalog'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.METRICS_CATALOG}>
@@ -457,8 +526,10 @@ const METRICS_ROUTES: RouteObject[] = [
     {
         path: 'metrics/canvas/:treeSlug',
         lazy: async () => {
-            const { default: MetricsCatalog } =
-                await import('./pages/MetricsCatalog');
+            const MetricsCatalog = await loadLazyRouteDefault(
+                './pages/MetricsCatalog',
+                () => import('./pages/MetricsCatalog'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.METRICS_CATALOG}>
@@ -484,7 +555,10 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     {
         path: 'home',
         lazy: async () => {
-            const { default: Home } = await import('./pages/Home');
+            const Home = await loadLazyRouteDefault(
+                './pages/Home',
+                () => import('./pages/Home'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.HOME}>
@@ -509,7 +583,10 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     {
         path: 'apps',
         lazy: async () => {
-            const { default: SavedApps } = await import('./pages/SavedApps');
+            const SavedApps = await loadLazyRouteDefault(
+                './pages/SavedApps',
+                () => import('./pages/SavedApps'),
+            );
             return { Component: SavedApps };
         },
     },
@@ -517,8 +594,10 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         path: 'apps/generate',
         handle: { hideAILauncher: true },
         lazy: async () => {
-            const { default: AppGenerate } =
-                await import('./pages/AppGenerate');
+            const AppGenerate = await loadLazyRouteDefault(
+                './pages/AppGenerate',
+                () => import('./pages/AppGenerate'),
+            );
             return { Component: AppGenerate };
         },
     },
@@ -526,8 +605,10 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         path: 'apps/:appUuid',
         handle: { hideAILauncher: true },
         lazy: async () => {
-            const { default: AppGenerate } =
-                await import('./pages/AppGenerate');
+            const AppGenerate = await loadLazyRouteDefault(
+                './pages/AppGenerate',
+                () => import('./pages/AppGenerate'),
+            );
             return { Component: AppGenerate };
         },
     },
@@ -535,8 +616,10 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         path: 'apps/:appUuid/versions/:version/preview',
         handle: { hideAILauncher: true },
         lazy: async () => {
-            const { default: AppPreviewTest } =
-                await import('./pages/AppPreviewTest');
+            const AppPreviewTest = await loadLazyRouteDefault(
+                './pages/AppPreviewTest',
+                () => import('./pages/AppPreviewTest'),
+            );
             return { Component: AppPreviewTest };
         },
     },
@@ -544,16 +627,20 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         path: 'apps/:appUuid/preview',
         handle: { hideAILauncher: true },
         lazy: async () => {
-            const { default: AppPreviewTest } =
-                await import('./pages/AppPreviewTest');
+            const AppPreviewTest = await loadLazyRouteDefault(
+                './pages/AppPreviewTest',
+                () => import('./pages/AppPreviewTest'),
+            );
             return { Component: AppPreviewTest };
         },
     },
     {
         path: 'user-activity',
         lazy: async () => {
-            const { default: UserActivity } =
-                await import('./pages/UserActivity');
+            const UserActivity = await loadLazyRouteDefault(
+                './pages/UserActivity',
+                () => import('./pages/UserActivity'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.USER_ACTIVITY}>
@@ -567,8 +654,10 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         path: 'funnel-builder',
         handle: { hideAILauncher: true },
         lazy: async () => {
-            const { default: FunnelBuilder } =
-                await import('./features/funnelBuilder/FunnelBuilderPage');
+            const FunnelBuilder = await loadLazyRouteDefault(
+                './features/funnelBuilder/FunnelBuilderPage',
+                () => import('./features/funnelBuilder/FunnelBuilderPage'),
+            );
             return {
                 Component: () => (
                     <TrackPage name={PageName.FUNNEL_BUILDER}>
@@ -592,8 +681,10 @@ const APP_ROUTES: RouteObject[] = [
             {
                 path: '/projects',
                 lazy: async () => {
-                    const { default: Projects } =
-                        await import('./pages/Projects');
+                    const Projects = await loadLazyRouteDefault(
+                        './pages/Projects',
+                        () => import('./pages/Projects'),
+                    );
                     return { Component: Projects };
                 },
             },
@@ -610,8 +701,10 @@ const APP_ROUTES: RouteObject[] = [
                     {
                         path: 'sqlRunner',
                         lazy: async () => {
-                            const { default: LegacySqlRunner } =
-                                await import('./pages/LegacySqlRunner');
+                            const LegacySqlRunner = await loadLazyRouteDefault(
+                                './pages/LegacySqlRunner',
+                                () => import('./pages/LegacySqlRunner'),
+                            );
                             return { Component: LegacySqlRunner };
                         },
                     },
@@ -651,16 +744,20 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 path: '/brand-prototype',
                 handle: { hideAILauncher: true },
                 lazy: async () => {
-                    const { default: BrandPrototype } =
-                        await import('./pages/BrandPrototype');
+                    const BrandPrototype = await loadLazyRouteDefault(
+                        './pages/BrandPrototype',
+                        () => import('./pages/BrandPrototype'),
+                    );
                     return { Component: BrandPrototype };
                 },
             },
             {
                 path: '/createProject/:method?',
                 lazy: async () => {
-                    const { default: CreateProject } =
-                        await import('./pages/CreateProject');
+                    const CreateProject = await loadLazyRouteDefault(
+                        './pages/CreateProject',
+                        () => import('./pages/CreateProject'),
+                    );
                     return {
                         Component: () => (
                             <>
@@ -689,8 +786,10 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 path: '/generalSettings/*',
                 handle: { hideAILauncher: true },
                 lazy: async () => {
-                    const { default: Settings } =
-                        await import('./pages/Settings');
+                    const Settings = await loadLazyRouteDefault(
+                        './pages/Settings',
+                        () => import('./pages/Settings'),
+                    );
                     return {
                         Component: () => (
                             <>
@@ -731,8 +830,10 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 path: '/share/:shareNanoid',
                 handle: { hideAILauncher: true },
                 lazy: async () => {
-                    const { default: ShareRedirect } =
-                        await import('./pages/ShareRedirect');
+                    const ShareRedirect = await loadLazyRouteDefault(
+                        './pages/ShareRedirect',
+                        () => import('./pages/ShareRedirect'),
+                    );
                     return {
                         Component: () => (
                             <>

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -1,5 +1,6 @@
 import { Navigate, type RouteObject } from 'react-router';
 import PrivateRoute from '../components/PrivateRoute';
+import { loadLazyRouteDefault } from '../features/chunkErrorHandler';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
 
@@ -8,16 +9,20 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
         path: '/embed',
         handle: { hideAILauncher: true },
         lazy: async () => {
-            const { default: EmbeddedApp } =
-                await import('./features/embed/EmbeddedApp');
+            const EmbeddedApp = await loadLazyRouteDefault(
+                './features/embed/EmbeddedApp',
+                () => import('./features/embed/EmbeddedApp'),
+            );
             return { Component: EmbeddedApp };
         },
         children: [
             {
                 path: '/embed/:projectUuid',
                 lazy: async () => {
-                    const { default: EmbedDashboard } =
-                        await import('./pages/EmbedDashboard');
+                    const EmbedDashboard = await loadLazyRouteDefault(
+                        './pages/EmbedDashboard',
+                        () => import('./pages/EmbedDashboard'),
+                    );
                     return {
                         Component: () => (
                             <TrackPage name={PageName.EMBED_DASHBOARD}>
@@ -30,8 +35,10 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
             {
                 path: '/embed/:projectUuid/tabs/:tabUuid',
                 lazy: async () => {
-                    const { default: EmbedDashboard } =
-                        await import('./pages/EmbedDashboard');
+                    const EmbedDashboard = await loadLazyRouteDefault(
+                        './pages/EmbedDashboard',
+                        () => import('./pages/EmbedDashboard'),
+                    );
                     return {
                         Component: () => (
                             <TrackPage name={PageName.EMBED_DASHBOARD}>
@@ -44,8 +51,10 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
             {
                 path: '/embed/:projectUuid/chart/:chartUuid',
                 lazy: async () => {
-                    const { default: EmbedChart } =
-                        await import('./pages/EmbedChart');
+                    const EmbedChart = await loadLazyRouteDefault(
+                        './pages/EmbedChart',
+                        () => import('./pages/EmbedChart'),
+                    );
                     return {
                         Component: () => (
                             <TrackPage name={PageName.EMBED_SAVED_CHART}>
@@ -58,8 +67,10 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
             {
                 path: '/embed/:projectUuid/app/:appUuid',
                 lazy: async () => {
-                    const { default: EmbedApp } =
-                        await import('./pages/EmbedApp');
+                    const EmbedApp = await loadLazyRouteDefault(
+                        './pages/EmbedApp',
+                        () => import('./pages/EmbedApp'),
+                    );
                     return {
                         Component: () => (
                             <TrackPage name={PageName.EMBED_DATA_APP}>
@@ -86,8 +97,10 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
             {
                 path: '/embed/:projectUuid/explore/:exploreId',
                 lazy: async () => {
-                    const { default: EmbedExplore } =
-                        await import('./pages/EmbedExplore');
+                    const EmbedExplore = await loadLazyRouteDefault(
+                        './pages/EmbedExplore',
+                        () => import('./pages/EmbedExplore'),
+                    );
                     return {
                         Component: () => (
                             <TrackPage name={PageName.EMBED_EXPLORE}>
@@ -100,16 +113,22 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
             {
                 path: '/embed/:projectUuid/ai-agents/not-authorized',
                 lazy: async () => {
-                    const { default: AiAgentsNotAuthorizedPage } =
-                        await import('./pages/AiAgents/AiAgentsNotAuthorizedPage');
+                    const AiAgentsNotAuthorizedPage =
+                        await loadLazyRouteDefault(
+                            './pages/AiAgents/AiAgentsNotAuthorizedPage',
+                            () =>
+                                import('./pages/AiAgents/AiAgentsNotAuthorizedPage'),
+                        );
                     return { Component: AiAgentsNotAuthorizedPage };
                 },
             },
             {
                 path: '/embed/:projectUuid/ai-agents/:agentUuid',
                 lazy: async () => {
-                    const { default: AgentPage } =
-                        await import('./pages/AiAgents/AgentPage');
+                    const AgentPage = await loadLazyRouteDefault(
+                        './pages/AiAgents/AgentPage',
+                        () => import('./pages/AiAgents/AgentPage'),
+                    );
                     return { Component: AgentPage };
                 },
                 children: [
@@ -123,8 +142,12 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
                             {
                                 index: true,
                                 lazy: async () => {
-                                    const { default: AiAgentNewThreadPage } =
-                                        await import('./pages/AiAgents/AiAgentNewThreadPage');
+                                    const AiAgentNewThreadPage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AiAgentNewThreadPage',
+                                            () =>
+                                                import('./pages/AiAgents/AiAgentNewThreadPage'),
+                                        );
                                     return {
                                         Component: AiAgentNewThreadPage,
                                     };
@@ -133,8 +156,12 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
                             {
                                 path: ':threadUuid/messages/:promptUuid/debug',
                                 lazy: async () => {
-                                    const { default: AiAgentThreadPage } =
-                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    const AiAgentThreadPage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AgentThreadPage',
+                                            () =>
+                                                import('./pages/AiAgents/AgentThreadPage'),
+                                        );
                                     return {
                                         Component: () => (
                                             <AiAgentThreadPage debug />
@@ -145,16 +172,24 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
                             {
                                 path: ':threadUuid/messages/:promptUuid',
                                 lazy: async () => {
-                                    const { default: AiAgentThreadPage } =
-                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    const AiAgentThreadPage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AgentThreadPage',
+                                            () =>
+                                                import('./pages/AiAgents/AgentThreadPage'),
+                                        );
                                     return { Component: AiAgentThreadPage };
                                 },
                             },
                             {
                                 path: ':threadUuid',
                                 lazy: async () => {
-                                    const { default: AiAgentThreadPage } =
-                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    const AiAgentThreadPage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AgentThreadPage',
+                                            () =>
+                                                import('./pages/AiAgents/AgentThreadPage'),
+                                        );
                                     return { Component: AiAgentThreadPage };
                                 },
                             },
@@ -190,8 +225,10 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
     {
         path: '/ai-agents/',
         lazy: async () => {
-            const { default: AgentsRedirect } =
-                await import('./pages/AiAgents/AgentsRedirect');
+            const AgentsRedirect = await loadLazyRouteDefault(
+                './pages/AiAgents/AgentsRedirect',
+                () => import('./pages/AiAgents/AgentsRedirect'),
+            );
             return {
                 Component: () => (
                     <PrivateRoute>
@@ -205,8 +242,10 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
         path: '/projects/:projectUuid/ai-agents',
         handle: { hideAILauncher: true },
         lazy: async () => {
-            const { default: AiAgentsRootLayout } =
-                await import('./pages/AiAgents/AiAgentsRootLayout');
+            const AiAgentsRootLayout = await loadLazyRouteDefault(
+                './pages/AiAgents/AiAgentsRootLayout',
+                () => import('./pages/AiAgents/AiAgentsRootLayout'),
+            );
             return {
                 Component: () => (
                     <PrivateRoute>
@@ -219,24 +258,32 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
             {
                 index: true,
                 lazy: async () => {
-                    const { default: AgentsWelcome } =
-                        await import('./pages/AiAgents/AgentsWelcome');
+                    const AgentsWelcome = await loadLazyRouteDefault(
+                        './pages/AiAgents/AgentsWelcome',
+                        () => import('./pages/AiAgents/AgentsWelcome'),
+                    );
                     return { Component: AgentsWelcome };
                 },
             },
             {
                 path: 'not-authorized',
                 lazy: async () => {
-                    const { default: AiAgentsNotAuthorizedPage } =
-                        await import('./pages/AiAgents/AiAgentsNotAuthorizedPage');
+                    const AiAgentsNotAuthorizedPage =
+                        await loadLazyRouteDefault(
+                            './pages/AiAgents/AiAgentsNotAuthorizedPage',
+                            () =>
+                                import('./pages/AiAgents/AiAgentsNotAuthorizedPage'),
+                        );
                     return { Component: AiAgentsNotAuthorizedPage };
                 },
             },
             {
                 path: 'new',
                 lazy: async () => {
-                    const { default: ProjectAiAgentEditPage } =
-                        await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                    const ProjectAiAgentEditPage = await loadLazyRouteDefault(
+                        './pages/AiAgents/ProjectAiAgentEditPage',
+                        () => import('./pages/AiAgents/ProjectAiAgentEditPage'),
+                    );
                     return {
                         Component: () => (
                             <ProjectAiAgentEditPage isCreateMode />
@@ -247,56 +294,80 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
             {
                 path: 'share/:aiThreadShareUuid',
                 lazy: async () => {
-                    const { default: AiAgentThreadSharePage } =
-                        await import('./pages/AiAgents/AiAgentThreadSharePage');
+                    const AiAgentThreadSharePage = await loadLazyRouteDefault(
+                        './pages/AiAgents/AiAgentThreadSharePage',
+                        () => import('./pages/AiAgents/AiAgentThreadSharePage'),
+                    );
                     return { Component: AiAgentThreadSharePage };
                 },
             },
             {
                 path: ':agentUuid/edit',
                 lazy: async () => {
-                    const { default: ProjectAiAgentEditPage } =
-                        await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                    const ProjectAiAgentEditPage = await loadLazyRouteDefault(
+                        './pages/AiAgents/ProjectAiAgentEditPage',
+                        () => import('./pages/AiAgents/ProjectAiAgentEditPage'),
+                    );
                     return { Component: ProjectAiAgentEditPage };
                 },
                 children: [
                     {
                         path: 'evals',
                         lazy: async () => {
-                            const { default: ProjectAiAgentEditPage } =
-                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            const ProjectAiAgentEditPage =
+                                await loadLazyRouteDefault(
+                                    './pages/AiAgents/ProjectAiAgentEditPage',
+                                    () =>
+                                        import('./pages/AiAgents/ProjectAiAgentEditPage'),
+                                );
                             return { Component: ProjectAiAgentEditPage };
                         },
                     },
                     {
                         path: 'evals/:evalUuid',
                         lazy: async () => {
-                            const { default: ProjectAiAgentEditPage } =
-                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            const ProjectAiAgentEditPage =
+                                await loadLazyRouteDefault(
+                                    './pages/AiAgents/ProjectAiAgentEditPage',
+                                    () =>
+                                        import('./pages/AiAgents/ProjectAiAgentEditPage'),
+                                );
                             return { Component: ProjectAiAgentEditPage };
                         },
                     },
                     {
                         path: 'evals/:evalUuid/run/:runUuid',
                         lazy: async () => {
-                            const { default: ProjectAiAgentEditPage } =
-                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            const ProjectAiAgentEditPage =
+                                await loadLazyRouteDefault(
+                                    './pages/AiAgents/ProjectAiAgentEditPage',
+                                    () =>
+                                        import('./pages/AiAgents/ProjectAiAgentEditPage'),
+                                );
                             return { Component: ProjectAiAgentEditPage };
                         },
                     },
                     {
                         path: 'verified-artifacts',
                         lazy: async () => {
-                            const { default: ProjectAiAgentEditPage } =
-                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            const ProjectAiAgentEditPage =
+                                await loadLazyRouteDefault(
+                                    './pages/AiAgents/ProjectAiAgentEditPage',
+                                    () =>
+                                        import('./pages/AiAgents/ProjectAiAgentEditPage'),
+                                );
                             return { Component: ProjectAiAgentEditPage };
                         },
                     },
                     {
                         path: 'verified-artifacts/:artifactUuid',
                         lazy: async () => {
-                            const { default: ProjectAiAgentEditPage } =
-                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            const ProjectAiAgentEditPage =
+                                await loadLazyRouteDefault(
+                                    './pages/AiAgents/ProjectAiAgentEditPage',
+                                    () =>
+                                        import('./pages/AiAgents/ProjectAiAgentEditPage'),
+                                );
                             return { Component: ProjectAiAgentEditPage };
                         },
                     },
@@ -305,8 +376,10 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
             {
                 path: ':agentUuid',
                 lazy: async () => {
-                    const { default: AgentPage } =
-                        await import('./pages/AiAgents/AgentPage');
+                    const AgentPage = await loadLazyRouteDefault(
+                        './pages/AiAgents/AgentPage',
+                        () => import('./pages/AiAgents/AgentPage'),
+                    );
                     return { Component: AgentPage };
                 },
                 children: [
@@ -320,8 +393,12 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                             {
                                 index: true,
                                 lazy: async () => {
-                                    const { default: AiAgentNewThreadPage } =
-                                        await import('./pages/AiAgents/AiAgentNewThreadPage');
+                                    const AiAgentNewThreadPage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AiAgentNewThreadPage',
+                                            () =>
+                                                import('./pages/AiAgents/AiAgentNewThreadPage'),
+                                        );
                                     return {
                                         Component: AiAgentNewThreadPage,
                                     };
@@ -330,8 +407,12 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                             {
                                 path: ':threadUuid/messages/:promptUuid/debug',
                                 lazy: async () => {
-                                    const { default: AiAgentThreadPage } =
-                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    const AiAgentThreadPage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AgentThreadPage',
+                                            () =>
+                                                import('./pages/AiAgents/AgentThreadPage'),
+                                        );
                                     return {
                                         Component: () => (
                                             <AiAgentThreadPage debug />
@@ -342,16 +423,24 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                             {
                                 path: ':threadUuid/messages/:promptUuid',
                                 lazy: async () => {
-                                    const { default: AiAgentThreadPage } =
-                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    const AiAgentThreadPage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AgentThreadPage',
+                                            () =>
+                                                import('./pages/AiAgents/AgentThreadPage'),
+                                        );
                                     return { Component: AiAgentThreadPage };
                                 },
                             },
                             {
                                 path: ':threadUuid',
                                 lazy: async () => {
-                                    const { default: AiAgentThreadPage } =
-                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    const AiAgentThreadPage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AgentThreadPage',
+                                            () =>
+                                                import('./pages/AiAgents/AgentThreadPage'),
+                                        );
                                     return { Component: AiAgentThreadPage };
                                 },
                             },
@@ -367,8 +456,10 @@ const COMMERCIAL_SLACK_AUTH_ROUTES: RouteObject[] = [
     {
         path: '/auth/slack/success',
         lazy: async () => {
-            const { default: SlackAuthSuccess } =
-                await import('./pages/SlackAuthSuccess');
+            const SlackAuthSuccess = await loadLazyRouteDefault(
+                './pages/SlackAuthSuccess',
+                () => import('./pages/SlackAuthSuccess'),
+            );
             return { Component: SlackAuthSuccess };
         },
     },

--- a/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.test.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { isChunkLoadError } from './chunkErrorHandler';
+import {
+    isChunkLoadError,
+    isChunkLoadErrorObject,
+    RouteChunkLoadError,
+} from './chunkErrorHandler';
 
 describe('chunkErrorHandler', () => {
     it('detects dynamic import and preload failures', () => {
@@ -19,10 +23,21 @@ describe('chunkErrorHandler', () => {
         expect(
             isChunkLoadError('Unable to preload CSS for /assets/app.css'),
         ).toBe(true);
+        expect(
+            isChunkLoadError(
+                "TypeError: Cannot destructure property 'default' of '(intermediate value)' as it is undefined.",
+            ),
+        ).toBe(true);
     });
 
     it('does not match unrelated errors', () => {
         expect(isChunkLoadError('Network request failed')).toBe(false);
         expect(isChunkLoadError('Something went wrong')).toBe(false);
+    });
+
+    it('detects route chunk load errors', () => {
+        expect(
+            isChunkLoadErrorObject(new RouteChunkLoadError('./pages/Home')),
+        ).toBe(true);
     });
 });

--- a/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
@@ -1,12 +1,24 @@
 const CHUNK_ERROR_RELOAD_KEY = 'lightdash-chunk-error-reload';
 const RELOAD_COOLDOWN_MS = 60_000; // 60 seconds before allowing another auto-reload
 
+export class RouteChunkLoadError extends Error {
+    routeModule: string;
+
+    constructor(routeModule: string) {
+        super(`Route chunk failed to load: ${routeModule}`);
+        this.name = 'RouteChunkLoadError';
+        this.routeModule = routeModule;
+    }
+}
+
 const CHUNK_ERROR_MESSAGES = [
     'Failed to fetch dynamically imported module',
     'error loading dynamically imported module',
     'Importing a module script failed',
     'Failed to load module script',
     'Unable to preload CSS',
+    // Route lazy imports can surface a failed preload as destructuring undefined.
+    "Cannot destructure property 'default' of '(intermediate value)' as it is undefined",
 ];
 
 let isChunkLoadErrorHandlerInstalled = false;
@@ -19,6 +31,9 @@ export const isChunkLoadError = (message: string): boolean => {
 };
 
 export const isChunkLoadErrorObject = (error: unknown): boolean => {
+    if (error instanceof RouteChunkLoadError) {
+        return true;
+    }
     if (error instanceof Error) {
         return isChunkLoadError(error.message);
     }

--- a/packages/frontend/src/features/chunkErrorHandler/index.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/index.ts
@@ -3,5 +3,7 @@ export {
     installChunkLoadErrorHandler,
     isChunkLoadError,
     isChunkLoadErrorObject,
+    RouteChunkLoadError,
     triggerChunkErrorReload,
 } from './chunkErrorHandler';
+export { loadLazyRouteDefault } from './loadLazyRouteDefault';

--- a/packages/frontend/src/features/chunkErrorHandler/loadLazyRouteDefault.test.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/loadLazyRouteDefault.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { type RouteChunkLoadError } from './chunkErrorHandler';
+import { loadLazyRouteDefault } from './loadLazyRouteDefault';
+
+describe('loadLazyRouteDefault', () => {
+    it('returns the default component from a lazy route module', async () => {
+        const RouteComponent = () => null;
+
+        await expect(
+            loadLazyRouteDefault('./pages/Home', async () => ({
+                default: RouteComponent,
+            })),
+        ).resolves.toBe(RouteComponent);
+    });
+
+    it('throws a route chunk error when the import resolves without a default export', async () => {
+        await expect(
+            loadLazyRouteDefault('./pages/Home', async () => undefined),
+        ).rejects.toMatchObject({
+            name: 'RouteChunkLoadError',
+            message: 'Route chunk failed to load: ./pages/Home',
+            routeModule: './pages/Home',
+        } satisfies Partial<RouteChunkLoadError>);
+    });
+});

--- a/packages/frontend/src/features/chunkErrorHandler/loadLazyRouteDefault.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/loadLazyRouteDefault.ts
@@ -1,0 +1,19 @@
+import { type ComponentType } from 'react';
+import { RouteChunkLoadError } from './chunkErrorHandler';
+
+type DefaultRouteModule<Component extends ComponentType> =
+    | { default?: Component }
+    | undefined;
+
+export const loadLazyRouteDefault = async <Component extends ComponentType>(
+    routeModule: string,
+    importer: () => Promise<DefaultRouteModule<Component>>,
+): Promise<Component> => {
+    const importedRouteModule = await importer();
+
+    if (!importedRouteModule?.default) {
+        throw new RouteChunkLoadError(routeModule);
+    }
+
+    return importedRouteModule.default;
+};

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -19,6 +19,7 @@ import {
 import {
     hasRecentChunkReload,
     isChunkLoadErrorObject,
+    RouteChunkLoadError,
 } from '../../features/chunkErrorHandler';
 
 const sentrySpotlightEnabled =
@@ -86,6 +87,14 @@ const useSentry = (
                 replaysOnErrorSampleRate: 1.0,
                 beforeSend(event, hint) {
                     const error = hint.originalException;
+                    if (error instanceof RouteChunkLoadError) {
+                        event.tags = {
+                            ...event.tags,
+                            'route.module': error.routeModule,
+                        };
+                        event.fingerprint = ['route-chunk-load-error'];
+                    }
+
                     // For chunk load errors, only send to Sentry if auto-reload already failed
                     if (
                         isChunkLoadErrorObject(error) &&


### PR DESCRIPTION
## Summary

- Add a typed `RouteChunkLoadError` for lazy route imports that resolve without a default export.
- Route all default-export lazy route loaders through `loadLazyRouteDefault` so failures produce actionable messages like `Route chunk failed to load: ./pages/Home` instead of destructuring `undefined`.
- Tag repeat Sentry reports with `route.module` and group them under a route chunk load fingerprint.

## Why

Route-level lazy chunk failures can surface as `Cannot destructure property 'default' of '(intermediate value)' as it is undefined`, which hides the route module that failed and creates noisy, unclear frontend issues.

## Validation

- `cd packages/frontend && ./node_modules/.bin/vitest run src/features/chunkErrorHandler/chunkErrorHandler.test.ts src/features/chunkErrorHandler/loadLazyRouteDefault.test.ts`
- `cd packages/frontend && ./node_modules/.bin/oxlint -c .oxlintrc.json src/features/chunkErrorHandler/chunkErrorHandler.ts src/features/chunkErrorHandler/chunkErrorHandler.test.ts src/features/chunkErrorHandler/index.ts src/features/chunkErrorHandler/loadLazyRouteDefault.ts src/features/chunkErrorHandler/loadLazyRouteDefault.test.ts src/hooks/thirdPartyServices/useSentry.ts src/Routes.tsx src/MobileRoutes.tsx src/ee/CommercialRoutes.tsx`
- `cd packages/frontend && ./node_modules/.bin/tsc6 --project tsconfig.json --noEmit`

Note: local pre-commit was bypassed because the pnpm wrapper hits the ignored-build-script policy in this worktree. The equivalent direct checks above passed.