### PR TITLE
feat: add user attributes to query tags

### DIFF
--- a/packages/backend/src/nats/NatsWorker.ts
+++ b/packages/backend/src/nats/NatsWorker.ts
@@ -1,4 +1,4 @@
-import { getErrorMessage } from '@lightdash/common';
+import { getErrorMessage, QueryExecutionContext } from '@lightdash/common';
 import { trace } from '@opentelemetry/api';
 import * as Sentry from '@sentry/node';
 import { StringCodec, type Consumer, type JsMsg } from 'nats';
@@ -20,8 +20,15 @@ import {
     type StreamConfig,
 } from './natsConfig';
 
-const asyncQueryPayloadSchema = z.object({
+const asyncQueryTagsSchema = z
+    .object({
+        query_context: z.nativeEnum(QueryExecutionContext),
+    })
+    .catchall(z.string());
+
+const asyncQueryPayloadSchema: z.ZodType<AsyncQueryJobPayload> = z.object({
     queryUuid: z.string().min(1),
+    queryTags: asyncQueryTagsSchema.optional(),
 });
 
 const asyncQueryEnvelopeSchema = z.object({
@@ -150,29 +157,38 @@ export class NatsWorker {
 
     private getQueryRunner(
         subject: string,
-    ): ((queryUuid: string, worker: string) => Promise<boolean>) | null {
+    ):
+        | ((
+              queryUuid: string,
+              worker: string,
+              queryTags?: AsyncQueryJobPayload['queryTags'],
+          ) => Promise<boolean>)
+        | null {
         if (subject === STREAM_CONFIGS.warehouse.subjects.query) {
-            return (queryUuid, worker) =>
+            return (queryUuid, worker, queryTags) =>
                 this.asyncQueryService.runAsyncWarehouseQueryFromHistory(
                     queryUuid,
                     worker,
+                    queryTags,
                 );
         }
 
         const preAgg = STREAM_CONFIGS['pre-aggregate'];
         if (preAgg && subject === preAgg.subjects.query) {
-            return (queryUuid, worker) =>
+            return (queryUuid, worker, queryTags) =>
                 this.asyncQueryService.runAsyncPreAggregateQueryFromHistory(
                     queryUuid,
                     worker,
+                    queryTags,
                 );
         }
 
         if (preAgg && subject === preAgg.subjects.materialization) {
-            return (queryUuid, worker) =>
+            return (queryUuid, worker, queryTags) =>
                 this.asyncQueryService.runAsyncWarehouseQueryFromHistory(
                     queryUuid,
                     worker,
+                    queryTags,
                 );
         }
 
@@ -182,7 +198,11 @@ export class NatsWorker {
     private async handleQueryMessage(
         message: JsMsg,
         workerLabel: string,
-        runQuery: (queryUuid: string, worker: string) => Promise<boolean>,
+        runQuery: (
+            queryUuid: string,
+            worker: string,
+            queryTags?: AsyncQueryJobPayload['queryTags'],
+        ) => Promise<boolean>,
     ): Promise<void> {
         const parsed = this.parseMessage(message);
         if (!parsed) {
@@ -233,6 +253,7 @@ export class NatsWorker {
                                     return runQuery(
                                         parsed.payload.queryUuid,
                                         workerLabel,
+                                        parsed.payload.queryTags,
                                     );
                                 },
                             ),

--- a/packages/backend/src/nats/natsConfig.ts
+++ b/packages/backend/src/nats/natsConfig.ts
@@ -1,3 +1,4 @@
+import type { RunQueryTags } from '@lightdash/common';
 import { z } from 'zod';
 
 export type NatsTraceProperties = {
@@ -13,11 +14,9 @@ export type AsyncQueryNatsEnvelope<TPayload> = NatsTraceProperties & {
     payload: TPayload;
 };
 
-/**
- * Lightweight NATS payload — the worker looks up everything else from query_history.
- */
 export type AsyncQueryJobPayload = {
     queryUuid: string;
+    queryTags?: RunQueryTags;
 };
 
 export type AsyncQueryJobMessage = AsyncQueryNatsEnvelope<AsyncQueryJobPayload>;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1376,6 +1376,9 @@ describe('AsyncQueryService', () => {
             expect(enqueuePreAggregateSpy).toHaveBeenCalledTimes(1);
             expect(enqueuePreAggregateSpy).toHaveBeenCalledWith({
                 queryUuid: 'test-query-uuid',
+                queryTags: {
+                    query_context: QueryExecutionContext.EXPLORE,
+                },
             });
             expect(service.queryHistoryModel.update).toHaveBeenCalledWith(
                 'test-query-uuid',
@@ -1457,6 +1460,9 @@ describe('AsyncQueryService', () => {
             expect(enqueueWarehouseSpy).toHaveBeenCalledTimes(1);
             expect(enqueueWarehouseSpy).toHaveBeenCalledWith({
                 queryUuid: 'test-query-uuid',
+                queryTags: {
+                    query_context: QueryExecutionContext.EXPLORE,
+                },
             });
             expect(runAsyncSpy).not.toHaveBeenCalled();
         });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -54,6 +54,7 @@ import {
     getMetricOverridesWithPopInheritance,
     getMetrics,
     getMetricsWithValidParameters,
+    getUserAttributeQueryTags,
     hasReservedParameterReference,
     isCartesianChartConfig,
     isCustomBinDimension,
@@ -2390,6 +2391,7 @@ export class AsyncQueryService extends ProjectService {
     public async runAsyncWarehouseQueryFromHistory(
         queryUuid: string,
         workerLabel: string,
+        queryTagsOverride?: RunQueryTags,
     ): Promise<boolean> {
         const canRun = await this.prepareQueuedQueryForExecution(
             queryUuid,
@@ -2400,7 +2402,10 @@ export class AsyncQueryService extends ProjectService {
             return false;
         }
 
-        const args = await this.buildWarehouseQueryArgs(queryUuid);
+        const args = await this.buildWarehouseQueryArgs(
+            queryUuid,
+            queryTagsOverride,
+        );
         await this.runAsyncWarehouseQuery(args);
         return true;
     }
@@ -2408,6 +2413,7 @@ export class AsyncQueryService extends ProjectService {
     public async runAsyncPreAggregateQueryFromHistory(
         queryUuid: string,
         workerLabel: string,
+        queryTagsOverride?: RunQueryTags,
     ): Promise<boolean> {
         const canRun = await this.prepareQueuedQueryForExecution(
             queryUuid,
@@ -2418,7 +2424,10 @@ export class AsyncQueryService extends ProjectService {
             return false;
         }
 
-        const args = await this.buildPreAggregateQueryArgs(queryUuid);
+        const args = await this.buildPreAggregateQueryArgs(
+            queryUuid,
+            queryTagsOverride,
+        );
         await this.runAsyncPreAggregateQuery(args);
         return true;
     }
@@ -3028,10 +3037,12 @@ export class AsyncQueryService extends ProjectService {
 
     private async buildWarehouseQueryArgs(
         queryUuid: string,
+        queryTagsOverride?: RunQueryTags,
     ): Promise<RunAsyncWarehouseQueryArgs> {
         const query = await this.getQueryHistoryFromHistory(queryUuid);
         const actor = AsyncQueryService.getQueryHistoryActor(query);
-        const queryTags = AsyncQueryService.buildQueryTags(query);
+        const queryTags =
+            queryTagsOverride ?? AsyncQueryService.buildQueryTags(query);
         const warehouseCredentialsOverrides =
             await this.deriveWarehouseCredentialsOverrides(query);
         const displayTimezone = query.metricQuery.timezone ?? null;
@@ -3067,6 +3078,7 @@ export class AsyncQueryService extends ProjectService {
 
     private async buildPreAggregateQueryArgs(
         queryUuid: string,
+        queryTagsOverride?: RunQueryTags,
     ): Promise<RunAsyncPreAggregateQueryArgs> {
         const query = await this.getQueryHistoryFromHistory(queryUuid);
 
@@ -3077,7 +3089,8 @@ export class AsyncQueryService extends ProjectService {
         }
 
         const actor = AsyncQueryService.getQueryHistoryActor(query);
-        const queryTags = AsyncQueryService.buildQueryTags(query);
+        const queryTags =
+            queryTagsOverride ?? AsyncQueryService.buildQueryTags(query);
         const warehouseCredentialsOverrides =
             await this.deriveWarehouseCredentialsOverrides(query);
         const displayTimezone = query.metricQuery.timezone ?? null;
@@ -3272,6 +3285,16 @@ export class AsyncQueryService extends ProjectService {
     private static getAppQueryTags(): Partial<RunQueryTags> {
         const { app_uuid: appUuid } = getAppContext();
         return appUuid ? { app_uuid: appUuid } : {};
+    }
+
+    private static addUserAttributeQueryTags(
+        queryTags: RunQueryTags,
+        userAccessControls: UserAccessControls,
+    ): RunQueryTags {
+        return {
+            ...queryTags,
+            ...getUserAttributeQueryTags(userAccessControls.userAttributes),
+        };
     }
 
     private static buildQueryTags(query: QueryHistory): RunQueryTags {
@@ -4041,6 +4064,7 @@ export class AsyncQueryService extends ProjectService {
                         try {
                             const natsPayload = {
                                 queryUuid: queryHistoryUuid,
+                                queryTags,
                             };
 
                             const enqueueQuery = () => {
@@ -4434,6 +4458,12 @@ export class AsyncQueryService extends ProjectService {
         });
         const prepareMs = Date.now() - prepareStart;
 
+        const queryTagsWithUserAttributes =
+            AsyncQueryService.addUserAttributeQueryTags(
+                queryTags,
+                userAccessControls,
+            );
+
         const requestParameters: ExecuteAsyncMetricQueryRequestParams = {
             context,
             query: metricQuery,
@@ -4467,7 +4497,7 @@ export class AsyncQueryService extends ProjectService {
                 organizationUuid,
                 explore,
                 context,
-                queryTags,
+                queryTags: queryTagsWithUserAttributes,
                 dateZoom,
                 invalidateCache,
                 parameters: combinedParameters,
@@ -4623,7 +4653,7 @@ export class AsyncQueryService extends ProjectService {
                 exploreResolver: this.projectModel,
             });
 
-        const queryTags: RunQueryTags = {
+        const baseQueryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
             ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
@@ -4654,6 +4684,7 @@ export class AsyncQueryService extends ProjectService {
             sql,
             fields,
             missingParameterReferences,
+            userAccessControls,
             resolvedTimezone,
             displayTimezone,
             useTimezoneAwareDateTrunc,
@@ -4667,6 +4698,12 @@ export class AsyncQueryService extends ProjectService {
             userAttributeOverrides,
             columnTimezone: getColumnTimezone(warehouseCredentials),
         });
+
+        const queryTagsWithUserAttributes =
+            AsyncQueryService.addUserAttributeQueryTags(
+                baseQueryTags,
+                userAccessControls,
+            );
 
         const requestParameters: ExecuteAsyncFieldValueSearchRequestParams = {
             context,
@@ -4687,7 +4724,7 @@ export class AsyncQueryService extends ProjectService {
                 organizationUuid,
                 explore,
                 context,
-                queryTags,
+                queryTags: queryTagsWithUserAttributes,
                 invalidateCache: invalidateCache || forceRefresh,
                 parameters: combinedParameters,
                 fields,
@@ -5004,6 +5041,12 @@ export class AsyncQueryService extends ProjectService {
             queryContext: context,
         });
 
+        const queryTagsWithUserAttributes =
+            AsyncQueryService.addUserAttributeQueryTags(
+                queryTags,
+                userAccessControls,
+            );
+
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 account,
@@ -5012,7 +5055,7 @@ export class AsyncQueryService extends ProjectService {
                 explore,
                 chart: { uuid: savedChart.uuid },
                 context,
-                queryTags,
+                queryTags: queryTagsWithUserAttributes,
                 invalidateCache,
                 metricQuery: metricQueryWithLimit,
                 parameters: combinedParameters,
@@ -5317,7 +5360,7 @@ export class AsyncQueryService extends ProjectService {
             };
         }
 
-        const queryTags: RunQueryTags = {
+        const baseQueryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
             ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
@@ -5470,6 +5513,12 @@ export class AsyncQueryService extends ProjectService {
             queryContext: context,
         });
 
+        const queryTagsWithUserAttributes =
+            AsyncQueryService.addUserAttributeQueryTags(
+                baseQueryTags,
+                queryUserAccessControls,
+            );
+
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 account,
@@ -5479,7 +5528,7 @@ export class AsyncQueryService extends ProjectService {
                 chart: { uuid: savedChart.uuid },
                 metricQuery: metricQueryWithLimit,
                 context,
-                queryTags,
+                queryTags: queryTagsWithUserAttributes,
                 invalidateCache,
                 dateZoom,
                 parameters: combinedParameters,
@@ -5734,7 +5783,7 @@ export class AsyncQueryService extends ProjectService {
             sorts,
         };
 
-        const queryTags: RunQueryTags = {
+        const baseQueryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
             ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
@@ -5778,6 +5827,7 @@ export class AsyncQueryService extends ProjectService {
             missingParameterReferences,
             usedParameters,
             responseMetricQuery,
+            userAccessControls,
             resolvedTimezone,
             displayTimezone,
             useTimezoneAwareDateTrunc,
@@ -5795,6 +5845,12 @@ export class AsyncQueryService extends ProjectService {
             preloadedUserAccessControls,
         });
 
+        const queryTagsWithUserAttributes =
+            AsyncQueryService.addUserAttributeQueryTags(
+                baseQueryTags,
+                userAccessControls,
+            );
+
         const { queryUuid: underlyingDataQueryUuid, cacheMetadata } =
             await this.executeAsyncQuery(
                 {
@@ -5804,7 +5860,7 @@ export class AsyncQueryService extends ProjectService {
                     organizationUuid,
                     explore,
                     context,
-                    queryTags,
+                    queryTags: queryTagsWithUserAttributes,
                     invalidateCache,
                     dateZoom,
                     fields,
@@ -5975,7 +6031,7 @@ export class AsyncQueryService extends ProjectService {
             warehouseCredentials,
         );
 
-        const queryTags: RunQueryTags = {
+        const baseQueryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
             ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
@@ -5984,6 +6040,10 @@ export class AsyncQueryService extends ProjectService {
             ...(chartUuid ? { chart_uuid: chartUuid } : {}),
             ...(dashboardUuid ? { dashboard_uuid: dashboardUuid } : {}),
         };
+        const queryTags = AsyncQueryService.addUserAttributeQueryTags(
+            baseQueryTags,
+            { userAttributes, intrinsicUserAttributes },
+        );
         const durationWarehouseAndUserAttributes =
             performance.now() - sectionStartWarehouse;
 
@@ -6847,6 +6907,12 @@ export class AsyncQueryService extends ProjectService {
             );
         }
 
+        const queryTagsWithUserAttributes =
+            AsyncQueryService.addUserAttributeQueryTags(
+                queryTags,
+                resolvedUserAccessControls,
+            );
+
         const { queryUuid, cacheMetadata } =
             await this.executePreparedAsyncQuery(
                 {
@@ -6856,7 +6922,7 @@ export class AsyncQueryService extends ProjectService {
                     explore,
                     metricQuery,
                     context,
-                    queryTags,
+                    queryTags: queryTagsWithUserAttributes,
                     invalidateCache,
                     dateZoom,
                     parameters,

--- a/packages/common/src/types/warehouse.test.ts
+++ b/packages/common/src/types/warehouse.test.ts
@@ -1,0 +1,72 @@
+import {
+    getUserAttributeQueryTags,
+    sanitizeQueryTagKey,
+    sanitizeQueryTagValue,
+} from './warehouse';
+
+describe('getUserAttributeQueryTags', () => {
+    it('prefixes and sanitizes user attribute names for query tags', () => {
+        expect(
+            getUserAttributeQueryTags({
+                country: ['US'],
+                'Plan Tier': ['Enterprise Customer/EMEA'],
+            }),
+        ).toEqual({
+            user_attribute_country: 'us',
+            user_attribute_plan_tier: 'enterprise_customer_emea',
+        });
+    });
+
+    it('joins and sanitizes multi-value user attributes', () => {
+        expect(
+            getUserAttributeQueryTags({
+                region: ['north', 'south'],
+            }),
+        ).toEqual({
+            user_attribute_region: 'north_south',
+        });
+    });
+
+    it('skips empty user attributes', () => {
+        expect(
+            getUserAttributeQueryTags({
+                empty: [],
+                blank: [''],
+                whitespace: ['   '],
+                present: ['yes'],
+            }),
+        ).toEqual({
+            user_attribute_present: 'yes',
+        });
+    });
+
+    it('limits user attribute query tags to safe metadata sizes', () => {
+        const result = getUserAttributeQueryTags({
+            ...Object.fromEntries(
+                Array.from({ length: 5 }, (_, index) => [
+                    `blank_${index}`,
+                    [''],
+                ]),
+            ),
+            ...Object.fromEntries(
+                Array.from({ length: 25 }, (_, index) => [
+                    `attribute_${index}`,
+                    ['x'.repeat(250)],
+                ]),
+            ),
+        });
+
+        expect(Object.keys(result)).toHaveLength(20);
+        expect(result.user_attribute_attribute_0).toHaveLength(60);
+        expect(result.user_attribute_attribute_19).toHaveLength(60);
+        expect(result.user_attribute_attribute_20).toBeUndefined();
+        expect(result.user_attribute_attribute_24).toBeUndefined();
+    });
+
+    it('uses BigQuery-compatible metadata normalization', () => {
+        expect(sanitizeQueryTagKey('Invalid query tag !')).toBe(
+            'invalid_query_tag__',
+        );
+        expect(sanitizeQueryTagValue("O'Reilly Media")).toBe('o_reilly_media');
+    });
+});

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -5,8 +5,16 @@ import { type SupportedDbtAdapter } from './dbt';
 import { type DimensionType, type Metric } from './field';
 import { type CreateWarehouseCredentials } from './projects';
 import type { WarehouseQueryMetadata } from './queryHistory';
+import { type UserAttributeValueMap } from './userAttributes';
 
-export type RunQueryTags = {
+const MAX_USER_ATTRIBUTE_QUERY_TAGS = 20;
+const MAX_QUERY_TAG_KEY_LENGTH = 60;
+const MAX_QUERY_TAG_VALUE_LENGTH = 60;
+const USER_ATTRIBUTE_QUERY_TAG_PREFIX = 'user_attribute_';
+
+export type UserAttributeQueryTag = `user_attribute_${string}`;
+
+export type RunQueryTags = Record<UserAttributeQueryTag, string> & {
     project_uuid?: string;
     user_uuid?: string;
     organization_uuid?: string;
@@ -20,6 +28,53 @@ export type RunQueryTags = {
     explore_name?: string;
     query_context: QueryExecutionContext;
 };
+
+const sanitizeQueryTagString = (
+    value: string,
+    fallback: string,
+    maxLength: number,
+) =>
+    value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '_')
+        .substring(0, maxLength) || fallback;
+
+export const sanitizeQueryTagKey = (key: string): string =>
+    sanitizeQueryTagString(key, 'empty_key', MAX_QUERY_TAG_KEY_LENGTH);
+
+export const sanitizeQueryTagValue = (value: string): string =>
+    sanitizeQueryTagString(value, 'empty_value', MAX_QUERY_TAG_VALUE_LENGTH);
+
+export const getUserAttributeQueryTags = (
+    userAttributes: UserAttributeValueMap,
+): Record<UserAttributeQueryTag, string> =>
+    Object.fromEntries(
+        Object.entries(userAttributes).reduce<
+            [UserAttributeQueryTag, string][]
+        >((acc, [name, values]) => {
+            if (acc.length >= MAX_USER_ATTRIBUTE_QUERY_TAGS) {
+                return acc;
+            }
+
+            const tagName = sanitizeQueryTagKey(
+                `${USER_ATTRIBUTE_QUERY_TAG_PREFIX}${name}`,
+            );
+            const value = values
+                .map((attribute) => attribute.trim())
+                .filter(Boolean)
+                .join(',')
+                .trim();
+            if (value) {
+                acc.push([
+                    tagName as UserAttributeQueryTag,
+                    sanitizeQueryTagValue(value),
+                ]);
+            }
+
+            return acc;
+        }, []),
+    ) as Record<UserAttributeQueryTag, string>;
 
 export type WarehouseTableSchema = {
     [column: string]: DimensionType;

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -105,6 +105,50 @@ describe('BigqueryWarehouseClient.sanitizeLabelsWithValues', () => {
             expect.objectContaining({ valueType: 'boolean' }),
         );
     });
+
+    it('sanitizes user attribute query tags for BigQuery labels', () => {
+        const result = BigqueryWarehouseClient.sanitizeLabelsWithValues({
+            'user_attribute_User Tier': 'Enterprise Customer/EMEA',
+            user_attribute_company: "O'Reilly Media",
+        });
+        expect(result).toEqual({
+            user_attribute_user_tier: 'enterprise_customer_emea',
+            user_attribute_company: 'o_reilly_media',
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('limits labels to the BigQuery maximum', () => {
+        const labels = Object.fromEntries(
+            Array.from({ length: 70 }, (_, index) => [
+                `user_attribute_${index}`,
+                `value_${index}`,
+            ]),
+        );
+
+        const result = BigqueryWarehouseClient.sanitizeLabelsWithValues(labels);
+
+        expect(Object.keys(result ?? {})).toHaveLength(64);
+    });
+
+    it('keeps non-user-attribute labels when user attributes exceed the BigQuery maximum', () => {
+        const labels = {
+            ...Object.fromEntries(
+                Array.from({ length: 70 }, (_, index) => [
+                    `user_attribute_${index}`,
+                    `value_${index}`,
+                ]),
+            ),
+            query_uuid: 'query-uuid',
+        };
+
+        const result = BigqueryWarehouseClient.sanitizeLabelsWithValues(labels);
+
+        expect(result).toEqual(
+            expect.objectContaining({ query_uuid: 'query-uuid' }),
+        );
+        expect(Object.keys(result ?? {})).toHaveLength(64);
+    });
 });
 
 describe('BigquerySqlBuilder escaping', () => {

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -22,6 +22,8 @@ import {
     MetricType,
     PartitionColumn,
     PartitionType,
+    sanitizeQueryTagKey,
+    sanitizeQueryTagValue,
     SupportedDbtAdapter,
     TimeIntervalUnit,
     WarehouseConnectionError,
@@ -220,6 +222,8 @@ export class BigquerySqlBuilder extends WarehouseBaseSqlBuilder {
 }
 
 export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryCredentials> {
+    private static readonly MAX_LABELS = 64;
+
     client: BigQuery;
 
     constructor(credentials: CreateBigqueryCredentials) {
@@ -268,32 +272,33 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         labels?: Record<string, string>,
     ): Record<string, string> | undefined {
         if (!labels) return undefined;
+        const entries = Object.entries(labels);
+        const orderedEntries = [
+            ...entries.filter(([key]) => !key.startsWith('user_attribute_')),
+            ...entries.filter(([key]) => key.startsWith('user_attribute_')),
+        ];
         return Object.fromEntries(
-            Object.entries(labels).map(([key, value]) => {
-                const safeKey = typeof key === 'string' ? key : String(key);
-                let safeValue: string;
-                if (typeof value === 'string') {
-                    safeValue = value;
-                } else if (value === null || value === undefined) {
-                    safeValue = '';
-                } else {
-                    console.warn(
-                        'BigqueryWarehouseClient.sanitizeLabelsWithValues: coerced non-string label value',
-                        { key: safeKey, valueType: typeof value },
-                    );
-                    safeValue = String(value);
-                }
-                return [
-                    safeKey
-                        .toLowerCase()
-                        .replace(/[^a-z0-9_-]/g, '_')
-                        .substring(0, 60) || 'empty_key',
-                    safeValue
-                        .toLowerCase()
-                        .replace(/[^a-z0-9_-]/g, '_')
-                        .substring(0, 60) || 'empty_value',
-                ];
-            }),
+            orderedEntries
+                .slice(0, BigqueryWarehouseClient.MAX_LABELS)
+                .map(([key, value]) => {
+                    const safeKey = typeof key === 'string' ? key : String(key);
+                    let safeValue: string;
+                    if (typeof value === 'string') {
+                        safeValue = value;
+                    } else if (value === null || value === undefined) {
+                        safeValue = '';
+                    } else {
+                        console.warn(
+                            'BigqueryWarehouseClient.sanitizeLabelsWithValues: coerced non-string label value',
+                            { key: safeKey, valueType: typeof value },
+                        );
+                        safeValue = String(value);
+                    }
+                    return [
+                        sanitizeQueryTagKey(safeKey),
+                        sanitizeQueryTagValue(safeValue),
+                    ];
+                }),
         );
     }
 

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -69,6 +69,34 @@ describe('SnowflakeWarehouseClient', () => {
         expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(expectedRow);
     });
+
+    it('escapes single quotes in query tags for session SQL', () => {
+        expect(
+            SnowflakeWarehouseClient.formatQueryTag({
+                user_attribute_company: "O'Reilly Media",
+            }),
+        ).toBe('{"user_attribute_company":"O\'\'Reilly Media"}');
+    });
+
+    it('limits query tag value to Snowflake maximum length', () => {
+        expect(
+            SnowflakeWarehouseClient.formatQueryTag({
+                user_attribute_company: 'x'.repeat(3000),
+            }).length,
+        ).toBe(2000);
+    });
+
+    it('keeps long escaped query tags safe for Snowflake session SQL', () => {
+        const result = SnowflakeWarehouseClient.formatQueryTag({
+            user_attribute_company: "'".repeat(3000),
+        });
+        const singleQuoteRuns = result.match(/'+/g) ?? [];
+
+        expect(result.length).toBeGreaterThan(2000);
+        expect(result.replace(/''/g, "'")).toHaveLength(2000);
+        expect(singleQuoteRuns.every((run) => run.length % 2 === 0)).toBe(true);
+    });
+
     it('expect schema with snowflake types mapped to dimension types', async () => {
         (createConnection as Mock).mockImplementationOnce(() => ({
             connect: vi.fn((callback) => callback(null, {})),

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -205,9 +205,18 @@ export class SnowflakeSqlBuilder extends WarehouseBaseSqlBuilder {
 }
 
 export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflakeCredentials> {
+    private static readonly MAX_QUERY_TAG_LENGTH = 2000;
+
     connectionOptions: ConnectionOptions;
 
     quotedIdentifiersIgnoreCase?: boolean;
+
+    static formatQueryTag(tags: Record<string, string>): string {
+        return Array.from(JSON.stringify(tags))
+            .slice(0, SnowflakeWarehouseClient.MAX_QUERY_TAG_LENGTH)
+            .join('')
+            .replace(/'/g, "''");
+    }
 
     // Cache connection promise for external browser authentication to avoid opening multiple browser tabs
     // We cache the promise itself (not the resolved connection) to prevent race conditions
@@ -525,7 +534,11 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         }
 
         if (options?.tags) {
-            sessionParams.push(`QUERY_TAG = '${JSON.stringify(options.tags)}'`);
+            sessionParams.push(
+                `QUERY_TAG = '${SnowflakeWarehouseClient.formatQueryTag(
+                    options.tags,
+                )}'`,
+            );
         }
 
         const timezoneQuery = options?.timezone || 'UTC';


### PR DESCRIPTION
### Description
- Adds embed/user attribute values to warehouse query tags for async query execution.
- Carries query tags through the NATS async query payload so user attributes are preserved without a database migration.
- Hardens warehouse metadata formatting so invalid or excessive tag metadata does not prevent queries from running.

### Validation
- Ran focused common, warehouse, and backend tests locally.
- Verified a fresh embedded dashboard tile query against BigQuery completes successfully and includes user attribute labels on the BigQuery job.

Closes: PROD-3555