### PR TITLE
feat(admin-mcp): overview stats panel on the MCP activity page

### DIFF
--- a/.claude/skills/frontend-style-guide/SKILL.md
+++ b/.claude/skills/frontend-style-guide/SKILL.md
@@ -319,6 +319,13 @@ const MyComponent = () => {
 - Use `Callout` from `components/common/Callout`
 - Variants: `danger`, `warning`, `info`
 
+### Empty / Unavailable Sections (dotted style)
+
+- **`<Paper variant="dotted">`** (also `Card`) renders a dashed `ldGray.3` border with a transparent background — the house style for empty, placeholder, or unavailable sections. Defined in `mantine8Theme.ts` (`paperDottedStyles`); used by e.g. `FavoritesPanel` and `AiAgentKnowledgeFilesSection`.
+- **Section failed to load**: use `InlineErrorState` from `components/common/InlineErrorState` — a dotted Paper with a muted message and optional `onRetry` button. Keep it quiet; a failing secondary panel shouldn't shout.
+- **Placeholder values** (stat tiles etc. with no data): render an em dash (`—`) in `ldGray.5` inside a dotted container rather than fake zeros or endless skeletons. Skeletons mean "loading", dotted means "nothing here".
+- Reserve `ErrorState` / `SuboptimalState` for whole-page failures.
+
 ### Polymorphic Clickable Containers
 
 Use these when you need a layout container that is also clickable — avoids the native `<button>` background/border reset problem.

--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -16,6 +16,7 @@ import {
     ApiAiReviewNotificationSettingsResponse,
     ApiErrorPayload,
     ApiMcpActivityResponse,
+    ApiMcpActivityStatsResponse,
     ApiSuccessEmpty,
     ApiUpdateAiOrganizationSettingsResponse,
     assertRegisteredAccount,
@@ -24,6 +25,7 @@ import {
     KnexPaginateArgs,
     McpActivityFilters,
     McpActivitySort,
+    McpActivityStatsFilters,
     ParameterError,
     ReorderAiAgentReviewItems,
     UpdateAiAgentReviewItemAssignee,
@@ -50,6 +52,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { validate as isUuid } from 'uuid';
 import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
@@ -72,6 +75,17 @@ const validateDateFilter = (
         throw new ParameterError(`Invalid ${name}: expected an ISO date`);
     }
     return value;
+};
+
+// Same rationale: a non-uuid value in a whereIn on a uuid column is a
+// Postgres cast error (500), not an empty result
+const validateUuidFilter = (
+    name: string,
+    values: string[] | undefined,
+): void => {
+    if (values?.some((value) => !isUuid(value))) {
+        throw new ParameterError(`Invalid ${name}: expected UUIDs`);
+    }
 };
 
 @Route('/api/v1/aiAgents/admin')
@@ -176,6 +190,9 @@ export class AiAgentAdminController extends BaseController {
         assertRegisteredAccount(req.account);
         validateDateFilter('dateFrom', dateFrom);
         validateDateFilter('dateTo', dateTo);
+        validateUuidFilter('projectUuids', projectUuids);
+        validateUuidFilter('userUuids', userUuids);
+        validateUuidFilter('agentUuids', agentUuids);
         // Rows can carry up to 64KB of tool_args each, so cap the page size
         const paginateArgs: KnexPaginateArgs = {
             page: page ?? 1,
@@ -205,6 +222,53 @@ export class AiAgentAdminController extends BaseController {
             paginateArgs,
             filters,
             sort,
+        );
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Get aggregated MCP tool call stats for admin
+     * @summary Get MCP activity stats
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/mcp-activity/stats')
+    @OperationId('getMcpActivityStats')
+    async getMcpActivityStats(
+        @Request() req: express.Request,
+        @Query() projectUuids?: McpActivityFilters['projectUuids'],
+        @Query() userUuids?: McpActivityFilters['userUuids'],
+        @Query() agentUuids?: McpActivityFilters['agentUuids'],
+        @Query() toolNames?: McpActivityFilters['toolNames'],
+        @Query() clientNames?: McpActivityFilters['clientNames'],
+        @Query() dateFrom?: McpActivityFilters['dateFrom'],
+        @Query() dateTo?: McpActivityFilters['dateTo'],
+    ): Promise<ApiMcpActivityStatsResponse> {
+        assertRegisteredAccount(req.account);
+        validateDateFilter('dateFrom', dateFrom);
+        validateDateFilter('dateTo', dateTo);
+        validateUuidFilter('projectUuids', projectUuids);
+        validateUuidFilter('userUuids', userUuids);
+        validateUuidFilter('agentUuids', agentUuids);
+
+        const filters: McpActivityStatsFilters = {
+            ...(projectUuids && { projectUuids }),
+            ...(userUuids && { userUuids }),
+            ...(agentUuids && { agentUuids }),
+            ...(toolNames && { toolNames }),
+            ...(clientNames && { clientNames }),
+            ...(dateFrom && { dateFrom }),
+            ...(dateTo && { dateTo }),
+        };
+
+        const results = await this.getAiAgentAdminService().getMcpActivityStats(
+            toSessionUser(req.account),
+            filters,
         );
 
         this.setStatus(200);

--- a/packages/backend/src/ee/models/McpToolCallModel.ts
+++ b/packages/backend/src/ee/models/McpToolCallModel.ts
@@ -4,6 +4,8 @@ import {
     McpActivityFilters,
     McpActivityItem,
     McpActivitySort,
+    McpActivityStats,
+    McpActivityStatsFilters,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { EmailTableName } from '../../database/entities/emails';
@@ -37,6 +39,10 @@ export type UpsertMcpClientInfo = {
 // Oversized args are replaced (not truncated mid-JSON) so tool_args stays
 // valid jsonb; the original size is kept for the admin UI to explain the gap.
 const MAX_TOOL_ARGS_BYTES = 64 * 1024;
+
+const STATS_TOP_TOOLS_LIMIT = 6;
+const STATS_AGENTS_LIMIT = 6;
+const STATS_RECENT_ERRORS_LIMIT = 5;
 
 const capToolArgs = (args: object): object => {
     const serialized = JSON.stringify(args);
@@ -286,6 +292,95 @@ export class McpToolCallModel {
                 protocolVersion: row.protocol_version,
             })),
             pagination,
+        };
+    }
+
+    async getActivityStats({
+        organizationUuid,
+        filters,
+    }: {
+        organizationUuid: string;
+        filters?: McpActivityStatsFilters;
+    }): Promise<McpActivityStats> {
+        const countsQuery = this.buildActivityQuery(organizationUuid, filters)
+            .select<{ total_calls: number; error_calls: number }[]>(
+                this.database.raw('count(*)::int as total_calls'),
+                this.database.raw(
+                    `count(*) filter (where ${McpToolCallTableName}.status = 'error')::int as error_calls`,
+                ),
+            )
+            .first();
+
+        const topToolsQuery = this.buildActivityQuery(organizationUuid, filters)
+            .select<{ tool_name: string; count: number }[]>(
+                `${McpToolCallTableName}.tool_name`,
+                this.database.raw('count(*)::int as count'),
+            )
+            .groupBy(`${McpToolCallTableName}.tool_name`)
+            .orderBy([
+                { column: 'count', order: 'desc' },
+                { column: 'tool_name', order: 'asc' },
+            ])
+            .limit(STATS_TOP_TOOLS_LIMIT);
+
+        const agentsQuery = this.buildActivityQuery(organizationUuid, filters)
+            .leftJoin(
+                AiAgentTableName,
+                `${AiAgentTableName}.ai_agent_uuid`,
+                `${McpToolCallTableName}.agent_uuid`,
+            )
+            .select<
+                {
+                    agent_uuid: string | null;
+                    agent_name: string | null;
+                    count: number;
+                }[]
+            >(
+                `${McpToolCallTableName}.agent_uuid`,
+                `${AiAgentTableName}.name as agent_name`,
+                this.database.raw('count(*)::int as count'),
+            )
+            .groupBy([
+                `${McpToolCallTableName}.agent_uuid`,
+                `${AiAgentTableName}.name`,
+            ])
+            .orderBy([
+                { column: 'count', order: 'desc' },
+                { column: 'agent_name', order: 'asc' },
+            ])
+            .limit(STATS_AGENTS_LIMIT);
+
+        const recentErrorsQuery = this.findActivityPaginated({
+            organizationUuid,
+            paginateArgs: { page: 1, pageSize: STATS_RECENT_ERRORS_LIMIT },
+            filters: { ...filters, status: 'error' },
+            sort: { field: 'createdAt', direction: 'desc' },
+        });
+
+        const [counts, topTools, agents, recentErrors] = await Promise.all([
+            countsQuery,
+            topToolsQuery,
+            agentsQuery,
+            recentErrorsQuery,
+        ]);
+
+        return {
+            totalCalls: counts?.total_calls ?? 0,
+            errorCalls: counts?.error_calls ?? 0,
+            topTools: topTools.map((row) => ({
+                toolName: row.tool_name,
+                count: row.count,
+            })),
+            agents: agents.map((row) => ({
+                agent: row.agent_uuid
+                    ? {
+                          uuid: row.agent_uuid,
+                          name: row.agent_name ?? 'Unknown agent',
+                      }
+                    : null,
+                count: row.count,
+            })),
+            recentErrors: recentErrors.data,
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -32,6 +32,8 @@ import {
     KnexPaginatedData,
     McpActivityFilters,
     McpActivitySort,
+    McpActivityStats,
+    McpActivityStatsFilters,
     McpActivitySummary,
     MissingConfigError,
     NotFoundError,
@@ -593,6 +595,35 @@ export class AiAgentAdminService extends BaseService {
             });
 
         return { data: { toolCalls: data }, pagination };
+    }
+
+    async getMcpActivityStats(
+        user: SessionUser,
+        filters?: McpActivityStatsFilters,
+    ): Promise<McpActivityStats> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        const scope = await this.resolveReadScope(user, organizationUuid);
+        // Forcing projectUuids for project-scoped principals also hides rows
+        // with no project — those are visible to org-wide admins only
+        const { filters: scopedFilters, empty } =
+            AiAgentAdminService.restrictFiltersToScope(scope, filters);
+        if (empty) {
+            return {
+                totalCalls: 0,
+                errorCalls: 0,
+                topTools: [],
+                agents: [],
+                recentErrors: [],
+            };
+        }
+
+        return this.mcpToolCallModel.getActivityStats({
+            organizationUuid,
+            filters: scopedFilters,
+        });
     }
 
     async getPromptActivity(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12437,8 +12437,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -13086,8 +13086,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -15736,13 +15736,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -15835,10 +15835,10 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                fieldValueType:
+                                                                                isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
-                                                                                            'string',
+                                                                                            'boolean',
                                                                                         required: true,
                                                                                     },
                                                                                 caseSensitiveFilters:
@@ -15871,19 +15871,53 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
                                                                                 fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -15908,45 +15942,11 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                             },
                                                                     },
                                                                     required: true,
@@ -16229,17 +16229,17 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 name: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
+                                                uuid: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -16586,13 +16586,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -16705,25 +16705,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16804,6 +16785,25 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 type: {
                                                                     dataType:
                                                                         'union',
@@ -16813,14 +16813,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
@@ -23439,6 +23439,93 @@ const models: TsoaRoute.Models = {
             ],
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    McpActivityToolCount: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                count: { dataType: 'double', required: true },
+                toolName: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    McpActivityAgentCount: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                count: { dataType: 'double', required: true },
+                agent: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                name: { dataType: 'string', required: true },
+                                uuid: { dataType: 'string', required: true },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    McpActivityStats: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                recentErrors: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'McpActivityItem' },
+                    required: true,
+                },
+                agents: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'McpActivityAgentCount',
+                    },
+                    required: true,
+                },
+                topTools: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'McpActivityToolCount',
+                    },
+                    required: true,
+                },
+                errorCalls: { dataType: 'double', required: true },
+                totalCalls: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_McpActivityStats_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'McpActivityStats', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiMcpActivityStatsResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_McpActivityStats_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentAdminPromptActivityPoint: {
@@ -33310,7 +33397,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33320,7 +33407,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33330,7 +33417,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -33343,7 +33430,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -58617,6 +58704,93 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getMcpActivity',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getMcpActivityStats: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuids: {
+            in: 'query',
+            name: 'projectUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        userUuids: {
+            in: 'query',
+            name: 'userUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        agentUuids: {
+            in: 'query',
+            name: 'agentUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        toolNames: {
+            in: 'query',
+            name: 'toolNames',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        clientNames: {
+            in: 'query',
+            name: 'clientNames',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        dateFrom: { in: 'query', name: 'dateFrom', dataType: 'string' },
+        dateTo: { in: 'query', name: 'dateTo', dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/mcp-activity/stats',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getMcpActivityStats,
+        ),
+
+        async function AiAgentAdminController_getMcpActivityStats(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getMcpActivityStats,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getMcpActivityStats',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14045,7 +14045,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -14675,7 +14675,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16931,19 +16931,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -16987,8 +16987,8 @@
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
                                                                                 },
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
@@ -16998,47 +16998,47 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
                                                                                 "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "fieldValueType",
-                                                                                "caseSensitiveFilters",
                                                                                 "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
                                                                                 "fieldFilterType",
+                                                                                "fieldValueType",
                                                                                 "table",
-                                                                                "description",
                                                                                 "fieldType",
+                                                                                "fieldId",
                                                                                 "label",
-                                                                                "name",
-                                                                                "fieldId"
+                                                                                "description",
+                                                                                "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -17227,16 +17227,16 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "uuid": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "uuid": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
@@ -17244,9 +17244,9 @@
                                                     "warnings",
                                                     "href",
                                                     "slug",
-                                                    "uuid",
+                                                    "status",
                                                     "name",
-                                                    "status"
+                                                    "uuid"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17350,20 +17350,20 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
                                                     "slug",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17403,10 +17403,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17443,19 +17439,23 @@
                                                                 },
                                                                 "type": "array"
                                                             },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -23740,6 +23740,97 @@
             "McpActivitySortField": {
                 "type": "string",
                 "enum": ["createdAt", "durationMs"]
+            },
+            "McpActivityToolCount": {
+                "properties": {
+                    "count": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "toolName": {
+                        "type": "string"
+                    }
+                },
+                "required": ["count", "toolName"],
+                "type": "object"
+            },
+            "McpActivityAgentCount": {
+                "properties": {
+                    "count": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "agent": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name", "uuid"],
+                        "type": "object",
+                        "nullable": true
+                    }
+                },
+                "required": ["count", "agent"],
+                "type": "object"
+            },
+            "McpActivityStats": {
+                "properties": {
+                    "recentErrors": {
+                        "items": {
+                            "$ref": "#/components/schemas/McpActivityItem"
+                        },
+                        "type": "array"
+                    },
+                    "agents": {
+                        "items": {
+                            "$ref": "#/components/schemas/McpActivityAgentCount"
+                        },
+                        "type": "array"
+                    },
+                    "topTools": {
+                        "items": {
+                            "$ref": "#/components/schemas/McpActivityToolCount"
+                        },
+                        "type": "array"
+                    },
+                    "errorCalls": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "totalCalls": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": [
+                    "recentErrors",
+                    "agents",
+                    "topTools",
+                    "errorCalls",
+                    "totalCalls"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_McpActivityStats_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/McpActivityStats"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiMcpActivityStatsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_McpActivityStats_"
             },
             "AiAgentAdminPromptActivityPoint": {
                 "properties": {
@@ -33807,22 +33898,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -43969,7 +44060,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3333.0",
+        "version": "0.3334.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -51216,6 +51307,109 @@
                         "schema": {
                             "type": "string",
                             "enum": ["asc", "desc"]
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/aiAgents/admin/mcp-activity/stats": {
+            "get": {
+                "operationId": "getMcpActivityStats",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiMcpActivityStatsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get aggregated MCP tool call stats for admin",
+                "summary": "Get MCP activity stats",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "projectUuids",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "userUuids",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "agentUuids",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "toolNames",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "clientNames",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "dateFrom",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "dateTo",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ]

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -130,6 +130,34 @@ export type ApiMcpActivityResponse = ApiSuccess<
     KnexPaginatedData<McpActivitySummary>
 >;
 
+export type McpActivityToolCount = {
+    toolName: string;
+    count: number;
+};
+
+export type McpActivityAgentCount = {
+    // null represents tool calls made without an agent
+    agent: {
+        uuid: string;
+        name: string;
+    } | null;
+    count: number;
+};
+
+export type McpActivityStats = {
+    totalCalls: number;
+    errorCalls: number;
+    topTools: McpActivityToolCount[];
+    agents: McpActivityAgentCount[];
+    recentErrors: McpActivityItem[];
+};
+
+// Status is not accepted as a filter: the response already breaks results
+// down by status, and recentErrors is always error-only
+export type McpActivityStatsFilters = Omit<McpActivityFilters, 'status'>;
+
+export type ApiMcpActivityStatsResponse = ApiSuccess<McpActivityStats>;
+
 export type ComputedAiOrganizationSettings = {
     isCopilotEnabled: boolean;
     isTrial: boolean;

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -964,7 +964,7 @@
                 "idempotentHint": true,
                 "readOnlyHint": true
             },
-            "description": "Tool: \"listContent\"\nPurpose:\nLists accessible Lightdash content in a project as a browsable hierarchy.\n\nUsage tips:\n- By default, lists root-level spaces.\n- Pass a spaceSlug to list direct children and content inside that space.\n- Use page for pagination. Page starts at 1.\n- Results include names, slugs, content types, and space content counts.",
+            "description": "Tool: \"listContent\"\nPurpose:\nLists accessible Lightdash content in a project as a browsable hierarchy.\n\nUsage tips:\n- By default, lists root-level spaces.\n- Pass a spaceSlug to list direct children and content inside that space.\n- Use page for pagination. Page starts at 1.\n- Results include names, slugs, content types, URLs, and space content counts.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -55,6 +55,7 @@ import type {
     ApiManagedAgentRunResponse,
     ApiManagedAgentRunsListResponse,
     ApiMcpActivityResponse,
+    ApiMcpActivityStatsResponse,
     ApiMyAppsResponse,
     ApiOrganizationDesignFileResponse,
     ApiOrganizationDesignResponse,
@@ -1141,6 +1142,7 @@ type ApiResults =
     | ApiAiAgentAdminConversationsResponse['results']
     | ApiAiAgentAdminPromptActivityResponse['results']
     | ApiMcpActivityResponse['results']
+    | ApiMcpActivityStatsResponse['results']
     | ApiAiAgentReviewItemWritebackPreviewResponse['results']
     | ApiAiAgentReviewItemPrDiffResponse['results']
     | ApiAiAgentReviewItemActivityResponse['results']

--- a/packages/frontend/src/components/common/InlineErrorState.tsx
+++ b/packages/frontend/src/components/common/InlineErrorState.tsx
@@ -1,0 +1,30 @@
+import { Button, Group, Paper, Text, type PaperProps } from '@mantine-8/core';
+import { type FC } from 'react';
+
+type InlineErrorStateProps = PaperProps & {
+    message: string;
+    onRetry?: () => void;
+};
+
+// Compact failure state for a single section, styled with the theme's dotted
+// Paper variant. For whole-view failures use ErrorState/SuboptimalState.
+const InlineErrorState: FC<InlineErrorStateProps> = ({
+    message,
+    onRetry,
+    ...paperProps
+}) => (
+    <Paper variant="dotted" p="md" {...paperProps}>
+        <Group justify="space-between" gap="xs">
+            <Text fz="sm" c="ldGray.6">
+                {message}
+            </Text>
+            {onRetry && (
+                <Button variant="subtle" size="compact-xs" onClick={onRetry}>
+                    Retry
+                </Button>
+            )}
+        </Group>
+    </Paper>
+);
+
+export default InlineErrorState;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityOverview.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityOverview.module.css
@@ -1,0 +1,172 @@
+/* Container-based (not viewport-based) so the rail responds to the actual
+   content width, which changes when the settings sidebar collapses */
+.layout {
+    container-type: inline-size;
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-md);
+}
+
+.strip {
+    display: none;
+}
+
+.columns {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--mantine-spacing-md);
+}
+
+.tableArea {
+    flex: 1;
+    min-width: 0;
+}
+
+.rail {
+    width: 300px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-md);
+    position: sticky;
+    top: var(--mantine-spacing-md);
+}
+
+/* Narrow: tiles become a strip above the table and the cards re-flow into
+   a grid below it, so the table keeps priority but nothing is lost */
+@container (max-width: 65em) {
+    .columns {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .rail {
+        width: 100%;
+        position: static;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        order: -1;
+    }
+
+    .rail .tileRow {
+        display: none;
+    }
+
+    /* Full-width row so long error messages keep a comfortable measure */
+    .rail > *:last-child {
+        grid-column: 1 / -1;
+    }
+
+    .strip {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--mantine-spacing-md);
+    }
+}
+
+@container (max-width: 40em) {
+    .rail {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+.tileRow {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--mantine-spacing-xs);
+}
+
+/* Matches the border/radius/shadow McpActivityTable sets on its paper */
+.card {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-spacing-sm);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+/* Radius only — border and background come from Paper's dotted variant */
+.dottedCard {
+    border-radius: var(--mantine-spacing-sm);
+}
+
+.statLabel {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.statValue {
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 1.4;
+    font-variant-numeric: tabular-nums;
+}
+
+.num {
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}
+
+.truncatingGroup {
+    min-width: 0;
+}
+
+.noShrink {
+    flex-shrink: 0;
+}
+
+.barTrack {
+    height: 3px;
+    border-radius: 2px;
+    background: var(--mantine-color-ldGray-2);
+    overflow: hidden;
+}
+
+.barFill {
+    height: 100%;
+    border-radius: 2px;
+    background: var(--mantine-color-ldGray-5);
+    width: var(--tool-share);
+}
+
+.agentDot,
+.errorDot,
+.okDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.agentDot {
+    background: var(--mantine-color-ldGray-4);
+}
+
+.errorDot {
+    background: var(--mantine-color-red-6);
+}
+
+.okDot {
+    background: var(--mantine-color-green-6);
+}
+
+.errorRow {
+    display: block;
+    width: 100%;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+    text-align: left;
+}
+
+.errorRow + .errorRow {
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.errorRow:hover {
+    background: var(--mantine-color-ldGray-0);
+}
+
+.errorRow:focus-visible {
+    outline: 2px solid var(--mantine-color-blue-5);
+    outline-offset: -2px;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityOverview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityOverview.tsx
@@ -1,0 +1,337 @@
+import { type McpActivityItem, type McpActivityStats } from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Group,
+    Paper,
+    Skeleton,
+    Stack,
+    Text,
+    Tooltip,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import InlineErrorState from '../../../../../components/common/InlineErrorState';
+import {
+    formatToolCallTime,
+    formatToolCallTimeFull,
+} from './mcpActivityFormat';
+import styles from './McpActivityOverview.module.css';
+
+const percentFormat = new Intl.NumberFormat(undefined, {
+    style: 'percent',
+    maximumFractionDigits: 0,
+});
+const countFormat = new Intl.NumberFormat(undefined);
+
+type StatTone = 'neutral' | 'success' | 'error';
+
+// Theme-aware colors: green-text/error flip with the color scheme
+const STAT_TONE_COLOR: Record<StatTone, string> = {
+    neutral: 'foreground',
+    success: 'var(--mantine-color-green-text)',
+    error: 'var(--mantine-color-error)',
+};
+
+const StatTile: FC<{
+    label: string;
+    value: string;
+    tone: StatTone;
+    dotted?: boolean;
+}> = ({ label, value, tone, dotted = false }) => (
+    <Paper
+        className={dotted ? styles.dottedCard : styles.card}
+        variant={dotted ? 'dotted' : undefined}
+        p="sm"
+    >
+        <Text className={styles.statLabel}>{label}</Text>
+        <Text
+            className={styles.statValue}
+            c={dotted ? 'dimmed' : STAT_TONE_COLOR[tone]}
+        >
+            {value}
+        </Text>
+    </Paper>
+);
+
+export const McpActivityStatTiles: FC<{
+    stats: McpActivityStats | undefined;
+    isError: boolean;
+}> = ({ stats, isError }) => {
+    if (!stats) {
+        if (isError) {
+            return (
+                <>
+                    <StatTile label="Calls" value="—" tone="neutral" dotted />
+                    <StatTile label="Success" value="—" tone="neutral" dotted />
+                    <StatTile label="Errors" value="—" tone="neutral" dotted />
+                </>
+            );
+        }
+        return (
+            <>
+                <Skeleton h={62} radius={12} />
+                <Skeleton h={62} radius={12} />
+                <Skeleton h={62} radius={12} />
+            </>
+        );
+    }
+
+    const successRate =
+        stats.totalCalls > 0
+            ? (stats.totalCalls - stats.errorCalls) / stats.totalCalls
+            : null;
+
+    return (
+        <>
+            <StatTile
+                label="Calls"
+                value={countFormat.format(stats.totalCalls)}
+                tone="neutral"
+            />
+            <StatTile
+                label="Success"
+                value={
+                    successRate === null
+                        ? '—'
+                        : percentFormat.format(successRate)
+                }
+                tone={successRate === null ? 'neutral' : 'success'}
+            />
+            <StatTile
+                label="Errors"
+                value={countFormat.format(stats.errorCalls)}
+                tone={stats.errorCalls > 0 ? 'error' : 'neutral'}
+            />
+        </>
+    );
+};
+
+const OverviewCard: FC<
+    PropsWithChildren<{ title: string; suffix?: ReactNode }>
+> = ({ title, suffix, children }) => (
+    <Paper className={styles.card} p="md">
+        <Group justify="space-between" align="center" gap="xs" mb="sm">
+            <Text fz="sm" fw={600} c="ldGray.9">
+                {title}
+            </Text>
+            {suffix}
+        </Group>
+        {children}
+    </Paper>
+);
+
+const TopToolsCard: FC<{ tools: McpActivityStats['topTools'] }> = ({
+    tools,
+}) => {
+    const maxCount = Math.max(...tools.map((tool) => tool.count), 1);
+    return (
+        <OverviewCard title="Top tools">
+            <Stack gap="sm">
+                {tools.map((tool) => (
+                    <Box key={tool.toolName}>
+                        <Group
+                            justify="space-between"
+                            wrap="nowrap"
+                            gap="xs"
+                            mb={4}
+                        >
+                            <Text fz="xs" ff="monospace" c="ldGray.8" truncate>
+                                {tool.toolName}
+                            </Text>
+                            <Text fz="xs" c="ldGray.7" className={styles.num}>
+                                {countFormat.format(tool.count)}
+                            </Text>
+                        </Group>
+                        <Box className={styles.barTrack}>
+                            <Box
+                                className={styles.barFill}
+                                __vars={{
+                                    '--tool-share': `${Math.round(
+                                        (tool.count / maxCount) * 100,
+                                    )}%`,
+                                }}
+                            />
+                        </Box>
+                    </Box>
+                ))}
+            </Stack>
+        </OverviewCard>
+    );
+};
+
+const AgentsCard: FC<{ agents: McpActivityStats['agents'] }> = ({ agents }) => (
+    <OverviewCard title="Active agents">
+        <Stack gap={6}>
+            {agents.map(({ agent, count }) => (
+                <Group
+                    key={agent?.uuid ?? 'no-agent'}
+                    justify="space-between"
+                    wrap="nowrap"
+                    gap="xs"
+                >
+                    <Group
+                        gap={6}
+                        wrap="nowrap"
+                        className={styles.truncatingGroup}
+                    >
+                        <Box className={styles.agentDot} />
+                        <Text
+                            fz="sm"
+                            c={agent ? 'ldGray.9' : 'ldGray.6'}
+                            truncate
+                        >
+                            {agent?.name ?? 'No agent'}
+                        </Text>
+                    </Group>
+                    <Text fz="xs" c="ldGray.7" className={styles.num}>
+                        {countFormat.format(count)}{' '}
+                        {count === 1 ? 'call' : 'calls'}
+                    </Text>
+                </Group>
+            ))}
+        </Stack>
+    </OverviewCard>
+);
+
+const RecentErrorsCard: FC<{
+    errorCalls: number;
+    recentErrors: McpActivityItem[];
+    onErrorSelect: (toolCall: McpActivityItem) => void;
+}> = ({ errorCalls, recentErrors, onErrorSelect }) => (
+    <Paper className={styles.card}>
+        <Group justify="space-between" align="center" gap="xs" p="md" pb="sm">
+            <Text fz="sm" fw={600} c="ldGray.9">
+                Recent errors
+            </Text>
+            {errorCalls > 0 && (
+                <Badge variant="light" color="red" size="sm">
+                    {countFormat.format(errorCalls)}
+                </Badge>
+            )}
+        </Group>
+        {recentErrors.length === 0 ? (
+            <Group gap={6} px="md" pb="md">
+                <Box className={styles.okDot} />
+                <Text fz="xs" c="ldGray.6">
+                    No errors in this period
+                </Text>
+            </Group>
+        ) : (
+            <Box pb={6}>
+                {recentErrors.map((item) => (
+                    <UnstyledButton
+                        key={item.uuid}
+                        className={styles.errorRow}
+                        onClick={() => onErrorSelect(item)}
+                    >
+                        <Group
+                            justify="space-between"
+                            wrap="nowrap"
+                            gap="xs"
+                            mb={2}
+                        >
+                            <Group
+                                gap={6}
+                                wrap="nowrap"
+                                className={styles.truncatingGroup}
+                            >
+                                <Box className={styles.errorDot} />
+                                <Text
+                                    fz="xs"
+                                    ff="monospace"
+                                    c="ldGray.8"
+                                    truncate
+                                >
+                                    {item.toolName}
+                                </Text>
+                            </Group>
+                            <Tooltip
+                                withinPortal
+                                variant="xs"
+                                label={formatToolCallTimeFull(item.createdAt)}
+                            >
+                                <Text
+                                    fz={11}
+                                    c="ldGray.5"
+                                    className={styles.noShrink}
+                                >
+                                    {formatToolCallTime(item.createdAt)}
+                                </Text>
+                            </Tooltip>
+                        </Group>
+                        <Text fz="xs" c="ldGray.7" lineClamp={2}>
+                            {item.errorMessage ?? 'Unknown error'}
+                        </Text>
+                    </UnstyledButton>
+                ))}
+            </Box>
+        )}
+    </Paper>
+);
+
+type McpActivityOverviewProps = {
+    stats: McpActivityStats | undefined;
+    isError: boolean;
+    onRetry: () => void;
+    hasActiveFilters: boolean;
+    onErrorSelect: (toolCall: McpActivityItem) => void;
+};
+
+export const McpActivityOverview: FC<McpActivityOverviewProps> = ({
+    stats,
+    isError,
+    onRetry,
+    hasActiveFilters,
+    onErrorSelect,
+}) => {
+    if (!stats) {
+        return (
+            <>
+                <Box className={styles.tileRow}>
+                    <McpActivityStatTiles stats={undefined} isError={isError} />
+                </Box>
+                {isError ? (
+                    <InlineErrorState
+                        className={styles.dottedCard}
+                        message="Couldn't load activity stats."
+                        onRetry={onRetry}
+                    />
+                ) : (
+                    <>
+                        <Skeleton h={200} radius={12} />
+                        <Skeleton h={140} radius={12} />
+                        <Skeleton h={180} radius={12} />
+                    </>
+                )}
+            </>
+        );
+    }
+
+    return (
+        <>
+            <Box className={styles.tileRow}>
+                <McpActivityStatTiles stats={stats} isError={false} />
+            </Box>
+            {stats.totalCalls === 0 ? (
+                <Paper className={styles.card} p="md">
+                    <Text fz="sm" c="ldGray.6">
+                        {hasActiveFilters
+                            ? 'No tool calls match the current filters.'
+                            : 'No MCP tool calls in the last 90 days.'}
+                    </Text>
+                </Paper>
+            ) : (
+                <>
+                    <TopToolsCard tools={stats.topTools} />
+                    <AgentsCard agents={stats.agents} />
+                    <RecentErrorsCard
+                        errorCalls={stats.errorCalls}
+                        recentErrors={stats.recentErrors}
+                        onErrorSelect={onErrorSelect}
+                    />
+                </>
+            )}
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage.tsx
@@ -1,13 +1,23 @@
-import { type McpActivityItem } from '@lightdash/common';
-import { Drawer, Group, Stack, Text } from '@mantine-8/core';
-import { useState } from 'react';
+import {
+    type McpActivityItem,
+    type McpActivityStatsFilters,
+} from '@lightdash/common';
+import { Box, Drawer, Group, Stack, Text } from '@mantine-8/core';
+import { useMemo, useState } from 'react';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
+import { useMcpActivityStats } from '../../../hooks/useMcpActivity';
+import { useMcpActivityFilters } from '../../../hooks/useMcpActivityFilters';
 import {
     McpActivityDetail,
     McpActivityDetailTitle,
 } from '../McpActivityDetail';
+import {
+    McpActivityOverview,
+    McpActivityStatTiles,
+} from '../McpActivityOverview';
+import overviewClasses from '../McpActivityOverview.module.css';
 import McpActivityTable from '../McpActivityTable';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
 import drawerClasses from './ThreadPreviewDrawer.module.css';
@@ -18,6 +28,29 @@ export const McpActivitySettingsPage = () => {
     const [selectedCall, setSelectedCall] = useState<McpActivityItem | null>(
         null,
     );
+
+    const { selectedProjectUuids, selectedAgentUuids, hasActiveFilters } =
+        useMcpActivityFilters();
+
+    // Status is deliberately not part of stats filters: the overview always
+    // shows the full success/error split for the current scope
+    const statsFilters = useMemo<McpActivityStatsFilters>(
+        () => ({
+            ...(selectedProjectUuids.length > 0 && {
+                projectUuids: selectedProjectUuids,
+            }),
+            ...(selectedAgentUuids.length > 0 && {
+                agentUuids: selectedAgentUuids,
+            }),
+        }),
+        [selectedProjectUuids, selectedAgentUuids],
+    );
+
+    const {
+        data: stats,
+        isError: isStatsError,
+        refetch: refetchStats,
+    } = useMcpActivityStats(statsFilters);
 
     return (
         <Stack mb="lg" gap="md">
@@ -35,10 +68,34 @@ export const McpActivitySettingsPage = () => {
 
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
 
-            <McpActivityTable
-                onCallSelect={setSelectedCall}
-                selectedCall={selectedCall}
-            />
+            <Box className={overviewClasses.layout}>
+                <Box className={overviewClasses.strip}>
+                    <McpActivityStatTiles
+                        stats={stats}
+                        isError={isStatsError}
+                    />
+                </Box>
+                <Box className={overviewClasses.columns}>
+                    <Box className={overviewClasses.tableArea}>
+                        <McpActivityTable
+                            onCallSelect={setSelectedCall}
+                            selectedCall={selectedCall}
+                        />
+                    </Box>
+                    <aside
+                        className={overviewClasses.rail}
+                        aria-label="MCP activity overview"
+                    >
+                        <McpActivityOverview
+                            stats={stats}
+                            isError={isStatsError}
+                            onRetry={() => void refetchStats()}
+                            hasActiveFilters={hasActiveFilters}
+                            onErrorSelect={setSelectedCall}
+                        />
+                    </aside>
+                </Box>
+            </Box>
 
             <Drawer
                 opened={!!selectedCall}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useMcpActivity.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useMcpActivity.ts
@@ -1,11 +1,14 @@
 import {
     type ApiError,
     type ApiMcpActivityResponse,
+    type ApiMcpActivityStatsResponse,
     type McpActivityFilters,
     type McpActivitySort,
+    type McpActivityStatsFilters,
 } from '@lightdash/common';
 import {
     useInfiniteQuery,
+    useQuery,
     type UseInfiniteQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
@@ -48,6 +51,23 @@ const getMcpActivity = async (
         body: undefined,
     });
 };
+
+const getMcpActivityStats = async (filters: McpActivityStatsFilters) => {
+    const params = createQueryString(filters);
+    return lightdashApi<ApiMcpActivityStatsResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/mcp-activity/stats?${params}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useMcpActivityStats = (filters: McpActivityStatsFilters) =>
+    useQuery<ApiMcpActivityStatsResponse['results'], ApiError>({
+        queryKey: ['mcp-activity-stats', filters],
+        queryFn: () => getMcpActivityStats(filters),
+        keepPreviousData: true,
+    });
 
 export const useInfiniteMcpActivity = (
     args: McpActivityArgs,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useMcpActivityFilters.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useMcpActivityFilters.ts
@@ -6,6 +6,7 @@ import type {
 } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import { validate as isUuid } from 'uuid';
 import useSearchParams from '../../../../hooks/useSearchParams';
 
 type McpActivityFiltersState = {
@@ -40,11 +41,13 @@ export const useMcpActivityFilters = () => {
 
     const currentFilters = useMemo<McpActivityFiltersState>(
         () => ({
+            // Non-uuid values (hand-edited URLs) are dropped: they can't
+            // match anything and the filter UI can't display them
             selectedProjectUuids:
-                projectsParam?.split(',').filter(Boolean) ||
+                projectsParam?.split(',').filter(isUuid) ||
                 DEFAULT_FILTERS.selectedProjectUuids,
             selectedAgentUuids:
-                agentsParam?.split(',').filter(Boolean) ||
+                agentsParam?.split(',').filter(isUuid) ||
                 DEFAULT_FILTERS.selectedAgentUuids,
             selectedStatus: statusParam || DEFAULT_FILTERS.selectedStatus,
             sortField: sortByParam || DEFAULT_FILTERS.sortField,


### PR DESCRIPTION
Part of the MCP observability stack (overview UI).

Adds an overview panel to the MCP activity settings page so admins can read the health of MCP usage at a glance without scanning the table:

- Stat tiles: total calls, success rate, error count
- Top tools with proportional usage bars
- Active agents with per-agent call counts (including calls made without an agent)
- Recent errors — clicking one opens the same tool call drawer as a table row

States are covered end to end: loading skeletons, a filtered/global empty state, a positive "no errors" state, and a failure state (stat tiles fall back to em dashes and a quiet card offers Retry, which refetches in place). When a filter change fails mid-flight, previously loaded stats stay on screen instead of flashing to the error state.

The panel shares the page's project/agent filters, so the stats always describe exactly what the table is scoped to. The status filter deliberately doesn't affect it, so the success/error split stays meaningful while the table is filtered to errors.

Layout is container-query based (it reacts to actual content width, so it also handles the settings sidebar collapsing): at wide widths the panel is a 300px rail to the right of the table; below ~1040px the tiles become a strip above the table and the cards re-flow into a grid above it (Top tools and Active agents side by side with equal heights, Recent errors full width); below ~640px everything is single column.

Relates: PROD-6844

🤖 Generated with [Claude Code](https://claude.com/claude-code)