### PR TITLE
fix(tables): show URL menu items for zero-valued cells

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -117,7 +117,7 @@ const CellContextMenu: FC<
 
     return (
         <>
-            {!!value.raw && isField(item) && (
+            {value.raw !== undefined && value.raw !== null && isField(item) && (
                 <UrlMenuItems
                     urls={item.urls}
                     cell={cell}

--- a/packages/frontend/src/components/MetricQueryData/CellContextMenu.tsx
+++ b/packages/frontend/src/components/MetricQueryData/CellContextMenu.tsx
@@ -24,7 +24,10 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     }, [value, clipboard, showToastSuccess]);
 
     const urls: FieldUrl[] | undefined = useMemo(
-        () => (value.raw && isField(item) ? item.urls : undefined),
+        () =>
+            value.raw !== undefined && value.raw !== null && isField(item)
+                ? item.urls
+                : undefined,
         [value, item],
     );
 

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -76,7 +76,10 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
 
     return (
         <>
-            {item && value.raw && isField(item) ? (
+            {item &&
+            value.raw !== undefined &&
+            value.raw !== null &&
+            isField(item) ? (
                 <UrlMenuItems urls={item.urls} cell={cell} />
             ) : null}
 

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -151,7 +151,10 @@ const DashboardCellContextMenu: FC<
 
     return (
         <>
-            {item && value.raw && isField(item) ? (
+            {item &&
+            value.raw !== undefined &&
+            value.raw !== null &&
+            isField(item) ? (
                 <UrlMenuItems urls={item.urls} cell={cell} />
             ) : null}
 

--- a/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
@@ -51,7 +51,10 @@ const MinimalCellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({
 
     return (
         <>
-            {item && value.raw && isField(item) ? (
+            {item &&
+            value.raw !== undefined &&
+            value.raw !== null &&
+            isField(item) ? (
                 <UrlMenuItems urls={item.urls} cell={cell} showErrors={false} />
             ) : null}
 


### PR DESCRIPTION
### Description

Dimensions with `urls` metadata did not show their link actions when the cell value was `0`: all five cell context menus gated the URL menu items on the truthiness of the raw cell value (`value.raw && ...`), so `0` (and empty string / `false`) was treated the same as an empty cell. The gate is now an explicit `value.raw !== undefined && value.raw !== null`, so links render for any real value while null/empty cells still hide them.

Touched menus: Explorer results table, SimpleTable (explore chart + dashboard + minimal), and underlying-data table.

### How to test

1. Add a `urls` entry to a number dimension that has rows with value `0` (e.g. `payments.amount` in the jaffle demo) and refresh dbt.
2. Run a query including that dimension and click a `0` cell — the URL menu item now appears and opens the templated URL with `0` substituted.
3. Verified pre-fix (repro), post-fix, and a non-zero control cell in the browser.

Closes: PROD-8706
Closes: #25206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

test-frontend