### PR TITLE
fix: use static MCP OAuth callback

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1489,7 +1489,9 @@ export class AiAgentModel {
         trx?: Knex;
     }): Promise<AiMcpCredential | undefined> {
         const trx = args.trx ?? this.database;
-        const rows = await trx(AiMcpServerCredentialTableName)
+        const rows: DbAiMcpServerCredential[] = await trx(
+            AiMcpServerCredentialTableName,
+        )
             .select<DbAiMcpServerCredential[]>({
                 ai_mcp_server_credential_uuid: `${AiMcpServerCredentialTableName}.ai_mcp_server_credential_uuid`,
                 ai_mcp_server_uuid: `${AiMcpServerCredentialTableName}.ai_mcp_server_uuid`,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -571,7 +571,6 @@ describe('AiAgentService MCP support', () => {
         const services = getServices(context.app);
         const models = getModels(context.app);
         const suffix = crypto.randomUUID().slice(0, 8);
-
         const mcpServer = await services.aiAgentService.createMcpServer(
             context.testUser,
             SEED_PROJECT.project_uuid,
@@ -626,7 +625,6 @@ describe('AiAgentService MCP support', () => {
         const services = getServices(context.app);
         const models = getModels(context.app);
         const suffix = crypto.randomUUID().slice(0, 8);
-
         const mcpServer = await services.aiAgentService.createMcpServer(
             context.testUser,
             SEED_PROJECT.project_uuid,
@@ -636,7 +634,6 @@ describe('AiAgentService MCP support', () => {
                 authType: 'oauth',
             },
         );
-
         await models.aiAgentModel.upsertCredential({
             serverUuid: mcpServer.uuid,
             scope: 'shared',
@@ -937,6 +934,19 @@ describe('AiAgentService MCP support', () => {
         const services = getServices(context.app);
         const models = getModels(context.app);
         const suffix = crypto.randomUUID().slice(0, 8);
+        const getOauthCredentialByStateSpy = vi.spyOn(
+            models.aiAgentModel,
+            'getOauthCredentialByState',
+        );
+
+        await expect(
+            services.aiAgentService.completeMcpOAuthConnection({
+                code: 'oauth-code',
+                state: 'unscoped-state',
+            }),
+        ).rejects.toThrow('Invalid OAuth state');
+
+        expect(getOauthCredentialByStateSpy).not.toHaveBeenCalled();
 
         const mcpServer = await services.aiAgentService.createMcpServer(
             context.testUser,
@@ -947,6 +957,7 @@ describe('AiAgentService MCP support', () => {
                 authType: 'oauth',
             },
         );
+        const oauthState = `${mcpServer.uuid}.user-oauth-state`;
 
         await models.aiAgentModel.upsertCredential({
             serverUuid: mcpServer.uuid,
@@ -956,7 +967,7 @@ describe('AiAgentService MCP support', () => {
                 type: 'oauth',
                 credentialScope: 'user',
                 connectionStatus: 'connecting',
-                state: 'user-oauth-state',
+                state: oauthState,
             },
             actorUserUuid: context.testUser.userUuid,
         });
@@ -965,9 +976,14 @@ describe('AiAgentService MCP support', () => {
             services.aiAgentService.completeMcpOAuthConnection({
                 projectUuid: SEED_PROJECT.project_uuid,
                 mcpServerUuid: mcpServer.uuid,
-                state: 'user-oauth-state',
+                state: oauthState,
             }),
         ).rejects.toThrow('OAuth callback is missing code or state');
+
+        expect(getOauthCredentialByStateSpy).toHaveBeenCalledWith({
+            serverUuid: mcpServer.uuid,
+            state: oauthState,
+        });
 
         await expect(
             models.aiAgentModel.getCredential(mcpServer.uuid, 'user', {
@@ -996,14 +1012,13 @@ describe('AiAgentService MCP support', () => {
             .mockResolvedValue([]);
 
         await services.aiAgentService.completeMcpOAuthConnection({
-            projectUuid: SEED_PROJECT.project_uuid,
-            mcpServerUuid: mcpServer.uuid,
             code: 'oauth-code',
-            state: 'user-oauth-state',
+            state: oauthState,
         });
 
         expect(completeOAuthConnectionSpy).toHaveBeenCalledWith(
             expect.objectContaining({
+                projectUuid: SEED_PROJECT.project_uuid,
                 mcpServerUuid: mcpServer.uuid,
                 credential: expect.objectContaining({
                     credentialScope: 'user',
@@ -1014,5 +1029,6 @@ describe('AiAgentService MCP support', () => {
 
         completeOAuthConnectionSpy.mockRestore();
         discoverMcpServerToolsSpy.mockRestore();
+        getOauthCredentialByStateSpy.mockRestore();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3684,34 +3684,31 @@ export class AiAgentService extends BaseService {
     }
 
     public async completeMcpOAuthConnection(args: {
-        projectUuid: string;
-        mcpServerUuid: string;
+        projectUuid?: string;
+        mcpServerUuid?: string;
         code?: string;
         state?: string;
     }): Promise<void> {
-        const server = await this.getProjectMcpServerOrThrow(
-            args.projectUuid,
-            args.mcpServerUuid,
-        );
-
-        if (server.authType !== 'oauth') {
-            throw new ParameterError('MCP server is not configured for OAuth');
-        }
-
-        const credential = args.state
-            ? await this.aiAgentModel.getOauthCredentialByState({
-                  serverUuid: args.mcpServerUuid,
-                  state: args.state,
-              })
-            : undefined;
+        const stateServerUuid =
+            args.mcpServerUuid ??
+            AiAgentService.getMcpServerUuidFromOAuthState(args.state);
+        const credential =
+            args.state && stateServerUuid
+                ? await this.aiAgentModel.getOauthCredentialByState({
+                      serverUuid: stateServerUuid,
+                      state: args.state,
+                  })
+                : undefined;
 
         if (!args.code || !args.state) {
             const errorMessage = 'OAuth callback is missing code or state';
-            await this.persistMcpOAuthConnectionError(
-                args.mcpServerUuid,
-                errorMessage,
-                credential,
-            );
+            if (stateServerUuid || credential) {
+                await this.persistMcpOAuthConnectionError(
+                    stateServerUuid ?? credential?.mcpServerUuid ?? '',
+                    errorMessage,
+                    credential,
+                );
+            }
             throw new ParameterError(errorMessage);
         }
 
@@ -3719,17 +3716,36 @@ export class AiAgentService extends BaseService {
             throw new ParameterError('Invalid OAuth state');
         }
 
+        const server = args.projectUuid
+            ? await this.getProjectMcpServerOrThrow(
+                  args.projectUuid,
+                  credential.mcpServerUuid,
+              )
+            : await this.aiAgentModel.getMcpServer(credential.mcpServerUuid);
+
+        if (!server) {
+            throw new ParameterError('Invalid OAuth state');
+        }
+
+        if (args.mcpServerUuid && server.uuid !== args.mcpServerUuid) {
+            throw new ParameterError('Invalid OAuth state');
+        }
+
+        if (server.authType !== 'oauth') {
+            throw new ParameterError('MCP server is not configured for OAuth');
+        }
+
         await this.aiAgentMcpRuntimeClient.completeOAuthConnection({
-            projectUuid: args.projectUuid,
-            mcpServerUuid: args.mcpServerUuid,
+            projectUuid: server.projectUuid,
+            mcpServerUuid: server.uuid,
             serverUrl: server.url,
             code: args.code,
             credential,
         });
 
         await this.discoverMcpServerTools({
-            projectUuid: args.projectUuid,
-            mcpServerUuid: args.mcpServerUuid,
+            projectUuid: server.projectUuid,
+            mcpServerUuid: server.uuid,
             actorUserUuid:
                 credential.userUuid ??
                 credential.updatedByUserUuid ??
@@ -3743,6 +3759,13 @@ export class AiAgentService extends BaseService {
                 error,
             );
         });
+    }
+
+    private static getMcpServerUuidFromOAuthState(
+        state: string | undefined,
+    ): string | undefined {
+        const [mcpServerUuid, nonce] = state?.split('.', 2) ?? [];
+        return mcpServerUuid && nonce ? mcpServerUuid : undefined;
     }
 
     private async persistMcpOAuthConnectionError(

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -5,8 +5,10 @@ import type { AiAgentModel } from '../../models/AiAgentModel';
 import {
     AiAgentMcpRuntimeClient,
     createHttpMcpClient,
+    getMcpOAuthCallbackUrl,
     McpAuthorizationRequiredError,
     McpTimeoutError,
+    normalizeMcpOAuthPayloadForRedirect,
 } from './AiAgentMcpRuntimeClient';
 import type { AiAgentMcpServer } from './types/aiAgent';
 
@@ -35,6 +37,93 @@ const getMcpServer = (
     resolvedCredential: null,
     resolvedCredentialScope: null,
     ...overrides,
+});
+
+describe('getMcpOAuthCallbackUrl', () => {
+    it('returns the static MCP OAuth callback URL', () => {
+        expect(getMcpOAuthCallbackUrl('https://lightdash.example.com')).toEqual(
+            'https://lightdash.example.com/api/v1/aiAgents/mcp/oauth/callback',
+        );
+
+        expect(
+            getMcpOAuthCallbackUrl('https://lightdash.example.com/'),
+        ).toEqual(
+            'https://lightdash.example.com/api/v1/aiAgents/mcp/oauth/callback',
+        );
+    });
+});
+
+describe('normalizeMcpOAuthPayloadForRedirect', () => {
+    const staticMetadata = {
+        client_name: 'Lightdash MCP',
+        redirect_uris: [
+            'https://lightdash.example.com/api/v1/aiAgents/mcp/oauth/callback',
+        ],
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+        logo_uri: undefined,
+        tos_uri: undefined,
+    };
+
+    it('clears cached client information when redirect metadata is stale', () => {
+        expect(
+            normalizeMcpOAuthPayloadForRedirect(
+                {
+                    type: 'oauth',
+                    credentialScope: 'user',
+                    connectionStatus: 'connecting',
+                    clientInformation: { client_id: 'stale-client' },
+                    clientMetadata: {
+                        redirect_uris: [
+                            'https://lightdash.example.com/api/v1/projects/project-uuid/aiAgents/mcpServers/server-uuid/oauth/callback',
+                        ],
+                    },
+                    codeVerifier: 'verifier',
+                    state: 'state',
+                    tokens: {
+                        accessToken: 'access-token',
+                        tokenType: 'Bearer',
+                    },
+                },
+                'user',
+                staticMetadata.redirect_uris[0],
+                staticMetadata,
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                type: 'oauth',
+                credentialScope: 'user',
+                clientInformation: undefined,
+                clientMetadata: staticMetadata,
+                codeVerifier: undefined,
+                state: undefined,
+                tokens: undefined,
+            }),
+        );
+    });
+
+    it('keeps cached client information when redirect metadata matches', () => {
+        expect(
+            normalizeMcpOAuthPayloadForRedirect(
+                {
+                    type: 'oauth',
+                    credentialScope: 'user',
+                    connectionStatus: 'connecting',
+                    clientInformation: { client_id: 'current-client' },
+                    clientMetadata: staticMetadata,
+                },
+                'user',
+                staticMetadata.redirect_uris[0],
+                staticMetadata,
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                clientInformation: { client_id: 'current-client' },
+                clientMetadata: staticMetadata,
+            }),
+        );
+    });
 });
 
 describe('resolveMcpTools', () => {

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -76,6 +76,41 @@ const buildDefaultClientMetadata = (
     token_endpoint_auth_method: 'none',
 });
 
+export const getMcpOAuthCallbackUrl = (siteUrl: string): string =>
+    new URL('/api/v1/aiAgents/mcp/oauth/callback', siteUrl).toString();
+
+export const normalizeMcpOAuthPayloadForRedirect = (
+    payload: AiMcpOAuthCredentialPayload,
+    credentialScope: AiMcpCredentialScope,
+    redirectTargetUrl: string,
+    defaultClientMetadata: OAuthClientMetadata,
+): AiMcpOAuthCredentialPayload => {
+    if (payload.type !== 'oauth') {
+        return payload;
+    }
+
+    const redirectUris = payload.clientMetadata?.redirect_uris;
+    if (
+        Array.isArray(redirectUris) &&
+        !redirectUris.includes(redirectTargetUrl)
+    ) {
+        return {
+            ...payload,
+            credentialScope,
+            clientInformation: undefined,
+            clientMetadata: defaultClientMetadata,
+            codeVerifier: undefined,
+            state: undefined,
+            tokens: undefined,
+        };
+    }
+
+    return {
+        ...payload,
+        credentialScope,
+    };
+};
+
 const toSdkTokens = (
     payload: AiMcpOAuthCredentialPayload,
 ): OAuthTokens | undefined => {
@@ -161,6 +196,8 @@ export class McpAuthorizationRequiredError extends Error {
 }
 
 class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
+    private readonly mcpServerUuid: string;
+
     private readonly credentialScope: AiMcpCredentialScope;
 
     private readonly redirectTargetUrl: string;
@@ -180,6 +217,7 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
     private readonly defaultClientMetadata: OAuthClientMetadata;
 
     constructor(args: {
+        mcpServerUuid: string;
         credentialScope: AiMcpCredentialScope;
         redirectUrl: string;
         getCredential: () => Promise<AiMcpCredential | undefined>;
@@ -189,6 +227,7 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         connectionStatusOnAuthorization?: AiMcpServerConnectionStatus;
         clientMetadata?: OAuthClientMetadata;
     }) {
+        this.mcpServerUuid = args.mcpServerUuid;
         this.credentialScope = args.credentialScope;
         this.redirectTargetUrl = args.redirectUrl;
         this.getCredential = args.getCredential;
@@ -215,10 +254,12 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         const payload = credential?.credentials;
 
         if (payload?.type === 'oauth') {
-            return {
-                ...payload,
-                credentialScope: credential!.credentialScope,
-            };
+            return normalizeMcpOAuthPayloadForRedirect(
+                payload,
+                credential!.credentialScope,
+                this.redirectTargetUrl,
+                this.defaultClientMetadata,
+            );
         }
 
         return {
@@ -238,7 +279,7 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
 
     async state(): Promise<string> {
         const payload = await this.loadPayload();
-        const state = crypto.randomUUID();
+        const state = `${this.mcpServerUuid}.${crypto.randomUUID()}`;
         await this.persist({
             ...payload,
             state,
@@ -700,16 +741,6 @@ export class AiAgentMcpRuntimeClient {
         }
     }
 
-    private getMcpOAuthCallbackUrl(
-        projectUuid: string,
-        mcpServerUuid: string,
-    ): string {
-        return new URL(
-            `/api/v1/projects/${projectUuid}/aiAgents/mcpServers/${mcpServerUuid}/oauth/callback`,
-            this.lightdashConfig.siteUrl,
-        ).toString();
-    }
-
     private createMcpOAuthProvider(args: {
         projectUuid: string;
         mcpServerUuid: string;
@@ -721,11 +752,9 @@ export class AiAgentMcpRuntimeClient {
         connectionStatusOnAuthorization?: AiMcpServerConnectionStatus;
     }) {
         return new PersistentMcpOAuthClientProvider({
+            mcpServerUuid: args.mcpServerUuid,
             credentialScope: args.credentialScope,
-            redirectUrl: this.getMcpOAuthCallbackUrl(
-                args.projectUuid,
-                args.mcpServerUuid,
-            ),
+            redirectUrl: getMcpOAuthCallbackUrl(this.lightdashConfig.siteUrl),
             getCredential: () =>
                 this.aiAgentModel.getCredential(
                     args.mcpServerUuid,

--- a/packages/backend/src/routers/aiAgentMcpServerRouter.ts
+++ b/packages/backend/src/routers/aiAgentMcpServerRouter.ts
@@ -3,50 +3,37 @@ import { lightdashConfig } from '../config/lightdashConfig';
 import { AiAgentService } from '../ee/services/AiAgentService/AiAgentService';
 import Logger from '../logging/logger';
 
-export const aiAgentMcpServerRouter: Router = express.Router({
-    mergeParams: true,
-});
+export const aiAgentMcpOAuthCallbackRouter: Router = express.Router();
 
 const getAiAgentService = (req: express.Request): AiAgentService =>
     req.services.getAiAgentService<AiAgentService>();
 
-const getProjectParams = (
+const handleOAuthCallback = async (
     req: express.Request,
-): { projectUuid: string; mcpServerUuid: string } =>
-    req.params as {
-        projectUuid: string;
-        mcpServerUuid: string;
-    };
+    res: express.Response,
+) => {
+    const { code, state } = req.query;
+    const successRedirect = new URL(
+        '/auth/popup/success',
+        lightdashConfig.siteUrl,
+    ).toString();
+    const failureRedirect = new URL(
+        '/auth/popup/failure',
+        lightdashConfig.siteUrl,
+    ).toString();
 
-aiAgentMcpServerRouter.get(
-    '/aiAgents/mcpServers/:mcpServerUuid/oauth/callback',
-    async (req, res) => {
-        const { projectUuid, mcpServerUuid } = getProjectParams(req);
-        const { code, state } = req.query;
+    try {
+        await getAiAgentService(req).completeMcpOAuthConnection({
+            code: typeof code === 'string' ? code : undefined,
+            state: typeof state === 'string' ? state : undefined,
+        });
+        res.redirect(302, successRedirect);
+    } catch (error) {
+        Logger.error(`[AiAgent][MCP] OAuth callback failed`, error);
+        res.redirect(302, failureRedirect);
+    }
+};
 
-        const successRedirect = new URL(
-            '/auth/popup/success',
-            lightdashConfig.siteUrl,
-        ).toString();
-        const failureRedirect = new URL(
-            '/auth/popup/failure',
-            lightdashConfig.siteUrl,
-        ).toString();
-
-        try {
-            await getAiAgentService(req).completeMcpOAuthConnection({
-                projectUuid,
-                mcpServerUuid,
-                code: typeof code === 'string' ? code : undefined,
-                state: typeof state === 'string' ? state : undefined,
-            });
-            res.redirect(302, successRedirect);
-        } catch (error) {
-            Logger.error(
-                `[AiAgent][MCP][${mcpServerUuid}] OAuth callback failed`,
-                error,
-            );
-            res.redirect(302, failureRedirect);
-        }
-    },
+aiAgentMcpOAuthCallbackRouter.get('/aiAgents/mcp/oauth/callback', (req, res) =>
+    handleOAuthCallback(req, res),
 );

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -38,7 +38,7 @@ import { createActorFromUser } from '../logging/caslAuditWrapper';
 import Logger from '../logging/logger';
 import { logAuditEvent } from '../logging/winston';
 import { UserModel } from '../models/UserModel';
-import { aiAgentMcpServerRouter } from './aiAgentMcpServerRouter';
+import { aiAgentMcpOAuthCallbackRouter } from './aiAgentMcpServerRouter';
 import { dashboardRouter } from './dashboardRouter';
 import { headlessBrowserRouter } from './headlessBrowser';
 import { jobsRouter } from './jobsRouter';
@@ -877,7 +877,7 @@ apiV1Router.get('/logout', (req, res, next) => {
 apiV1Router.use('/saved', savedChartRouter);
 apiV1Router.use('/org', organizationRouter);
 apiV1Router.use('/user', userRouter);
-apiV1Router.use('/projects/:projectUuid', aiAgentMcpServerRouter);
+apiV1Router.use('/', aiAgentMcpOAuthCallbackRouter);
 apiV1Router.use('/projects/:projectUuid', projectRouter);
 apiV1Router.use('/dashboards', dashboardRouter);
 apiV1Router.use('/password-reset', passwordResetLinksRouter);


### PR DESCRIPTION
Summary:

- Use a static MCP OAuth callback route.
- Resolve project/server context from OAuth state.
- Remove legacy scoped callback routing and keep state lookup bounded by server UUID.
- Clear stale cached DCR client information when stored redirect metadata does not match the static callback.

Validations:

- pnpm -F backend test src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
- pnpm -F backend typecheck:fast
- curl callback smoke tested earlier for static route and removed scoped route

Closes: https://linear.app/lightdash/issue/ZAP-597/support-oauth-client-idclient-secret-for-mcp-servers