### PR TITLE
chore(ai): remove github-user-credentials feature flag

### DIFF
--- a/packages/backend/src/services/GithubAppService/GithubAppService.test.ts
+++ b/packages/backend/src/services/GithubAppService/GithubAppService.test.ts
@@ -11,7 +11,6 @@ import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import type { GitUserCredentialsModel } from '../../models/GitUserCredentials/GitUserCredentialsModel';
 import type { UserModel } from '../../models/UserModel';
-import type { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 import { GithubAppService } from './GithubAppService';
 
 vi.mock('../../clients/github/Github', () => ({
@@ -35,12 +34,10 @@ const user = {
 } as SessionUser;
 
 const buildService = ({
-    featureEnabled = true,
     findCredential,
     deleteCredential = vi.fn(),
     updateTokens = vi.fn(),
 }: {
-    featureEnabled?: boolean;
     findCredential?: import('vitest').Mock;
     deleteCredential?: import('vitest').Mock;
     updateTokens?: import('vitest').Mock;
@@ -57,9 +54,6 @@ const buildService = ({
         userModel: {} as unknown as UserModel,
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
-        featureFlagService: {
-            get: vi.fn().mockResolvedValue({ enabled: featureEnabled }),
-        } as unknown as FeatureFlagService,
     });
 
 describe('GithubAppService', () => {
@@ -101,22 +95,8 @@ describe('GithubAppService', () => {
     });
 
     describe('getAiWritebackAttribution', () => {
-        it('reports org/canLink:false without reading the credential when the feature is disabled', async () => {
-            const findCredential = vi.fn();
-            const service = buildService({
-                featureEnabled: false,
-                findCredential,
-            });
-
-            const attribution = await service.getAiWritebackAttribution(user);
-
-            expect(attribution).toEqual({ mode: 'org', canLink: false });
-            expect(findCredential).not.toHaveBeenCalled();
-        });
-
         it('reports personal attribution with the linked login when a credential exists', async () => {
             const service = buildService({
-                featureEnabled: true,
                 findCredential: vi.fn().mockResolvedValue({
                     providerLogin: 'octocat',
                     token: 't',
@@ -132,9 +112,8 @@ describe('GithubAppService', () => {
             });
         });
 
-        it('reports org/canLink:true when the feature is on but no credential is linked', async () => {
+        it('reports org/canLink:true when no credential is linked', async () => {
             const service = buildService({
-                featureEnabled: true,
                 findCredential: vi.fn().mockResolvedValue(undefined),
             });
 
@@ -146,7 +125,6 @@ describe('GithubAppService', () => {
         it('throws ForbiddenError when the caller cannot view their organization', async () => {
             const findCredential = vi.fn();
             const service = buildService({
-                featureEnabled: true,
                 findCredential,
             });
             // Ability scoped to a different org → cannot view this org.

--- a/packages/backend/src/services/GithubAppService/GithubAppService.ts
+++ b/packages/backend/src/services/GithubAppService/GithubAppService.ts
@@ -2,7 +2,6 @@ import { subject } from '@casl/ability';
 import {
     AiWritebackAttribution,
     AuthorizationError,
-    FeatureFlags,
     ForbiddenError,
     getErrorMessage,
     GithubUserCredential,
@@ -31,7 +30,6 @@ import { GithubAppInstallationsModel } from '../../models/GithubAppInstallations
 import { GitUserCredentialsModel } from '../../models/GitUserCredentials/GitUserCredentialsModel';
 import { UserModel } from '../../models/UserModel';
 import { BaseService } from '../BaseService';
-import { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 
 /**
  * GitHub OAuth error codes that mean the stored refresh token is no longer
@@ -67,7 +65,6 @@ type GithubAppServiceArguments = {
     userModel: UserModel;
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
-    featureFlagService: FeatureFlagService;
 };
 
 export class GithubAppService extends BaseService {
@@ -81,8 +78,6 @@ export class GithubAppService extends BaseService {
 
     private readonly analytics: LightdashAnalytics;
 
-    private readonly featureFlagService: FeatureFlagService;
-
     constructor(args: GithubAppServiceArguments) {
         super();
         this.githubAppInstallationsModel = args.githubAppInstallationsModel;
@@ -90,20 +85,6 @@ export class GithubAppService extends BaseService {
         this.userModel = args.userModel;
         this.lightdashConfig = args.lightdashConfig;
         this.analytics = args.analytics;
-        this.featureFlagService = args.featureFlagService;
-    }
-
-    private async isUserCredentialsFeatureEnabled(
-        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
-    ): Promise<boolean> {
-        const flag = await this.featureFlagService.get({
-            user: {
-                userUuid: user.userUuid,
-                organizationUuid: user.organizationUuid,
-            },
-            featureFlagId: FeatureFlags.GithubUserCredentials,
-        });
-        return flag.enabled;
     }
 
     async installRedirect(user: SessionUser) {
@@ -479,11 +460,6 @@ export class GithubAppService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
-        if (!(await this.isUserCredentialsFeatureEnabled(user))) {
-            throw new ForbiddenError(
-                'Linking personal GitHub accounts is not enabled',
-            );
-        }
 
         this.analytics.track({
             event: 'github_user_link.started',
@@ -518,11 +494,6 @@ export class GithubAppService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
         try {
-            if (!(await this.isUserCredentialsFeatureEnabled(user))) {
-                throw new ForbiddenError(
-                    'Linking personal GitHub accounts is not enabled',
-                );
-            }
             if (!state || state !== oauth?.state) {
                 throw new AuthorizationError('State does not match');
             }
@@ -582,9 +553,6 @@ export class GithubAppService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
-        if (!(await this.isUserCredentialsFeatureEnabled(user))) {
-            return null;
-        }
         const credential = await this.gitUserCredentialsModel.findCredential(
             user.userUuid,
             user.organizationUuid,
@@ -605,11 +573,6 @@ export class GithubAppService extends BaseService {
      * single indexed credential lookup — no token refresh and no GitHub API
      * call — so it never blocks a chat turn. The authoritative resolution still
      * happens later in the writeback run (GithubProvider.resolveInstallation).
-     *
-     * Mirrors that resolution's gating: when the feature is disabled the
-     * writeback-time path ignores any stored credential and falls back to the
-     * org app, so we report `org`/`canLink: false` without even reading the
-     * credential (and never nudge towards a hidden settings panel).
      */
     async getAiWritebackAttribution(
         user: SessionUser,
@@ -630,10 +593,6 @@ export class GithubAppService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
-        const canLink = await this.isUserCredentialsFeatureEnabled(user);
-        if (!canLink) {
-            return { mode: 'org', canLink: false };
-        }
         const credential = await this.gitUserCredentialsModel.findCredential(
             user.userUuid,
             user.organizationUuid,
@@ -645,10 +604,8 @@ export class GithubAppService extends BaseService {
         return { mode: 'org', canLink: true };
     }
 
-    // Intentionally NOT gated on the GithubUserCredentials feature flag: if an
-    // org disables the flag after users have linked, those users must still be
-    // able to revoke their stored token. Unlink only ever removes the caller's
-    // own credential, so there is no exposure in leaving it always available.
+    // Unlink only ever removes the caller's own credential, so there is no
+    // exposure in leaving it always available.
     async unlinkUser(user: SessionUser): Promise<void> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
@@ -699,14 +656,6 @@ export class GithubAppService extends BaseService {
         userUuid: string,
         organizationUuid: string,
     ): Promise<string | undefined> {
-        if (
-            !(await this.isUserCredentialsFeatureEnabled({
-                userUuid,
-                organizationUuid,
-            }))
-        ) {
-            return undefined;
-        }
         const credential = await this.gitUserCredentialsModel.findCredential(
             userUuid,
             organizationUuid,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -502,7 +502,6 @@ export class ServiceRepository
                     userModel: this.models.getUserModel(),
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
-                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -202,15 +202,6 @@ export enum FeatureFlags {
     AiSlackSystemAgentFallback = 'ai-slack-system-agent-fallback',
 
     /**
-     * Let users link their personal GitHub account (user-to-server OAuth
-     * token) so write-back commits and pull requests are authored as them
-     * instead of the Lightdash GitHub App bot. Off by default while the
-     * link/unlink UX and token lifecycle are validated; when off, write-backs
-     * keep today's bot identity.
-     */
-    GithubUserCredentials = 'github-user-credentials',
-
-    /**
      * Gate the org-level export Limits settings panel (per-org query max rows
      * and CSV cells limit). Backend enforcement of any stored overrides is
      * always on; this flag only controls who can see/configure the panel.

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -121,8 +121,8 @@ export type ApiGithubUserCredentialResponse = {
  * - `personal`: the user has a linked personal GitHub account; the PR will be
  *   attributed to `githubLogin`.
  * - `org`: the PR will fall back to the shared org-level GitHub App. `canLink`
- *   is whether the user can link a personal account (the github-user-credentials
- *   feature is enabled), i.e. whether nudging to settings is worthwhile.
+ *   is whether the user can link a personal account, i.e. whether nudging to
+ *   settings is worthwhile.
  */
 export type AiWritebackAttribution =
     | { mode: 'personal'; githubLogin: string }

--- a/packages/frontend/src/components/UserSettings/GithubUserSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubUserSettingsPanel/index.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlags } from '@lightdash/common';
 import {
     Avatar,
     Box,
@@ -12,7 +11,6 @@ import {
 } from '@mantine-8/core';
 import { IconBrandGithub, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import githubIcon from '../../../svgs/github-icon.svg';
 import {
     GITHUB_USER_AUTHORIZE_URL,
@@ -23,15 +21,8 @@ import MantineIcon from '../../common/MantineIcon';
 import { SettingsGridCard } from '../../common/Settings/SettingsCard';
 
 const GithubUserSettingsPanel: FC = () => {
-    const { data: flag } = useServerFeatureFlag(
-        FeatureFlags.GithubUserCredentials,
-    );
     const { data: credential, isInitialLoading } = useGithubUserCredential();
     const unlinkGithubUserMutation = useUnlinkGithubUserMutation();
-
-    if (!flag?.enabled) {
-        return null;
-    }
 
     if (isInitialLoading) {
         return <Loader />;

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
@@ -1,6 +1,5 @@
 import {
     DbtProjectType,
-    FeatureFlags,
     type ApiGithubDbtWritePreview,
 } from '@lightdash/common';
 import {
@@ -30,7 +29,6 @@ import MantineModal, {
 } from '../../../components/common/MantineModal';
 import useHealth from '../../../hooks/health/useHealth';
 import { useProject } from '../../../hooks/useProject';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { useGithubDbtWriteBack } from '../hooks/useGithubDbtWriteBack';
 import { useGithubDbtWritePreview } from '../hooks/useGithubDbtWritePreview';
 import { useAppSelector } from '../store/hooks';
@@ -66,9 +64,6 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
 
     const { data: project } = useProject(projectUuid);
     const { data: health } = useHealth();
-    const { data: githubUserCredentialsFlag } = useServerFeatureFlag(
-        FeatureFlags.GithubUserCredentials,
-    );
     const { data: githubUserCredential } = useGithubUserCredential();
 
     const canWriteToDbtProject = !!(
@@ -201,7 +196,6 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
                     </Stack>
 
                     {isGithubProject &&
-                        githubUserCredentialsFlag?.enabled &&
                         (githubUserCredential ? (
                             <Text fz="xs" c="dimmed">
                                 The pull request will be authored as{' '}


### PR DESCRIPTION
## What & why

Split out of #24777, which bundled five now-default-enabled flag removals into one PR. This one covers just `github-user-credentials`.

Linking a personal GitHub account for writeback PR authorship is enabled by default in production, so this removes the flag and its gating, leaving the feature always-on.

## Approach

- Removed `GithubUserCredentials` from the `FeatureFlags` enum.
- Removed `GithubAppService.isUserCredentialsFeatureEnabled` and its five call sites (link redirect, OAuth callback, credential read, writeback attribution, and token resolution), along with the now-dead `featureFlagService` dependency and its DI wiring in `ServiceRepository`.
- Removed the flag check gating `GithubUserSettingsPanel` (now always rendered) and the attribution-nudge condition in `WriteBackToDbtModal` (now always shown for GitHub projects).
- Updated stale doc comments referencing the removed flag.

## Testing

Not run in this environment — see CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)