### PR TITLE
fix(mcp): accept explicit null for nullable tool inputs

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/McpSchemaCompatLayer.ts
+++ b/packages/common/src/ee/AiAgent/schemas/McpSchemaCompatLayer.ts
@@ -70,12 +70,19 @@ export class McpSchemaCompatLayer extends SchemaCompatLayer {
                 innerType = innerType.optional();
             }
 
-            return innerType
-                .describe(
-                    [
-                        v.description ?? '',
-                        v._def.innerType.description ?? '',
-                    ].join(', '),
+            // Accept an explicit null too: descriptions advertise nullable
+            // fields as "or null", so MCP clients send null as often as they
+            // omit the key. Coerce it to undefined before validation and let
+            // the transform below restore null on output.
+            return z
+                .preprocess(
+                    (val) => (val === null ? undefined : val),
+                    innerType.describe(
+                        [
+                            v.description ?? '',
+                            v._def.innerType.description ?? '',
+                        ].join(', '),
+                    ),
                 )
                 .transform((val: AnyType) => (val === undefined ? null : val));
         }


### PR DESCRIPTION
## Summary
The MCP schema compat layer maps `.nullable()` tool inputs to `.optional()` with an `undefined → null` output transform, so an MCP client sending an explicit `null` failed validation with a protocol error, while omitting the key worked. Tool descriptions actively advertise the null spelling (e.g. `grep_fields`' `exploreName`: "or null to search all explores"), and this affects every nullable input on MCP tools (`find_content`, `list_content`, `run_metric_query`, …).

## Changes
- Preprocess an explicit `null` to `undefined` before validation in `McpSchemaCompatLayer`; the existing transform restores `null` on output, so both spellings parse to the same result.
- The emitted JSON schema is unchanged (`z.preprocess` is transparent to `zodToJsonSchema`, same as the existing number-coercion preprocess).

## Verification
- pnpm -F common exec vitest run src/ee/AiAgent/schemas/McpSchemaCompatLayer.test.ts
- pnpm -F common check:mcp-tools-snapshot (contract byte-identical)
- pnpm -F backend exec vitest run src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
- pnpm -F common typecheck:fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)