### PR TITLE
feat(ai-agents): recover broken MCP connections — rotate bearer tokens + persist status [PROD-8746]

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -61,6 +61,7 @@ import {
     ApiSuccessEmpty,
     ApiUpdateAiAgent,
     ApiUpdateAiAgentMcpServerToolsRequest,
+    ApiUpdateAiMcpServerCredentialBody,
     ApiUpdateEvaluationRequest,
     ApiUpdateUserAgentPreferences,
     ApiUpdateUserAgentPreferencesResponse,
@@ -235,6 +236,34 @@ export class AiAgentController extends BaseController {
                 projectUuid,
                 body,
             ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/mcpServers/{mcpServerUuid}/credential')
+    @OperationId('updateMcpServerBearerCredential')
+    async updateMcpServerBearerCredential(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() mcpServerUuid: string,
+        @Body() body: ApiUpdateAiMcpServerCredentialBody,
+    ): Promise<ApiAiMcpServerResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentService().updateMcpServerBearerCredential(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    mcpServerUuid,
+                    body,
+                ),
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -24,6 +24,7 @@ import {
     AiDuplicateSlackPromptError,
     AiMcpCredentialScope,
     AiMcpGithubAvailability,
+    AiMcpServer,
     AiMetricQueryWithFilters,
     AiModelOption,
     AiPromptContext,
@@ -47,6 +48,7 @@ import {
     ApiCreateEvaluationRequest,
     ApiUpdateAiAgent,
     ApiUpdateAiAgentMcpServerToolsRequest,
+    ApiUpdateAiMcpServerCredentialBody,
     ApiUpdateEvaluationRequest,
     ApiUpdateUserAgentPreferences,
     assertUnreachable,
@@ -3065,16 +3067,29 @@ export class AiAgentService extends BaseService {
         await this.assertCanManageMcpServers(user, projectUuid);
 
         try {
-            return await this.discoverMcpServerTools({
+            const tools = await this.discoverMcpServerTools({
                 projectUuid,
                 mcpServerUuid,
                 actorUserUuid: user.userUuid,
             });
+            await this.aiAgentModel.updateMcpServerRuntimeState({
+                serverUuid: mcpServerUuid,
+                connectionStatus: 'connected',
+                error: null,
+                actorUserUuid: user.userUuid,
+            });
+            return tools;
         } catch (error) {
+            const message =
+                error instanceof Error ? error.message : String(error);
+            await this.aiAgentModel.updateMcpServerRuntimeState({
+                serverUuid: mcpServerUuid,
+                connectionStatus: 'error',
+                error: message,
+                actorUserUuid: user.userUuid,
+            });
             throw new ParameterError(
-                `We couldn't refresh this MCP server's tools. Check the connection and authentication settings, then try again. Details: ${
-                    error instanceof Error ? error.message : String(error)
-                }`,
+                `We couldn't refresh this MCP server's tools. Check the connection and authentication settings, then try again. Details: ${message}`,
             );
         }
     }
@@ -3318,6 +3333,84 @@ export class AiAgentService extends BaseService {
         }
 
         return server;
+    }
+
+    public async updateMcpServerBearerCredential(
+        user: SessionUser,
+        projectUuid: string,
+        mcpServerUuid: string,
+        body: ApiUpdateAiMcpServerCredentialBody,
+    ): Promise<AiMcpServer> {
+        await this.assertCanManageMcpServers(user, projectUuid);
+
+        const server = await this.getProjectMcpServerOrThrow(
+            projectUuid,
+            mcpServerUuid,
+        );
+        if (server.authType !== 'bearer') {
+            throw new ParameterError(
+                'Only bearer-token MCP servers support updating the token',
+            );
+        }
+
+        const bearerToken = body.bearerToken.trim();
+        if (!bearerToken) {
+            throw new ParameterError('A bearer token is required');
+        }
+
+        let mcpConnectionMetadata: { iconUrl: string | null };
+        try {
+            mcpConnectionMetadata =
+                await this.aiAgentMcpRuntimeClient.testConnection({
+                    name: server.name,
+                    url: server.url,
+                    authType: 'bearer',
+                    bearerToken,
+                    onUncaughtError: (error) => {
+                        Logger.error(
+                            `[AiAgent][MCP][${server.name}] Uncaught MCP client error while validating updated token`,
+                            error,
+                        );
+                    },
+                });
+        } catch (error) {
+            throw new ParameterError(
+                `We couldn't connect to this MCP server with that token. Check the token and its access, then try again. Details: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+
+        await this.aiAgentModel.upsertCredential({
+            serverUuid: mcpServerUuid,
+            scope: 'shared',
+            credentials: { type: 'bearer', bearerToken },
+            actorUserUuid: user.userUuid,
+        });
+        await this.aiAgentModel.updateMcpServerRuntimeState({
+            serverUuid: mcpServerUuid,
+            connectionStatus: 'connected',
+            error: null,
+            iconUrl: mcpConnectionMetadata.iconUrl,
+            actorUserUuid: user.userUuid,
+        });
+
+        await this.discoverMcpServerTools({
+            projectUuid,
+            mcpServerUuid,
+            actorUserUuid: user.userUuid,
+        }).catch((error) => {
+            Logger.error(
+                `[AiAgent][MCP][${server.name}] Failed to discover tools after token update`,
+                error,
+            );
+        });
+
+        const updated = await this.aiAgentModel.getMcpServer(mcpServerUuid);
+        if (!updated) {
+            throw new NotFoundError('MCP server not found');
+        }
+        return updated;
     }
 
     /**

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -361,6 +361,8 @@ const ALLOWED_AGENT_AVATAR_MIME_TYPES = new Set([
 // comfortably under the usual 30-60s idle timeouts.
 const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
 
+const MAX_MCP_BEARER_TOKEN_LENGTH = 8192;
+
 type EmbedAiAgentRuntimeOptions = {
     embedSpaceUuid: string;
     spaceAccess: string[];
@@ -3248,6 +3250,14 @@ export class AiAgentService extends BaseService {
                         'Bearer MCP servers require a bearer token',
                     );
                 }
+                if (
+                    body.credentials.bearerToken.trim().length >
+                    MAX_MCP_BEARER_TOKEN_LENGTH
+                ) {
+                    throw new ParameterError(
+                        `Bearer token must be at most ${MAX_MCP_BEARER_TOKEN_LENGTH} characters`,
+                    );
+                }
                 if (allowOAuthCredentialSharing) {
                     throw new ParameterError(
                         'OAuth credential sharing is only allowed for auth type "oauth"',
@@ -3356,6 +3366,11 @@ export class AiAgentService extends BaseService {
         const bearerToken = body.bearerToken.trim();
         if (!bearerToken) {
             throw new ParameterError('A bearer token is required');
+        }
+        if (bearerToken.length > MAX_MCP_BEARER_TOKEN_LENGTH) {
+            throw new ParameterError(
+                `Bearer token must be at most ${MAX_MCP_BEARER_TOKEN_LENGTH} characters`,
+            );
         }
 
         let mcpConnectionMetadata: { iconUrl: string | null };

--- a/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
@@ -194,6 +194,21 @@ describe('updateMcpServerBearerCredential', () => {
         expect(aiAgentModel.upsertCredential).not.toHaveBeenCalled();
     });
 
+    it('rejects a token longer than the max length', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        await expect(
+            service.updateMcpServerBearerCredential(
+                user,
+                PROJECT_UUID,
+                SERVER_UUID,
+                { bearerToken: 'a'.repeat(8193) },
+            ),
+        ).rejects.toBeInstanceOf(ParameterError);
+
+        expect(aiAgentModel.upsertCredential).not.toHaveBeenCalled();
+    });
+
     it('rejects a non-bearer server', async () => {
         const { service, aiAgentModel } = buildService({
             getMcpServer: { ...bearerServer, authType: 'oauth' },

--- a/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
@@ -1,0 +1,213 @@
+import { ParameterError, type SessionUser } from '@lightdash/common';
+import { AiAgentService } from './AiAgentService';
+
+vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+const ORGANIZATION_UUID = 'org-uuid';
+const PROJECT_UUID = 'project-uuid';
+const USER_UUID = 'user-uuid';
+const SERVER_UUID = 'server-uuid';
+
+const user = {
+    userUuid: USER_UUID,
+    organizationUuid: ORGANIZATION_UUID,
+    organizationName: 'Org',
+} as unknown as SessionUser;
+
+const bearerServer = {
+    uuid: SERVER_UUID,
+    projectUuid: PROJECT_UUID,
+    name: 'GITHUB test',
+    url: 'https://api.githubcopilot.com/mcp/',
+    iconUrl: null,
+    authType: 'bearer' as const,
+    allowOAuthCredentialSharing: false,
+    hasCredentials: true,
+    credentialScope: 'shared' as const,
+    connectionStatus: 'connected' as const,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const buildService = (overrides?: {
+    discoverImpl?: () => Promise<unknown>;
+    testConnectionImpl?: () => Promise<{ iconUrl: string | null }>;
+    getMcpServer?: unknown;
+}) => {
+    const aiAgentModel = {
+        getMcpServer: vi
+            .fn()
+            .mockResolvedValue(overrides?.getMcpServer ?? bearerServer),
+        updateMcpServerRuntimeState: vi.fn().mockResolvedValue(undefined),
+        upsertCredential: vi.fn().mockResolvedValue({}),
+        upsertDiscoveredMcpServerTools: vi.fn().mockResolvedValue([]),
+        resolveCredential: vi.fn().mockResolvedValue(null),
+        getCredential: vi.fn().mockResolvedValue(null),
+    };
+    const aiAgentMcpRuntimeClient = {
+        testConnection:
+            overrides?.testConnectionImpl ??
+            vi.fn().mockResolvedValue({ iconUrl: null }),
+        listTools: vi.fn().mockResolvedValue([]),
+    };
+    const featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: true }),
+    };
+    const service = new AiAgentService({
+        aiAgentModel,
+        featureFlagService,
+        analytics: { track: vi.fn() },
+        lightdashConfig: { ai: { copilot: {} } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    // The runtime client is constructed internally; replace it with the mock.
+    (
+        service as unknown as { aiAgentMcpRuntimeClient: unknown }
+    ).aiAgentMcpRuntimeClient = aiAgentMcpRuntimeClient;
+    // Match the EE test-suite pattern for bypassing the ability layer.
+    (
+        service as unknown as { createAuditedAbility: () => unknown }
+    ).createAuditedAbility = () => ({ cannot: () => false, can: () => true });
+    // discoverMcpServerTools is private; override it for these unit tests.
+    (
+        service as unknown as { discoverMcpServerTools: () => Promise<unknown> }
+    ).discoverMcpServerTools =
+        overrides?.discoverImpl ?? vi.fn().mockResolvedValue([]);
+    return { service, aiAgentModel, aiAgentMcpRuntimeClient };
+};
+
+describe('refreshMcpServerTools status persistence', () => {
+    it('marks the server connected when discovery succeeds', async () => {
+        const { service, aiAgentModel } = buildService({
+            discoverImpl: vi.fn().mockResolvedValue([]),
+        });
+
+        await service.refreshMcpServerTools(user, PROJECT_UUID, SERVER_UUID);
+
+        expect(aiAgentModel.updateMcpServerRuntimeState).toHaveBeenCalledWith(
+            expect.objectContaining({
+                serverUuid: SERVER_UUID,
+                connectionStatus: 'connected',
+                error: null,
+            }),
+        );
+    });
+
+    it('marks the server errored when discovery fails, then throws', async () => {
+        const { service, aiAgentModel } = buildService({
+            discoverImpl: vi
+                .fn()
+                .mockRejectedValue(new Error('HTTP 401 unauthorized')),
+        });
+
+        await expect(
+            service.refreshMcpServerTools(user, PROJECT_UUID, SERVER_UUID),
+        ).rejects.toBeInstanceOf(ParameterError);
+
+        expect(aiAgentModel.updateMcpServerRuntimeState).toHaveBeenCalledWith(
+            expect.objectContaining({
+                serverUuid: SERVER_UUID,
+                connectionStatus: 'error',
+            }),
+        );
+    });
+});
+
+describe('updateMcpServerBearerCredential', () => {
+    it('validates then saves the new token and marks connected', async () => {
+        const testConnection = vi
+            .fn()
+            .mockResolvedValue({ iconUrl: 'https://x/icon.png' });
+        const { service, aiAgentModel } = buildService({
+            testConnectionImpl: testConnection,
+        });
+
+        const result = await service.updateMcpServerBearerCredential(
+            user,
+            PROJECT_UUID,
+            SERVER_UUID,
+            { bearerToken: '  new-token  ' },
+        );
+
+        expect(testConnection).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: bearerServer.url,
+                authType: 'bearer',
+                bearerToken: 'new-token',
+            }),
+        );
+        expect(aiAgentModel.upsertCredential).toHaveBeenCalledWith(
+            expect.objectContaining({
+                serverUuid: SERVER_UUID,
+                scope: 'shared',
+                credentials: { type: 'bearer', bearerToken: 'new-token' },
+            }),
+        );
+        expect(aiAgentModel.updateMcpServerRuntimeState).toHaveBeenCalledWith(
+            expect.objectContaining({
+                serverUuid: SERVER_UUID,
+                connectionStatus: 'connected',
+                error: null,
+            }),
+        );
+        expect(result.uuid).toBe(SERVER_UUID);
+    });
+
+    it('rejects a bad token and does NOT save it', async () => {
+        const { service, aiAgentModel } = buildService({
+            testConnectionImpl: vi
+                .fn()
+                .mockRejectedValue(new Error('HTTP 401 unauthorized')),
+        });
+
+        await expect(
+            service.updateMcpServerBearerCredential(
+                user,
+                PROJECT_UUID,
+                SERVER_UUID,
+                { bearerToken: 'bad-token' },
+            ),
+        ).rejects.toBeInstanceOf(ParameterError);
+
+        expect(aiAgentModel.upsertCredential).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty token', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        await expect(
+            service.updateMcpServerBearerCredential(
+                user,
+                PROJECT_UUID,
+                SERVER_UUID,
+                { bearerToken: '   ' },
+            ),
+        ).rejects.toBeInstanceOf(ParameterError);
+
+        expect(aiAgentModel.upsertCredential).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-bearer server', async () => {
+        const { service, aiAgentModel } = buildService({
+            getMcpServer: { ...bearerServer, authType: 'oauth' },
+        });
+
+        await expect(
+            service.updateMcpServerBearerCredential(
+                user,
+                PROJECT_UUID,
+                SERVER_UUID,
+                { bearerToken: 'x' },
+            ),
+        ).rejects.toBeInstanceOf(ParameterError);
+
+        expect(aiAgentModel.upsertCredential).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12462,8 +12462,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -12733,6 +12733,17 @@ const models: TsoaRoute.Models = {
                 authType: { ref: 'AiMcpServerAuthType', required: true },
                 url: { dataType: 'string', required: true },
                 name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateAiMcpServerCredentialBody: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                bearerToken: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -13111,8 +13122,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -14995,11 +15006,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -15057,11 +15068,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -15098,11 +15109,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15117,11 +15128,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15136,11 +15147,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15155,11 +15166,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15265,17 +15276,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15304,6 +15315,29 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -15348,12 +15382,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                operator:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 tableName:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15367,6 +15395,12 @@ const models: TsoaRoute.Models = {
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                                 fieldId:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
@@ -15394,29 +15428,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         dataType:
                                                                                                                             'string',
                                                                                                                     },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15468,11 +15479,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15563,14 +15574,14 @@ const models: TsoaRoute.Models = {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'success',
+                                                                                                    'error',
                                                                                                 ],
                                                                                             },
                                                                                             {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'error',
+                                                                                                    'success',
                                                                                                 ],
                                                                                             },
                                                                                             {
@@ -15663,17 +15674,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15705,11 +15716,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15724,11 +15735,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15743,11 +15754,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15790,11 +15801,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15833,25 +15844,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15908,11 +15900,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -15936,17 +15923,6 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15967,6 +15943,22 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -15974,6 +15966,25 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -16025,12 +16036,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         'boolean',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            operator:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             tableName:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16049,6 +16054,12 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
+                                                                                                            operator:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                         },
                                                                                                 },
                                                                                             },
@@ -16058,12 +16069,6 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -16072,6 +16077,12 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -16239,6 +16250,10 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
+                                                href: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
@@ -16246,20 +16261,12 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                name: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16267,6 +16274,10 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                             },
                                         },
                                         {
@@ -16277,11 +16288,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16296,11 +16307,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16315,11 +16326,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16334,11 +16345,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16527,6 +16538,12 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -16534,12 +16551,6 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
-                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16579,11 +16590,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16607,13 +16618,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -16644,11 +16655,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16663,11 +16674,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16682,7 +16693,7 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['timeout'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16694,7 +16705,7 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['timeout'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16709,11 +16720,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16790,17 +16801,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -16871,11 +16882,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16890,11 +16901,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16909,11 +16920,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16928,11 +16939,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16947,11 +16958,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -33423,7 +33434,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33433,7 +33444,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33443,7 +33454,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -33456,7 +33467,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -34118,7 +34129,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34128,7 +34139,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34138,7 +34149,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34151,7 +34162,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -51899,6 +51910,77 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_updateMcpServerBearerCredential: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        mcpServerUuid: {
+            in: 'path',
+            name: 'mcpServerUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiUpdateAiMcpServerCredentialBody',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/mcpServers/:mcpServerUuid/credential',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.updateMcpServerBearerCredential,
+        ),
+
+        async function AiAgentController_updateMcpServerBearerCredential(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_updateMcpServerBearerCredential,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateMcpServerBearerCredential',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14069,7 +14069,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -14354,6 +14354,15 @@
                     }
                 },
                 "required": ["authType", "url", "name"],
+                "type": "object"
+            },
+            "ApiUpdateAiMcpServerCredentialBody": {
+                "properties": {
+                    "bearerToken": {
+                        "type": "string"
+                    }
+                },
+                "required": ["bearerToken"],
                 "type": "object"
             },
             "AiMcpGithubAvailability": {
@@ -14699,7 +14708,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16603,8 +16612,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16662,8 +16671,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16697,8 +16706,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16730,10 +16739,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -16742,8 +16751,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -16753,6 +16762,11 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -16764,9 +16778,6 @@
                                                                                     "required": {
                                                                                         "type": "boolean"
                                                                                     },
-                                                                                    "operator": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
@@ -16775,14 +16786,17 @@
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "operator": {
+                                                                                        "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "required",
-                                                                                    "operator",
                                                                                     "tableName",
                                                                                     "fieldRef",
-                                                                                    "fieldId"
+                                                                                    "fieldId",
+                                                                                    "operator"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -16793,11 +16807,6 @@
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -16827,8 +16836,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16875,8 +16884,8 @@
                                                                         "status": {
                                                                             "type": "string",
                                                                             "enum": [
-                                                                                "success",
-                                                                                "error"
+                                                                                "error",
+                                                                                "success"
                                                                             ]
                                                                         },
                                                                         "results": {
@@ -16900,10 +16909,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -16912,8 +16921,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -16941,8 +16950,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16976,8 +16985,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "not_found"
                                                         ]
                                                     }
@@ -17004,10 +17013,6 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
-                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -17028,9 +17033,6 @@
                                                                                 "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
@@ -17038,15 +17040,18 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
@@ -17057,16 +17062,20 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldFilterType",
                                                                                 "fieldValueType",
-                                                                                "table",
                                                                                 "fieldType",
-                                                                                "fieldId",
-                                                                                "label",
                                                                                 "description",
+                                                                                "label",
+                                                                                "fieldId",
+                                                                                "table",
                                                                                 "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
+                                                                    },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -17081,9 +17090,6 @@
                                                                                         "required": {
                                                                                             "type": "boolean"
                                                                                         },
-                                                                                        "operator": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "tableName": {
                                                                                             "type": "string"
                                                                                         },
@@ -17092,27 +17098,30 @@
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "type": "string"
                                                                                         }
                                                                                     },
                                                                                     "required": [
                                                                                         "required",
-                                                                                        "operator",
                                                                                         "tableName",
                                                                                         "fieldRef",
-                                                                                        "fieldId"
+                                                                                        "fieldId",
+                                                                                        "operator"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
                                                                                 "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
                                                                             },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -17122,8 +17131,8 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
@@ -17138,8 +17147,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "rationale",
                                                                     "fields",
+                                                                    "rationale",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -17239,38 +17248,38 @@
                                                         ],
                                                         "type": "object"
                                                     },
+                                                    "href": {
+                                                        "type": "string"
+                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
                                                     },
-                                                    "href": {
-                                                        "type": "string"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
-                                                    "name": {
+                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "uuid": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
                                                         "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
-                                                    "slug",
+                                                    "warnings",
                                                     "status",
-                                                    "name",
-                                                    "uuid"
+                                                    "slug",
+                                                    "uuid",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17348,9 +17357,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
+                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -17371,13 +17380,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -17385,8 +17394,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "status",
+                                                    "slug",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -17400,8 +17409,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -17413,10 +17422,10 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
+                                                            "timeout",
                                                             "error",
                                                             "rejected",
-                                                            "timeout"
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -17443,10 +17452,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17455,8 +17464,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -17487,8 +17496,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -33923,22 +33932,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -34502,22 +34511,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -44085,7 +44094,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3334.0",
+        "version": "0.3340.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -46322,6 +46331,62 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ApiCreateAiMcpServer"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/mcpServers/{mcpServerUuid}/credential": {
+            "post": {
+                "operationId": "updateMcpServerBearerCredential",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiMcpServerResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "mcpServerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiUpdateAiMcpServerCredentialBody"
                             }
                         }
                     }

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -399,6 +399,10 @@ export type ApiCreateAiMcpServer = {
     } | null;
 };
 
+export type ApiUpdateAiMcpServerCredentialBody = {
+    bearerToken: string;
+};
+
 export type ApiAiMcpOAuthCredentialRequest = {
     credentialScope?: AiMcpCredentialScope;
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1414,6 +1414,46 @@ export const AiAgentMcpServersInput = ({
                                                         },
                                                     )}
                                                 </Badge>
+                                                {connectionStatus ===
+                                                    'connected' &&
+                                                    shouldShowMcpRetestConnection(
+                                                        mcpServer,
+                                                        connectionStatus,
+                                                    ) && (
+                                                        <Tooltip
+                                                            label="Re-test connection"
+                                                            withArrow
+                                                            withinPortal
+                                                        >
+                                                            <ActionIcon
+                                                                type="button"
+                                                                variant="subtle"
+                                                                color="gray"
+                                                                size="sm"
+                                                                loading={
+                                                                    isRetesting
+                                                                }
+                                                                disabled={
+                                                                    isRetesting ||
+                                                                    isPersistingSelection
+                                                                }
+                                                                onClick={(
+                                                                    event,
+                                                                ) => {
+                                                                    event.stopPropagation();
+                                                                    void handleRetestMcpServerConnection(
+                                                                        mcpServer.uuid,
+                                                                    );
+                                                                }}
+                                                            >
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconRefresh
+                                                                    }
+                                                                />
+                                                            </ActionIcon>
+                                                        </Tooltip>
+                                                    )}
                                                 {sharingPolicyLabel && (
                                                     <Tooltip
                                                         label={

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -139,15 +139,6 @@ const getMcpOAuthSharingPolicyLabel = (
             : 'Personal sign-in only'
         : null;
 
-const getMcpOAuthSharingPolicyTooltip = (
-    mcpServer: Pick<AiMcpServer, 'authType' | 'allowOAuthCredentialSharing'>,
-) =>
-    mcpServer.authType === 'oauth'
-        ? mcpServer.allowOAuthCredentialSharing
-            ? 'This MCP can use a shared project sign-in or each person can sign in with their own account.'
-            : 'This MCP only supports personal sign-in. Each person must connect their own account.'
-        : null;
-
 const getMcpOAuthConnectionSummary = (
     mcpServer: Pick<
         AiMcpServer,
@@ -1322,12 +1313,6 @@ export const AiAgentMcpServersInput = ({
                                         allowOAuthCredentialSharing:
                                             mcpServer.allowOAuthCredentialSharing,
                                     });
-                                const sharingPolicyTooltip =
-                                    getMcpOAuthSharingPolicyTooltip({
-                                        authType: mcpServer.authType,
-                                        allowOAuthCredentialSharing:
-                                            mcpServer.allowOAuthCredentialSharing,
-                                    });
 
                                 return (
                                     <Paper
@@ -1377,6 +1362,18 @@ export const AiAgentMcpServersInput = ({
                                                             )}
                                                         </Text>
                                                     )}
+                                                    <Text
+                                                        size="sm"
+                                                        c="dimmed"
+                                                        fw={450}
+                                                    >
+                                                        {getMcpAuthTypeLabel(
+                                                            mcpServer.authType,
+                                                        )}
+                                                        {sharingPolicyLabel
+                                                            ? ` · ${sharingPolicyLabel}`
+                                                            : ''}
+                                                    </Text>
                                                     {mcpServer.error && (
                                                         <Text
                                                             size="xs"
@@ -1392,14 +1389,6 @@ export const AiAgentMcpServersInput = ({
                                                 align="center"
                                                 wrap="nowrap"
                                             >
-                                                <Badge
-                                                    variant="default"
-                                                    color="gray"
-                                                >
-                                                    {getMcpAuthTypeLabel(
-                                                        mcpServer.authType,
-                                                    )}
-                                                </Badge>
                                                 <Badge
                                                     variant="light"
                                                     color={getMcpConnectionStatusColor(
@@ -1454,22 +1443,6 @@ export const AiAgentMcpServersInput = ({
                                                             </ActionIcon>
                                                         </Tooltip>
                                                     )}
-                                                {sharingPolicyLabel && (
-                                                    <Tooltip
-                                                        label={
-                                                            sharingPolicyTooltip
-                                                        }
-                                                        withArrow
-                                                        withinPortal
-                                                    >
-                                                        <Badge
-                                                            variant="default"
-                                                            color="gray"
-                                                        >
-                                                            {sharingPolicyLabel}
-                                                        </Badge>
-                                                    </Tooltip>
-                                                )}
                                                 {mcpServer.authType ===
                                                     'oauth' &&
                                                     shouldShowMcpOAuthPrimaryAction(

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -46,6 +46,7 @@ import { z } from 'zod';
 import { BetaBadge } from '../../../../components/common/BetaBadge';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
+import useToaster from '../../../../hooks/toaster/useToaster';
 import { useProjectUpdateAiAgentMutation } from '../hooks/useProjectAiAgents';
 import {
     useConnectGithubMcpServerMutation,
@@ -54,6 +55,7 @@ import {
     useProjectAiMcpServers,
     useAgentAiMcpServerTools,
     useProjectCreateAiMcpServerMutation,
+    useRefreshAiMcpServerToolsMutation,
     useStartMcpOAuthConnectionMutation,
 } from '../hooks/useProjectAiMcpServers';
 import { AiAgentMcpServerToolsPanel } from './AiAgentMcpServerToolsPanel';
@@ -179,9 +181,9 @@ const getMcpOAuthPrimaryActionLabel = (
 ) => {
     switch (mcpServer.connectionStatus) {
         case 'connected':
-            return `Sign in to ${mcpServer.name}`;
+            return 'Reauthenticate';
         case 'error':
-            return `Sign in to ${mcpServer.name}`;
+            return 'Reauthenticate';
         case 'connecting':
             return 'Connecting...';
         case 'not_connected':
@@ -195,6 +197,17 @@ const shouldShowMcpOAuthPrimaryAction = (
 ) =>
     mcpServer.connectionStatus === 'not_connected' ||
     mcpServer.credentialScope === 'shared';
+
+// Re-testing reconnects to the server and rediscovers tools, so it only makes
+// sense once credentials exist. Non-oauth servers always have what they need;
+// oauth servers must already be connected (or in an error state worth retrying).
+const shouldShowMcpRetestConnection = (
+    mcpServer: Pick<AiMcpServer, 'authType'>,
+    connectionStatus: AiMcpServerConnectionStatus | null,
+) =>
+    mcpServer.authType !== 'oauth' ||
+    connectionStatus === 'connected' ||
+    connectionStatus === 'error';
 
 const getMcpServerIconColor = (
     connectionStatus: AiMcpServerConnectionStatus | null,
@@ -557,6 +570,7 @@ export const AiAgentMcpServersInput = ({
     const [expandedMcpServers, setExpandedMcpServers] = useState<string[]>([]);
     const [isPersistingSelection, setIsPersistingSelection] = useState(false);
     const isPersistingSelectionRef = useRef(false);
+    const { showToastSuccess } = useToaster();
     const { data: mcpServers, isLoading: isLoadingMcpServers } =
         useProjectAiMcpServers(projectUuid);
     const { mutateAsync: createMcpServer, isLoading: isCreatingMcpServer } =
@@ -575,6 +589,11 @@ export const AiAgentMcpServersInput = ({
         isLoading: isDisconnectingMcpOAuthConnection,
         variables: disconnectingMcpOAuthConnection,
     } = useDisconnectMcpOAuthConnectionMutation(projectUuid);
+    const {
+        mutateAsync: refreshMcpServerTools,
+        isLoading: isRetestingMcpServerConnection,
+        variables: retestingMcpServerConnection,
+    } = useRefreshAiMcpServerToolsMutation(projectUuid);
     const { data: githubMcpAvailability } =
         useGithubMcpAvailability(projectUuid);
     const { mutateAsync: connectGithubMcp, isLoading: isConnectingGithubMcp } =
@@ -825,6 +844,23 @@ export const AiAgentMcpServersInput = ({
         [startMcpOAuthConnection],
     );
 
+    const handleRetestMcpServerConnection = useCallback(
+        async (mcpServerUuid: string) => {
+            try {
+                await refreshMcpServerTools({
+                    mcpServerUuid,
+                    agentUuid,
+                    showSuccessToast: false,
+                });
+                showToastSuccess({ title: 'Connection re-tested successfully' });
+            } catch {
+                // The mutation surfaces the failure via an error toast, and the
+                // server's connection status/error is refreshed in the list.
+            }
+        },
+        [agentUuid, refreshMcpServerTools, showToastSuccess],
+    );
+
     const handleDisconnectMcpOAuthConnection = useCallback(
         async (mcpServerUuid: string) => {
             await disconnectMcpOAuthConnection({ mcpServerUuid });
@@ -890,6 +926,7 @@ export const AiAgentMcpServersInput = ({
             connectionStatus: AiMcpServerConnectionStatus | null,
             isConnecting: boolean,
             isDisconnecting: boolean,
+            isRetesting: boolean,
             isExpanded: boolean,
         ) => {
             return (
@@ -930,7 +967,8 @@ export const AiAgentMcpServersInput = ({
                                 leftSection={
                                     <MantineIcon
                                         icon={
-                                            connectionStatus === 'connected'
+                                            connectionStatus === 'connected' ||
+                                            connectionStatus === 'error'
                                                 ? IconRefresh
                                                 : IconPlugConnected
                                         }
@@ -952,6 +990,32 @@ export const AiAgentMcpServersInput = ({
                                           credentialScope:
                                               mcpServer.credentialScope,
                                       })}
+                            </Menu.Item>
+                        )}
+                        {shouldShowMcpRetestConnection(
+                            mcpServer,
+                            connectionStatus,
+                        ) && (
+                            <Menu.Item
+                                type="button"
+                                leftSection={
+                                    <MantineIcon icon={IconPlugConnected} />
+                                }
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    void handleRetestMcpServerConnection(
+                                        mcpServer.uuid,
+                                    );
+                                }}
+                                disabled={
+                                    isRetesting ||
+                                    isConnecting ||
+                                    isPersistingSelection
+                                }
+                            >
+                                {isRetesting
+                                    ? 'Re-testing...'
+                                    : 'Re-test connection'}
                             </Menu.Item>
                         )}
                         {mcpServer.hasCredentials &&
@@ -999,6 +1063,7 @@ export const AiAgentMcpServersInput = ({
         [
             handleDisconnectMcpOAuthConnection,
             handleRemoveMcpServer,
+            handleRetestMcpServerConnection,
             handleSetExpandedMcpServer,
             handleStartMcpOAuthConnection,
             isPersistingSelection,
@@ -1113,6 +1178,10 @@ export const AiAgentMcpServersInput = ({
                                     mcpServer.authType === 'oauth' &&
                                     isDisconnectingMcpOAuthConnection &&
                                     disconnectingMcpOAuthConnection?.mcpServerUuid ===
+                                        mcpServer.uuid;
+                                const isRetesting =
+                                    isRetestingMcpServerConnection &&
+                                    retestingMcpServerConnection?.mcpServerUuid ===
                                         mcpServer.uuid;
                                 const connectionStatus = isConnecting
                                     ? 'connecting'
@@ -1274,6 +1343,7 @@ export const AiAgentMcpServersInput = ({
                                                     connectionStatus,
                                                     isConnecting,
                                                     isDisconnecting,
+                                                    isRetesting,
                                                     isExpanded,
                                                 )}
                                             </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -36,6 +36,7 @@ import {
     IconChevronRight,
     IconDots,
     IconEye,
+    IconKey,
     IconPlug,
     IconPlugConnected,
     IconRefresh,
@@ -57,6 +58,7 @@ import {
     useProjectCreateAiMcpServerMutation,
     useRefreshAiMcpServerToolsMutation,
     useStartMcpOAuthConnectionMutation,
+    useUpdateAiMcpServerCredentialMutation,
 } from '../hooks/useProjectAiMcpServers';
 import { AiAgentMcpServerToolsPanel } from './AiAgentMcpServerToolsPanel';
 import { AiMcpServerIcon } from './AiMcpServerIcon';
@@ -427,6 +429,90 @@ const CreateMcpServerModal = ({
     );
 };
 
+const updateMcpTokenFormSchema = z.object({
+    bearerToken: z.string().trim().min(1, 'Bearer token is required'),
+});
+
+const UpdateMcpServerTokenModal = ({
+    mcpServer,
+    isLoading,
+    onClose,
+    onSubmit,
+}: {
+    mcpServer: AiMcpServer | null;
+    isLoading: boolean;
+    onClose: () => void;
+    onSubmit: (
+        values: z.infer<typeof updateMcpTokenFormSchema>,
+    ) => Promise<void> | void;
+}) => {
+    const form = useForm<z.infer<typeof updateMcpTokenFormSchema>>({
+        initialValues: { bearerToken: '' },
+        validate: zodResolver(updateMcpTokenFormSchema),
+    });
+
+    const handleClose = useCallback(() => {
+        form.reset();
+        onClose();
+    }, [form, onClose]);
+
+    const handleSubmit = form.onSubmit(async (values) => {
+        await onSubmit(values);
+        form.reset();
+    });
+
+    return (
+        <MantineModal
+            opened={mcpServer !== null}
+            onClose={handleClose}
+            title="Update token"
+            icon={IconKey}
+            cancelDisabled={isLoading}
+            actions={
+                <Button
+                    type="submit"
+                    form="update-mcp-token-form"
+                    loading={isLoading}
+                >
+                    Update token
+                </Button>
+            }
+        >
+            <form id="update-mcp-token-form" onSubmit={handleSubmit}>
+                <Stack gap="md">
+                    <TextInput
+                        variant="subtle"
+                        label="Name"
+                        value={mcpServer?.name ?? ''}
+                        disabled
+                    />
+                    <TextInput
+                        variant="subtle"
+                        label="URL"
+                        value={mcpServer?.url ?? ''}
+                        disabled
+                    />
+                    <Box>
+                        <PasswordInput
+                            variant="subtle"
+                            label="New bearer token"
+                            placeholder="API key or personal access token"
+                            disabled={isLoading}
+                            autoComplete="off"
+                            {...form.getInputProps('bearerToken')}
+                        />
+                        <Text size="xs" c="dimmed" mt="xs">
+                            Enter a new token to replace the current one. It will
+                            be encrypted and shared across all users of the
+                            agent.
+                        </Text>
+                    </Box>
+                </Stack>
+            </form>
+        </MantineModal>
+    );
+};
+
 const AttachMcpServersModal = ({
     opened,
     isLoading,
@@ -569,12 +655,18 @@ export const AiAgentMcpServersInput = ({
     const [attachSelection, setAttachSelection] = useState<string[]>([]);
     const [expandedMcpServers, setExpandedMcpServers] = useState<string[]>([]);
     const [isPersistingSelection, setIsPersistingSelection] = useState(false);
+    const [editingTokenMcpServer, setEditingTokenMcpServer] =
+        useState<AiMcpServer | null>(null);
     const isPersistingSelectionRef = useRef(false);
     const { showToastSuccess } = useToaster();
     const { data: mcpServers, isLoading: isLoadingMcpServers } =
         useProjectAiMcpServers(projectUuid);
     const { mutateAsync: createMcpServer, isLoading: isCreatingMcpServer } =
         useProjectCreateAiMcpServerMutation(projectUuid);
+    const {
+        mutateAsync: updateMcpServerCredential,
+        isLoading: isUpdatingToken,
+    } = useUpdateAiMcpServerCredentialMutation(projectUuid);
     const { mutateAsync: updateAgentMcpServers } =
         useProjectUpdateAiAgentMutation(projectUuid, {
             showSuccessToast: false,
@@ -837,6 +929,23 @@ export const AiAgentMcpServersInput = ({
         ],
     );
 
+    const handleUpdateMcpToken = useCallback(
+        async (values: { bearerToken: string }) => {
+            if (!editingTokenMcpServer) return;
+            try {
+                await updateMcpServerCredential({
+                    mcpServerUuid: editingTokenMcpServer.uuid,
+                    bearerToken: values.bearerToken.trim(),
+                });
+                setEditingTokenMcpServer(null);
+            } catch {
+                // The mutation surfaces the failure via an error toast; keep the
+                // modal open so the user can correct the token.
+            }
+        },
+        [editingTokenMcpServer, updateMcpServerCredential],
+    );
+
     const handleStartMcpOAuthConnection = useCallback(
         async (mcpServerUuid: string) => {
             await startMcpOAuthConnection({ mcpServerUuid });
@@ -961,6 +1070,19 @@ export const AiAgentMcpServersInput = ({
                         >
                             {isExpanded ? 'Hide tools' : 'View tools'}
                         </Menu.Item>
+                        {mcpServer.authType === 'bearer' && (
+                            <Menu.Item
+                                type="button"
+                                leftSection={<MantineIcon icon={IconKey} />}
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    setEditingTokenMcpServer(mcpServer);
+                                }}
+                                disabled={isPersistingSelection}
+                            >
+                                Update token
+                            </Menu.Item>
+                        )}
                         {mcpServer.authType === 'oauth' && (
                             <Menu.Item
                                 type="button"
@@ -1067,6 +1189,7 @@ export const AiAgentMcpServersInput = ({
             handleSetExpandedMcpServer,
             handleStartMcpOAuthConnection,
             isPersistingSelection,
+            setEditingTokenMcpServer,
         ],
     );
 
@@ -1439,6 +1562,12 @@ export const AiAgentMcpServersInput = ({
                 onClose={createMcpServerModalHandlers.close}
                 onSubmit={handleCreateMcpServer}
                 isLoading={isCreatingMcpServer || isPersistingSelection}
+            />
+            <UpdateMcpServerTokenModal
+                mcpServer={editingTokenMcpServer}
+                isLoading={isUpdatingToken}
+                onClose={() => setEditingTokenMcpServer(null)}
+                onSubmit={handleUpdateMcpToken}
             />
             <AttachMcpServersModal
                 opened={isAttachMcpServersModalOpen}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -493,8 +493,8 @@ const UpdateMcpServerTokenModal = ({
                             {...form.getInputProps('bearerToken')}
                         />
                         <Text size="xs" c="dimmed" mt="xs">
-                            Enter a new token to replace the current one. It will
-                            be encrypted and shared across all users of the
+                            Enter a new token to replace the current one. It
+                            will be encrypted and shared across all users of the
                             agent.
                         </Text>
                     </Box>
@@ -952,7 +952,9 @@ export const AiAgentMcpServersInput = ({
                     agentUuid,
                     showSuccessToast: false,
                 });
-                showToastSuccess({ title: 'Connection re-tested successfully' });
+                showToastSuccess({
+                    title: 'Connection re-tested successfully',
+                });
             } catch {
                 // The mutation surfaces the failure via an error toast, and the
                 // server's connection status/error is refreshed in the list.

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -9,6 +9,7 @@ import type {
     ApiCreateAiMcpServer,
     ApiError,
     ApiUpdateAiAgentMcpServerToolsRequest,
+    ApiUpdateAiMcpServerCredentialBody,
 } from '@lightdash/common';
 import {
     useMutation,
@@ -53,6 +54,18 @@ const createProjectAiMcpServer = async (
     lightdashApi<ApiAiMcpServerResponse['results']>({
         version: 'v1',
         url: `/projects/${projectUuid}/aiAgents/mcpServers`,
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+const updateProjectAiMcpServerCredential = async (
+    projectUuid: string,
+    mcpServerUuid: string,
+    data: ApiUpdateAiMcpServerCredentialBody,
+): Promise<ApiAiMcpServerResponse['results']> =>
+    lightdashApi<ApiAiMcpServerResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers/${mcpServerUuid}/credential`,
         method: 'POST',
         body: JSON.stringify(data),
     });
@@ -360,6 +373,34 @@ export const useProjectCreateAiMcpServerMutation = (projectUuid: string) => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to create MCP server',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useUpdateAiMcpServerCredentialMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<
+        ApiAiMcpServerResponse['results'],
+        ApiError,
+        { mcpServerUuid: string; bearerToken: string }
+    >({
+        mutationFn: ({ mcpServerUuid, bearerToken }) =>
+            updateProjectAiMcpServerCredential(projectUuid, mcpServerUuid, {
+                bearerToken,
+            }),
+        onSuccess: async () => {
+            showToastSuccess({ title: 'Token updated' });
+            await queryClient.invalidateQueries({
+                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update token',
                 apiError: error,
             });
         },

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -456,6 +456,21 @@ export const useRefreshAiMcpServerToolsMutation = (projectUuid: string) => {
                     ],
                 });
             }
+
+            // Refreshing tools re-tests the connection and updates the
+            // server's connection status, so refresh the server lists too.
+            await queryClient.invalidateQueries({
+                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+            });
+            if (variables.agentUuid) {
+                await queryClient.invalidateQueries({
+                    queryKey: [
+                        AGENT_AI_MCP_SERVERS_KEY,
+                        projectUuid,
+                        variables.agentUuid,
+                    ],
+                });
+            }
         },
         onError: ({ error }) => {
             showToastApiError({


### PR DESCRIPTION
## What & why

[PROD-8746](https://linear.app/lightdash/issue/PROD-8746) — give users a way to **recover a broken MCP connection without removing and re-adding the server**.

This started as a "Re-test connection" button, but that alone couldn't actually deliver the goal:

- For **bearer-token** servers, a re-test can never recover an expired/revoked token — there was no way to enter a new one. The only "fix" was to remove the server (which orphans it — `Remove` only detaches from the agent, there's no delete) and add it again.
- The re-test path also had a bug: it ran a live check but **never persisted the result**, so a `401` left the badge stuck on a green "Connected". The status was misleading exactly when you needed it.

This PR completes the recovery story and fixes the status bug.

## Changes

**Rotate a bearer token (the real fix)**
- New endpoint `POST /api/v1/projects/{projectUuid}/aiAgents/mcpServers/{mcpServerUuid}/credential`.
- Mirrors the existing create flow 1:1: same auth gate (`assertCanManageMcpServers`), same middlewares (incl. `unauthorisedInDemo`), same AES-256-GCM encryption via `upsertCredential`. It validates the new token with `testConnection` **before** saving — a bad token is rejected with a toast and **nothing is written** (the old token stays intact) — then re-validates and refreshes tools.
- The token is never returned in any response (the server is serialized with only `hasCredentials`/`connectionStatus`).
- Frontend: an **"Update token"** item on the MCP server menu (bearer servers only) opens a small modal (name + URL read-only, one token field).

**Fix the stuck-green status badge**
- `refreshMcpServerTools` ("Re-test connection") now persists `connection_status` on both success (`connected`) and failure (`error` + message). Previously a failed re-test threw a toast but left the stored status untouched → badge stayed green.

**Card polish**
- One-click re-test: a refresh action icon with a "Re-test connection" tooltip next to the Connected badge (bearer/none, and connected OAuth).
- Decluttered the card: auth type and sign-in policy moved into the left identity column as metadata, so the right side is just `[status] · re-test · ⋯`.

## Security

No new posture — the update endpoint mirrors create. Token-only editing is *safer* than a fuller edit: because the URL never changes, the SSRF-guarding `validatePublicHttpUrl` isn't re-run and a validated server can't be re-pointed at an internal address while keeping its identity. The single outbound call (re-validate with the new token) is the same one "Re-test connection" already makes to the same validated URL.

## Regression analysis

- **Bearer MCP servers**: behavior change is strictly additive — a new way to rotate the token; existing create/re-test/remove unchanged.
- **OAuth MCP servers**: unaffected by the new endpoint (it rejects non-bearer servers). They keep their existing connect/reauthenticate/disconnect flow. The status-persistence fix applies to their re-test too, which only makes the badge more accurate.
- **"No auth" servers**: unaffected (no credential to rotate; "Update token" not shown).
- **Service accounts / API keys**: the endpoint is gated by the same ability as create, so no new capability is granted to anyone who couldn't already manage MCP servers.

## Testing

- 6 backend unit tests (`mcpBearerCredential.test.ts`): valid token → validate-then-save + status `connected`; bad token → `ParameterError`, nothing saved (old token intact); empty token → rejected; non-bearer server → rejected; re-test success/failure → status persisted `connected`/`error`.
- Typecheck (common/backend/frontend) and lint clean.

Manual: revoke a GitHub PAT → Re-test flips the badge to red "Reconnect required" (no longer stuck green) → Update token with a fresh PAT → back to Connected; a bad token shows an error and leaves the old one in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018z1HojXaGp9erbHX9AHheW