### PR TITLE
feat: support MCP OAuth client credentials

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -213,6 +213,8 @@ export type AiMcpOAuthCredentialPayload = {
     type: 'oauth';
     credentialScope: AiMcpCredentialScope;
     connectionStatus: AiMcpServerConnectionStatus;
+    configuredClientId?: string;
+    configuredClientSecret?: string;
     tokens?: {
         accessToken: string;
         refreshToken?: string;
@@ -967,7 +969,23 @@ export class AiAgentModel {
                     bearerToken: credentials.bearerToken,
                 };
             case 'oauth':
-                return null;
+                if (!credentials?.clientId && !credentials?.clientSecret) {
+                    return null;
+                }
+
+                if (!credentials.clientId || !credentials.clientSecret) {
+                    throw new ParameterError(
+                        'OAuth client ID and secret must be provided together',
+                    );
+                }
+
+                return {
+                    type: 'oauth',
+                    credentialScope: 'shared',
+                    connectionStatus: 'not_connected',
+                    configuredClientId: credentials.clientId,
+                    configuredClientSecret: credentials.clientSecret,
+                };
             default:
                 return assertUnreachable(
                     authType,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3229,7 +3229,11 @@ export class AiAgentService extends BaseService {
 
         switch (body.authType) {
             case 'none':
-                if (body.credentials?.bearerToken) {
+                if (
+                    body.credentials?.bearerToken ||
+                    body.credentials?.clientId ||
+                    body.credentials?.clientSecret
+                ) {
                     throw new ParameterError(
                         'Credentials are not allowed for auth type "none"',
                     );
@@ -3246,7 +3250,7 @@ export class AiAgentService extends BaseService {
                 }
                 break;
             case 'bearer':
-                if (!body.credentials?.bearerToken.trim()) {
+                if (!body.credentials?.bearerToken?.trim()) {
                     throw new ParameterError(
                         'Bearer MCP servers require a bearer token',
                     );
@@ -3259,6 +3263,15 @@ export class AiAgentService extends BaseService {
                         `Bearer token must be at most ${MAX_MCP_BEARER_TOKEN_LENGTH} characters`,
                     );
                 }
+
+                if (
+                    body.credentials?.clientId ||
+                    body.credentials?.clientSecret
+                ) {
+                    throw new ParameterError(
+                        'OAuth client credentials are not allowed for auth type "bearer"',
+                    );
+                }
                 if (allowOAuthCredentialSharing) {
                     throw new ParameterError(
                         'OAuth credential sharing is only allowed for auth type "oauth"',
@@ -3269,6 +3282,25 @@ export class AiAgentService extends BaseService {
                 if (body.credentials?.bearerToken) {
                     throw new ParameterError(
                         'Bearer credentials are not allowed for auth type "oauth"',
+                    );
+                }
+                if (
+                    (body.credentials?.clientId?.trim() &&
+                        !body.credentials?.clientSecret?.trim()) ||
+                    (!body.credentials?.clientId?.trim() &&
+                        body.credentials?.clientSecret?.trim())
+                ) {
+                    throw new ParameterError(
+                        'OAuth client ID and secret must be provided together',
+                    );
+                }
+                if (
+                    allowOAuthCredentialSharing &&
+                    (body.credentials?.clientId?.trim() ||
+                        body.credentials?.clientSecret?.trim())
+                ) {
+                    throw new ParameterError(
+                        'OAuth client ID and secret are only supported for personal OAuth credentials',
                     );
                 }
                 if (body.credentialScope !== undefined) {
@@ -3284,12 +3316,22 @@ export class AiAgentService extends BaseService {
                 );
         }
 
-        const credentials =
-            body.authType === 'bearer'
-                ? {
-                      bearerToken: body.credentials!.bearerToken.trim(),
-                  }
-                : null;
+        let credentials: ApiCreateAiMcpServer['credentials'] = null;
+        if (body.authType === 'bearer') {
+            credentials = {
+                bearerToken: body.credentials!.bearerToken!.trim(),
+            };
+        }
+        if (
+            body.authType === 'oauth' &&
+            body.credentials?.clientId?.trim() &&
+            body.credentials?.clientSecret?.trim()
+        ) {
+            credentials = {
+                clientId: body.credentials.clientId.trim(),
+                clientSecret: body.credentials.clientSecret.trim(),
+            };
+        }
 
         let mcpConnectionMetadata: { iconUrl: string | null } | null = null;
 

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -1,7 +1,7 @@
 import * as mcpSdk from '@ai-sdk/mcp';
 import type { MCPClient } from '@ai-sdk/mcp';
 import type { LightdashConfig } from '../../../config/parseConfig';
-import type { AiAgentModel } from '../../models/AiAgentModel';
+import type { AiAgentModel, AiMcpCredential } from '../../models/AiAgentModel';
 import {
     AiAgentMcpRuntimeClient,
     createHttpMcpClient,
@@ -121,6 +121,129 @@ describe('normalizeMcpOAuthPayloadForRedirect', () => {
             expect.objectContaining({
                 clientInformation: { client_id: 'current-client' },
                 clientMetadata: staticMetadata,
+            }),
+        );
+    });
+
+    it('keeps configured client credentials when redirect metadata is stale', () => {
+        expect(
+            normalizeMcpOAuthPayloadForRedirect(
+                {
+                    type: 'oauth',
+                    credentialScope: 'shared',
+                    connectionStatus: 'not_connected',
+                    configuredClientId: 'configured-client',
+                    configuredClientSecret: 'configured-secret',
+                    clientMetadata: {
+                        redirect_uris: [
+                            'https://lightdash.example.com/api/v1/projects/project-uuid/aiAgents/mcpServers/server-uuid/oauth/callback',
+                        ],
+                    },
+                },
+                'shared',
+                staticMetadata.redirect_uris[0],
+                staticMetadata,
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                configuredClientId: 'configured-client',
+                configuredClientSecret: 'configured-secret',
+                clientInformation: {
+                    client_id: 'configured-client',
+                    client_secret: 'configured-secret',
+                },
+                clientMetadata: staticMetadata,
+            }),
+        );
+    });
+});
+
+describe('PersistentMcpOAuthClientProvider', () => {
+    it('uses shared configured client credentials for user-scoped OAuth', async () => {
+        const sharedCredential = {
+            uuid: 'credential-uuid',
+            mcpServerUuid: 'server-uuid',
+            credentialScope: 'shared',
+            userUuid: null,
+            createdByUserUuid: 'creator-uuid',
+            updatedByUserUuid: 'creator-uuid',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            credentials: {
+                type: 'oauth',
+                credentialScope: 'shared',
+                connectionStatus: 'not_connected',
+                configuredClientId: 'configured-client',
+                configuredClientSecret: 'configured-secret',
+            },
+        } satisfies AiMcpCredential;
+        const aiAgentModel = {
+            getCredential: vi
+                .fn()
+                .mockResolvedValueOnce(undefined)
+                .mockResolvedValueOnce(sharedCredential),
+            upsertCredential: vi.fn(),
+        } as unknown as AiAgentModel;
+        const runtimeClient = new AiAgentMcpRuntimeClient({
+            aiAgentModel,
+            lightdashConfig: {
+                siteUrl: 'https://lightdash.example.com',
+                ai: {
+                    copilot: { mcpConnectionTimeoutMs: 20_000 },
+                },
+            } as LightdashConfig,
+        });
+        const provider = (
+            runtimeClient as unknown as {
+                createMcpOAuthProvider: (args: {
+                    projectUuid: string;
+                    mcpServerUuid: string;
+                    credentialScope: 'user';
+                    userUuid: string;
+                    actorUserUuid: string;
+                }) => {
+                    clientInformation: () => Promise<unknown>;
+                    state: () => Promise<string>;
+                };
+            }
+        ).createMcpOAuthProvider({
+            projectUuid: 'project-uuid',
+            mcpServerUuid: 'server-uuid',
+            credentialScope: 'user',
+            userUuid: 'user-uuid',
+            actorUserUuid: 'user-uuid',
+        });
+
+        await expect(provider.clientInformation()).resolves.toEqual({
+            client_id: 'configured-client',
+            client_secret: 'configured-secret',
+        });
+        expect(aiAgentModel.getCredential).toHaveBeenCalledWith(
+            'server-uuid',
+            'user',
+            {
+                userUuid: 'user-uuid',
+            },
+        );
+        expect(aiAgentModel.getCredential).toHaveBeenCalledWith(
+            'server-uuid',
+            'shared',
+        );
+
+        await provider.state();
+        expect(aiAgentModel.upsertCredential).toHaveBeenCalledWith(
+            expect.objectContaining({
+                serverUuid: 'server-uuid',
+                scope: 'user',
+                userUuid: 'user-uuid',
+                credentials: expect.not.objectContaining({
+                    configuredClientId: 'configured-client',
+                    configuredClientSecret: 'configured-secret',
+                    clientInformation: {
+                        client_id: 'configured-client',
+                        client_secret: 'configured-secret',
+                    },
+                }),
             }),
         );
     });

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -76,6 +76,39 @@ const buildDefaultClientMetadata = (
     token_endpoint_auth_method: 'none',
 });
 
+const getOAuthClientInformation = (
+    payload: AiMcpOAuthCredentialPayload,
+): OAuthClientInformationMixed | undefined => {
+    if (payload.configuredClientId && payload.configuredClientSecret) {
+        return {
+            client_id: payload.configuredClientId,
+            client_secret: payload.configuredClientSecret,
+        };
+    }
+
+    return payload.clientInformation as OAuthClientInformationMixed | undefined;
+};
+
+const toPersistedOAuthPayload = (
+    payload: AiMcpOAuthCredentialPayload,
+    credentialScope: AiMcpCredentialScope,
+): AiMcpOAuthCredentialPayload => {
+    if (
+        credentialScope !== 'user' ||
+        !payload.configuredClientId ||
+        !payload.configuredClientSecret
+    ) {
+        return payload;
+    }
+
+    return {
+        ...payload,
+        configuredClientId: undefined,
+        configuredClientSecret: undefined,
+        clientInformation: undefined,
+    };
+};
+
 export const getMcpOAuthCallbackUrl = (siteUrl: string): string =>
     new URL('/api/v1/aiAgents/mcp/oauth/callback', siteUrl).toString();
 
@@ -97,7 +130,13 @@ export const normalizeMcpOAuthPayloadForRedirect = (
         return {
             ...payload,
             credentialScope,
-            clientInformation: undefined,
+            clientInformation:
+                payload.configuredClientId && payload.configuredClientSecret
+                    ? {
+                          client_id: payload.configuredClientId,
+                          client_secret: payload.configuredClientSecret,
+                      }
+                    : undefined,
             clientMetadata: defaultClientMetadata,
             codeVerifier: undefined,
             state: undefined,
@@ -254,8 +293,23 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         const payload = credential?.credentials;
 
         if (payload?.type === 'oauth') {
-            return normalizeMcpOAuthPayloadForRedirect(
+            const normalizedPayload = normalizeMcpOAuthPayloadForRedirect(
                 payload,
+                credential!.credentialScope,
+                this.redirectTargetUrl,
+                this.defaultClientMetadata,
+            );
+
+            return normalizeMcpOAuthPayloadForRedirect(
+                {
+                    ...normalizedPayload,
+                    clientInformation: getOAuthClientInformation(
+                        normalizedPayload,
+                    ) as Record<string, unknown> | undefined,
+                    clientMetadata:
+                        normalizedPayload.clientMetadata ??
+                        this.defaultClientMetadata,
+                },
                 credential!.credentialScope,
                 this.redirectTargetUrl,
                 this.defaultClientMetadata,
@@ -292,9 +346,7 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         OAuthClientInformationMixed | undefined
     > {
         const payload = await this.loadPayload();
-        return payload.clientInformation as
-            | OAuthClientInformationMixed
-            | undefined;
+        return getOAuthClientInformation(payload);
     }
 
     async saveClientInformation(
@@ -751,23 +803,82 @@ export class AiAgentMcpRuntimeClient {
         forceReauth?: boolean;
         connectionStatusOnAuthorization?: AiMcpServerConnectionStatus;
     }) {
+        const getCredentialWithConfiguredClient = async () => {
+            const credential = await this.aiAgentModel.getCredential(
+                args.mcpServerUuid,
+                args.credentialScope,
+                {
+                    userUuid: args.userUuid,
+                },
+            );
+            const sharedCredential =
+                args.credentialScope === 'shared'
+                    ? credential
+                    : await this.aiAgentModel.getCredential(
+                          args.mcpServerUuid,
+                          'shared',
+                      );
+            const sharedPayload = sharedCredential?.credentials;
+
+            if (
+                !sharedCredential ||
+                sharedPayload?.type !== 'oauth' ||
+                !sharedPayload.configuredClientId ||
+                !sharedPayload.configuredClientSecret
+            ) {
+                return credential;
+            }
+
+            if (!credential) {
+                return {
+                    ...sharedCredential,
+                    credentialScope: args.credentialScope,
+                    userUuid:
+                        args.credentialScope === 'user'
+                            ? (args.userUuid ?? null)
+                            : null,
+                    credentials: {
+                        type: 'oauth',
+                        credentialScope: args.credentialScope,
+                        connectionStatus: 'not_connected',
+                        configuredClientId: sharedPayload.configuredClientId,
+                        configuredClientSecret:
+                            sharedPayload.configuredClientSecret,
+                    },
+                } satisfies AiMcpCredential;
+            }
+
+            if (credential.credentials.type !== 'oauth') {
+                return credential;
+            }
+
+            return {
+                ...credential,
+                credentials: {
+                    ...credential.credentials,
+                    configuredClientId:
+                        credential.credentials.configuredClientId ??
+                        sharedPayload.configuredClientId,
+                    configuredClientSecret:
+                        credential.credentials.configuredClientSecret ??
+                        sharedPayload.configuredClientSecret,
+                },
+            } satisfies AiMcpCredential;
+        };
+
         return new PersistentMcpOAuthClientProvider({
             mcpServerUuid: args.mcpServerUuid,
             credentialScope: args.credentialScope,
             redirectUrl: getMcpOAuthCallbackUrl(this.lightdashConfig.siteUrl),
-            getCredential: () =>
-                this.aiAgentModel.getCredential(
-                    args.mcpServerUuid,
-                    args.credentialScope,
-                    {
-                        userUuid: args.userUuid,
-                    },
-                ),
+            getCredential: getCredentialWithConfiguredClient,
             saveCredential: async (payload) => {
                 await this.aiAgentModel.upsertCredential({
                     serverUuid: args.mcpServerUuid,
                     scope: args.credentialScope,
-                    credentials: payload,
+                    credentials: toPersistedOAuthPayload(
+                        payload,
+                        args.credentialScope,
+                    ),
                     userUuid: args.userUuid,
                     actorUserUuid: args.actorUserUuid ?? null,
                 });

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12756,9 +12756,14 @@ const models: TsoaRoute.Models = {
                         {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
+                                clientSecret: {
+                                    dataType: 'string',
+                                },
+                                clientId: {
+                                    dataType: 'string',
+                                },
                                 bearerToken: {
                                     dataType: 'string',
-                                    required: true,
                                 },
                             },
                         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14381,11 +14381,16 @@
                 "properties": {
                     "credentials": {
                         "properties": {
+                            "clientSecret": {
+                                "type": "string"
+                            },
+                            "clientId": {
+                                "type": "string"
+                            },
                             "bearerToken": {
                                 "type": "string"
                             }
                         },
-                        "required": ["bearerToken"],
                         "type": "object",
                         "nullable": true
                     },

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -402,7 +402,9 @@ export type ApiCreateAiMcpServer = {
     allowOAuthCredentialSharing?: boolean;
     credentialScope?: AiMcpCredentialScope;
     credentials?: {
-        bearerToken: string;
+        bearerToken?: string;
+        clientId?: string;
+        clientSecret?: string;
     } | null;
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -72,6 +72,8 @@ const createMcpServerFormSchema = z
         url: z.string().trim().url('Enter a valid URL'),
         authType: z.enum(['none', 'bearer', 'oauth']),
         bearerToken: z.string(),
+        clientId: z.string(),
+        clientSecret: z.string(),
         allowOAuthCredentialSharing: z.boolean(),
     })
     .superRefine((values, ctx) => {
@@ -83,6 +85,41 @@ const createMcpServerFormSchema = z
                 code: z.ZodIssueCode.custom,
                 message: 'Bearer token is required',
                 path: ['bearerToken'],
+            });
+        }
+        if (
+            values.authType === 'oauth' &&
+            values.clientId.trim().length > 0 &&
+            values.clientSecret.trim().length === 0
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'Client secret is required',
+                path: ['clientSecret'],
+            });
+        }
+        if (
+            values.authType === 'oauth' &&
+            values.clientSecret.trim().length > 0 &&
+            values.clientId.trim().length === 0
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'Client ID is required',
+                path: ['clientId'],
+            });
+        }
+        if (
+            values.authType === 'oauth' &&
+            values.allowOAuthCredentialSharing &&
+            (values.clientId.trim().length > 0 ||
+                values.clientSecret.trim().length > 0)
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                    'Client credentials are only supported for personal OAuth',
+                path: ['clientId'],
             });
         }
     });
@@ -241,6 +278,8 @@ const CreateMcpServerModal = ({
             url: '',
             authType: 'none',
             bearerToken: '',
+            clientId: '',
+            clientSecret: '',
             allowOAuthCredentialSharing: false,
         },
         validate: zodResolver(createMcpServerFormSchema),
@@ -354,16 +393,64 @@ const CreateMcpServerModal = ({
                                     }
                                 >
                                     <Box pt="xs">
+                                        {!form.values
+                                            .allowOAuthCredentialSharing && (
+                                            <>
+                                                <TextInput
+                                                    variant="subtle"
+                                                    label="OAuth client ID"
+                                                    placeholder="client_id"
+                                                    disabled={isLoading}
+                                                    autoComplete="off"
+                                                    {...form.getInputProps(
+                                                        'clientId',
+                                                    )}
+                                                />
+                                                <PasswordInput
+                                                    mt="sm"
+                                                    variant="subtle"
+                                                    label="OAuth client secret"
+                                                    placeholder="client_secret"
+                                                    disabled={isLoading}
+                                                    autoComplete="off"
+                                                    {...form.getInputProps(
+                                                        'clientSecret',
+                                                    )}
+                                                />
+                                            </>
+                                        )}
                                         <Checkbox
+                                            mt={
+                                                form.values
+                                                    .allowOAuthCredentialSharing
+                                                    ? undefined
+                                                    : 'md'
+                                            }
                                             label="Allow shared project credentials for this MCP"
                                             description="Optional. Agent managers can connect a shared project account for this MCP."
                                             disabled={isLoading}
-                                            {...form.getInputProps(
-                                                'allowOAuthCredentialSharing',
-                                                {
-                                                    type: 'checkbox',
-                                                },
-                                            )}
+                                            checked={
+                                                form.values
+                                                    .allowOAuthCredentialSharing
+                                            }
+                                            onChange={(event) => {
+                                                const checked =
+                                                    event.currentTarget.checked;
+                                                form.setFieldValue(
+                                                    'allowOAuthCredentialSharing',
+                                                    checked,
+                                                );
+                                                if (checked) {
+                                                    form.setFieldValue(
+                                                        'clientId',
+                                                        '',
+                                                    );
+                                                    form.setFieldValue(
+                                                        'clientSecret',
+                                                        '',
+                                                    );
+                                                }
+                                            }}
                                         />
                                     </Box>
                                 </Collapse>
@@ -874,7 +961,14 @@ export const AiAgentMcpServersInput = ({
                             ? {
                                   bearerToken: values.bearerToken.trim(),
                               }
-                            : null,
+                            : values.authType === 'oauth' &&
+                                values.clientId.trim() &&
+                                values.clientSecret.trim()
+                              ? {
+                                    clientId: values.clientId.trim(),
+                                    clientSecret: values.clientSecret.trim(),
+                                }
+                              : null,
                 });
             } catch (error) {
                 popupWindow?.close();


### PR DESCRIPTION
Summary:

- Add optional MCP OAuth client ID and client secret fields for personal OAuth MCP servers.
- Store configured client credentials in encrypted MCP server credentials.
- Reuse configured client credentials to bypass DCR during personal OAuth, without duplicating secrets into user credential rows.
- Add create-form fields and keep shared OAuth as the final option.

Validations:

- pnpm -F backend test src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
- pnpm -F backend typecheck:fast
- pnpm -F frontend typecheck:fast
- pnpm -F common typecheck:fast

Closes: https://linear.app/lightdash/issue/ZAP-597/support-oauth-client-idclient-secret-for-mcp-servers