### PR TITLE
chore(ai): remove github-mcp-one-click feature flag

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3336,14 +3336,6 @@ export class AiAgentService extends BaseService {
             return { available: false, alreadyConnected: false };
         }
 
-        const { enabled: oneClickEnabled } = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.GithubMcpOneClick,
-        });
-        if (!oneClickEnabled) {
-            return { available: false, alreadyConnected: false };
-        }
-
         const isCopilotEnabled = await this.getIsCopilotEnabled(user);
         if (!isCopilotEnabled) {
             return { available: false, alreadyConnected: false };
@@ -3386,16 +3378,6 @@ export class AiAgentService extends BaseService {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
-        }
-
-        const { enabled: oneClickEnabled } = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.GithubMcpOneClick,
-        });
-        if (!oneClickEnabled) {
-            throw new ForbiddenError(
-                'One-click GitHub MCP setup is not enabled',
-            );
         }
 
         const bearerToken = personalAccessToken.trim();

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -220,14 +220,6 @@ export enum FeatureFlags {
     AiSlackSystemAgentFallback = 'ai-slack-system-agent-fallback',
 
     /**
-     * Enable one-click "Connect GitHub" setup for AI agent MCP servers. When
-     * enabled (and the org has a GitHub App installation the user can manage),
-     * the agent MCP settings offer a button that provisions the hosted GitHub
-     * MCP using the org's existing installation token — no manual URL/auth.
-     */
-    GithubMcpOneClick = 'github-mcp-one-click',
-
-    /**
      * Let users link their personal GitHub account (user-to-server OAuth
      * token) so write-back commits and pull requests are authored as them
      * instead of the Lightdash GitHub App bot. Off by default while the


### PR DESCRIPTION
## What & why

Split out of #24777, which bundled five now-default-enabled flag removals into one PR. This one covers just `github-mcp-one-click`.

One-click "Connect GitHub" setup for AI agent MCP servers is enabled by default in production, so this removes the flag and its gating, leaving the feature always-on.

## Approach

- Removed `GithubMcpOneClick` from the `FeatureFlags` enum.
- Removed the flag fetch/check at both call sites in `AiAgentService`: `getGithubMcpAvailability` and `connectGithubMcpServer`. The Copilot-enabled check, `manage:AiAgent` permission, and GitHub App installation guards are unchanged.

## Testing

Not run in this environment — see CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)