### PR TITLE
fix(e2e): apply intended 30s timeout to /home redirect assertion

### DIFF
--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -172,7 +172,7 @@ const testCompile = (): Cypress.Chainable<string> => {
     cy.contains(/selected \d+ models/);
     // Configure
     cy.contains('button', 'Save changes').click();
-    cy.url().should('include', '/home', { timeout: 30000 });
+    cy.url({ timeout: 30000 }).should('include', '/home');
     cy.contains('Welcome, David');
     cy.findByText('Charts and Dashboards');
     cy.findByText('get started by creating some charts');


### PR DESCRIPTION
### Description:
`cy.url().should('include', '/home', { timeout: 30000 })` passes the options object to `.should()`, which silently ignores it, so the assertion ran with the default 10s command timeout. This is the top e2e flake: after saving table configuration the app awaits four serial requests (PATCH tablesConfiguration, explores refetch, health, org) before navigating, which exceeds 10s on a loaded preview env. Move the timeout onto `cy.url()` where it is honoured.
