### PR TITLE
ci: pin npm to 11.x in the release job, unbreaking Build & Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,13 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
+      # Pinned to the npm 11.x line, not `latest`: npm 12.0.0 raised its engines
+      # requirement to Node >=22.22.2 / >=24.15.0 / >=26.0.0, breaking this step
+      # on our current Node 20 (.nvmrc). npm 11.x still supports Node ^20.17.0
+      # and OIDC/trusted publishing. Temporary until the Node 24 cutover
+      # (PROD-8557, due 2026-07-29) lands and this step can track latest again.
       - name: Upgrade npm for OIDC support
-        run: sfw npm install -g npm@latest
+        run: sfw npm install -g npm@11.18.0
 
       - name: Install dependencies
         run: sfw pnpm install --frozen-lockfile --prefer-offline --prod=false


### PR DESCRIPTION
## What & why

The `release` job's Build & Release workflow has been failing on every push to main since npm published 12.0.0, which bumped its `engines` requirement to `node: ^22.22.2 || ^24.15.0 || >=26.0.0`. The "Upgrade npm for OIDC support" step does `sfw npm install -g npm@latest`, which now fails with `EBADENGINE` since our release job runs on Node 20 (`.nvmrc`):

```
npm error engine Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.19.6"}
```

`Build & Test` is unaffected (it doesn't touch npm's own version) — only the `release` job (semantic-release/npm publish) breaks, so recent merges landed on main but didn't get released.

## Fix

Pin the install to the latest npm 11.x release instead of `latest`. npm 11.x still supports Node `^20.17.0` and the OIDC/trusted-publishing flow this step exists for.

This is a **temporary** pin — [PROD-8557](https://linear.app/lightdash/issue/PROD-8557) (the already-scheduled Node 24 cutover, due 2026-07-29) will bump `.nvmrc` and this step can go back to tracking `npm@latest` at that point.

## Testing

Not run in this environment — see CI. (This is the fix for CI itself, so worth watching the `release` job specifically once this merges.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)