### PR TITLE
feat: add dashboard filter requirements module (unmounted)

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -172,6 +172,12 @@ export enum FeatureFlags {
     LockDashboardFilters = 'lock-dashboard-filters',
 
     /**
+     * Filter requirement groups + the guided locked-dashboard UX; off = legacy
+     * required-filter behavior and `requiredGroupId` is ignored.
+     */
+    DashboardFilterRequirements = 'dashboard-filter-requirements',
+
+    /**
      * Gate the "Schedule delivery" entry point for data apps. Disabled by
      * default while the screenshot pipeline is producing blank pages in
      * production. Enable per-org once the underlying rendering issue is

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1834,7 +1834,7 @@ describe('getUnmetFilterRequirements', () => {
         expect(getUnmetFilterRequirements(filters)).toEqual([]);
     });
 
-    test('a valueless rule with both required and requiredGroupId is an unmet single and a group member', () => {
+    test('a rule with both required and requiredGroupId is a single, not a group member', () => {
         const both = createRule('a', {
             required: true,
             requiredGroupId: 'g1',
@@ -1845,12 +1845,27 @@ describe('getUnmetFilterRequirements', () => {
             disabled: true,
         });
 
+        // `required` wins: the dual-flag rule is excluded from its group
         const unmetGroupFilters = toDashboardFilters({
             dimensions: [both, memberB],
         });
         expect(getUnmetFilterRequirements(unmetGroupFilters)).toEqual([
             { type: 'single', filter: both },
-            { type: 'group', groupId: 'g1', filters: [both, memberB] },
+            { type: 'group', groupId: 'g1', filters: [memberB] },
+        ]);
+
+        // A value on the dual-flag rule satisfies its single, not the group
+        const satisfiedSingle = createRule('a', {
+            required: true,
+            requiredGroupId: 'g1',
+            disabled: false,
+            values: ['x'],
+        });
+        const satisfiedSingleFilters = toDashboardFilters({
+            dimensions: [satisfiedSingle, memberB],
+        });
+        expect(getUnmetFilterRequirements(satisfiedSingleFilters)).toEqual([
+            { type: 'group', groupId: 'g1', filters: [memberB] },
         ]);
 
         // Group satisfied by the other member, but the required single remains unmet

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -1544,6 +1544,60 @@ export type UnmetFilterRequirement =
     | { type: 'single'; filter: DashboardFilterRule }
     | { type: 'group'; groupId: string; filters: DashboardFilterRule[] };
 
+export type FilterRequirementRule = {
+    type: 'single' | 'group';
+    /**
+     * `requiredGroupId` for shared rules; the filter's own id for one-member
+     * rules expressed via `required: true`.
+     */
+    id: string;
+    members: DashboardFilterRule[];
+};
+
+/**
+ * Unified view of filter requirements: every requirement is a rule, a set of
+ * filters where at least one must be set. `required: true` is a one-member
+ * rule; filters sharing a `requiredGroupId` form one rule. Rules are returned
+ * in first-appearance order (dimensions before metrics). `required` wins when
+ * hand-authored JSON sets both flags on the same filter.
+ */
+export const getFilterRequirementRules = (
+    dashboardFilters: Pick<DashboardFilters, 'dimensions' | 'metrics'>,
+): FilterRequirementRule[] => {
+    const filterRules = [
+        ...dashboardFilters.dimensions,
+        ...dashboardFilters.metrics,
+    ];
+
+    const rules: FilterRequirementRule[] = [];
+    const groupRulesById = new Map<string, FilterRequirementRule>();
+    filterRules.forEach((filterRule) => {
+        if (filterRule.required) {
+            rules.push({
+                type: 'single',
+                id: filterRule.id,
+                members: [filterRule],
+            });
+            return;
+        }
+        if (!filterRule.requiredGroupId) return;
+
+        const existingRule = groupRulesById.get(filterRule.requiredGroupId);
+        if (existingRule) {
+            existingRule.members.push(filterRule);
+            return;
+        }
+        const rule: FilterRequirementRule = {
+            type: 'group',
+            id: filterRule.requiredGroupId,
+            members: [filterRule],
+        };
+        groupRulesById.set(filterRule.requiredGroupId, rule);
+        rules.push(rule);
+    });
+    return rules;
+};
+
 /**
  * A rule only satisfies a requirement when it actually filters the query:
  * disabled rules and enabled rules with a value-requiring operator and no
@@ -1554,35 +1608,24 @@ export const isValuelessDashboardFilterRule = (
     rule: DashboardFilterRule,
 ): boolean => rule.disabled === true || isEmptyDashboardFilterRule(rule);
 
+/** A rule is satisfied when any member actually filters the query */
+export const isRequirementRuleSatisfied = (
+    rule: FilterRequirementRule,
+): boolean =>
+    rule.members.some((member) => !isValuelessDashboardFilterRule(member));
+
 /**
- * Unmet requirements over dimensions + metrics: valueless `required` rules as
- * singles (even when also in a group), then groups whose members are all
- * valueless, in first-appearance order.
+ * Unmet requirements over dimensions + metrics, derived from
+ * `getFilterRequirementRules` so the dashboard lock and the requirement UIs
+ * share a single rule derivation.
  */
 export const getUnmetFilterRequirements = (
     dashboardFilters: DashboardFilters,
-): UnmetFilterRequirement[] => {
-    const rules = [...dashboardFilters.dimensions, ...dashboardFilters.metrics];
-
-    const unmetSingles = rules
-        .filter((rule) => rule.required && isValuelessDashboardFilterRule(rule))
-        .map<UnmetFilterRequirement>((filter) => ({ type: 'single', filter }));
-
-    const groups = new Map<string, DashboardFilterRule[]>();
-    rules.forEach((rule) => {
-        if (!rule.requiredGroupId) return;
-        const members = groups.get(rule.requiredGroupId) ?? [];
-        members.push(rule);
-        groups.set(rule.requiredGroupId, members);
-    });
-
-    const unmetGroups = [...groups.entries()]
-        .filter(([, members]) => members.every(isValuelessDashboardFilterRule))
-        .map<UnmetFilterRequirement>(([groupId, filters]) => ({
-            type: 'group',
-            groupId,
-            filters,
-        }));
-
-    return [...unmetSingles, ...unmetGroups];
-};
+): UnmetFilterRequirement[] =>
+    getFilterRequirementRules(dashboardFilters)
+        .filter((rule) => !isRequirementRuleSatisfied(rule))
+        .map<UnmetFilterRequirement>((rule) =>
+            rule.type === 'single'
+                ? { type: 'single', filter: rule.members[0] }
+                : { type: 'group', groupId: rule.id, filters: rule.members },
+        );

--- a/packages/frontend/src/components/DashboardTiles/UnmetRequirementsPlaceholder.test.tsx
+++ b/packages/frontend/src/components/DashboardTiles/UnmetRequirementsPlaceholder.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import UnmetRequirementsPlaceholder from './UnmetRequirementsPlaceholder';
+
+describe('UnmetRequirementsPlaceholder', () => {
+    it('renders the placeholder with its filter-exclamation icon', () => {
+        const { getByTestId } = renderWithProviders(
+            <UnmetRequirementsPlaceholder />,
+        );
+
+        const placeholder = getByTestId('unmet-requirements-placeholder');
+        expect(placeholder.querySelector('svg')).not.toBeNull();
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/UnmetRequirementsPlaceholder.tsx
+++ b/packages/frontend/src/components/DashboardTiles/UnmetRequirementsPlaceholder.tsx
@@ -1,0 +1,13 @@
+import { Center } from '@mantine-8/core';
+import { IconFilterExclamation } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+
+/** Shown in place of a tile's content while filter requirements are unmet. */
+const UnmetRequirementsPlaceholder: FC = () => (
+    <Center h="100%" w="100%" data-testid="unmet-requirements-placeholder">
+        <MantineIcon icon={IconFilterExclamation} size="xl" color="ldGray.4" />
+    </Center>
+);
+
+export default UnmetRequirementsPlaceholder;

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterBarPopoversContext.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterBarPopoversContext.ts
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+
+export type FilterBarPopoversState = {
+    isRulesPopoverOpen: boolean;
+    openRulesPopover: () => void;
+    closeRulesPopover: () => void;
+    /**
+     * Open popover in the filter bar: a filter chip (keyed by the dashboard
+     * filter rule id) or the add-filter popover (ad-hoc id).
+     */
+    openFilterPopoverId: string | undefined;
+    openFilterPopover: (popoverId: string) => void;
+    closeFilterPopover: () => void;
+};
+
+/**
+ * Coordinates the filter bar popovers across the dashboard: the "Edit rule"
+ * link in a filter chip popover can open the Filter rules popover, and the
+ * required-filters banner can open a specific filter chip's popover.
+ */
+export const FilterBarPopoversContext =
+    createContext<FilterBarPopoversState | null>(null);

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterBarPopoversProvider.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterBarPopoversProvider.test.tsx
@@ -1,0 +1,47 @@
+import { Box } from '@mantine-8/core';
+import { act, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { FilterBarPopoversProvider } from './FilterBarPopoversProvider';
+import { useFilterBarPopovers } from './useFilterBarPopovers';
+
+describe('FilterBarPopoversProvider', () => {
+    it('renders its children', () => {
+        renderWithProviders(
+            <FilterBarPopoversProvider>
+                <Box data-testid="child" />
+            </FilterBarPopoversProvider>,
+        );
+
+        expect(screen.getByTestId('child')).not.toBeNull();
+    });
+
+    it('exposes rules popover and filter popover state through the context hook', () => {
+        const { result } = renderHook(() => useFilterBarPopovers(), {
+            wrapper: FilterBarPopoversProvider,
+        });
+
+        expect(result.current?.isRulesPopoverOpen).toBe(false);
+        expect(result.current?.openFilterPopoverId).toBeUndefined();
+
+        act(() => {
+            result.current?.openRulesPopover();
+        });
+        expect(result.current?.isRulesPopoverOpen).toBe(true);
+
+        act(() => {
+            result.current?.closeRulesPopover();
+        });
+        expect(result.current?.isRulesPopoverOpen).toBe(false);
+
+        act(() => {
+            result.current?.openFilterPopover('chip-1');
+        });
+        expect(result.current?.openFilterPopoverId).toBe('chip-1');
+
+        act(() => {
+            result.current?.closeFilterPopover();
+        });
+        expect(result.current?.openFilterPopoverId).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterBarPopoversProvider.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterBarPopoversProvider.tsx
@@ -1,0 +1,52 @@
+import { useDisclosure } from '@mantine-8/hooks';
+import {
+    useCallback,
+    useMemo,
+    useState,
+    type FC,
+    type PropsWithChildren,
+} from 'react';
+import { FilterBarPopoversContext } from './FilterBarPopoversContext';
+
+export const FilterBarPopoversProvider: FC<PropsWithChildren> = ({
+    children,
+}) => {
+    const [
+        isRulesPopoverOpen,
+        { open: openRulesPopover, close: closeRulesPopover },
+    ] = useDisclosure(false);
+    const [openFilterPopoverId, setOpenFilterPopoverId] = useState<string>();
+
+    const openFilterPopover = useCallback((popoverId: string) => {
+        setOpenFilterPopoverId(popoverId);
+    }, []);
+
+    const closeFilterPopover = useCallback(() => {
+        setOpenFilterPopoverId(undefined);
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            isRulesPopoverOpen,
+            openRulesPopover,
+            closeRulesPopover,
+            openFilterPopoverId,
+            openFilterPopover,
+            closeFilterPopover,
+        }),
+        [
+            isRulesPopoverOpen,
+            openRulesPopover,
+            closeRulesPopover,
+            openFilterPopoverId,
+            openFilterPopover,
+            closeFilterPopover,
+        ],
+    );
+
+    return (
+        <FilterBarPopoversContext.Provider value={value}>
+            {children}
+        </FilterBarPopoversContext.Provider>
+    );
+};

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirements.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirements.module.css
@@ -1,0 +1,48 @@
+.requirementsButton {
+    border-style: dashed;
+}
+
+/* Yellow signals the requirement system; dark theme matches the design's
+   yellow-6 text, light theme uses yellow-9 for readable contrast */
+.requirementsButtonActive {
+    border-color: alpha(var(--mantine-color-yellow-6), 0.35);
+
+    @mixin light {
+        color: var(--mantine-color-yellow-9);
+        background-color: var(--mantine-color-yellow-0);
+    }
+    @mixin dark {
+        color: var(--mantine-color-yellow-6);
+        background-color: alpha(var(--mantine-color-yellow-9), 0.25);
+    }
+}
+
+.ruleRow {
+    padding: var(--mantine-spacing-xs);
+    border: 1px solid var(--mantine-color-default-border);
+    border-radius: var(--mantine-radius-md);
+}
+
+.memberChip {
+    padding: 2px 4px 2px 8px;
+    border: 1px solid alpha(var(--mantine-color-yellow-6), 0.35);
+    border-radius: 100px;
+    max-width: 100%;
+
+    @mixin light {
+        background-color: var(--mantine-color-yellow-0);
+    }
+    @mixin dark {
+        background-color: alpha(var(--mantine-color-yellow-6), 0.1);
+    }
+}
+
+.addFilterInput {
+    border-style: dashed;
+    border-radius: 100px;
+}
+
+.saveBar {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+    border-top: 1px solid var(--mantine-color-default-border);
+}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.test.tsx
@@ -1,0 +1,292 @@
+import { FilterOperator, type DashboardFilterRule } from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import FilterRequirementsButton from './FilterRequirementsButton';
+
+const requiredRule: DashboardFilterRule = {
+    id: 'filter-1',
+    target: {
+        fieldId: 'customers_first_name',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    required: true,
+    label: undefined,
+};
+
+const eligibleRule: DashboardFilterRule = {
+    id: 'filter-2',
+    target: {
+        fieldId: 'customers_age',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    label: undefined,
+};
+
+const setRequiredFiltersNote = vi.fn();
+const closeRulesPopover = vi.fn();
+const updateFilterRule = vi.hoisted(() => vi.fn());
+
+const mockDashboardContext = vi.hoisted(() => ({
+    current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../providers/Dashboard/useDashboardContext', () => ({
+    default: vi.fn((selector) => selector(mockDashboardContext.current)),
+}));
+
+vi.mock('./useFilterableItemsMap', () => ({
+    useFilterableItemsMap: vi.fn(() => ({})),
+}));
+
+vi.mock('./useUpdateDashboardFilterRule', () => ({
+    useUpdateDashboardFilterRule: vi.fn(() => updateFilterRule),
+}));
+
+vi.mock('./useFilterBarPopovers', () => ({
+    useFilterBarPopovers: vi.fn(() => ({
+        isRulesPopoverOpen: true,
+        openRulesPopover: vi.fn(),
+        closeRulesPopover,
+    })),
+}));
+
+const getNoteTextarea = () =>
+    screen.getByLabelText<HTMLTextAreaElement>('Note for viewers');
+// jsdom never positions the floating dropdown (inline display:none), so its
+// contents are outside the a11y tree; include hidden elements when querying
+const getSaveButton = () =>
+    screen.getByRole<HTMLButtonElement>('button', {
+        name: 'Save',
+        hidden: true,
+    });
+const queryRemoveChipButton = () =>
+    screen.queryByRole('button', {
+        name: 'Remove customers_first_name',
+        hidden: true,
+    });
+const openFilterSelect = async (placeholder: string) => {
+    await userEvent.click(screen.getByPlaceholderText(placeholder));
+};
+// jsdom keeps the combobox dropdown display:none, so bypass the
+// pointer-events check with fireEvent
+const clickFilterOption = (label: string) => {
+    fireEvent.click(
+        screen.getByRole('option', { name: new RegExp(label), hidden: true }),
+    );
+};
+
+describe('FilterRequirementsButton explicit save', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockDashboardContext.current = {
+            isFilterRequirementsEnabled: true,
+            dashboardFilters: {
+                dimensions: [requiredRule],
+                metrics: [],
+                tableCalculations: [],
+            },
+            requiredFiltersNote: 'Saved note',
+            setRequiredFiltersNote,
+        };
+    });
+
+    it('disables Save until something is edited', async () => {
+        renderWithProviders(<FilterRequirementsButton />);
+
+        expect(getSaveButton().disabled).toBe(true);
+
+        await userEvent.type(getNoteTextarea(), '!');
+        expect(getSaveButton().disabled).toBe(false);
+    });
+
+    it('keeps note edits local and commits them on Save', async () => {
+        renderWithProviders(<FilterRequirementsButton />);
+
+        const textarea = getNoteTextarea();
+        await userEvent.type(textarea, '!');
+        expect(textarea.value).toBe('Saved note!');
+
+        await userEvent.tab();
+        expect(setRequiredFiltersNote).not.toHaveBeenCalled();
+
+        await userEvent.click(getSaveButton());
+        expect(setRequiredFiltersNote).toHaveBeenCalledTimes(1);
+        expect(setRequiredFiltersNote).toHaveBeenCalledWith('Saved note!');
+        expect(closeRulesPopover).toHaveBeenCalled();
+    });
+
+    it('allows clearing a saved note', async () => {
+        renderWithProviders(<FilterRequirementsButton />);
+
+        const textarea = getNoteTextarea();
+        await userEvent.clear(textarea);
+        expect(textarea.value).toBe('');
+
+        await userEvent.click(getSaveButton());
+        expect(setRequiredFiltersNote).toHaveBeenCalledWith('');
+    });
+
+    it('stages member removal and applies it on Save', async () => {
+        renderWithProviders(<FilterRequirementsButton />);
+
+        const removeButton = queryRemoveChipButton();
+        expect(removeButton).not.toBeNull();
+        await userEvent.click(removeButton!);
+
+        // Staged: the chip is gone from the draft view, nothing committed yet
+        expect(queryRemoveChipButton()).toBeNull();
+        expect(updateFilterRule).not.toHaveBeenCalled();
+
+        await userEvent.click(getSaveButton());
+        expect(updateFilterRule).toHaveBeenCalledWith('filter-1', {
+            required: false,
+            requiredGroupId: undefined,
+        });
+    });
+
+    it('saves via keyboard activation of the Save button', async () => {
+        renderWithProviders(<FilterRequirementsButton />);
+
+        await userEvent.type(getNoteTextarea(), '!');
+
+        getSaveButton().focus();
+        await userEvent.keyboard('{Enter}');
+
+        expect(setRequiredFiltersNote).toHaveBeenCalledWith('Saved note!');
+        expect(closeRulesPopover).toHaveBeenCalled();
+    });
+
+    it('converts a required singleton to a shared group when adding a member', async () => {
+        mockDashboardContext.current = {
+            ...mockDashboardContext.current,
+            dashboardFilters: {
+                dimensions: [requiredRule, eligibleRule],
+                metrics: [],
+                tableCalculations: [],
+            },
+        };
+        renderWithProviders(<FilterRequirementsButton />);
+
+        await openFilterSelect('+ or another filter');
+        clickFilterOption('customers_age');
+
+        // Staged: both chips render as one rule, nothing committed yet
+        expect(
+            screen.getByText('Viewers must set at least one of:'),
+        ).not.toBeNull();
+        expect(queryRemoveChipButton()).not.toBeNull();
+        expect(updateFilterRule).not.toHaveBeenCalled();
+
+        await userEvent.click(getSaveButton());
+        expect(updateFilterRule).toHaveBeenCalledTimes(2);
+        const [existingMemberCall, newMemberCall] = updateFilterRule.mock.calls;
+        expect(existingMemberCall[0]).toBe('filter-1');
+        expect(existingMemberCall[1]).toMatchObject({
+            required: false,
+            disabled: true,
+            values: [],
+        });
+        expect(newMemberCall[0]).toBe('filter-2');
+        expect(newMemberCall[1]).toMatchObject({
+            required: false,
+            disabled: true,
+            values: [],
+        });
+        // Both members join the same freshly minted group
+        expect(typeof existingMemberCall[1].requiredGroupId).toBe('string');
+        expect(newMemberCall[1].requiredGroupId).toBe(
+            existingMemberCall[1].requiredGroupId,
+        );
+    });
+
+    it('stages rule deletion for every member and applies it on Save', async () => {
+        mockDashboardContext.current = {
+            ...mockDashboardContext.current,
+            dashboardFilters: {
+                dimensions: [
+                    { ...requiredRule, required: false, requiredGroupId: 'g1' },
+                    { ...eligibleRule, requiredGroupId: 'g1' },
+                ],
+                metrics: [],
+                tableCalculations: [],
+            },
+        };
+        renderWithProviders(<FilterRequirementsButton />);
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Delete rule', hidden: true }),
+        );
+
+        expect(queryRemoveChipButton()).toBeNull();
+        expect(updateFilterRule).not.toHaveBeenCalled();
+
+        await userEvent.click(getSaveButton());
+        expect(updateFilterRule).toHaveBeenCalledWith('filter-1', {
+            required: false,
+            requiredGroupId: undefined,
+        });
+        expect(updateFilterRule).toHaveBeenCalledWith('filter-2', {
+            required: false,
+            requiredGroupId: undefined,
+        });
+    });
+
+    it('creates a rule from a draft row and applies it on Save', async () => {
+        mockDashboardContext.current = {
+            ...mockDashboardContext.current,
+            dashboardFilters: {
+                dimensions: [eligibleRule],
+                metrics: [],
+                tableCalculations: [],
+            },
+        };
+        renderWithProviders(<FilterRequirementsButton />);
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Add rule', hidden: true }),
+        );
+        await openFilterSelect('+ Add filter');
+        clickFilterOption('customers_age');
+
+        expect(updateFilterRule).not.toHaveBeenCalled();
+
+        await userEvent.click(getSaveButton());
+        expect(updateFilterRule).toHaveBeenCalledTimes(1);
+        const [[filterId, updates]] = updateFilterRule.mock.calls;
+        expect(filterId).toBe('filter-2');
+        expect(updates).toMatchObject({
+            required: false,
+            disabled: true,
+            values: [],
+        });
+        expect(typeof updates.requiredGroupId).toBe('string');
+    });
+
+    it('discards staged edits when the popover closes without saving', async () => {
+        renderWithProviders(<FilterRequirementsButton />);
+
+        await userEvent.type(getNoteTextarea(), '!');
+        await userEvent.click(queryRemoveChipButton()!);
+
+        // The target button toggles the open popover closed
+        await userEvent.click(
+            screen.getByRole('button', { name: /Filter rules/ }),
+        );
+
+        expect(closeRulesPopover).toHaveBeenCalled();
+        expect(setRequiredFiltersNote).not.toHaveBeenCalled();
+        expect(updateFilterRule).not.toHaveBeenCalled();
+
+        // Drafts reset: saved state is displayed again
+        expect(getNoteTextarea().value).toBe('Saved note');
+        expect(queryRemoveChipButton()).not.toBeNull();
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
@@ -1,0 +1,465 @@
+import {
+    type DashboardFilterRule,
+    type FilterableItem,
+} from '@lightdash/common';
+import {
+    Badge,
+    Button,
+    CloseButton,
+    Group,
+    Popover,
+    Stack,
+    Text,
+    Textarea,
+} from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
+import { clsx } from '@mantine/core';
+import { IconInfoCircle, IconPlus, IconTrash } from '@tabler/icons-react';
+import { Fragment, useCallback, useMemo, useState, type FC } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import FieldIcon from '../../../components/common/Filters/FieldIcon';
+import MantineIcon from '../../../components/common/MantineIcon';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import classes from './FilterRequirements.module.css';
+import FilterSelect, { type SelectableFilter } from './FilterSelect';
+import { AndSeparator } from './RuleSeparators';
+import { useFilterableItemsMap } from './useFilterableItemsMap';
+import { useFilterBarPopovers } from './useFilterBarPopovers';
+import { useUpdateDashboardFilterRule } from './useUpdateDashboardFilterRule';
+import {
+    getDashboardFilterRuleLabel,
+    getFilterRequirementRules,
+    getSelectableFilters,
+    type FilterRequirementRule,
+} from './utils';
+
+type MemberChipProps = {
+    item: FilterableItem | undefined;
+    label: string;
+    onRemove: () => void;
+};
+
+const MemberChip: FC<MemberChipProps> = ({ item, label, onRemove }) => (
+    <Group gap={4} wrap="nowrap" className={classes.memberChip}>
+        {item && <FieldIcon item={item} size="sm" />}
+        <Text size="xs" truncate>
+            {label}
+        </Text>
+        <CloseButton
+            size="xs"
+            aria-label={`Remove ${label}`}
+            onClick={onRemove}
+        />
+    </Group>
+);
+
+type RuleCardProps = {
+    members: DashboardFilterRule[];
+    selectableFilters: SelectableFilter[];
+    getFilterLabel: (filterRule: DashboardFilterRule) => string;
+    getFilterItem: (
+        filterRule: DashboardFilterRule,
+    ) => FilterableItem | undefined;
+    onAddMember: (filterId: string) => void;
+    onRemoveMember: (filterId: string) => void;
+    onDeleteRule: () => void;
+};
+
+const RuleCard: FC<RuleCardProps> = ({
+    members,
+    selectableFilters,
+    getFilterLabel,
+    getFilterItem,
+    onAddMember,
+    onRemoveMember,
+    onDeleteRule,
+}) => (
+    <Stack gap="xs" className={classes.ruleRow}>
+        <Text size="xs" fw={500}>
+            {members.length > 1
+                ? 'Viewers must set at least one of:'
+                : 'Viewers must set:'}
+        </Text>
+        <Group gap="xs">
+            {members.map((member) => (
+                <MemberChip
+                    key={member.id}
+                    item={getFilterItem(member)}
+                    label={getFilterLabel(member)}
+                    onRemove={() => onRemoveMember(member.id)}
+                />
+            ))}
+            <FilterSelect
+                selectableFilters={selectableFilters}
+                placeholder={
+                    members.length > 0 ? '+ or another filter' : '+ Add filter'
+                }
+                onSelect={onAddMember}
+            />
+            <Button
+                size="compact-xs"
+                variant="subtle"
+                color="ldGray.6"
+                ml="auto"
+                leftSection={<MantineIcon icon={IconTrash} />}
+                onClick={onDeleteRule}
+            >
+                Delete rule
+            </Button>
+        </Group>
+    </Stack>
+);
+
+const FilterRequirementsButton: FC = () => {
+    const isFilterRequirementsEnabled = useDashboardContext(
+        (c) => c.isFilterRequirementsEnabled,
+    );
+    const [isLocalPopoverOpen, { open: openLocal, close: closeLocal }] =
+        useDisclosure(false);
+    const popovers = useFilterBarPopovers();
+    const isPopoverOpen = popovers?.isRulesPopoverOpen ?? isLocalPopoverOpen;
+    const open = popovers?.openRulesPopover ?? openLocal;
+    const close = popovers?.closeRulesPopover ?? closeLocal;
+    const [draftRuleIds, setDraftRuleIds] = useState<string[]>([]);
+
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const requiredFiltersNote = useDashboardContext(
+        (c) => c.requiredFiltersNote,
+    );
+    const setRequiredFiltersNote = useDashboardContext(
+        (c) => c.setRequiredFiltersNote,
+    );
+    // Edits are staged locally and only reach the dashboard context on Save;
+    // closing the popover without saving discards them. null = no pending
+    // edits. The note is also kept out of context while typing because every
+    // context write re-renders the whole dashboard.
+    const [noteDraft, setNoteDraft] = useState<string | null>(null);
+    const [stagedRuleUpdates, setStagedRuleUpdates] = useState<Record<
+        string,
+        Partial<DashboardFilterRule>
+    > | null>(null);
+
+    const stageRuleUpdate = useCallback(
+        (filterId: string, updates: Partial<DashboardFilterRule>) => {
+            setStagedRuleUpdates((previous) => ({
+                ...previous,
+                [filterId]: { ...previous?.[filterId], ...updates },
+            }));
+        },
+        [],
+    );
+
+    const savedRequirementRules = useMemo(
+        () => getFilterRequirementRules(dashboardFilters),
+        [dashboardFilters],
+    );
+
+    const fieldsMap = useFilterableItemsMap();
+
+    const getFilterLabel = useCallback(
+        (filterRule: DashboardFilterRule) =>
+            getDashboardFilterRuleLabel(filterRule, fieldsMap),
+        [fieldsMap],
+    );
+
+    const getFilterItem = useCallback(
+        (filterRule: DashboardFilterRule) =>
+            fieldsMap[filterRule.target.fieldId],
+        [fieldsMap],
+    );
+
+    // Saved filters with staged edits applied on top; drives the rule cards
+    // and eligibility so staged changes are visible before Save
+    const allFilterRules = useMemo(() => {
+        const saved = [
+            ...dashboardFilters.dimensions,
+            ...dashboardFilters.metrics,
+        ];
+        if (!stagedRuleUpdates) return saved;
+        return saved.map((filterRule) =>
+            stagedRuleUpdates[filterRule.id]
+                ? { ...filterRule, ...stagedRuleUpdates[filterRule.id] }
+                : filterRule,
+        );
+    }, [dashboardFilters, stagedRuleUpdates]);
+
+    const requirementRules = useMemo(
+        () =>
+            stagedRuleUpdates
+                ? getFilterRequirementRules({
+                      dimensions: allFilterRules,
+                      metrics: [],
+                  })
+                : savedRequirementRules,
+        [stagedRuleUpdates, allFilterRules, savedRequirementRules],
+    );
+
+    const selectableFiltersFor = useCallback(
+        (memberIds: string[]): SelectableFilter[] =>
+            getSelectableFilters(allFilterRules, memberIds, fieldsMap),
+        [allFilterRules, fieldsMap],
+    );
+
+    const updateFilterRule = useUpdateDashboardFilterRule();
+
+    const handleAddRule = useCallback(() => {
+        setDraftRuleIds((previous) => [...previous, uuidv4()]);
+    }, []);
+
+    const addMemberToGroup = useCallback(
+        (groupId: string, filterId: string) => {
+            // Rule members are valueless by definition
+            stageRuleUpdate(filterId, {
+                requiredGroupId: groupId,
+                required: false,
+                disabled: true,
+                values: [],
+            });
+        },
+        [stageRuleUpdate],
+    );
+
+    const handleAddMember = useCallback(
+        (rule: FilterRequirementRule, filterId: string) => {
+            const requiredSingleton = rule.members.find(
+                (member) => member.required,
+            );
+            if (requiredSingleton) {
+                // One-member rule expressed via `required`: convert it to a
+                // shared rule before adding the sibling
+                const groupId = uuidv4();
+                addMemberToGroup(groupId, requiredSingleton.id);
+                addMemberToGroup(groupId, filterId);
+                return;
+            }
+            addMemberToGroup(rule.id, filterId);
+        },
+        [addMemberToGroup],
+    );
+
+    const handleAddMemberToDraft = useCallback(
+        (draftId: string, filterId: string) => {
+            addMemberToGroup(draftId, filterId);
+            setDraftRuleIds((previous) =>
+                previous.filter((id) => id !== draftId),
+            );
+        },
+        [addMemberToGroup],
+    );
+
+    const handleRemoveMember = useCallback(
+        (filterId: string) => {
+            stageRuleUpdate(filterId, {
+                required: false,
+                requiredGroupId: undefined,
+            });
+        },
+        [stageRuleUpdate],
+    );
+
+    const handleDeleteRule = useCallback(
+        (rule: FilterRequirementRule) => {
+            rule.members.forEach((member) =>
+                stageRuleUpdate(member.id, {
+                    required: false,
+                    requiredGroupId: undefined,
+                }),
+            );
+        },
+        [stageRuleUpdate],
+    );
+
+    const hasStagedChanges = stagedRuleUpdates !== null || noteDraft !== null;
+
+    const handleSave = useCallback(() => {
+        if (stagedRuleUpdates) {
+            Object.entries(stagedRuleUpdates).forEach(([filterId, updates]) =>
+                updateFilterRule(filterId, updates),
+            );
+        }
+        if (noteDraft !== null) {
+            setRequiredFiltersNote(noteDraft);
+        }
+        setStagedRuleUpdates(null);
+        setNoteDraft(null);
+        setDraftRuleIds([]);
+        close();
+    }, [
+        stagedRuleUpdates,
+        noteDraft,
+        updateFilterRule,
+        setRequiredFiltersNote,
+        close,
+    ]);
+
+    const handleClose = useCallback(() => {
+        close();
+        setStagedRuleUpdates(null);
+        setNoteDraft(null);
+        setDraftRuleIds([]);
+    }, [close]);
+
+    const requirementCount = savedRequirementRules.length;
+    const hasRuleRows = requirementRules.length > 0 || draftRuleIds.length > 0;
+
+    if (!isFilterRequirementsEnabled) {
+        return null;
+    }
+
+    return (
+        <Popover
+            position="bottom-start"
+            opened={isPopoverOpen}
+            onClose={handleClose}
+            onDismiss={handleClose}
+            transitionProps={{ transition: 'pop-top-left' }}
+            withArrow
+            shadow="md"
+            offset={1}
+            arrowOffset={14}
+            withinPortal
+        >
+            <Popover.Target>
+                <Button
+                    size="xs"
+                    variant="default"
+                    radius={100}
+                    className={clsx(
+                        classes.requirementsButton,
+                        requirementCount > 0 &&
+                            classes.requirementsButtonActive,
+                    )}
+                    rightSection={
+                        requirementCount > 0 ? (
+                            <Badge size="xs" color="yellow" autoContrast circle>
+                                {requirementCount}
+                            </Badge>
+                        ) : undefined
+                    }
+                    onClick={() => (isPopoverOpen ? handleClose() : open())}
+                >
+                    Filter rules
+                </Button>
+            </Popover.Target>
+
+            <Popover.Dropdown p={0}>
+                <Stack w={400} gap="sm" p="md">
+                    <Stack gap={2}>
+                        <Text size="sm" fw={600}>
+                            Filter rules
+                        </Text>
+                        <Text size="xs" c="ldGray.6">
+                            Dashboard won't load until all rules are met.
+                        </Text>
+                    </Stack>
+                    {!hasRuleRows && (
+                        <Text size="xs" c="ldGray.6">
+                            Require viewers to set filters before the dashboard
+                            loads, either individually or at least one from a
+                            set.
+                        </Text>
+                    )}
+                    {requirementRules.map((rule, index) => (
+                        <Fragment key={rule.id}>
+                            {index > 0 && <AndSeparator />}
+                            <RuleCard
+                                members={rule.members}
+                                selectableFilters={selectableFiltersFor(
+                                    rule.members.map((member) => member.id),
+                                )}
+                                getFilterLabel={getFilterLabel}
+                                getFilterItem={getFilterItem}
+                                onAddMember={(filterId) =>
+                                    handleAddMember(rule, filterId)
+                                }
+                                onRemoveMember={handleRemoveMember}
+                                onDeleteRule={() => handleDeleteRule(rule)}
+                            />
+                        </Fragment>
+                    ))}
+                    {draftRuleIds.map((draftId, index) => (
+                        <Fragment key={draftId}>
+                            {(requirementRules.length > 0 || index > 0) && (
+                                <AndSeparator />
+                            )}
+                            <RuleCard
+                                members={[]}
+                                selectableFilters={selectableFiltersFor([])}
+                                getFilterLabel={getFilterLabel}
+                                getFilterItem={getFilterItem}
+                                onAddMember={(filterId) =>
+                                    handleAddMemberToDraft(draftId, filterId)
+                                }
+                                onRemoveMember={handleRemoveMember}
+                                onDeleteRule={() =>
+                                    setDraftRuleIds((previous) =>
+                                        previous.filter((id) => id !== draftId),
+                                    )
+                                }
+                            />
+                        </Fragment>
+                    ))}
+                    <Button
+                        size="xs"
+                        variant="subtle"
+                        color="blue"
+                        fullWidth
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        onClick={handleAddRule}
+                    >
+                        {hasRuleRows ? 'Add another rule' : 'Add rule'}
+                    </Button>
+                    {hasRuleRows && (
+                        <Textarea
+                            size="xs"
+                            label="Note for viewers"
+                            placeholder="Explain why these filters are required, e.g. pick your region to keep this dashboard fast"
+                            autosize
+                            minRows={2}
+                            maxRows={4}
+                            value={noteDraft ?? requiredFiltersNote ?? ''}
+                            onChange={(event) =>
+                                setNoteDraft(event.currentTarget.value)
+                            }
+                        />
+                    )}
+                </Stack>
+                {(hasRuleRows || hasStagedChanges) && (
+                    <Group
+                        justify="space-between"
+                        wrap="nowrap"
+                        className={classes.saveBar}
+                    >
+                        <Group gap={6} wrap="nowrap">
+                            <MantineIcon
+                                icon={IconInfoCircle}
+                                color="ldGray.6"
+                            />
+                            <Text size="xs" c="ldGray.6">
+                                Tiles stay locked until every rule is satisfied.
+                            </Text>
+                        </Group>
+                        <Button
+                            size="xs"
+                            variant="filled"
+                            disabled={!hasStagedChanges}
+                            // Mouse saves on mousedown: with an inline dropdown
+                            // open, Mantine's click-outside handling re-layouts
+                            // on mousedown and the click never arrives. onClick
+                            // keeps keyboard activation working; the save
+                            // disables the button, so it cannot fire twice.
+                            onMouseDown={(event) => {
+                                if (event.button === 0) handleSave();
+                            }}
+                            onClick={handleSave}
+                        >
+                            Save
+                        </Button>
+                    </Group>
+                )}
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+export default FilterRequirementsButton;

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterSelect.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterSelect.tsx
@@ -1,0 +1,56 @@
+import { Select, Stack, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import classes from './FilterRequirements.module.css';
+
+export type SelectableFilter = {
+    value: string;
+    label: string;
+    disabled: boolean;
+    reason: string | null;
+};
+
+type FilterSelectProps = {
+    selectableFilters: SelectableFilter[];
+    placeholder: string;
+    onSelect: (filterId: string) => void;
+};
+
+/**
+ * Dashed pill-shaped select used to add a dashboard filter to a filter rule.
+ * Ineligible filters are disabled with their reason as a second line.
+ */
+const FilterSelect: FC<FilterSelectProps> = ({
+    selectableFilters,
+    placeholder,
+    onSelect,
+}) => (
+    <Select
+        size="xs"
+        w={150}
+        placeholder={placeholder}
+        value={null}
+        data={selectableFilters}
+        comboboxProps={{ withinPortal: false }}
+        classNames={{ input: classes.addFilterInput }}
+        onChange={(filterId) => {
+            if (filterId) onSelect(filterId);
+        }}
+        renderOption={({ option }) => {
+            const reason = selectableFilters.find(
+                (filter) => filter.value === option.value,
+            )?.reason;
+            return (
+                <Stack gap={0}>
+                    <Text size="xs">{option.label}</Text>
+                    {reason && (
+                        <Text size="xs" c="ldGray.6">
+                            {reason}
+                        </Text>
+                    )}
+                </Stack>
+            );
+        }}
+    />
+);
+
+export default FilterSelect;

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.module.css
@@ -1,0 +1,16 @@
+/* The card renders its own Paper; the modal content is just a transparent
+   shell so the standard Modal positioning/scrolling applies to the card */
+.content {
+    background-color: transparent;
+    box-shadow: none;
+}
+
+.cardWrapper {
+    width: 420px;
+    max-width: 100%;
+    height: fit-content;
+}
+
+.summaryRow {
+    min-height: 30px;
+}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
@@ -1,0 +1,462 @@
+import {
+    DimensionType,
+    getFilterTypeFromItem,
+    getFilterTypeFromItemType,
+    isValuelessDashboardFilterRule,
+    type DashboardFilterRule,
+    type FilterableItem,
+    type WeekDay,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Box,
+    CloseButton,
+    Collapse,
+    Divider,
+    Group,
+    Paper,
+    Progress,
+    ScrollArea,
+    Stack,
+    Text,
+    ThemeIcon,
+} from '@mantine-8/core';
+import {
+    IconCheck,
+    IconCircleDashed,
+    IconFilterExclamation,
+} from '@tabler/icons-react';
+import {
+    Fragment,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import FilterInputComponent from '../../../components/common/Filters/FilterInputs';
+import { getConditionalRuleLabelFromItem } from '../../../components/common/Filters/FilterInputs/utils';
+import FiltersProvider from '../../../components/common/Filters/FiltersProvider';
+import MantineIcon from '../../../components/common/MantineIcon';
+import TruncatedText from '../../../components/common/TruncatedText';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import { hasFilterValueSet } from '../FilterConfiguration/utils';
+import classes from './GuidedFilterSetup.module.css';
+import { AndSeparator, OrSeparator } from './RuleSeparators';
+import { useFilterableItemsMap } from './useFilterableItemsMap';
+import {
+    getDashboardFilterRuleLabel,
+    getFilterRequirementRules,
+    isRequirementRuleSatisfied,
+    type FilterRequirementRule,
+} from './utils';
+
+const RuleStatusIcon: FC<{ satisfied: boolean }> = ({ satisfied }) =>
+    satisfied ? (
+        <ThemeIcon size={16} radius="xl" color="green" variant="filled">
+            <MantineIcon icon={IconCheck} size={10} />
+        </ThemeIcon>
+    ) : (
+        <MantineIcon icon={IconCircleDashed} size={16} color="ldGray.5" />
+    );
+
+type MemberInputProps = {
+    member: DashboardFilterRule;
+    field: FilterableItem | undefined;
+    label: string;
+    /** Multi-member rules label each row; single rules are labeled by the rule heading */
+    showLabel: boolean;
+    popoverProps: {
+        withinPortal: boolean;
+        onOpen?: () => void;
+        onClose?: () => void;
+    };
+    onChange: (newRule: DashboardFilterRule) => void;
+};
+
+const MemberInput: FC<MemberInputProps> = ({
+    member,
+    field,
+    label,
+    showLabel,
+    popoverProps,
+    onChange,
+}) => (
+    <Group gap="xs" wrap="nowrap">
+        {showLabel && (
+            <TruncatedText maxWidth={90} w={90} fz="xs" c="ldGray.6">
+                {label}
+            </TruncatedText>
+        )}
+        <Box flex={1} miw={0}>
+            <FilterInputComponent
+                filterType={
+                    field
+                        ? getFilterTypeFromItem(field)
+                        : getFilterTypeFromItemType(
+                              member.target.fallbackType ??
+                                  DimensionType.STRING,
+                          )
+                }
+                field={field}
+                rule={member}
+                popoverProps={popoverProps}
+                onChange={(newRule) => onChange(newRule as DashboardFilterRule)}
+            />
+        </Box>
+    </Group>
+);
+
+type RuleSummaryProps = {
+    rule: FilterRequirementRule;
+    fieldsMap: Record<string, FilterableItem>;
+    onChange: () => void;
+};
+
+const RuleSummary: FC<RuleSummaryProps> = ({ rule, fieldsMap, onChange }) => {
+    // Same test as isRequirementRuleSatisfied, so the summary always shows
+    // the member that actually satisfies the rule
+    const setMember = rule.members.find(
+        (member) => !isValuelessDashboardFilterRule(member),
+    );
+    if (!setMember) return null;
+
+    const field = fieldsMap[setMember.target.fieldId];
+    const valueLabel = field
+        ? getConditionalRuleLabelFromItem(setMember, field).value
+        : undefined;
+
+    return (
+        <Group gap="xs" wrap="nowrap" className={classes.summaryRow}>
+            <RuleStatusIcon satisfied />
+            <Text size="xs" fw={500} truncate>
+                {getDashboardFilterRuleLabel(setMember, fieldsMap)}
+            </Text>
+            <Text size="xs" c="dimmed" truncate flex={1}>
+                {valueLabel}
+            </Text>
+            <Anchor
+                component="button"
+                type="button"
+                size="xs"
+                onClick={onChange}
+            >
+                Change
+            </Anchor>
+        </Group>
+    );
+};
+
+type Props = {
+    onDismiss: () => void;
+    startOfWeek?: WeekDay;
+    /** Report nested filter dropdown state, like the chip popovers do */
+    onSubPopoverOpen?: () => void;
+    onSubPopoverClose?: () => void;
+};
+
+/**
+ * Viewer-facing setup card shown over the locked grid while filter
+ * requirements are unmet: every rule gets a real value picker (same state as
+ * the filter bar chips), satisfied rules collapse to a summary line, and the
+ * dashboard unlocks live once the last rule is met.
+ */
+const GuidedFilterSetup: FC<Props> = ({
+    onDismiss,
+    startOfWeek,
+    onSubPopoverOpen,
+    onSubPopoverClose,
+}) => {
+    const projectUuid = useDashboardContext((c) => c.projectUuid);
+    const dashboard = useDashboardContext((c) => c.dashboard);
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const allFilters = useDashboardContext((c) => c.allFilters);
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const filterableFieldsByTileUuid = useDashboardContext(
+        (c) => c.filterableFieldsByTileUuid,
+    );
+    const allFilterableFieldsMap = useDashboardContext(
+        (c) => c.allFilterableFieldsMap,
+    );
+    const requiredFiltersNote = useDashboardContext(
+        (c) => c.requiredFiltersNote,
+    );
+    const activeTab = useDashboardContext((c) => c.activeTab);
+    const updateDimensionDashboardFilter = useDashboardContext(
+        (c) => c.updateDimensionDashboardFilter,
+    );
+    const updateMetricDashboardFilter = useDashboardContext(
+        (c) => c.updateMetricDashboardFilter,
+    );
+
+    // Rules a viewer re-opened via "Change"; satisfied rules collapse to a
+    // summary line unless they're in here
+    const [expandedRuleIds, setExpandedRuleIds] = useState<string[]>([]);
+
+    const fieldsMap = useFilterableItemsMap();
+
+    const rules = useMemo(
+        () => getFilterRequirementRules(dashboardFilters),
+        [dashboardFilters],
+    );
+
+    const satisfiedCount = rules.filter(isRequirementRuleSatisfied).length;
+
+    // Keep the first unmet rule in view as the viewer works down the list
+    const viewportRef = useRef<HTMLDivElement>(null);
+    const firstUnmetRule = rules.find(
+        (rule) => !isRequirementRuleSatisfied(rule),
+    );
+    const firstUnmetRuleId = firstUnmetRule?.id;
+    useEffect(() => {
+        if (!firstUnmetRuleId || !viewportRef.current) return;
+        const target = viewportRef.current.querySelector(
+            `[data-rule-id="${CSS.escape(firstUnmetRuleId)}"]`,
+        );
+        target?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }, [firstUnmetRuleId]);
+
+    const handleChangeFilterRule = useCallback(
+        (newRule: DashboardFilterRule) => {
+            // Mirrors the chip popover's view-mode behavior: a value enables the
+            // filter, clearing it goes back to "any value" (and re-locks)
+            const updatedRule = {
+                ...newRule,
+                disabled: !hasFilterValueSet(newRule),
+            };
+            const dimensionIndex = dashboardFilters.dimensions.findIndex(
+                (filter) => filter.id === newRule.id,
+            );
+            if (dimensionIndex >= 0) {
+                updateDimensionDashboardFilter(
+                    updatedRule,
+                    dimensionIndex,
+                    false,
+                    false,
+                );
+                return;
+            }
+            const metricIndex = dashboardFilters.metrics.findIndex(
+                (filter) => filter.id === newRule.id,
+            );
+            if (metricIndex >= 0) {
+                updateMetricDashboardFilter(
+                    updatedRule,
+                    metricIndex,
+                    false,
+                    false,
+                );
+            }
+        },
+        [
+            dashboardFilters,
+            updateDimensionDashboardFilter,
+            updateMetricDashboardFilter,
+        ],
+    );
+
+    if (!allFilterableFieldsMap) return null;
+
+    return (
+        <FiltersProvider
+            projectUuid={projectUuid}
+            itemsMap={allFilterableFieldsMap}
+            startOfWeek={startOfWeek}
+            dashboardFilters={allFilters}
+            dashboardTiles={dashboardTiles}
+            filterableFieldsByTileUuid={filterableFieldsByTileUuid}
+            activeTabUuid={activeTab?.uuid}
+        >
+            <Paper
+                shadow="xl"
+                radius="md"
+                withBorder
+                className={classes.cardWrapper}
+                data-testid="guided-filter-setup"
+            >
+                <Stack gap="xs" p="lg" pb="md">
+                    <Group
+                        justify="space-between"
+                        align="flex-start"
+                        wrap="nowrap"
+                    >
+                        <Group gap="sm" wrap="nowrap">
+                            <Paper p="6px" withBorder radius="md">
+                                <MantineIcon
+                                    icon={IconFilterExclamation}
+                                    size="md"
+                                    color="yellow.7"
+                                />
+                            </Paper>
+                            <Text c="ldDark.9" fw={700} fz="md" lh="28px">
+                                Set filters to load{' '}
+                                {dashboard?.name ?? 'this dashboard'}
+                            </Text>
+                        </Group>
+                        <CloseButton
+                            aria-label="Close setup"
+                            onClick={onDismiss}
+                        />
+                    </Group>
+                    <Text size="xs" c="ldGray.6">
+                        {requiredFiltersNote ||
+                            'Data loads automatically once the filters below are set.'}
+                    </Text>
+                </Stack>
+                <Divider />
+                <ScrollArea.Autosize
+                    mah="min(400px, 45vh)"
+                    viewportRef={viewportRef}
+                >
+                    <Stack gap="sm" p="lg" py="md">
+                        {rules.map((rule, ruleIndex) => {
+                            const isSatisfied =
+                                isRequirementRuleSatisfied(rule);
+                            const isCollapsed =
+                                isSatisfied &&
+                                !expandedRuleIds.includes(rule.id);
+                            const isMultiMember = rule.members.length > 1;
+
+                            return (
+                                <Fragment key={rule.id}>
+                                    {ruleIndex > 0 && <AndSeparator />}
+                                    <Box data-rule-id={rule.id}>
+                                        <Collapse in={isCollapsed}>
+                                            <RuleSummary
+                                                rule={rule}
+                                                fieldsMap={fieldsMap}
+                                                onChange={() =>
+                                                    setExpandedRuleIds(
+                                                        (previous) => [
+                                                            ...previous,
+                                                            rule.id,
+                                                        ],
+                                                    )
+                                                }
+                                            />
+                                        </Collapse>
+                                        <Collapse in={!isCollapsed}>
+                                            <Stack gap={6}>
+                                                <Group gap={6} wrap="nowrap">
+                                                    <RuleStatusIcon
+                                                        satisfied={isSatisfied}
+                                                    />
+                                                    <Text
+                                                        size="xs"
+                                                        fw={500}
+                                                        truncate
+                                                    >
+                                                        {isMultiMember
+                                                            ? 'At least one of'
+                                                            : getDashboardFilterRuleLabel(
+                                                                  rule
+                                                                      .members[0],
+                                                                  fieldsMap,
+                                                              )}
+                                                    </Text>
+                                                </Group>
+                                                <Stack
+                                                    gap={6}
+                                                    pl={isMultiMember ? 22 : 0}
+                                                >
+                                                    {rule.members.map(
+                                                        (
+                                                            member,
+                                                            memberIndex,
+                                                        ) => (
+                                                            <Fragment
+                                                                key={member.id}
+                                                            >
+                                                                {memberIndex >
+                                                                    0 && (
+                                                                    <OrSeparator />
+                                                                )}
+                                                                <MemberInput
+                                                                    member={
+                                                                        member
+                                                                    }
+                                                                    field={
+                                                                        fieldsMap[
+                                                                            member
+                                                                                .target
+                                                                                .fieldId
+                                                                        ]
+                                                                    }
+                                                                    label={getDashboardFilterRuleLabel(
+                                                                        member,
+                                                                        fieldsMap,
+                                                                    )}
+                                                                    showLabel={
+                                                                        isMultiMember
+                                                                    }
+                                                                    popoverProps={{
+                                                                        withinPortal: true,
+                                                                        onOpen: onSubPopoverOpen,
+                                                                        onClose:
+                                                                            onSubPopoverClose,
+                                                                    }}
+                                                                    onChange={
+                                                                        handleChangeFilterRule
+                                                                    }
+                                                                />
+                                                            </Fragment>
+                                                        ),
+                                                    )}
+                                                </Stack>
+                                            </Stack>
+                                        </Collapse>
+                                    </Box>
+                                </Fragment>
+                            );
+                        })}
+                    </Stack>
+                </ScrollArea.Autosize>
+                <Divider />
+                <Stack gap={6} p="lg" pt="md">
+                    <Group justify="space-between">
+                        <Text size="xs" c="ldGray.6">
+                            {satisfiedCount} of {rules.length} set
+                        </Text>
+                        <Text
+                            size="xs"
+                            c={
+                                rules.length - satisfiedCount === 0
+                                    ? 'green'
+                                    : 'ldGray.5'
+                            }
+                        >
+                            {rules.length - satisfiedCount === 0
+                                ? 'Loading your dashboard'
+                                : `${rules.length - satisfiedCount} more to go`}
+                        </Text>
+                    </Group>
+                    <Progress
+                        size="xs"
+                        color={
+                            satisfiedCount === rules.length ? 'green' : 'yellow'
+                        }
+                        value={
+                            rules.length > 0
+                                ? (satisfiedCount / rules.length) * 100
+                                : 0
+                        }
+                    />
+                    <Anchor
+                        component="button"
+                        type="button"
+                        size="xs"
+                        c="ldGray.6"
+                        ta="center"
+                        mt={4}
+                        onClick={onDismiss}
+                    >
+                        Set filters in the toolbar instead
+                    </Anchor>
+                </Stack>
+            </Paper>
+        </FiltersProvider>
+    );
+};
+
+export default GuidedFilterSetup;

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
@@ -1,0 +1,154 @@
+import { FilterOperator, type DashboardFilterRule } from '@lightdash/common';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import GuidedFilterSetupOverlay from './GuidedFilterSetupOverlay';
+
+const unmetRule: DashboardFilterRule = {
+    id: 'filter-1',
+    target: {
+        fieldId: 'customers_first_name',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    required: true,
+    label: undefined,
+};
+
+const mockDashboardContext = vi.hoisted(() => ({
+    current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../providers/Dashboard/useDashboardContext', () => ({
+    default: vi.fn((selector) => selector(mockDashboardContext.current)),
+}));
+
+vi.mock('./useFilterableItemsMap', () => ({
+    useFilterableItemsMap: vi.fn(() => ({})),
+}));
+
+// Stub the filter input (its Mantine autocomplete is inert in jsdom) but
+// capture popoverProps so tests can drive the dropdown open/close protocol
+const memberInputPopoverProps = vi.hoisted(() => ({
+    current: null as {
+        onOpen?: () => void;
+        onClose?: () => void;
+    } | null,
+}));
+
+vi.mock('../../../components/common/Filters/FilterInputs', () => ({
+    default: vi.fn(({ popoverProps }) => {
+        memberInputPopoverProps.current = popoverProps;
+        return <input placeholder="any value" />;
+    }),
+}));
+
+describe('GuidedFilterSetupOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // jsdom does not implement scrollIntoView
+        Object.defineProperty(Element.prototype, 'scrollIntoView', {
+            configurable: true,
+            writable: true,
+            value: vi.fn(),
+        });
+        mockDashboardContext.current = {
+            projectUuid: 'project-1',
+            dashboard: { name: 'Sales dashboard' },
+            dashboardFilters: {
+                dimensions: [unmetRule],
+                metrics: [],
+                tableCalculations: [],
+            },
+            allFilters: {
+                dimensions: [unmetRule],
+                metrics: [],
+                tableCalculations: [],
+            },
+            dashboardTiles: [],
+            filterableFieldsByTileUuid: {},
+            allFilterableFieldsMap: {},
+            requiredFiltersNote: 'Pick a customer to get started',
+            activeTab: undefined,
+            updateDimensionDashboardFilter: vi.fn(),
+            updateMetricDashboardFilter: vi.fn(),
+        };
+    });
+
+    afterEach(() => {
+        delete (Element.prototype as Partial<Element>).scrollIntoView;
+    });
+
+    it('renders the guided setup with the unmet rule and requirement progress', () => {
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={vi.fn()} />);
+
+        expect(screen.getByTestId('guided-filter-setup')).not.toBeNull();
+        expect(
+            screen.getByText('Set filters to load Sales dashboard'),
+        ).not.toBeNull();
+        expect(
+            screen.getByText('Pick a customer to get started'),
+        ).not.toBeNull();
+        expect(screen.getByText('customers_first_name')).not.toBeNull();
+        expect(screen.getByText('0 of 1 set')).not.toBeNull();
+        expect(screen.getByText('1 more to go')).not.toBeNull();
+    });
+
+    it('dismisses from the close button but not from clicks inside the card', async () => {
+        const onDismiss = vi.fn();
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={onDismiss} />);
+
+        await userEvent.click(screen.getByTestId('guided-filter-setup'));
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Close setup' }),
+        );
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismisses on backdrop clicks only', async () => {
+        const onDismiss = vi.fn();
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={onDismiss} />);
+
+        const backdrop = document.querySelector('.mantine-8-Modal-overlay');
+        expect(backdrop).not.toBeNull();
+        await userEvent.click(backdrop as HTMLElement);
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders as a focused dialog and dismisses on Escape', async () => {
+        const onDismiss = vi.fn();
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={onDismiss} />);
+
+        const dialog = screen.getByRole('dialog', {
+            name: 'Set filters to load this dashboard',
+        });
+        // The modal's focus trap activates asynchronously
+        await waitFor(() =>
+            expect(dialog.contains(document.activeElement)).toBe(true),
+        );
+
+        await userEvent.keyboard('{Escape}');
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not dismiss on Escape while a filter dropdown inside the card is open', async () => {
+        const onDismiss = vi.fn();
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={onDismiss} />);
+
+        // The filter input reports its open dropdown via popoverProps.onOpen,
+        // so Escape stands down while it is open
+        act(() => memberInputPopoverProps.current?.onOpen?.());
+        await userEvent.keyboard('{Escape}');
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        // With the dropdown closed again, Escape dismisses the overlay
+        act(() => memberInputPopoverProps.current?.onClose?.());
+        await userEvent.keyboard('{Escape}');
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
@@ -1,0 +1,57 @@
+import { type WeekDay } from '@lightdash/common';
+import { Modal } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
+import { type FC } from 'react';
+import GuidedFilterSetup from './GuidedFilterSetup';
+import classes from './GuidedFilterSetup.module.css';
+
+type Props = {
+    /** Applied to the modal root (embed passes its contract class) */
+    className?: string;
+    startOfWeek?: WeekDay;
+    onDismiss: () => void;
+};
+
+/**
+ * Composes Modal.Root directly (like SchedulerModal) instead of MantineModal:
+ * the takeover card has no dialog chrome, and the header/footer MantineModal
+ * hard-codes doesn't fit.
+ */
+const GuidedFilterSetupOverlay: FC<Props> = ({
+    className,
+    startOfWeek,
+    onDismiss,
+}) => {
+    // Filter inputs report their dropdown state via popoverProps.onOpen/
+    // onClose; Escape stands down while a dropdown is open so it only closes
+    // the dropdown (the v6 date inputs don't set data-mantine-stop-propagation)
+    const [isSubPopoverOpen, { open: openSubPopover, close: closeSubPopover }] =
+        useDisclosure();
+
+    return (
+        <Modal.Root
+            opened
+            onClose={onDismiss}
+            size={420}
+            yOffset="max(170px, 20vh)"
+            closeOnEscape={!isSubPopoverOpen}
+            transitionProps={{ duration: 0 }}
+            className={className}
+        >
+            <Modal.Overlay />
+            <Modal.Content
+                className={classes.content}
+                aria-label="Set filters to load this dashboard"
+            >
+                <GuidedFilterSetup
+                    startOfWeek={startOfWeek}
+                    onDismiss={onDismiss}
+                    onSubPopoverOpen={openSubPopover}
+                    onSubPopoverClose={closeSubPopover}
+                />
+            </Modal.Content>
+        </Modal.Root>
+    );
+};
+
+export default GuidedFilterSetupOverlay;

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.module.css
@@ -1,0 +1,29 @@
+.card {
+    border: 1px solid var(--mantine-color-default-border);
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-xs);
+}
+
+.cardActive {
+    border-color: alpha(var(--mantine-color-yellow-6), 0.35);
+
+    @mixin light {
+        background-color: var(--mantine-color-yellow-0);
+    }
+    @mixin dark {
+        background-color: alpha(var(--mantine-color-yellow-9), 0.2);
+    }
+}
+
+.groupSection {
+    margin-top: var(--mantine-spacing-xs);
+    padding: var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+
+    @mixin light {
+        background-color: alpha(var(--mantine-color-black), 0.04);
+    }
+    @mixin dark {
+        background-color: alpha(var(--mantine-color-white), 0.04);
+    }
+}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.test.tsx
@@ -1,0 +1,196 @@
+import { FilterOperator, type DashboardFilterRule } from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import RequiredFilterCard from './RequiredFilterCard';
+
+const buildRule = (
+    overrides: Partial<DashboardFilterRule> = {},
+): DashboardFilterRule => ({
+    id: 'filter-1',
+    target: {
+        fieldId: 'customers_first_name',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    label: undefined,
+    ...overrides,
+});
+
+const updateFilterRule = vi.hoisted(() => vi.fn());
+
+const mockDashboardContext = vi.hoisted(() => ({
+    current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../providers/Dashboard/useDashboardContext', () => ({
+    default: vi.fn((selector) => selector(mockDashboardContext.current)),
+}));
+
+vi.mock('./useFilterableItemsMap', () => ({
+    useFilterableItemsMap: vi.fn(() => ({})),
+}));
+
+vi.mock('./useUpdateDashboardFilterRule', () => ({
+    useUpdateDashboardFilterRule: vi.fn(() => updateFilterRule),
+}));
+
+const setDashboardFilters = (dimensions: DashboardFilterRule[]) => {
+    mockDashboardContext.current = {
+        dashboardFilters: {
+            dimensions,
+            metrics: [],
+            tableCalculations: [],
+        },
+    };
+};
+
+const getRequiredSwitch = () =>
+    screen.getByLabelText<HTMLInputElement>('Required');
+
+describe('RequiredFilterCard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders inactive and reports toggling required on', async () => {
+        const rule = buildRule();
+        setDashboardFilters([rule]);
+        const onToggleRequired = vi.fn();
+
+        renderWithProviders(
+            <RequiredFilterCard
+                filterRule={rule}
+                onToggleRequired={onToggleRequired}
+                onChangeFilterRule={vi.fn()}
+            />,
+        );
+
+        expect(getRequiredSwitch().checked).toBe(false);
+        expect(
+            screen.queryByText(
+                'Viewers must set this filter to load the dashboard.',
+            ),
+        ).toBeNull();
+
+        await userEvent.click(getRequiredSwitch());
+        expect(onToggleRequired).toHaveBeenCalledWith(true);
+    });
+
+    it('offers an alternative filter when it is the only rule member and saved', async () => {
+        const rule = buildRule({ required: true });
+        setDashboardFilters([rule]);
+
+        renderWithProviders(
+            <RequiredFilterCard
+                filterRule={rule}
+                onToggleRequired={vi.fn()}
+                onChangeFilterRule={vi.fn()}
+            />,
+        );
+
+        expect(getRequiredSwitch().checked).toBe(true);
+        expect(
+            screen.getByText(
+                'Viewers must set this filter to load the dashboard.',
+            ),
+        ).not.toBeNull();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Add an alternative filter' }),
+        );
+        expect(screen.getByPlaceholderText('+ Add a filter')).not.toBeNull();
+    });
+
+    it('converts both filters to valueless group members when adding an alternative', async () => {
+        const rule = buildRule({ required: true });
+        const sibling = buildRule({
+            id: 'filter-2',
+            target: { fieldId: 'customers_age', tableName: 'customers' },
+        });
+        setDashboardFilters([rule, sibling]);
+        const onChangeFilterRule = vi.fn();
+
+        renderWithProviders(
+            <RequiredFilterCard
+                filterRule={rule}
+                onToggleRequired={vi.fn()}
+                onChangeFilterRule={onChangeFilterRule}
+            />,
+        );
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Add an alternative filter' }),
+        );
+        await userEvent.click(screen.getByPlaceholderText('+ Add a filter'));
+        // jsdom keeps the combobox dropdown display:none, so bypass the
+        // pointer-events check with fireEvent
+        fireEvent.click(
+            screen.getByRole('option', {
+                name: /customers_age/,
+                hidden: true,
+            }),
+        );
+
+        expect(updateFilterRule).toHaveBeenCalledTimes(2);
+        const [siblingCall, currentCall] = updateFilterRule.mock.calls;
+        expect(siblingCall[0]).toBe('filter-2');
+        expect(siblingCall[1]).toMatchObject({
+            required: false,
+            disabled: true,
+            values: [],
+        });
+        // The current filter gets the same full valueless conversion, so a
+        // cancelled popover cannot leave a group member with values
+        expect(currentCall[0]).toBe('filter-1');
+        expect(currentCall[1]).toMatchObject({
+            required: false,
+            disabled: true,
+            values: [],
+        });
+        expect(typeof siblingCall[1].requiredGroupId).toBe('string');
+        expect(currentCall[1].requiredGroupId).toBe(
+            siblingCall[1].requiredGroupId,
+        );
+        expect(onChangeFilterRule).toHaveBeenCalledWith(
+            expect.objectContaining({
+                required: false,
+                disabled: true,
+                values: [],
+                requiredGroupId: siblingCall[1].requiredGroupId,
+            }),
+        );
+    });
+
+    it('lists rule siblings and opens the rule editor when sharing a rule', async () => {
+        const rule = buildRule({ requiredGroupId: 'group-1' });
+        const sibling = buildRule({
+            id: 'filter-2',
+            requiredGroupId: 'group-1',
+            label: 'Status',
+        });
+        setDashboardFilters([rule, sibling]);
+        const onEditRules = vi.fn();
+
+        renderWithProviders(
+            <RequiredFilterCard
+                filterRule={rule}
+                onToggleRequired={vi.fn()}
+                onChangeFilterRule={vi.fn()}
+                onEditRules={onEditRules}
+            />,
+        );
+
+        expect(getRequiredSwitch().checked).toBe(true);
+        expect(screen.getByText(/Shares a rule/)).not.toBeNull();
+        expect(screen.getByText('Status')).not.toBeNull();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Edit rule →' }),
+        );
+        expect(onEditRules).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.tsx
@@ -1,0 +1,193 @@
+import { type DashboardFilterRule } from '@lightdash/common';
+import {
+    Anchor,
+    Badge,
+    Box,
+    Button,
+    Group,
+    Stack,
+    Switch,
+    Text,
+} from '@mantine-8/core';
+import { clsx } from '@mantine/core';
+import { IconAsterisk, IconPlus } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import MantineIcon from '../../../components/common/MantineIcon';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import FilterSelect, { type SelectableFilter } from './FilterSelect';
+import classes from './RequiredFilterCard.module.css';
+import { useFilterableItemsMap } from './useFilterableItemsMap';
+import { useUpdateDashboardFilterRule } from './useUpdateDashboardFilterRule';
+import { getDashboardFilterRuleLabel, getSelectableFilters } from './utils';
+
+type Props = {
+    filterRule: DashboardFilterRule;
+    onToggleRequired: (checked: boolean) => void;
+    onChangeFilterRule: (filterRule: DashboardFilterRule) => void;
+    onEditRules?: () => void;
+};
+
+const RequiredFilterCard: FC<Props> = ({
+    filterRule,
+    onToggleRequired,
+    onChangeFilterRule,
+    onEditRules,
+}) => {
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const updateFilterRule = useUpdateDashboardFilterRule();
+    const [isAddingAlternative, setIsAddingAlternative] = useState(false);
+
+    const isActive = !!filterRule.required || !!filterRule.requiredGroupId;
+
+    const fieldsMap = useFilterableItemsMap();
+
+    const allFilterRules = useMemo(
+        () => [...dashboardFilters.dimensions, ...dashboardFilters.metrics],
+        [dashboardFilters],
+    );
+
+    // Siblings come from the saved dashboard filters; this filter's own flags
+    // come from the draft being edited in this popover
+    const siblings = useMemo(
+        () =>
+            filterRule.requiredGroupId
+                ? allFilterRules.filter(
+                      (rule) =>
+                          rule.id !== filterRule.id &&
+                          rule.requiredGroupId === filterRule.requiredGroupId,
+                  )
+                : [],
+        [allFilterRules, filterRule.id, filterRule.requiredGroupId],
+    );
+
+    const sharesRule = isActive && siblings.length > 0;
+    const isOnlyMember = isActive && siblings.length === 0;
+
+    // Adding an alternative writes to the sibling filter immediately, so it
+    // is only offered once this filter itself is saved on the dashboard
+    const isSavedFilter = useMemo(
+        () => allFilterRules.some((rule) => rule.id === filterRule.id),
+        [allFilterRules, filterRule.id],
+    );
+
+    const selectableFilters = useMemo<SelectableFilter[]>(
+        () => getSelectableFilters(allFilterRules, [filterRule.id], fieldsMap),
+        [allFilterRules, filterRule.id, fieldsMap],
+    );
+
+    const handleAddAlternative = useCallback(
+        (siblingId: string) => {
+            const groupId = filterRule.requiredGroupId ?? uuidv4();
+            // Rule members are valueless by definition; both filters get the
+            // full conversion immediately so cancelling the popover cannot
+            // leave a group member with values
+            updateFilterRule(siblingId, {
+                requiredGroupId: groupId,
+                required: false,
+                disabled: true,
+                values: [],
+            });
+            updateFilterRule(filterRule.id, {
+                required: false,
+                requiredGroupId: groupId,
+                disabled: true,
+                values: [],
+            });
+            onChangeFilterRule({
+                ...filterRule,
+                required: false,
+                requiredGroupId: groupId,
+                disabled: true,
+                values: [],
+            });
+            setIsAddingAlternative(false);
+        },
+        [filterRule, updateFilterRule, onChangeFilterRule],
+    );
+
+    return (
+        <Box className={clsx(classes.card, isActive && classes.cardActive)}>
+            <Group justify="space-between" wrap="nowrap">
+                <Group gap={6} wrap="nowrap">
+                    <MantineIcon
+                        icon={IconAsterisk}
+                        size="sm"
+                        color={isActive ? 'yellow.7' : 'ldGray.6'}
+                    />
+                    <Text size="xs" fw={600}>
+                        Required
+                    </Text>
+                </Group>
+                <Switch
+                    size="xs"
+                    color="yellow.6"
+                    aria-label="Required"
+                    checked={isActive}
+                    onChange={(e) => onToggleRequired(e.currentTarget.checked)}
+                />
+            </Group>
+            {isOnlyMember && (
+                <Stack gap={6} mt="xs">
+                    <Text size="xs" c="ldGray.7">
+                        Viewers must set this filter to load the dashboard.
+                    </Text>
+                    {isSavedFilter &&
+                        (isAddingAlternative ? (
+                            <FilterSelect
+                                selectableFilters={selectableFilters}
+                                placeholder="+ Add a filter"
+                                onSelect={handleAddAlternative}
+                            />
+                        ) : (
+                            <Button
+                                size="compact-xs"
+                                variant="light"
+                                color="blue"
+                                radius="xl"
+                                w="max-content"
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                                onClick={() => setIsAddingAlternative(true)}
+                            >
+                                Add an alternative filter
+                            </Button>
+                        ))}
+                </Stack>
+            )}
+            {sharesRule && (
+                <Stack gap={6} className={classes.groupSection}>
+                    <Text size="xs" c="ldGray.6">
+                        Shares a rule. Viewers can satisfy it by setting this or
+                        an alternative:
+                    </Text>
+                    <Group gap={4}>
+                        {siblings.map((member) => (
+                            <Badge
+                                key={member.id}
+                                variant="outline"
+                                color="yellow"
+                                radius="xl"
+                                tt="none"
+                                fw={500}
+                            >
+                                {getDashboardFilterRuleLabel(member, fieldsMap)}
+                            </Badge>
+                        ))}
+                        {onEditRules && (
+                            <Anchor
+                                component="button"
+                                type="button"
+                                size="xs"
+                                onClick={onEditRules}
+                            >
+                                Edit rule →
+                            </Anchor>
+                        )}
+                    </Group>
+                </Stack>
+            )}
+        </Box>
+    );
+};
+
+export default RequiredFilterCard;

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/RuleSeparators.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/RuleSeparators.tsx
@@ -1,0 +1,24 @@
+import { Divider, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+
+export const AndSeparator: FC = () => (
+    <Divider
+        label={
+            <Text size="10px" fw={600} c="ldGray.6">
+                AND
+            </Text>
+        }
+        labelPosition="center"
+    />
+);
+
+export const OrSeparator: FC = () => (
+    <Divider
+        label={
+            <Text size="10px" fw={500} c="ldGray.5">
+                OR
+            </Text>
+        }
+        labelPosition="center"
+    />
+);

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterBarPopovers.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterBarPopovers.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { FilterBarPopoversContext } from './FilterBarPopoversContext';
+
+export const useFilterBarPopovers = () => useContext(FilterBarPopoversContext);

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterChipRequirementState.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterChipRequirementState.test.tsx
@@ -1,0 +1,178 @@
+import {
+    FilterOperator,
+    type DashboardFilterRule,
+    type UnmetFilterRequirement,
+} from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHookWithProviders } from '../../../testing/testUtils';
+import { useFilterChipRequirementState } from './useFilterChipRequirementState';
+
+const buildRule = (
+    overrides: Partial<DashboardFilterRule> = {},
+): DashboardFilterRule => ({
+    id: 'filter-1',
+    target: {
+        fieldId: 'customers_first_name',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    label: undefined,
+    ...overrides,
+});
+
+const mockDashboardContext = vi.hoisted(() => ({
+    current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../providers/Dashboard/useDashboardContext', () => ({
+    default: vi.fn((selector) => selector(mockDashboardContext.current)),
+}));
+
+const setContext = (
+    isFilterRequirementsEnabled: boolean,
+    unmetFilterRequirements: UnmetFilterRequirement[] = [],
+) => {
+    mockDashboardContext.current = {
+        isFilterRequirementsEnabled,
+        unmetFilterRequirements,
+    };
+};
+
+const unmetGroupWith = (rule: DashboardFilterRule): UnmetFilterRequirement => ({
+    type: 'group',
+    groupId: 'group-1',
+    filters: [rule],
+});
+
+const renderState = (rule: DashboardFilterRule) =>
+    renderHookWithProviders(() => useFilterChipRequirementState(rule)).result
+        .current;
+
+const SINGLE_TOOLTIP = 'Required: set a value to run this dashboard';
+const GROUP_TOOLTIP =
+    'Required: set a value on this or an alternative filter to run this dashboard';
+
+describe('useFilterChipRequirementState', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('flag off (legacy parity)', () => {
+        it('legacy parity: required without value shows the legacy indicator and no rules-mode state', () => {
+            setContext(false);
+            const state = renderState(buildRule({ required: true }));
+
+            expect(state).toEqual({
+                showRequirementIcon: false,
+                isRequirementUnmet: false,
+                requirementTooltip: '',
+                showLegacyRequiredIndicator: true,
+            });
+        });
+
+        it('legacy parity: a rule in an unmet group shows nothing, legacy ignores groups', () => {
+            const rule = buildRule({ requiredGroupId: 'group-1' });
+            setContext(false, [unmetGroupWith(rule)]);
+            const state = renderState(rule);
+
+            expect(state).toEqual({
+                showRequirementIcon: false,
+                isRequirementUnmet: false,
+                requirementTooltip: '',
+                showLegacyRequiredIndicator: false,
+            });
+        });
+
+        it('legacy parity: required with a value set shows nothing', () => {
+            setContext(false);
+            const state = renderState(
+                buildRule({ required: true, values: ['Alice'] }),
+            );
+
+            expect(state.showLegacyRequiredIndicator).toBe(false);
+            expect(state.showRequirementIcon).toBe(false);
+            expect(state.isRequirementUnmet).toBe(false);
+        });
+    });
+
+    describe('flag on (rules mode)', () => {
+        it('required without a value is unmet with the single-filter wording', () => {
+            const rule = buildRule({ required: true });
+            setContext(true, [{ type: 'single', filter: rule }]);
+            const state = renderState(rule);
+
+            expect(state).toEqual({
+                showRequirementIcon: true,
+                isRequirementUnmet: true,
+                requirementTooltip: SINGLE_TOOLTIP,
+                showLegacyRequiredIndicator: false,
+            });
+        });
+
+        it('required but disabled with stale values is unmet when the lock says so', () => {
+            const rule = buildRule({
+                required: true,
+                disabled: true,
+                values: ['Alice'],
+            });
+            setContext(true, [{ type: 'single', filter: rule }]);
+            const state = renderState(rule);
+
+            expect(state.isRequirementUnmet).toBe(true);
+        });
+
+        it('a rule with both flags is a single: met when not in the unmet list, with single wording', () => {
+            const rule = buildRule({
+                required: true,
+                requiredGroupId: 'group-1',
+                disabled: false,
+                values: ['Alice'],
+            });
+            setContext(true, []);
+            const state = renderState(rule);
+
+            expect(state).toEqual({
+                showRequirementIcon: true,
+                isRequirementUnmet: false,
+                requirementTooltip: SINGLE_TOOLTIP,
+                showLegacyRequiredIndicator: false,
+            });
+        });
+
+        it('group-only member of an unmet group is unmet with the group wording', () => {
+            const rule = buildRule({ requiredGroupId: 'group-1' });
+            setContext(true, [unmetGroupWith(rule)]);
+            const state = renderState(rule);
+
+            expect(state).toEqual({
+                showRequirementIcon: true,
+                isRequirementUnmet: true,
+                requirementTooltip: GROUP_TOOLTIP,
+                showLegacyRequiredIndicator: false,
+            });
+        });
+
+        it('group member not in any unmet group shows the icon but is met', () => {
+            const rule = buildRule({ requiredGroupId: 'group-1' });
+            setContext(true, [
+                unmetGroupWith(buildRule({ id: 'other-filter' })),
+            ]);
+            const state = renderState(rule);
+
+            expect(state.showRequirementIcon).toBe(true);
+            expect(state.isRequirementUnmet).toBe(false);
+            expect(state.showLegacyRequiredIndicator).toBe(false);
+        });
+
+        it('nothing required shows no requirement state at all', () => {
+            setContext(true);
+            const state = renderState(buildRule());
+
+            expect(state.showRequirementIcon).toBe(false);
+            expect(state.isRequirementUnmet).toBe(false);
+            expect(state.showLegacyRequiredIndicator).toBe(false);
+        });
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterChipRequirementState.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterChipRequirementState.ts
@@ -1,0 +1,58 @@
+import { type DashboardFilterRule } from '@lightdash/common';
+import { useMemo } from 'react';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import { hasFilterValueSet } from '../FilterConfiguration/utils';
+
+export type FilterChipRequirementState = {
+    // Rules mode (flag on); all false/empty when the flag is off
+    showRequirementIcon: boolean;
+    isRequirementUnmet: boolean;
+    requirementTooltip: string;
+    // Legacy mode (flag off); always false when the flag is on
+    showLegacyRequiredIndicator: boolean;
+};
+
+export const useFilterChipRequirementState = (
+    filterRule: DashboardFilterRule,
+): FilterChipRequirementState => {
+    const isFilterRequirementsEnabled = useDashboardContext(
+        (c) => c.isFilterRequirementsEnabled,
+    );
+    const unmetFilterRequirements = useDashboardContext(
+        (c) => c.unmetFilterRequirements,
+    );
+
+    return useMemo(() => {
+        if (!isFilterRequirementsEnabled) {
+            return {
+                showRequirementIcon: false,
+                isRequirementUnmet: false,
+                requirementTooltip: '',
+                showLegacyRequiredIndicator:
+                    !!filterRule.required && !hasFilterValueSet(filterRule),
+            };
+        }
+
+        // Unmet state comes from the same context value that locks the
+        // dashboard, so the chip can never contradict the lock
+        const isRequirementUnmet = unmetFilterRequirements.some((requirement) =>
+            requirement.type === 'single'
+                ? requirement.filter.id === filterRule.id
+                : requirement.filters.some((f) => f.id === filterRule.id),
+        );
+
+        // `required` wins over `requiredGroupId`, matching getFilterRequirementRules
+        const isGroupMember =
+            !!filterRule.requiredGroupId && !filterRule.required;
+
+        return {
+            showRequirementIcon:
+                !!filterRule.required || !!filterRule.requiredGroupId,
+            isRequirementUnmet,
+            requirementTooltip: isGroupMember
+                ? 'Required: set a value on this or an alternative filter to run this dashboard'
+                : 'Required: set a value to run this dashboard',
+            showLegacyRequiredIndicator: false,
+        };
+    }, [isFilterRequirementsEnabled, unmetFilterRequirements, filterRule]);
+};

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterPopoverState.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterPopoverState.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from '@testing-library/react';
+import { type FC, type PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    FilterBarPopoversContext,
+    type FilterBarPopoversState,
+} from './FilterBarPopoversContext';
+import { useFilterPopoverState } from './useFilterPopoverState';
+
+describe('useFilterPopoverState', () => {
+    it('falls back to local open state without a provider', () => {
+        const { result } = renderHook(() => useFilterPopoverState());
+
+        expect(result.current.openPopoverId).toBeUndefined();
+
+        act(() => {
+            result.current.onPopoverOpen('chip-1');
+        });
+        expect(result.current.openPopoverId).toBe('chip-1');
+
+        act(() => {
+            result.current.onPopoverClose();
+        });
+        expect(result.current.openPopoverId).toBeUndefined();
+    });
+
+    it('delegates to the shared filter bar state when a provider is mounted', () => {
+        const openFilterPopover = vi.fn();
+        const closeFilterPopover = vi.fn();
+        const contextValue: FilterBarPopoversState = {
+            isRulesPopoverOpen: false,
+            openRulesPopover: vi.fn(),
+            closeRulesPopover: vi.fn(),
+            openFilterPopoverId: 'shared-chip',
+            openFilterPopover,
+            closeFilterPopover,
+        };
+        const wrapper: FC<PropsWithChildren> = ({ children }) => (
+            <FilterBarPopoversContext.Provider value={contextValue}>
+                {children}
+            </FilterBarPopoversContext.Provider>
+        );
+
+        const { result } = renderHook(() => useFilterPopoverState(), {
+            wrapper,
+        });
+
+        expect(result.current.openPopoverId).toBe('shared-chip');
+
+        act(() => {
+            result.current.onPopoverOpen('chip-1');
+        });
+        expect(openFilterPopover).toHaveBeenCalledWith('chip-1');
+
+        act(() => {
+            result.current.onPopoverClose();
+        });
+        expect(closeFilterPopover).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterPopoverState.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterPopoverState.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+import { useFilterBarPopovers } from './useFilterBarPopovers';
+
+/**
+ * Open state for filter bar popovers (filter chips, add-filter). Shared via
+ * FilterBarPopoversContext when a provider is mounted, so other surfaces can
+ * open a chip's popover; falls back to local state otherwise.
+ */
+export const useFilterPopoverState = () => {
+    const filterBarPopovers = useFilterBarPopovers();
+    const [localOpenPopoverId, setLocalPopoverId] = useState<string>();
+
+    const openPopoverId =
+        filterBarPopovers?.openFilterPopoverId ?? localOpenPopoverId;
+
+    const onPopoverOpen = useCallback(
+        (id: string) => {
+            if (filterBarPopovers) {
+                filterBarPopovers.openFilterPopover(id);
+            } else {
+                setLocalPopoverId(id);
+            }
+        },
+        [filterBarPopovers],
+    );
+
+    const onPopoverClose = useCallback(() => {
+        if (filterBarPopovers) {
+            filterBarPopovers.closeFilterPopover();
+        } else {
+            setLocalPopoverId(undefined);
+        }
+    }, [filterBarPopovers]);
+
+    return { openPopoverId, onPopoverOpen, onPopoverClose };
+};

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterableItemsMap.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/useFilterableItemsMap.ts
@@ -1,0 +1,18 @@
+import { type FilterableItem } from '@lightdash/common';
+import { useMemo } from 'react';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+
+/** Dashboard dimensions + metrics merged into one filterable-item lookup */
+export const useFilterableItemsMap = (): Record<string, FilterableItem> => {
+    const allFilterableFieldsMap = useDashboardContext(
+        (c) => c.allFilterableFieldsMap,
+    );
+    const allFilterableMetricsMap = useDashboardContext(
+        (c) => c.allFilterableMetricsMap,
+    );
+
+    return useMemo(
+        () => ({ ...allFilterableFieldsMap, ...allFilterableMetricsMap }),
+        [allFilterableFieldsMap, allFilterableMetricsMap],
+    );
+};

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/useUpdateDashboardFilterRule.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/useUpdateDashboardFilterRule.ts
@@ -1,0 +1,54 @@
+import { type DashboardFilterRule } from '@lightdash/common';
+import { useCallback } from 'react';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+
+/**
+ * Immediately applies a partial update to a saved dashboard filter
+ * (dimension or metric) by id. Used by the filter-rule editors, whose edits
+ * take effect without an Apply step.
+ */
+export const useUpdateDashboardFilterRule = () => {
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const updateDimensionDashboardFilter = useDashboardContext(
+        (c) => c.updateDimensionDashboardFilter,
+    );
+    const updateMetricDashboardFilter = useDashboardContext(
+        (c) => c.updateMetricDashboardFilter,
+    );
+
+    return useCallback(
+        (filterId: string, updates: Partial<DashboardFilterRule>) => {
+            const dimensionIndex = dashboardFilters.dimensions.findIndex(
+                (filterRule) => filterRule.id === filterId,
+            );
+            if (dimensionIndex >= 0) {
+                updateDimensionDashboardFilter(
+                    {
+                        ...dashboardFilters.dimensions[dimensionIndex],
+                        ...updates,
+                    },
+                    dimensionIndex,
+                    false,
+                    true,
+                );
+                return;
+            }
+            const metricIndex = dashboardFilters.metrics.findIndex(
+                (filterRule) => filterRule.id === filterId,
+            );
+            if (metricIndex >= 0) {
+                updateMetricDashboardFilter(
+                    { ...dashboardFilters.metrics[metricIndex], ...updates },
+                    metricIndex,
+                    false,
+                    true,
+                );
+            }
+        },
+        [
+            dashboardFilters,
+            updateDimensionDashboardFilter,
+            updateMetricDashboardFilter,
+        ],
+    );
+};

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/utils.test.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/utils.test.ts
@@ -1,0 +1,187 @@
+import {
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    type DashboardFilterRule,
+    type FilterableItem,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    getDashboardFilterRuleLabel,
+    getFilterRequirementRules,
+    getRequirementIneligibilityReason,
+    isRequirementRuleSatisfied,
+} from './utils';
+
+const createRule = (
+    overrides: Partial<DashboardFilterRule> & { id: string },
+): DashboardFilterRule => ({
+    target: {
+        fieldId: 'customers_first_name',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    label: undefined,
+    ...overrides,
+});
+
+describe('getFilterRequirementRules', () => {
+    it('returns no rules when no filter is required or grouped', () => {
+        expect(
+            getFilterRequirementRules({
+                dimensions: [createRule({ id: 'a' })],
+                metrics: [createRule({ id: 'b' })],
+            }),
+        ).toEqual([]);
+    });
+
+    it('groups dimension and metric filters sharing a requiredGroupId', () => {
+        const a = createRule({ id: 'a', requiredGroupId: 'g1' });
+        const b = createRule({ id: 'b' });
+        const c = createRule({ id: 'c', requiredGroupId: 'g1' });
+
+        expect(
+            getFilterRequirementRules({ dimensions: [a, b], metrics: [c] }),
+        ).toEqual([{ type: 'group', id: 'g1', members: [a, c] }]);
+    });
+
+    it('returns a required filter as a one-member rule', () => {
+        const a = createRule({ id: 'a', required: true });
+
+        expect(
+            getFilterRequirementRules({ dimensions: [a], metrics: [] }),
+        ).toEqual([{ type: 'single', id: 'a', members: [a] }]);
+    });
+
+    it('returns rules in first-appearance order, interleaving required filters and groups', () => {
+        const a = createRule({ id: 'a', requiredGroupId: 'g2' });
+        const b = createRule({ id: 'b', required: true });
+        const c = createRule({ id: 'c', requiredGroupId: 'g2' });
+
+        expect(
+            getFilterRequirementRules({ dimensions: [a, b, c], metrics: [] }),
+        ).toEqual([
+            { type: 'group', id: 'g2', members: [a, c] },
+            { type: 'single', id: 'b', members: [b] },
+        ]);
+    });
+
+    it('treats a filter with both flags as required, not a group member', () => {
+        const a = createRule({
+            id: 'a',
+            required: true,
+            requiredGroupId: 'g1',
+        });
+        const b = createRule({ id: 'b', requiredGroupId: 'g1' });
+
+        expect(
+            getFilterRequirementRules({ dimensions: [a, b], metrics: [] }),
+        ).toEqual([
+            { type: 'single', id: 'a', members: [a] },
+            { type: 'group', id: 'g1', members: [b] },
+        ]);
+    });
+});
+
+describe('getRequirementIneligibilityReason', () => {
+    it('is eligible when valueless and not in a rule', () => {
+        expect(
+            getRequirementIneligibilityReason(createRule({ id: 'a' })),
+        ).toBeNull();
+    });
+
+    it('is eligible when enabled but valueless', () => {
+        expect(
+            getRequirementIneligibilityReason(
+                createRule({ id: 'a', disabled: false }),
+            ),
+        ).toBeNull();
+    });
+
+    it('is ineligible when already a member of a rule', () => {
+        expect(
+            getRequirementIneligibilityReason(
+                createRule({ id: 'a', requiredGroupId: 'g1' }),
+            ),
+        ).toBe('Already part of a filter rule');
+    });
+
+    it('is ineligible when individually required', () => {
+        expect(
+            getRequirementIneligibilityReason(
+                createRule({ id: 'a', required: true }),
+            ),
+        ).toBe('Already part of a filter rule');
+    });
+
+    it('is ineligible when it has a default value', () => {
+        expect(
+            getRequirementIneligibilityReason(
+                createRule({ id: 'a', disabled: false, values: ['adam'] }),
+            ),
+        ).toBe('Has a default value, so the rule would always be satisfied');
+    });
+});
+
+describe('getDashboardFilterRuleLabel', () => {
+    const field = {
+        name: 'first_name',
+        type: DimensionType.STRING,
+        table: 'customers',
+        tableLabel: 'Customers',
+        label: 'First name',
+        fieldType: FieldType.DIMENSION,
+        sql: 'first_name',
+        hidden: false,
+    } as unknown as FilterableItem;
+
+    it('prefers the custom filter label', () => {
+        expect(
+            getDashboardFilterRuleLabel(
+                createRule({ id: 'a', label: 'My label' }),
+                { customers_first_name: field },
+            ),
+        ).toBe('My label');
+    });
+
+    it('falls back to the field label', () => {
+        expect(
+            getDashboardFilterRuleLabel(createRule({ id: 'a' }), {
+                customers_first_name: field,
+            }),
+        ).toBe('First name');
+    });
+
+    it('falls back to the field id when the field is unknown', () => {
+        expect(getDashboardFilterRuleLabel(createRule({ id: 'a' }), {})).toBe(
+            'customers_first_name',
+        );
+    });
+});
+
+describe('isRequirementRuleSatisfied', () => {
+    it('is unsatisfied while every member is disabled', () => {
+        expect(
+            isRequirementRuleSatisfied({
+                type: 'group',
+                id: 'g1',
+                members: [createRule({ id: 'a' }), createRule({ id: 'b' })],
+            }),
+        ).toBe(false);
+    });
+
+    it('is satisfied when any member has a value', () => {
+        expect(
+            isRequirementRuleSatisfied({
+                type: 'group',
+                id: 'g1',
+                members: [
+                    createRule({ id: 'a' }),
+                    createRule({ id: 'b', disabled: false, values: ['x'] }),
+                ],
+            }),
+        ).toBe(true);
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/utils.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/utils.ts
@@ -1,0 +1,61 @@
+import {
+    isValuelessDashboardFilterRule,
+    type DashboardFilterRule,
+    type FilterableItem,
+} from '@lightdash/common';
+import { getConditionalRuleLabelFromItem } from '../../../components/common/Filters/FilterInputs/utils';
+import { type SelectableFilter } from './FilterSelect';
+
+// Rule derivation is shared with the dashboard lock (`getUnmetFilterRequirements`)
+export {
+    getFilterRequirementRules,
+    isRequirementRuleSatisfied,
+    type FilterRequirementRule,
+} from '@lightdash/common';
+
+/**
+ * Why a dashboard filter can't be added to a filter rule; null when it is
+ * eligible. Rule members must be valueless (disabled with no default),
+ * matching the value stripping applied to required filters on dashboard save.
+ */
+export const getRequirementIneligibilityReason = (
+    filterRule: DashboardFilterRule,
+): string | null => {
+    if (filterRule.required || filterRule.requiredGroupId) {
+        return 'Already part of a filter rule';
+    }
+    if (!isValuelessDashboardFilterRule(filterRule)) {
+        return 'Has a default value, so the rule would always be satisfied';
+    }
+    return null;
+};
+
+export const getDashboardFilterRuleLabel = (
+    filterRule: DashboardFilterRule,
+    fieldsMap: Record<string, FilterableItem>,
+): string => {
+    if (filterRule.label) return filterRule.label;
+
+    const field = fieldsMap[filterRule.target.fieldId];
+    return field
+        ? getConditionalRuleLabelFromItem(filterRule, field).field
+        : filterRule.target.fieldId;
+};
+
+/** Options for the rule-member selects, with ineligible filters dimmed */
+export const getSelectableFilters = (
+    allFilterRules: DashboardFilterRule[],
+    excludedIds: string[],
+    fieldsMap: Record<string, FilterableItem>,
+): SelectableFilter[] =>
+    allFilterRules
+        .filter((rule) => !excludedIds.includes(rule.id))
+        .map((rule) => {
+            const reason = getRequirementIneligibilityReason(rule);
+            return {
+                value: rule.id,
+                label: getDashboardFilterRuleLabel(rule, fieldsMap),
+                disabled: reason !== null,
+                reason,
+            };
+        });

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -6,10 +6,12 @@ import {
     DashboardTileTypes,
     DateGranularity,
     EMPTY_DATE_ZOOM_CONFIG,
+    FeatureFlags,
     FilterInteractivityValues,
     getFilterInteractivityValue,
     getItemId,
     getMissingRequiredParameters,
+    getUnmetFilterRequirements,
     isDashboardChartTileType,
     isFilterLockedOnTab,
     isStandardDateGranularity,
@@ -32,6 +34,7 @@ import {
     type ParameterValue,
     type SavedChartsInfoForDashboardAvailableFilters,
     type SortField,
+    type UnmetFilterRequirement,
 } from '@lightdash/common';
 import clone from 'lodash/clone';
 import isEqual from 'lodash/isEqual';
@@ -70,6 +73,7 @@ import {
     hasSavedFiltersOverrides,
     useSavedDashboardFiltersOverrides,
 } from '../../hooks/useSavedDashboardFiltersOverrides';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import DashboardContext from './context';
 import DashboardTileStatusProvider from './DashboardTileStatusProvider';
 import { getActiveTabForTabs } from './getActiveTabForTabs';
@@ -256,6 +260,14 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             setIsAddFilterDisabled(true);
         }
     }, [dashboard]);
+
+    // Editor-authored note shown to viewers while filter rules are unmet;
+    // unsaved edits win over the saved config value
+    const [editedRequiredFiltersNote, setRequiredFiltersNote] =
+        useState<string>();
+    const requiredFiltersNote =
+        editedRequiredFiltersNote ??
+        currentDashboardConfig?.requiredFiltersNote;
 
     const [parameterDefinitions, setParameterDefinitions] =
         useState<ParameterDefinitions>({});
@@ -1681,6 +1693,36 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         ],
     );
 
+    // Unmet filter requirements. Flag off = main parity: `requiredGroupId`
+    // is ignored and the legacy disabled-only test applies.
+    const { data: filterRequirementsFlag, isSuccess: isFilterFlagResolved } =
+        useServerFeatureFlag(FeatureFlags.DashboardFilterRequirements);
+    const isFilterRequirementsEnabled =
+        filterRequirementsFlag?.enabled === true;
+    const unmetFilterRequirements = useMemo(() => {
+        const allFilterRules = [
+            ...dashboardFilters.dimensions,
+            ...dashboardFilters.metrics,
+        ];
+        // A `requiredGroupId` can only come from a flag-on editor, so while
+        // the flag query is unresolved (loading or failed) group dashboards
+        // fail closed: lock rather than fire unfiltered queries.
+        const failClosed =
+            !isFilterFlagResolved &&
+            allFilterRules.some((rule) => rule.requiredGroupId);
+        if (isFilterRequirementsEnabled || failClosed) {
+            return getUnmetFilterRequirements(dashboardFilters);
+        }
+        return allFilterRules
+            .filter((rule) => rule.required && rule.disabled)
+            .map(
+                (filter): UnmetFilterRequirement => ({
+                    type: 'single',
+                    filter,
+                }),
+            );
+    }, [dashboardFilters, isFilterRequirementsEnabled, isFilterFlagResolved]);
+
     const value = {
         projectUuid,
         isDashboardLoading,
@@ -1739,10 +1781,14 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         dashboardComments,
         hasTileComments,
         requiredDashboardFilters,
+        unmetFilterRequirements,
+        isFilterRequirementsEnabled,
         isDateZoomDisabled,
         setIsDateZoomDisabled,
         isAddFilterDisabled,
         setIsAddFilterDisabled,
+        requiredFiltersNote,
+        setRequiredFiltersNote,
         setSavedParameters,
         parametersHaveChanged,
         dashboardParameters: parameters,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -16,6 +16,7 @@ import {
     type PreAggregateMatchMiss,
     type ResultColumn,
     type SortField,
+    type UnmetFilterRequirement,
 } from '@lightdash/common';
 import { type Dispatch, type SetStateAction } from 'react';
 import {
@@ -128,10 +129,14 @@ export type DashboardContextType = {
     dashboardComments?: ReturnType<typeof useGetComments>['data'];
     hasTileComments: (tileUuid: string) => boolean;
     requiredDashboardFilters: Pick<DashboardFilterRule, 'id' | 'label'>[];
+    unmetFilterRequirements: UnmetFilterRequirement[];
+    isFilterRequirementsEnabled: boolean;
     isDateZoomDisabled: boolean;
     setIsDateZoomDisabled: Dispatch<SetStateAction<boolean>>;
     isAddFilterDisabled: boolean;
     setIsAddFilterDisabled: Dispatch<SetStateAction<boolean>>;
+    requiredFiltersNote: string | undefined;
+    setRequiredFiltersNote: Dispatch<SetStateAction<string | undefined>>;
     setSavedParameters: Dispatch<SetStateAction<DashboardParameters>>;
     parametersHaveChanged: boolean;
     dashboardParameters: DashboardParameters;


### PR DESCRIPTION
Adds the entire dashboard filter requirements feature module as **new, unmounted files** — nothing in app code imports any of it yet, so this PR cannot change behavior. Review it as fresh code (component quality, UX copy, a11y), not as a diff against existing behavior.

### What's in the module (`features/dashboardFilters/FilterRequirements/` + tile placeholder)

- `GuidedFilterSetup` + overlay: the viewer-facing setup card over a locked grid — one section per rule with real filter value pickers, satisfied rules collapse with a Change link, progress footer, escape hatch to the toolbar.
- `FilterRequirementsButton`: the edit-mode "Filter rules" popover with the any-of rule builder, staged edits behind an explicit Save, and the viewer-note textarea.
- `RequiredFilterCard`, `FilterSelect`, `RuleSeparators`, shared popover state (`FilterBarPopovers*`), and supporting hooks/utils with unit tests.
- `UnmetRequirementsPlaceholder`: the tile placeholder shown instead of running queries while rules are unmet.
- `useFilterChipRequirementState`: a mode-aware hook that folds the feature flag into named semantic state for the filter chip (requirement icon / unmet styling / tooltip when the flag is on; the legacy "Required" indicator + outline semantics when off). Its unit tests include explicit legacy-parity assertions — with the flag off it reproduces main's chip conditions exactly. The chip consumes it in the next PR and never reads the flag itself.

### Additive provider state

`DashboardProvider` gains the `dashboard-filter-requirements` flag read and three context values (`isFilterRequirementsEnabled`, `unmetFilterRequirements`, `requiredFiltersNote` + setter). The legacy `requiredDashboardFilters` context field and its computation are **kept untouched** in this PR; the switch PR migrates consumers and removes it. With the flag off, `unmetFilterRequirements` computes exactly main's legacy test (`required && disabled` singles); `requiredGroupId` is ignored.

### Risk class: dead code

- No app imports (enforced during the cut); every module file is exercised by unit tests only — including render/hook smoke tests for the components whose first app consumer arrives in the switch PR, which also keeps the repo-wide unused-exports check green on this slice.
- Flag behavior: the flag enum + provider read land here, but no consumer exists yet.
- Rollback: safe to leave merged indefinitely.

### Stack

PR 3/5 of the dashboard filter requirement groups stack (types → overrides hardening → **module** → switch → e2e). Branch name is historical from before the 2026-07-10 re-cut.

Relates: PROD-8661
Relates: #25095
