### PR TITLE
chore(ai): remove ai-writeback feature flag

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1,4 +1,4 @@
-import { FeatureFlags, ForbiddenError } from '@lightdash/common';
+import { ForbiddenError } from '@lightdash/common';
 import express, { Express } from 'express';
 import { AppArguments } from '../App';
 import {
@@ -454,7 +454,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getAiOrganizationSettingsModel(),
                     catalogModel: models.getCatalogModel(),
                     projectModel: models.getProjectModel(),
-                    featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,
                     aiAgentReviewNotificationService:
                         repository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
@@ -600,27 +599,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getGithubAppInstallationsModel(),
                     projectContextModel:
                         models.getProjectContextModel<ProjectContextModel>(),
-                    isProjectContextEnabled: async ({
-                        user,
-                        organizationUuid,
-                    }) => {
-                        const [reviewsEnabled, aiWritebackFlag] =
-                            await Promise.all([
-                                repository
-                                    .getAiOrganizationSettingsService<AiOrganizationSettingsService>()
-                                    .isAiAgentReviewsEnabled({
-                                        organizationUuid,
-                                    }),
-                                models.getFeatureFlagModel().get({
-                                    featureFlagId: FeatureFlags.AiWriteback,
-                                    user: {
-                                        userUuid: user.userUuid,
-                                        organizationUuid,
-                                    },
-                                }),
-                            ]);
-                        return reviewsEnabled && aiWritebackFlag.enabled;
-                    },
+                    isProjectContextEnabled: async ({ organizationUuid }) =>
+                        repository
+                            .getAiOrganizationSettingsService<AiOrganizationSettingsService>()
+                            .isAiAgentReviewsEnabled({
+                                organizationUuid,
+                            }),
                     // Lazy accessor (not the instance) to duplicate the
                     // upstream project's data apps when a preview is created.
                     // AppGenerateService depends on ProjectService, so resolving

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -885,19 +885,9 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             return false;
         }
-        const [reviewsEnabled, aiWritebackFlag] = await Promise.all([
-            this.aiOrganizationSettingsService.isAiAgentReviewsEnabled({
-                organizationUuid,
-            }),
-            this.featureFlagService.get({
-                featureFlagId: FeatureFlags.AiWriteback,
-                user: {
-                    userUuid: user.userUuid,
-                    organizationUuid,
-                },
-            }),
-        ]);
-        return reviewsEnabled && aiWritebackFlag.enabled;
+        return this.aiOrganizationSettingsService.isAiAgentReviewsEnabled({
+            organizationUuid,
+        });
     }
 
     private hasSemanticWritebackConfig(): boolean {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
@@ -140,7 +140,6 @@ const makeService = () =>
             getSummary: vi.fn(),
             findExploresFromCache: vi.fn(),
         } as never,
-        featureFlagService: {} as never,
         lightdashConfig: {
             ai: { copilot: { providers: {}, defaultProvider: 'openai' } },
         } as never,

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -1,11 +1,9 @@
 import {
-    FeatureFlags,
     ForbiddenError,
     ProjectType,
     type AiAgentReviewClassifierJudgeOutput,
     type AiAgentReviewClassifierTurnCandidate,
 } from '@lightdash/common';
-import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import {
@@ -244,47 +242,7 @@ const makeProductJudgeOutput = (): AiAgentReviewClassifierJudgeOutput =>
         },
     });
 
-const makeProjectContextJudgeOutput = (): AiAgentReviewClassifierJudgeOutput =>
-    makeJudgeOutput({
-        signal: 'implicit_correction',
-        implicitSignalSources: ['next_user_correction'],
-        confidence: 'high',
-        promotedToFinding: true,
-        promotionReason: 'LLM judge found missing project context.',
-        primaryRootCause: 'project_context',
-        secondaryRootCauses: [],
-        subcategories: ['wrong_explore_selection'],
-        fixTargets: ['project_context_rule'],
-        targetRefs: [
-            {
-                type: 'explore',
-                label: 'orders',
-                modelName: 'orders',
-                fieldName: 'orders',
-                setting: null,
-                key: null,
-            },
-        ],
-        ownerType: 'semantic_layer_owner',
-        projectContextEntry: {
-            op: 'create',
-            id: null,
-            kind: 'context',
-            content: 'Use the orders explore for revenue questions.',
-            terms: ['revenue'],
-            objects: ['orders'],
-        },
-        reviewItem: {
-            title: 'Review revenue routing',
-            description: 'LLM judge grouped missing project context.',
-        },
-    });
-
 describe('AiAgentReviewClassifierService', () => {
-    const featureFlagService = {
-        get: vi.fn(),
-    } as unknown as import('vitest').Mocked<FeatureFlagService>;
-
     const model = {
         listTurnReviewCandidates: vi.fn(),
         createRun: vi.fn(),
@@ -322,7 +280,6 @@ describe('AiAgentReviewClassifierService', () => {
         aiOrganizationSettingsModel,
         catalogModel: catalogModel as never,
         projectModel: projectModel as never,
-        featureFlagService,
         lightdashConfig: {} as never,
         judgeTurn,
         aiAgentReviewNotificationService:
@@ -331,10 +288,6 @@ describe('AiAgentReviewClassifierService', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
-        featureFlagService.get.mockResolvedValue({
-            id: FeatureFlags.AiWriteback,
-            enabled: true,
-        });
         aiOrganizationSettingsModel.findByOrganizationUuid.mockResolvedValue({
             organizationUuid: ORGANIZATION_UUID,
             aiAgentsVisible: true,
@@ -723,38 +676,6 @@ describe('AiAgentReviewClassifierService', () => {
             expect.objectContaining({
                 name: 'flightcount',
                 tableName: 'orders',
-            }),
-        );
-    });
-
-    it('drops project context entries when AI writeback is disabled', async () => {
-        featureFlagService.get.mockImplementation(({ featureFlagId }) =>
-            Promise.resolve({
-                id: featureFlagId,
-                enabled: false,
-            }),
-        );
-        judgeTurn.mockResolvedValueOnce(makeProjectContextJudgeOutput());
-        model.listTurnReviewCandidates.mockResolvedValue([
-            makeCandidate({
-                nextUserPrompt: 'No, use orders for revenue questions.',
-            }),
-        ]);
-
-        const result = await service.run({
-            organizationUuid: ORGANIZATION_UUID,
-            startedAt: NOW,
-            endedAt: NOW,
-            persistFindings: true,
-        });
-
-        expect(result.findingCount).toBe(1);
-        expect(model.createTurnSignal).toHaveBeenCalledWith(
-            expect.objectContaining({
-                finding: expect.objectContaining({
-                    primaryRootCause: 'project_context',
-                    projectContextEntry: null,
-                }),
             }),
         );
     });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -3,7 +3,6 @@ import {
     aiAgentReviewClassifierJudgeOutputSchema,
     assertUnreachable,
     CatalogType,
-    FeatureFlags,
     filterExploreByTags,
     ForbiddenError,
     getAiAgentConfigSnapshotHash,
@@ -42,7 +41,6 @@ import Logger from '../../logging/logger';
 import { type CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../services/BaseService';
-import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type AiAgentDocumentModel } from '../models/AiAgentDocumentModel';
 import { type AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
@@ -95,7 +93,6 @@ type AiAgentReviewClassifierServiceDependencies = {
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
     catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
     projectModel: Pick<ProjectModel, 'getSummary' | 'findExploresFromCache'>;
-    featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
     aiAgentReviewNotificationService: AiAgentReviewNotificationService;
     judgeTurn?: AiAgentReviewClassifierJudge;
@@ -286,8 +283,6 @@ export class AiAgentReviewClassifierService extends BaseService {
 
     private readonly aiOrganizationSettingsModel: AiOrganizationSettingsModel;
 
-    private readonly featureFlagService: FeatureFlagService;
-
     private readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
 
     private readonly lightdashConfig: LightdashConfig;
@@ -304,7 +299,6 @@ export class AiAgentReviewClassifierService extends BaseService {
         this.projectModel = dependencies.projectModel;
         this.aiOrganizationSettingsModel =
             dependencies.aiOrganizationSettingsModel;
-        this.featureFlagService = dependencies.featureFlagService;
         this.aiAgentReviewNotificationService =
             dependencies.aiAgentReviewNotificationService;
         this.lightdashConfig = dependencies.lightdashConfig;
@@ -548,13 +542,6 @@ export class AiAgentReviewClassifierService extends BaseService {
         const runAgentConfig = args.candidates[0]
             ? getAgentConfig(args.candidates[0].subject.agentUuid)
             : AiAgentReviewClassifierService.emptyAgentConfigEvidence();
-        const aiWritebackFlag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiWriteback,
-            user: {
-                userUuid: args.requestedByUserUuid ?? 'system',
-                organizationUuid: args.organizationUuid,
-            },
-        });
 
         const run = await this.aiAgentReviewClassifierModel.createRun({
             organizationUuid: args.organizationUuid,
@@ -609,10 +596,7 @@ export class AiAgentReviewClassifierService extends BaseService {
                                         getAgentConfig(
                                             candidate.subject.agentUuid,
                                         ),
-                                        {
-                                            projectContextEnabled:
-                                                aiWritebackFlag.enabled,
-                                        },
+                                        { projectContextEnabled: true },
                                     ),
                             };
                         } catch (error) {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7619,17 +7619,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 user,
                 featureFlagId: FeatureFlags.AiGrepFields,
             });
-        let { enabled: aiWritebackEnabled } = await this.featureFlagService.get(
-            {
-                user,
-                featureFlagId: FeatureFlags.AiWriteback,
-            },
-        );
-        if (aiWritebackEnabled && !hasTrustedPromptUserIdentity) {
+        let aiWritebackEnabled = hasTrustedPromptUserIdentity;
+        if (!aiWritebackEnabled) {
             this.logger.info(
                 `Disabling editDbtProject for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
             );
-            aiWritebackEnabled = false;
         }
         // Writeback opens a pull request and only supports GitHub and GitLab
         // dbt connections (see AiWritebackService.getGitProvider, which throws

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -384,22 +384,8 @@ describe('AiWritebackService.prepareTurn', () => {
         return prepared.kind === 'run' ? prepared.turn : prepared;
     };
 
-    it('rejects when the AI writeback feature flag is disabled', async () => {
-        const service = buildService({
-            featureFlagModel: {
-                get: vi.fn().mockResolvedValue({ enabled: false }),
-            } as AnyType,
-        });
-        await expect(prepareTurn(service, userWithOrg(true))).rejects.toThrow(
-            ForbiddenError,
-        );
-    });
-
     it('rejects when the user cannot manage source code', async () => {
         const service = buildService({
-            featureFlagModel: {
-                get: vi.fn().mockResolvedValue({ enabled: true }),
-            } as AnyType,
             projectModel: {
                 get: vi.fn().mockResolvedValue(githubProject()),
             } as AnyType,
@@ -1167,11 +1153,7 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
                 aiWriteback: { anthropicApiKey: 'anthropic-key' },
             } as AnyType,
             featureFlagModel: {
-                get: vi.fn(({ featureFlagId }: AnyType) =>
-                    Promise.resolve({
-                        enabled: featureFlagId === FeatureFlags.AiWriteback,
-                    }),
-                ),
+                get: vi.fn().mockResolvedValue({ enabled: true }),
             } as AnyType,
             projectModel: {
                 get: vi.fn().mockResolvedValue({
@@ -2360,7 +2342,7 @@ describe('AiWritebackService.prepareTurn (stale-PR recovery, M4)', () => {
             projectUuid: 'p1',
             aiThreadUuid: 'thread-1',
             source: 'web',
-            featureFlag: FeatureFlags.AiWriteback,
+            featureFlag: undefined,
             mode: 'dbt',
             repoTarget: undefined,
             prUrl: undefined,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1247,9 +1247,9 @@ export class AiWritebackService extends BaseService {
     private async assertEnabled(
         user: SessionUser,
         source: AiWritebackSource,
-        featureFlag: FeatureFlags,
+        featureFlag: FeatureFlags | undefined,
     ): Promise<void> {
-        if (source === 'admin_review') {
+        if (source === 'admin_review' || featureFlag === undefined) {
             return;
         }
         const { enabled } = await this.featureFlagModel.get({
@@ -1257,11 +1257,7 @@ export class AiWritebackService extends BaseService {
             featureFlagId: featureFlag,
         });
         if (!enabled) {
-            throw new ForbiddenError(
-                featureFlag === FeatureFlags.CodingAgent
-                    ? 'AI coding agent is not enabled'
-                    : 'AI writeback is not enabled',
-            );
+            throw new ForbiddenError('AI coding agent is not enabled');
         }
     }
 
@@ -2060,7 +2056,7 @@ export class AiWritebackService extends BaseService {
          * re-call after a `select` outcome. Ignored by the general agent.
          */
         dbtSourceUuid: string | undefined;
-        featureFlag: FeatureFlags;
+        featureFlag: FeatureFlags | undefined;
         mode: CodingAgentConfig['mode'];
         /** The general agent's `owner/repo` target; ignored for dbt writeback. */
         repoTarget: string | undefined;
@@ -3483,7 +3479,6 @@ export class AiWritebackService extends BaseService {
     private dbtWritebackConfig(): CodingAgentConfig {
         return {
             mode: 'dbt-writeback',
-            featureFlag: FeatureFlags.AiWriteback,
             // Provider-aware writeback template (E2B template ref on e2b, the
             // Docker image on docker) — the same resolution the rest of the
             // sandbox lifecycle uses.

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -141,11 +141,11 @@ export type CodingAgentConfig = {
     /** Tags logs/analytics and selects the few remaining mode branches. */
     mode: 'dbt-writeback' | 'general';
     /**
-     * The rollout feature flag this mode is gated behind (AiWriteback for dbt,
-     * CodingAgent for the general agent). Asserted in `prepareTurn` for non
-     * admin/changeset sources.
+     * The rollout feature flag this mode is gated behind (CodingAgent for the
+     * general agent). Undefined for dbt writeback, which is always enabled.
+     * Asserted in `prepareTurn` for non admin/changeset sources.
      */
-    featureFlag: FeatureFlags;
+    featureFlag?: FeatureFlags;
     /** E2B template a fresh sandbox is created from (dbt vs lean image). */
     resolveTemplateRef: () => string;
     /** Extra options merged into `sandbox.git.clone` (e.g. a blob filter). */

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -17,7 +17,6 @@ import {
     createToolRunSqlArgsSchema,
     editContentToolDefinition,
     Explore,
-    FeatureFlags,
     findContentToolDefinition,
     findExploresToolDefinition,
     findFieldsToolDefinition,
@@ -3223,22 +3222,6 @@ export class McpService extends BaseService {
             aiCopilotFlag.enabled,
             user.organizationUuid,
         );
-    }
-
-    /**
-     * Whether the run_ai_writeback tool should be exposed to this caller.
-     * Gated behind the AiWriteback feature flag (off by default) so the tool
-     * can be dark launched — clients without the flag never see it in
-     * tools/list. Resolved per-request and passed into createServer.
-     */
-    public async isAiWritebackEnabled(
-        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
-    ): Promise<boolean> {
-        const flag = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.AiWriteback,
-        });
-        return flag.enabled;
     }
 
     public async isMcpContentWritesEnabled(

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -234,20 +234,15 @@ mcpRouter.all(
                         userAgent,
                     });
                 }
-                // Dark launch: the run_ai_writeback tool is only registered
-                // (and thus only listed/invocable) when the AiWriteback flag is
-                // enabled for this caller. Resolved here because tool
-                // registration in setupHandlers is synchronous (createServer
-                // only awaits to register skill resources afterwards).
-                const aiWritebackEnabled =
-                    await mcpService.isAiWritebackEnabled(req.user!);
                 // Content-write tools are only registered when the org-level
                 // setting allows it, so admins can lock down MCP edits.
                 const mcpContentWritesEnabled =
                     await mcpService.isMcpContentWritesEnabled(req.user!);
                 const mcpServer = await mcpService.createServer({
                     projectPinned: headerProjectUuid !== undefined,
-                    aiWritebackEnabled,
+                    // The run_ai_writeback tool is always registered now that
+                    // AI writeback has graduated from its dark-launch flag.
+                    aiWritebackEnabled: true,
                     mcpContentWritesEnabled,
                 });
                 const transport = new StreamableHTTPServerTransport({

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -177,15 +177,6 @@ export enum FeatureFlags {
     OrganizationTrialBlock = 'organization-trial-block',
 
     /**
-     * Enable the (in-progress) AI writeback feature. Spins up an e2b
-     * sandbox pre-loaded with dbt and the Claude Code CLI, then runs a
-     * user-supplied prompt against it synchronously. Off by default — gated
-     * while the sandbox runtime and write-back semantics are still being
-     * built out.
-     */
-    AiWriteback = 'ai-writeback',
-
-    /**
      * Enable the admin API endpoint that captures AI review judge replay
      * inputs (candidate + evidence packet) for the offline eval scoreboard.
      * Off by default — intended only for orgs running classifier evals.


### PR DESCRIPTION
## What & why

Split out of #24777, which bundled five now-default-enabled flag removals into one PR. This one covers just `ai-writeback`.

The AI writeback sandbox is enabled by default in production, so this removes the flag and its gating, leaving the feature always-on.

## Approach

- Removed `AiWriteback` from the `FeatureFlags` enum.
- At each check site, removed the flag fetch and kept the always-enabled behaviour. Non-flag guards are preserved: trusted Slack identity (`aiRequireOAuth`), writeback connection-type support (GitHub/GitLab only), `manage:SourceCode` permission, and org-level review settings.
- `AiWritebackService.assertEnabled` is shared with the newer `CodingAgent` flow (added after #24777 was opened), so instead of deleting it, its `featureFlag` param is now optional — `dbtWritebackConfig()` no longer passes one (always enabled), while `generalCodingAgentConfig()` still passes `FeatureFlags.CodingAgent` and remains gated.
- `featureFlagService`/`featureFlagModel` stay injected in `AiAgentAdminService`, `McpService`, and `AiWritebackService` — each still gates an unrelated flag (`AiReviewReplayCapture`, `AiCopilot`, `CodingAgent` respectively). Fully removed from `AiAgentReviewClassifierService`, whose only use was this flag.
- Dropped the now-obsolete "feature disabled" tests and stale enum references (adjusted for the Jest→Vitest migration that's landed on main since #24777 was opened).

## Testing

Not run in this environment — see CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)