### PR TITLE
test: e2e coverage for dashboard filter requirement groups

### DIFF
--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -93,6 +93,10 @@ services:
             # enabledFeatureFlags allowlist (step 1a).
             EMBEDDING_ENABLED: true
 
+            # Force-enable feature flags in preview envs so their e2e specs
+            # exercise the flag-on UX (dashboardFilterRequiredGroups.cy.ts).
+            LIGHTDASH_ENABLE_FEATURE_FLAGS: dashboard-filter-requirements
+
             PERSISTENT_DOWNLOAD_URLS_ENABLED: true
 
             # these were set in https://dashboard.render.com/env-group/evg-cfn4dlhmbjst4ho7s160 but can be public

--- a/packages/e2e/cypress/e2e/app/dashboardFilterRequiredGroups.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboardFilterRequiredGroups.cy.ts
@@ -150,9 +150,7 @@ describe('Dashboard filter required groups', () => {
 
         // Set a value on ONE member of the group via its filter pill
         cy.contains('button', 'Payment method').click();
-        cy.findByPlaceholderText('Start typing to filter results').type(
-            'credit_card',
-        );
+        cy.findByPlaceholderText('any value').type('credit_card');
         cy.findByRole('option', { name: 'credit_card' }).click();
         cy.contains('button', 'Apply').click({ force: true });
 
@@ -169,6 +167,11 @@ describe('Dashboard filter required groups', () => {
     it('completes setup through the guided card and unlocks live', () => {
         cy.intercept('POST', '**/api/v2/projects/*/query/dashboard-chart').as(
             'chartQuery',
+        );
+        // The card's focused autocomplete is disabled while its initial
+        // field-values search is in flight; wait for it before typing
+        cy.intercept('POST', '**/field/payments_payment_method/search').as(
+            'paymentValuesSearch',
         );
 
         createDashboardWithFilters(
@@ -188,6 +191,7 @@ describe('Dashboard filter required groups', () => {
         });
 
         // Two rules qualify for the card; the editor note is its subtitle
+        cy.wait('@paymentValuesSearch');
         cy.findByTestId('guided-filter-setup').within(() => {
             cy.findByText(GUIDED_SETUP_NOTE).should('be.visible');
             cy.findByText('0 of 2 set').should('be.visible');
@@ -195,6 +199,7 @@ describe('Dashboard filter required groups', () => {
             // Set the first rule (Payment method) from the card
             cy.findAllByPlaceholderText('any value')
                 .first()
+                .should('be.enabled')
                 .type('credit_card');
         });
         // Autocomplete options render in a portal outside the card
@@ -204,12 +209,18 @@ describe('Dashboard filter required groups', () => {
         cy.findByTestId('guided-filter-setup').within(() => {
             cy.findByText('1 of 2 set').should('be.visible');
             cy.findByText('Change').should('be.visible');
-            cy.findByText('credit_card').should('be.visible');
+            // Both the summary line and the tag input render the value
+            cy.findAllByText('credit_card').first().should('be.visible');
 
-            // Set the second rule (Order status)
-            cy.findAllByPlaceholderText('any value').first().type('completed');
+            // Open the second rule's input (Order status); its field values
+            // load on focus, so pick from the option list instead of typing
+            cy.findAllByPlaceholderText('any value').first().click();
         });
-        cy.findByRole('option', { name: 'Completed order' }).click();
+        // Autocomplete options render in a portal outside the card
+        cy.findByRole('option', {
+            name: 'Completed order',
+            timeout: 15000,
+        }).click();
 
         // All rules met: the card unmounts and the dashboard loads live
         cy.findByTestId('guided-filter-setup').should('not.exist');
@@ -221,7 +232,7 @@ describe('Dashboard filter required groups', () => {
         cy.get('.echarts-for-react').should('exist');
     });
 
-    it('locks a dashboard with a singleton required filter without the guided card', () => {
+    it('locks a dashboard with a singleton required filter and shows the guided card', () => {
         cy.intercept('POST', '**/api/v2/projects/*/query/dashboard-chart').as(
             'chartQuery',
         );
@@ -234,11 +245,12 @@ describe('Dashboard filter required groups', () => {
             );
         });
 
-        // A single one-filter rule stays lightweight: no guided card, just
-        // the yellow required chip and blocked tiles. The chip unlock flow
-        // is covered by the group test above.
+        // A required filter is a one-member rule, so it also qualifies for
+        // the guided card. Tiles stay blocked and no chart query runs. The
+        // chip unlock flow is covered by the group test above.
         cy.findAllByTestId('unmet-requirements-placeholder').should('exist');
-        cy.findByTestId('guided-filter-setup').should('not.exist');
+        cy.findByTestId('guided-filter-setup').should('be.visible');
+        cy.findByText('0 of 1 set').should('be.visible');
         cy.get('@chartQuery.all').should('have.length', 0);
     });
 });

--- a/packages/e2e/cypress/e2e/app/dashboardFilterRequiredGroups.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboardFilterRequiredGroups.cy.ts
@@ -1,0 +1,244 @@
+// Requires the dashboard-filter-requirements feature flag on the server
+// under test (e.g. LIGHTDASH_ENABLE_FEATURE_FLAGS=dashboard-filter-requirements);
+// with the flag off, dashboards fall back to the legacy locked modal.
+import {
+    ApiChartSummaryListResponse,
+    CreateDashboard,
+    DashboardFilterRule,
+    DashboardTileTypes,
+    FilterOperator,
+    SEED_PROJECT,
+} from '@lightdash/common';
+
+const GROUP_DASHBOARD_NAME = 'e2e dashboard with filter requirement group';
+const SINGLE_DASHBOARD_NAME = 'e2e dashboard with single required filter';
+const GUIDED_DASHBOARD_NAME = 'e2e dashboard with guided filter setup';
+
+const GUIDED_SETUP_NOTE = 'Pick your region to keep this dashboard fast.';
+
+const CHART_NAME = 'How much revenue do we have per payment method?';
+
+const paymentMethodFilter = (
+    overrides: Partial<DashboardFilterRule>,
+): DashboardFilterRule => ({
+    id: 'e2e-payment-method-filter',
+    label: 'Payment method',
+    target: {
+        fieldId: 'payments_payment_method',
+        tableName: 'payments',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    ...overrides,
+});
+
+const orderStatusFilter = (
+    overrides: Partial<DashboardFilterRule>,
+): DashboardFilterRule => ({
+    id: 'e2e-order-status-filter',
+    label: 'Order status',
+    target: {
+        fieldId: 'orders_status',
+        tableName: 'orders',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    ...overrides,
+});
+
+const createDashboardWithFilters = (
+    name: string,
+    dimensionFilters: DashboardFilterRule[],
+    config?: CreateDashboard['config'],
+): Cypress.Chainable<string> =>
+    cy
+        .request<ApiChartSummaryListResponse>(
+            `api/v1/projects/${SEED_PROJECT.project_uuid}/charts`,
+        )
+        .then((chartsResponse) => {
+            expect(chartsResponse.status).to.eq(200);
+            const chart = chartsResponse.body.results.find(
+                ({ name: chartName }) => chartName === CHART_NAME,
+            );
+            expect(chart, `chart "${CHART_NAME}" in seed project`).to.not.eq(
+                undefined,
+            );
+
+            const body: CreateDashboard = {
+                name,
+                tiles: [
+                    {
+                        type: DashboardTileTypes.SAVED_CHART,
+                        x: 0,
+                        y: 0,
+                        w: 18,
+                        h: 9,
+                        tabUuid: null,
+                        properties: {
+                            savedChartUuid: chart!.uuid,
+                        },
+                    },
+                ],
+                filters: {
+                    dimensions: dimensionFilters,
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                tabs: [],
+                config,
+            };
+
+            return cy
+                .request({
+                    url: `api/v1/projects/${SEED_PROJECT.project_uuid}/dashboards`,
+                    method: 'POST',
+                    headers: { 'Content-type': 'application/json' },
+                    body,
+                })
+                .then((createResponse) => {
+                    expect(createResponse.status).to.eq(201);
+                    return cy.wrap<string>(createResponse.body.results.uuid);
+                });
+        });
+
+describe('Dashboard filter required groups', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+
+    after(() => {
+        cy.login();
+        cy.deleteDashboardsByName([
+            GROUP_DASHBOARD_NAME,
+            SINGLE_DASHBOARD_NAME,
+            GUIDED_DASHBOARD_NAME,
+        ]);
+    });
+
+    it('locks the dashboard until any filter in the required group has a value', () => {
+        cy.intercept('POST', '**/api/v2/projects/*/query/dashboard-chart').as(
+            'chartQuery',
+        );
+
+        createDashboardWithFilters(GROUP_DASHBOARD_NAME, [
+            paymentMethodFilter({ requiredGroupId: 'g1' }),
+            orderStatusFilter({ requiredGroupId: 'g1' }),
+        ]).then((dashboardUuid) => {
+            cy.visit(
+                `/projects/${SEED_PROJECT.project_uuid}/dashboards/${dashboardUuid}/view`,
+            );
+        });
+
+        // Locked: an any-of rule qualifies for the guided setup card
+        cy.findByTestId('guided-filter-setup').should('be.visible');
+
+        // Tiles show the locked skeleton placeholder: no chart rendered or loading
+        cy.findAllByTestId('unmet-requirements-placeholder').should('exist');
+        cy.findAllByText('Loading chart').should('have.length', 0);
+        cy.get('.echarts-for-react').should('not.exist');
+
+        // No chart query ran while locked
+        cy.get('@chartQuery.all').should('have.length', 0);
+
+        // The escape hatch dismisses the card; the yellow required chips in the
+        // toolbar remain the only affordance
+        cy.findByText('Set filters in the toolbar instead').click();
+        cy.findByTestId('guided-filter-setup').should('not.exist');
+        cy.findAllByTestId('unmet-requirements-placeholder').should('exist');
+
+        // Set a value on ONE member of the group via its filter pill
+        cy.contains('button', 'Payment method').click();
+        cy.findByPlaceholderText('Start typing to filter results').type(
+            'credit_card',
+        );
+        cy.findByRole('option', { name: 'credit_card' }).click();
+        cy.contains('button', 'Apply').click({ force: true });
+
+        // Unlocked: tile runs its query and renders
+        cy.wait('@chartQuery');
+        cy.findAllByTestId('unmet-requirements-placeholder').should(
+            'have.length',
+            0,
+        );
+        cy.findAllByText('Loading chart').should('have.length', 0);
+        cy.get('.echarts-for-react').should('exist');
+    });
+
+    it('completes setup through the guided card and unlocks live', () => {
+        cy.intercept('POST', '**/api/v2/projects/*/query/dashboard-chart').as(
+            'chartQuery',
+        );
+
+        createDashboardWithFilters(
+            GUIDED_DASHBOARD_NAME,
+            [
+                paymentMethodFilter({ required: true }),
+                orderStatusFilter({ requiredGroupId: 'g1' }),
+            ],
+            {
+                isDateZoomDisabled: false,
+                requiredFiltersNote: GUIDED_SETUP_NOTE,
+            },
+        ).then((dashboardUuid) => {
+            cy.visit(
+                `/projects/${SEED_PROJECT.project_uuid}/dashboards/${dashboardUuid}/view`,
+            );
+        });
+
+        // Two rules qualify for the card; the editor note is its subtitle
+        cy.findByTestId('guided-filter-setup').within(() => {
+            cy.findByText(GUIDED_SETUP_NOTE).should('be.visible');
+            cy.findByText('0 of 2 set').should('be.visible');
+
+            // Set the first rule (Payment method) from the card
+            cy.findAllByPlaceholderText('any value')
+                .first()
+                .type('credit_card');
+        });
+        // Autocomplete options render in a portal outside the card
+        cy.findByRole('option', { name: 'credit_card' }).click();
+
+        // The satisfied rule collapses to a summary line with a Change link
+        cy.findByTestId('guided-filter-setup').within(() => {
+            cy.findByText('1 of 2 set').should('be.visible');
+            cy.findByText('Change').should('be.visible');
+            cy.findByText('credit_card').should('be.visible');
+
+            // Set the second rule (Order status)
+            cy.findAllByPlaceholderText('any value').first().type('completed');
+        });
+        cy.findByRole('option', { name: 'Completed order' }).click();
+
+        // All rules met: the card unmounts and the dashboard loads live
+        cy.findByTestId('guided-filter-setup').should('not.exist');
+        cy.wait('@chartQuery');
+        cy.findAllByTestId('unmet-requirements-placeholder').should(
+            'have.length',
+            0,
+        );
+        cy.get('.echarts-for-react').should('exist');
+    });
+
+    it('locks a dashboard with a singleton required filter without the guided card', () => {
+        cy.intercept('POST', '**/api/v2/projects/*/query/dashboard-chart').as(
+            'chartQuery',
+        );
+
+        createDashboardWithFilters(SINGLE_DASHBOARD_NAME, [
+            paymentMethodFilter({ required: true }),
+        ]).then((dashboardUuid) => {
+            cy.visit(
+                `/projects/${SEED_PROJECT.project_uuid}/dashboards/${dashboardUuid}/view`,
+            );
+        });
+
+        // A single one-filter rule stays lightweight: no guided card, just
+        // the yellow required chip and blocked tiles. The chip unlock flow
+        // is covered by the group test above.
+        cy.findAllByTestId('unmet-requirements-placeholder').should('exist');
+        cy.findByTestId('guided-filter-setup').should('not.exist');
+        cy.get('@chartQuery.all').should('have.length', 0);
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -37,6 +37,7 @@ interface FilterSettingsProps {
     filterType: FilterType;
     field?: DashboardFilterableField;
     filterRule: DashboardFilterRule;
+    originalFilterRule?: DashboardFilterRule;
     popoverProps?: Omit<PopoverProps, 'children'>;
     onChangeFilterRule: (value: DashboardFilterRule) => void;
     onEditRequirementRules?: () => void;
@@ -48,6 +49,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
     field,
     filterType,
     filterRule,
+    originalFilterRule,
     popoverProps,
     onChangeFilterRule,
     onEditRequirementRules,
@@ -89,15 +91,29 @@ const FilterSettings: FC<FilterSettingsProps> = ({
         (isFilterRequirementsEnabled && !!filterRule.requiredGroupId);
 
     const handleToggleRequired = (checked: boolean) => {
-        // Toggling on creates a one-member rule; off removes it from its rule.
-        // Flag off leaves group membership untouched (main parity).
-        const newFilter: DashboardFilterRule = {
-            ...filterRule,
-            required: checked,
-            requiredGroupId: isFilterRequirementsEnabled
-                ? undefined
-                : filterRule.requiredGroupId,
-        };
+        // Toggling on restores the saved rule membership if there is one,
+        // otherwise it creates a one-member rule; off removes it from its
+        // rule. Flag off leaves group membership untouched (main parity).
+        const restoredGroupId =
+            checked && isFilterRequirementsEnabled
+                ? originalFilterRule?.requiredGroupId
+                : undefined;
+
+        const newFilter: DashboardFilterRule = restoredGroupId
+            ? {
+                  ...filterRule,
+                  required: false,
+                  requiredGroupId: restoredGroupId,
+                  disabled: true,
+                  values: [],
+              }
+            : {
+                  ...filterRule,
+                  required: checked,
+                  requiredGroupId: isFilterRequirementsEnabled
+                      ? undefined
+                      : filterRule.requiredGroupId,
+              };
 
         onChangeFilterRule(
             checked

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
@@ -92,6 +92,7 @@ describe('FilterConfiguration', () => {
             metrics: [],
             tableCalculations: [],
         };
+        mockDashboardContext.current.isFilterRequirementsEnabled = true;
     });
 
     it('saves a value typed into the input when Apply is clicked without pressing Enter', async () => {
@@ -205,6 +206,108 @@ describe('FilterConfiguration', () => {
         expect(requiredSwitch).toBeChecked();
         expect(screen.getByText(/Shares a rule/)).toBeInTheDocument();
         expect(screen.getByText('Last name')).toBeInTheDocument();
+    });
+
+    it('restores rule membership when the required toggle is turned off and back on', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+        const memberRule: DashboardFilterRule = {
+            ...anyValueRule,
+            requiredGroupId: 'group-1',
+        };
+        const otherMemberRule: DashboardFilterRule = {
+            id: 'filter-2',
+            target: {
+                fieldId: 'customers_last_name',
+                tableName: 'customers',
+            },
+            operator: FilterOperator.EQUALS,
+            values: [],
+            disabled: true,
+            label: 'Last name',
+            requiredGroupId: 'group-1',
+        };
+        mockDashboardContext.current.dashboardFilters.dimensions = [
+            memberRule,
+            otherMemberRule,
+        ];
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={memberRule}
+                originalFilterRule={memberRule}
+                onSave={onSave}
+            />,
+        );
+
+        const requiredSwitch = screen.getByLabelText('Required');
+        await user.click(requiredSwitch);
+        expect(requiredSwitch).not.toBeChecked();
+
+        await user.click(requiredSwitch);
+        expect(requiredSwitch).toBeChecked();
+        expect(screen.getByText(/Shares a rule/)).toBeInTheDocument();
+
+        fireEvent.mouseDown(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({
+                required: false,
+                requiredGroupId: 'group-1',
+            }),
+        );
+    });
+
+    it('renders the legacy checkbox and preserves rule membership when the flag is off', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+        mockDashboardContext.current.isFilterRequirementsEnabled = false;
+        const memberRule: DashboardFilterRule = {
+            ...anyValueRule,
+            requiredGroupId: 'group-1',
+        };
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={memberRule}
+                originalFilterRule={memberRule}
+                onSave={onSave}
+            />,
+        );
+
+        expect(screen.queryByLabelText('Required')).not.toBeInTheDocument();
+        const checkbox = screen.getByLabelText(
+            'Require viewers to pick a value to load the dashboard',
+        );
+        expect(checkbox).not.toBeChecked();
+
+        await user.click(checkbox);
+        expect(checkbox).toBeChecked();
+
+        fireEvent.mouseDown(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({
+                required: true,
+                requiredGroupId: 'group-1',
+            }),
+        );
     });
 
     it('shows an enabled unchecked required toggle when the filter is not part of a rule', () => {

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -520,6 +520,7 @@ const FilterConfiguration: FC<Props> = ({
                                 filterType={filterType}
                                 field={selectedField}
                                 filterRule={draftFilterRule}
+                                originalFilterRule={originalFilterRule}
                                 onChangeFilterRule={handleChangeFilterRule}
                                 onEditRequirementRules={onEditRequirementRules}
                                 popoverProps={inlinePopoverProps}


### PR DESCRIPTION
Cypress coverage for filter requirement groups: locking until any filter in a required group has a value (unlock via the chip popover), completing setup through the guided card with live unlock (zero tile queries while locked), and the guided card for a singleton required filter (a required filter is a one-member rule).

The spec requires the `dashboard-filter-requirements` feature flag on the server under test (e.g. `LIGHTDASH_ENABLE_FEATURE_FLAGS=dashboard-filter-requirements`) — with the flag off, dashboards fall back to the legacy locked modal.

**Run status:** verified green against a live dev stack (3 consecutive clean runs) on 2026-07-10, after fixing spec-only assumptions (autocomplete placeholder, duplicate text match, waiting on the card's field-values search before typing, and asserting the intended guided-card behavior for singleton required filters)

### Stack

PR 5/5 of the dashboard filter requirement groups stack (types → overrides hardening → module → switch → **e2e**).

Relates: #25095
