### PR TITLE
chore(ai): remove repo-fs feature flag

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7712,20 +7712,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const aiPreviewDeploySetupEnabled =
             aiWritebackEnabled && aiPreviewDeploySetupFlag;
 
-        let { enabled: repoDiscoveryEnabled } =
-            await this.featureFlagService.get({
-                user,
-                featureFlagId: FeatureFlags.RepoDiscovery,
-            });
         // exploreRepo/discoverRepos read repo source and the view:SourceCode
         // check evaluates against the resolved user. On Slack without
         // aiRequireOAuth that user is the app installer, not the requester — so
         // disable it, exactly as runSql and writeback do above.
-        if (repoDiscoveryEnabled && !hasTrustedPromptUserIdentity) {
+        const repoDiscoveryEnabled = hasTrustedPromptUserIdentity;
+        if (!repoDiscoveryEnabled) {
             this.logger.info(
                 `Disabling repo discovery for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
             );
-            repoDiscoveryEnabled = false;
         }
 
         // The dbt project's root within the repo, so the prompt can point the

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -220,22 +220,6 @@ export enum FeatureFlags {
     GithubUserCredentials = 'github-user-credentials',
 
     /**
-     * Let the AI agent discover and read any repository the org's GitHub App
-     * installation can see, through a read-only shell (ls/cat/find/grep/head)
-     * backed by the GitHub API — no E2B sandbox/clone. `discoverRepos` lists
-     * accessible repos and `exploreRepo` reads them through a single virtual
-     * filesystem: the dbt project is mounted (subPath-scoped) at `/dbt` and every
-     * accessible repo whole at `/<owner>/<repo>`, with per-repo trees fetched
-     * lazily and a per-run materialization budget bounding recursive walks. Lets
-     * the agent inspect source before diagnosing, instead of guessing or spinning
-     * up a writeback sandbox.
-     *
-     * Value kept as `repo-fs` for backwards compatibility with existing flag
-     * configuration; the symbol was renamed from `RepoFs`.
-     */
-    RepoDiscovery = 'repo-fs',
-
-    /**
      * Gate the org-level export Limits settings panel (per-org query max rows
      * and CSV cells limit). Backend enforcement of any stored overrides is
      * always on; this flag only controls who can see/configure the panel.


### PR DESCRIPTION
## What & why

Split out of #24777, which bundled five now-default-enabled flag removals into one PR. This one covers just `repo-fs` (`RepoDiscovery`).

Agent read-only repo discovery/exploration is enabled by default in production, so this removes the flag and its gating, leaving the feature always-on.

## Approach

- Removed `RepoDiscovery` from the `FeatureFlags` enum.
- Removed the flag fetch in `AiAgentService`, replacing it with an always-true default.
- Preserved the Slack `aiRequireOAuth` trusted-identity guard: repo discovery is still disabled when a Slack prompt resolves to the app installer rather than the actual requester.

## Testing

Not run in this environment — see CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)