### PR TITLE
feat(charts): conditional formatting for multi-metric bar charts

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
@@ -36,7 +36,7 @@ import {
 type ItemProps = {
     colorPalette: string[];
     config: ConditionalFormattingConfigWithSingleColor;
-    field: FilterableItem | undefined;
+    fields: FilterableItem[];
     index: number;
     isOpen: boolean;
     onChange: (config: ConditionalFormattingConfigWithSingleColor) => void;
@@ -48,7 +48,7 @@ type ItemProps = {
 const ChartConditionalFormattingItem: FC<ItemProps> = ({
     colorPalette,
     config,
-    field,
+    fields,
     index,
     isOpen,
     onChange,
@@ -56,6 +56,13 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
     addNewItem,
     removeItem,
 }) => {
+    const field = useMemo(
+        () =>
+            fields.find(
+                (candidate) => getItemId(candidate) === config.target?.fieldId,
+            ),
+        [fields, config.target?.fieldId],
+    );
     const accordionValue = `${index}`;
 
     const handleControlClick = useCallback(() => {
@@ -153,11 +160,17 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
             <Accordion.Panel>
                 <Config.Section>
                     <FieldSelect
-                        disabled
+                        disabled={fields.length <= 1}
                         size="xs"
                         item={field}
-                        items={field ? [field] : []}
-                        onChange={() => undefined}
+                        items={fields}
+                        onChange={(newField) => {
+                            if (!newField) return;
+                            onChange({
+                                ...config,
+                                target: { fieldId: getItemId(newField) },
+                            });
+                        }}
                         hasGrouping
                         label={<Config.Label>Select Field</Config.Label>}
                     />
@@ -210,7 +223,7 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
 
 type Props = {
     colorPalette: string[];
-    field: FilterableItem | undefined;
+    fields: FilterableItem[];
     conditionalFormattings: ConditionalFormattingConfig[];
     onSetConditionalFormattings: (
         configs: ConditionalFormattingConfig[],
@@ -219,7 +232,7 @@ type Props = {
 
 export const ChartConditionalFormatting: FC<Props> = ({
     colorPalette,
-    field,
+    fields,
     conditionalFormattings,
     onSetConditionalFormattings,
 }) => {
@@ -261,7 +274,10 @@ export const ChartConditionalFormatting: FC<Props> = ({
     );
 
     const handleAdd = useCallback(() => {
-        const fieldTarget = field ? { fieldId: getItemId(field) } : null;
+        const defaultField = fields[0];
+        const fieldTarget = defaultField
+            ? { fieldId: getItemId(defaultField) }
+            : null;
         setSupportedConfigs(
             produce(supportedConfigs, (draft) => {
                 draft.push(
@@ -276,7 +292,7 @@ export const ChartConditionalFormatting: FC<Props> = ({
     }, [
         addNewItem,
         colorPalette,
-        field,
+        fields,
         setSupportedConfigs,
         supportedConfigs,
     ]);
@@ -326,7 +342,7 @@ export const ChartConditionalFormatting: FC<Props> = ({
                         key={configIdsRef.current[index] ?? index}
                         colorPalette={colorPalette}
                         config={config}
-                        field={field}
+                        fields={fields}
                         index={index}
                         isOpen={openItems.includes(`${index}`)}
                         onChange={(newConfig) => handleChange(index, newConfig)}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
@@ -1,12 +1,13 @@
 import {
     createConditionalFormattingConfigWithSingleColor,
+    FilterOperator,
     getItemId,
+    isConditionalFormattingWithCompareTarget,
     isConditionalFormattingWithValues,
     type ConditionalFormattingConfig,
     type ConditionalFormattingConfigWithSingleColor,
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
-    type FilterOperator,
 } from '@lightdash/common';
 import { Accordion, Divider, Group } from '@mantine-8/core';
 import { produce } from 'immer';
@@ -32,6 +33,15 @@ import {
     getSupportedChartConditionalFormattingConfigs,
     mergeChartConditionalFormattingConfigs,
 } from './chartConditionalFormattingUtils';
+
+// A values-based rule with nothing filled in yet (fresh configs are created
+// with an empty `equals` rule)
+const isIncompleteRule = (rule: ConditionalFormattingWithFilterOperator) =>
+    isConditionalFormattingWithValues(rule) &&
+    !isConditionalFormattingWithCompareTarget(rule) &&
+    (rule.values ?? []).length === 0 &&
+    rule.operator !== FilterOperator.NULL &&
+    rule.operator !== FilterOperator.NOT_NULL;
 
 type ItemProps = {
     colorPalette: string[];
@@ -126,8 +136,9 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
     );
 
     const description = useMemo(() => {
-        if (config.rules.length === 0) return undefined;
+        if (config.rules.length === 0) return 'No condition set';
         const firstRule = config.rules[0];
+        if (isIncompleteRule(firstRule)) return 'No condition set';
         const operator =
             filterOperatorLabel[firstRule.operator] ?? firstRule.operator;
         const values = isConditionalFormattingWithValues(firstRule)
@@ -236,9 +247,6 @@ export const ChartConditionalFormatting: FC<Props> = ({
     conditionalFormattings,
     onSetConditionalFormattings,
 }) => {
-    const { openItems, handleAccordionChange, addNewItem, removeItem } =
-        useControlledAccordion();
-
     const supportedConfigs = useMemo(
         () =>
             getSupportedChartConditionalFormattingConfigs(
@@ -246,6 +254,16 @@ export const ChartConditionalFormatting: FC<Props> = ({
             ),
         [conditionalFormattings],
     );
+
+    // Expand the rule right away when the panel opens with a single
+    // not-yet-configured rule (fresh from the "Apply custom colors" toggle)
+    const { openItems, handleAccordionChange, addNewItem, removeItem } =
+        useControlledAccordion(
+            supportedConfigs.length === 1 &&
+                supportedConfigs[0].rules.every(isIncompleteRule)
+                ? ['0']
+                : [],
+        );
 
     const configIdsRef = useRef<string[]>([]);
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
@@ -24,7 +24,8 @@ type Props = {
     items: (Field | TableCalculation | CustomDimension)[];
     rows: ResultRow[] | undefined;
     xField: string | undefined;
-    yField: string | undefined;
+    yFields: string[];
+    canColorByCategory: boolean;
     colorPalette: string[];
     colorByCategory: boolean;
     categoryColorOverrides: Record<string, string>;
@@ -41,7 +42,8 @@ export const CustomColors: FC<Props> = ({
     items,
     rows,
     xField,
-    yField,
+    yFields,
+    canColorByCategory,
     colorPalette,
     colorByCategory,
     categoryColorOverrides,
@@ -80,19 +82,24 @@ export const CustomColors: FC<Props> = ({
 
     const [setAllColor, setSetAllColor] = useState<string | undefined>();
 
-    const customColorMode = colorByCategory
-        ? CUSTOM_COLOR_MODE.CATEGORY
-        : conditionalFormattings.length > 0
-          ? CUSTOM_COLOR_MODE.CONDITIONAL_FORMATTING
-          : CUSTOM_COLOR_MODE.CATEGORY;
+    const customColorMode =
+        canColorByCategory &&
+        (colorByCategory || conditionalFormattings.length === 0)
+            ? CUSTOM_COLOR_MODE.CATEGORY
+            : CUSTOM_COLOR_MODE.CONDITIONAL_FORMATTING;
 
-    const maybeTargetField = items.find(
-        (candidate) => getItemId(candidate) === yField,
+    const targetFields = useMemo(
+        () =>
+            yFields.flatMap((yFieldId) => {
+                const candidate = items.find(
+                    (item) => getItemId(item) === yFieldId,
+                );
+                return candidate && isFilterableItem(candidate)
+                    ? [candidate]
+                    : [];
+            }),
+        [items, yFields],
     );
-    const targetField =
-        maybeTargetField && isFilterableItem(maybeTargetField)
-            ? maybeTargetField
-            : undefined;
 
     const handleSetAllCategoryColors = useCallback(
         (color: string) => {
@@ -110,40 +117,44 @@ export const CustomColors: FC<Props> = ({
 
     return (
         <>
-            <SegmentedControl
-                size="xs"
-                value={customColorMode}
-                data={[
-                    {
-                        value: CUSTOM_COLOR_MODE.CATEGORY,
-                        label: 'Category',
-                    },
-                    {
-                        value: CUSTOM_COLOR_MODE.CONDITIONAL_FORMATTING,
-                        label: 'Conditional formatting',
-                    },
-                ]}
-                onChange={(value) => {
-                    if (value === CUSTOM_COLOR_MODE.CATEGORY) {
-                        setColorByCategory(true);
-                        return;
-                    }
+            {canColorByCategory && (
+                <SegmentedControl
+                    size="xs"
+                    value={customColorMode}
+                    data={[
+                        {
+                            value: CUSTOM_COLOR_MODE.CATEGORY,
+                            label: 'Category',
+                        },
+                        {
+                            value: CUSTOM_COLOR_MODE.CONDITIONAL_FORMATTING,
+                            label: 'Conditional formatting',
+                        },
+                    ]}
+                    onChange={(value) => {
+                        if (value === CUSTOM_COLOR_MODE.CATEGORY) {
+                            setColorByCategory(true);
+                            return;
+                        }
 
-                    setColorByCategory(false);
-                    if (conditionalFormattings.length === 0) {
-                        onSetConditionalFormattings([
-                            createConditionalFormattingConfigWithSingleColor(
-                                colorPalette[0],
-                                targetField
-                                    ? {
-                                          fieldId: getItemId(targetField),
-                                      }
-                                    : null,
-                            ),
-                        ]);
-                    }
-                }}
-            />
+                        setColorByCategory(false);
+                        if (conditionalFormattings.length === 0) {
+                            onSetConditionalFormattings([
+                                createConditionalFormattingConfigWithSingleColor(
+                                    colorPalette[0],
+                                    targetFields[0]
+                                        ? {
+                                              fieldId: getItemId(
+                                                  targetFields[0],
+                                              ),
+                                          }
+                                        : null,
+                                ),
+                            ]);
+                        }
+                    }}
+                />
+            )}
             {customColorMode === CUSTOM_COLOR_MODE.CATEGORY ? (
                 uniqueCategories.length > 0 && (
                     <>
@@ -213,7 +224,7 @@ export const CustomColors: FC<Props> = ({
             ) : (
                 <ChartConditionalFormatting
                     colorPalette={colorPalette}
-                    field={targetField}
+                    fields={targetFields}
                     conditionalFormattings={conditionalFormattings}
                     onSetConditionalFormattings={onSetConditionalFormattings}
                 />

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -168,10 +168,12 @@ export const Series: FC<Props> = ({ items }) => {
         (dirtyLayout?.stack !== undefined &&
             dirtyLayout.stack !== StackType.NONE);
 
-    // Conditional formatting: available for non-stacked bar charts without
-    // pivots, regardless of how many metrics are charted
+    // Conditional formatting: available for non-stacked all-bar charts
+    // without pivots, regardless of how many metrics are charted. Mixed
+    // bar/line charts are excluded since formatting only renders on bars.
     const supportsCustomColors =
         dirtyChartType === CartesianSeriesType.BAR &&
+        allSeries.every((series) => series.type === CartesianSeriesType.BAR) &&
         !pivotDimensions?.length &&
         !hasCustomColorsStacking;
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@hello-pangea/dnd';
 import {
     CartesianSeriesType,
+    createConditionalFormattingConfigWithSingleColor,
     getItemId,
     getSeriesId,
     StackType,
@@ -162,17 +163,20 @@ export const Series: FC<Props> = ({ items }) => {
         updateSeries(updatedSeries);
     };
 
-    // Color by category: available for single-series bar charts without pivots
     const hasCustomColorsStacking =
         allSeries.some((series) => Boolean(series.stack)) ||
         (dirtyLayout?.stack !== undefined &&
             dirtyLayout.stack !== StackType.NONE);
 
-    const isSingleSeriesBar =
+    // Conditional formatting: available for non-stacked bar charts without
+    // pivots, regardless of how many metrics are charted
+    const supportsCustomColors =
         dirtyChartType === CartesianSeriesType.BAR &&
         !pivotDimensions?.length &&
-        allSeries.length <= 1 &&
         !hasCustomColorsStacking;
+
+    // Color by category: only for single-series bar charts
+    const isSingleSeriesBar = supportsCustomColors && allSeries.length <= 1;
 
     const colorByCategory = dirtyLayout?.colorByCategory ?? false;
     const customColorsEnabled =
@@ -313,7 +317,7 @@ export const Series: FC<Props> = ({ items }) => {
                     )}
                 </Droppable>
             </DragDropContext>
-            {isSingleSeriesBar && (
+            {supportsCustomColors && (
                 <Config>
                     <Config.Section>
                         <Stack gap="xs">
@@ -325,7 +329,20 @@ export const Series: FC<Props> = ({ items }) => {
                                         if (conditionalFormattings.length > 0) {
                                             return;
                                         }
-                                        setColorByCategory(true);
+                                        if (isSingleSeriesBar) {
+                                            setColorByCategory(true);
+                                            return;
+                                        }
+                                        const firstYField =
+                                            dirtyLayout?.yField?.[0];
+                                        onSetConditionalFormattings([
+                                            createConditionalFormattingConfigWithSingleColor(
+                                                colorPalette[0],
+                                                firstYField
+                                                    ? { fieldId: firstYField }
+                                                    : null,
+                                            ),
+                                        ]);
                                         return;
                                     }
 
@@ -338,7 +355,8 @@ export const Series: FC<Props> = ({ items }) => {
                                     items={items}
                                     rows={resultsData?.rows}
                                     xField={dirtyLayout?.xField}
-                                    yField={dirtyLayout?.yField?.[0]}
+                                    yFields={dirtyLayout?.yField ?? []}
+                                    canColorByCategory={isSingleSeriesBar}
                                     colorPalette={colorPalette}
                                     colorByCategory={colorByCategory}
                                     categoryColorOverrides={

--- a/packages/frontend/src/components/VisualizationConfigs/common/hooks/useControlledAccordion.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/hooks/useControlledAccordion.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-export const useControlledAccordion = (defaultOpenItems = []) => {
+export const useControlledAccordion = (defaultOpenItems: string[] = []) => {
     const [openItems, setOpenItems] = useState<string[]>(defaultOpenItems);
 
     const handleAccordionChange = useCallback((itemValues: string[]) => {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1279,27 +1279,30 @@ const useCartesianChartConfig = ({
         [dirtyEchartsConfig?.series, dirtyLayout?.stack],
     );
 
-    const isCustomColorsEligible = useMemo(
+    // Conditional formatting: non-stacked bar charts without pivots,
+    // regardless of metric count
+    const isConditionalFormattingEligible = useMemo(
         () =>
             dirtyChartType === CartesianSeriesType.BAR &&
             !pivotKeys?.length &&
-            (dirtyLayout?.yField?.length ?? 0) <= 1 &&
             !hasCustomColorsStacking,
-        [
-            dirtyChartType,
-            pivotKeys,
-            dirtyLayout?.yField,
-            hasCustomColorsStacking,
-        ],
+        [dirtyChartType, pivotKeys, hasCustomColorsStacking],
+    );
+
+    // Color by category: only single-metric bar charts
+    const isColorByCategoryEligible = useMemo(
+        () =>
+            isConditionalFormattingEligible &&
+            (dirtyLayout?.yField?.length ?? 0) <= 1,
+        [isConditionalFormattingEligible, dirtyLayout?.yField],
     );
 
     useEffect(() => {
-        if (isCustomColorsEligible) return;
+        if (isColorByCategoryEligible) return;
 
         if (
             !dirtyLayout?.colorByCategory &&
-            !dirtyLayout?.categoryColorOverrides &&
-            conditionalFormattings.length === 0
+            !dirtyLayout?.categoryColorOverrides
         ) {
             return;
         }
@@ -1309,37 +1312,56 @@ const useCartesianChartConfig = ({
             colorByCategory: undefined,
             categoryColorOverrides: undefined,
         }));
-        setConditionalFormattings([]);
     }, [
-        isCustomColorsEligible,
+        isColorByCategoryEligible,
         dirtyLayout?.colorByCategory,
         dirtyLayout?.categoryColorOverrides,
-        conditionalFormattings,
     ]);
 
     useEffect(() => {
-        const targetFieldId = dirtyLayout?.yField?.[0];
+        if (isConditionalFormattingEligible) return;
+        if (conditionalFormattings.length === 0) return;
+
+        setConditionalFormattings([]);
+    }, [isConditionalFormattingEligible, conditionalFormattings]);
+
+    // Repair configs whose target no longer exists on the chart (e.g. the
+    // metric was swapped or removed) by pointing them at the first metric
+    useEffect(() => {
+        const yFields = dirtyLayout?.yField ?? [];
+        const firstYField = yFields[0];
         if (
-            !isCustomColorsEligible ||
-            !targetFieldId ||
+            !isConditionalFormattingEligible ||
+            !firstYField ||
             conditionalFormattings.length === 0
         ) {
             return;
         }
 
         const hasOutdatedTargets = conditionalFormattings.some(
-            (config) => config.target?.fieldId !== targetFieldId,
+            (config) =>
+                !config.target?.fieldId ||
+                !yFields.includes(config.target.fieldId),
         );
 
         if (!hasOutdatedTargets) return;
 
         setConditionalFormattings((prev) =>
-            prev.map((config) => ({
-                ...config,
-                target: { fieldId: targetFieldId },
-            })),
+            prev.map((config) =>
+                config.target?.fieldId &&
+                yFields.includes(config.target.fieldId)
+                    ? config
+                    : {
+                          ...config,
+                          target: { fieldId: firstYField },
+                      },
+            ),
         );
-    }, [isCustomColorsEligible, dirtyLayout?.yField, conditionalFormattings]);
+    }, [
+        isConditionalFormattingEligible,
+        dirtyLayout?.yField,
+        conditionalFormattings,
+    ]);
 
     const validConfig: CartesianChart = useMemo(() => {
         // Always use the dirtyLayout and dirtyEchartsConfig when possible, fallback to the empty config if not complete.

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1279,14 +1279,23 @@ const useCartesianChartConfig = ({
         [dirtyEchartsConfig?.series, dirtyLayout?.stack],
     );
 
-    // Conditional formatting: non-stacked bar charts without pivots,
-    // regardless of metric count
+    // Conditional formatting: non-stacked all-bar charts without pivots,
+    // regardless of metric count. Mixed bar/line charts are excluded since
+    // formatting only renders on bars.
     const isConditionalFormattingEligible = useMemo(
         () =>
             dirtyChartType === CartesianSeriesType.BAR &&
+            (dirtyEchartsConfig?.series ?? []).every(
+                (series) => series.type === CartesianSeriesType.BAR,
+            ) &&
             !pivotKeys?.length &&
             !hasCustomColorsStacking,
-        [dirtyChartType, pivotKeys, hasCustomColorsStacking],
+        [
+            dirtyChartType,
+            dirtyEchartsConfig?.series,
+            pivotKeys,
+            hasCustomColorsStacking,
+        ],
     );
 
     // Color by category: only single-metric bar charts

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1329,34 +1329,29 @@ const useCartesianChartConfig = ({
 
     useEffect(() => {
         if (isConditionalFormattingEligible) return;
-        if (conditionalFormattings.length === 0) return;
 
-        setConditionalFormattings([]);
-    }, [isConditionalFormattingEligible, conditionalFormattings]);
+        setConditionalFormattings((prev) => (prev.length === 0 ? prev : []));
+    }, [isConditionalFormattingEligible]);
 
     // Repair configs whose target no longer exists on the chart (e.g. the
     // metric was swapped or removed) by pointing them at the first metric
     useEffect(() => {
+        if (!isConditionalFormattingEligible) return;
+
         const yFields = dirtyLayout?.yField ?? [];
         const firstYField = yFields[0];
-        if (
-            !isConditionalFormattingEligible ||
-            !firstYField ||
-            conditionalFormattings.length === 0
-        ) {
-            return;
-        }
+        if (!firstYField) return;
 
-        const hasOutdatedTargets = conditionalFormattings.some(
-            (config) =>
-                !config.target?.fieldId ||
-                !yFields.includes(config.target.fieldId),
-        );
+        setConditionalFormattings((prev) => {
+            const hasOutdatedTargets = prev.some(
+                (config) =>
+                    !config.target?.fieldId ||
+                    !yFields.includes(config.target.fieldId),
+            );
 
-        if (!hasOutdatedTargets) return;
+            if (!hasOutdatedTargets) return prev;
 
-        setConditionalFormattings((prev) =>
-            prev.map((config) =>
+            return prev.map((config) =>
                 config.target?.fieldId &&
                 yFields.includes(config.target.fieldId)
                     ? config
@@ -1364,13 +1359,9 @@ const useCartesianChartConfig = ({
                           ...config,
                           target: { fieldId: firstYField },
                       },
-            ),
-        );
-    }, [
-        isConditionalFormattingEligible,
-        dirtyLayout?.yField,
-        conditionalFormattings,
-    ]);
+            );
+        });
+    }, [isConditionalFormattingEligible, dirtyLayout?.yField]);
 
     const validConfig: CartesianChart = useMemo(() => {
         // Always use the dirtyLayout and dirtyEchartsConfig when possible, fallback to the empty config if not complete.

--- a/packages/frontend/src/hooks/echarts/cartesianConditionalFormatting.test.ts
+++ b/packages/frontend/src/hooks/echarts/cartesianConditionalFormatting.test.ts
@@ -150,6 +150,101 @@ describe('getCartesianConditionalFormattingColor', () => {
         ).toBe('#ff0000');
     });
 
+    test('routes each config to its target series on multi-metric charts', () => {
+        const metricConfig = createConditionalFormattingConfigWithSingleColor(
+            '#ff0000',
+            {
+                fieldId: getItemId(itemsMap.metric_value),
+            },
+        );
+        metricConfig.rules = [
+            {
+                id: 'red',
+                operator: FilterOperator.LESS_THAN,
+                values: [10],
+            },
+        ];
+
+        const rowValues = { metric_value: 5, comparison_value: 5 };
+
+        // Both series' values match the rule, but only the targeted series
+        // gets the color
+        expect(
+            getCartesianConditionalFormattingColor({
+                itemsMap,
+                conditionalFormattings: [metricConfig],
+                rowValues,
+                series: {
+                    encode: { yRef: { field: 'metric_value' } },
+                } as any,
+            }),
+        ).toBe('#ff0000');
+        expect(
+            getCartesianConditionalFormattingColor({
+                itemsMap,
+                conditionalFormattings: [metricConfig],
+                rowValues,
+                series: {
+                    encode: { yRef: { field: 'comparison_value' } },
+                } as any,
+            }),
+        ).toBeUndefined();
+    });
+
+    test('applies independent configs to their own series on multi-metric charts', () => {
+        const redConfig = createConditionalFormattingConfigWithSingleColor(
+            '#ff0000',
+            {
+                fieldId: getItemId(itemsMap.metric_value),
+            },
+        );
+        redConfig.rules = [
+            {
+                id: 'red',
+                operator: FilterOperator.LESS_THAN,
+                values: [10],
+            },
+        ];
+
+        const blueConfig = createConditionalFormattingConfigWithSingleColor(
+            '#0000ff',
+            {
+                fieldId: getItemId(itemsMap.comparison_value),
+            },
+        );
+        blueConfig.rules = [
+            {
+                id: 'blue',
+                operator: FilterOperator.GREATER_THAN,
+                values: [8],
+            },
+        ];
+
+        const rowValues = { metric_value: 5, comparison_value: 10 };
+        const conditionalFormattings = [redConfig, blueConfig];
+
+        expect(
+            getCartesianConditionalFormattingColor({
+                itemsMap,
+                conditionalFormattings,
+                rowValues,
+                series: {
+                    encode: { yRef: { field: 'metric_value' } },
+                } as any,
+            }),
+        ).toBe('#ff0000');
+        expect(
+            getCartesianConditionalFormattingColor({
+                itemsMap,
+                conditionalFormattings,
+                rowValues,
+                series: {
+                    encode: { yRef: { field: 'comparison_value' } },
+                } as any,
+            }),
+        ).toBe('#0000ff');
+    });
+
     test('ignores unsupported config types when selecting the last matching color', () => {
         const singleColorConfig =
             createConditionalFormattingConfigWithSingleColor('#00ff00', {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3335,10 +3335,12 @@ const useEchartsCartesianConfig = (
             Boolean(validCartesianConfig?.layout?.colorByCategory) &&
             !pivotDimensions?.length &&
             !hasCustomColorsStacking;
-        // Applies per bar series: each config routes to its target field, so
-        // multi-metric charts color each metric's bars independently
+        // Applies per bar series on all-bar charts: each config routes to its
+        // target field, so multi-metric charts color each metric's bars
+        // independently
         const shouldApplyConditionalFormatting =
-            barSeries.length >= 1 &&
+            series.length > 0 &&
+            barSeries.length === series.length &&
             !pivotDimensions?.length &&
             !isColorByCategory &&
             !hasCustomColorsStacking &&

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3335,9 +3335,10 @@ const useEchartsCartesianConfig = (
             Boolean(validCartesianConfig?.layout?.colorByCategory) &&
             !pivotDimensions?.length &&
             !hasCustomColorsStacking;
+        // Applies per bar series: each config routes to its target field, so
+        // multi-metric charts color each metric's bars independently
         const shouldApplyConditionalFormatting =
-            barSeries.length === 1 &&
-            series.length === 1 &&
+            barSeries.length >= 1 &&
             !pivotDimensions?.length &&
             !isColorByCategory &&
             !hasCustomColorsStacking &&


### PR DESCRIPTION
### Description

Conditional formatting on bar charts was gated to a single metric — the option disappeared entirely as soon as the chart had more than one metric. This PR enables it for **non-stacked, non-pivoted bar charts with any number of metrics**: each rule targets a specific metric via a field select, its color applies only to that metric's bars, and untargeted series keep their default colors.

The single-metric gate lived in three layers, all relaxed in sync:
- UI eligibility in `Series/index.tsx` (panel visibility)
- Render gate `shouldApplyConditionalFormatting` in `useEchartsCartesianConfig.ts`
- `useCartesianChartConfig.ts` cleanup effects, which silently wiped CF configs on multi-metric charts and force-retargeted every config to the first metric (now only repairs configs whose target no longer exists on the chart)

Color-by-category remains single-metric only. **Stacked and 100% stacked charts stay excluded** — that half has open design questions (segment color vs legend encoding, raw-vs-percentage rule evaluation) and ships as a follow-up.

UX polish matching the table chart panel: a freshly created rule opens expanded, and a rule with no condition filled in shows "No condition set" instead of a dangling operator label.

### How to test

1. Bar chart with two or more metrics, no group, no stacking → Configure → Series → "Apply custom colors" now appears; toggling it opens a rule targeting the first metric.
2. Pick a target metric and a condition (e.g. `< 1500` → red): only that metric's matching bars recolor; the other metric's bars keep their default color even where their values match the condition.
3. Single-metric charts are unchanged: Category / Conditional formatting segmented control and category color overrides work as before.

Relates: PROD-8191
Relates: #24040

🤖 Generated with [Claude Code](https://claude.com/claude-code)