### PR TITLE
feat(charts): conditional formatting for stacked and 100% stacked bar charts

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
@@ -235,6 +235,9 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
 type Props = {
     colorPalette: string[];
     fields: FilterableItem[];
+    // Stacked charts allow a single target series, so target changes apply
+    // to every rule config
+    enforceSingleTarget: boolean;
     conditionalFormattings: ConditionalFormattingConfig[];
     onSetConditionalFormattings: (
         configs: ConditionalFormattingConfig[],
@@ -244,6 +247,7 @@ type Props = {
 export const ChartConditionalFormatting: FC<Props> = ({
     colorPalette,
     fields,
+    enforceSingleTarget,
     conditionalFormattings,
     onSetConditionalFormattings,
 }) => {
@@ -292,10 +296,14 @@ export const ChartConditionalFormatting: FC<Props> = ({
     );
 
     const handleAdd = useCallback(() => {
+        // With a single shared target, new rules follow the existing one
+        const sharedTarget = enforceSingleTarget
+            ? supportedConfigs[0]?.target
+            : undefined;
         const defaultField = fields[0];
-        const fieldTarget = defaultField
-            ? { fieldId: getItemId(defaultField) }
-            : null;
+        const fieldTarget =
+            sharedTarget ??
+            (defaultField ? { fieldId: getItemId(defaultField) } : null);
         setSupportedConfigs(
             produce(supportedConfigs, (draft) => {
                 draft.push(
@@ -310,6 +318,7 @@ export const ChartConditionalFormatting: FC<Props> = ({
     }, [
         addNewItem,
         colorPalette,
+        enforceSingleTarget,
         fields,
         setSupportedConfigs,
         supportedConfigs,
@@ -332,13 +341,24 @@ export const ChartConditionalFormatting: FC<Props> = ({
             index: number,
             newConfig: ConditionalFormattingConfigWithSingleColor,
         ) => {
+            const targetChanged =
+                newConfig.target?.fieldId !==
+                supportedConfigs[index]?.target?.fieldId;
             setSupportedConfigs(
                 produce(supportedConfigs, (draft) => {
                     draft[index] = newConfig;
+                    // Single shared target: retarget every rule together
+                    if (enforceSingleTarget && targetChanged) {
+                        draft.forEach((config, configIndex) => {
+                            if (configIndex !== index) {
+                                config.target = newConfig.target;
+                            }
+                        });
+                    }
                 }),
             );
         },
-        [setSupportedConfigs, supportedConfigs],
+        [enforceSingleTarget, setSupportedConfigs, supportedConfigs],
     );
 
     return (

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
@@ -235,8 +235,7 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
 type Props = {
     colorPalette: string[];
     fields: FilterableItem[];
-    // Stacked charts allow a single target series, so target changes apply
-    // to every rule config
+    // When true, all rules share a single target field (stacked charts)
     enforceSingleTarget: boolean;
     conditionalFormattings: ConditionalFormattingConfig[];
     onSetConditionalFormattings: (

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
@@ -26,6 +26,7 @@ type Props = {
     xField: string | undefined;
     yFields: string[];
     canColorByCategory: boolean;
+    enforceSingleTarget: boolean;
     colorPalette: string[];
     colorByCategory: boolean;
     categoryColorOverrides: Record<string, string>;
@@ -44,6 +45,7 @@ export const CustomColors: FC<Props> = ({
     xField,
     yFields,
     canColorByCategory,
+    enforceSingleTarget,
     colorPalette,
     colorByCategory,
     categoryColorOverrides,
@@ -225,6 +227,7 @@ export const CustomColors: FC<Props> = ({
                 <ChartConditionalFormatting
                     colorPalette={colorPalette}
                     fields={targetFields}
+                    enforceSingleTarget={enforceSingleTarget}
                     conditionalFormattings={conditionalFormattings}
                     onSetConditionalFormattings={onSetConditionalFormattings}
                 />

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -168,17 +168,19 @@ export const Series: FC<Props> = ({ items }) => {
         (dirtyLayout?.stack !== undefined &&
             dirtyLayout.stack !== StackType.NONE);
 
-    // Conditional formatting: available for non-stacked all-bar charts
-    // without pivots, regardless of how many metrics are charted. Mixed
-    // bar/line charts are excluded since formatting only renders on bars.
+    // Conditional formatting: available for all-bar charts without pivots,
+    // regardless of how many metrics are charted or stacking. Mixed bar/line
+    // charts are excluded since formatting only renders on bars.
     const supportsCustomColors =
         dirtyChartType === CartesianSeriesType.BAR &&
         allSeries.every((series) => series.type === CartesianSeriesType.BAR) &&
-        !pivotDimensions?.length &&
-        !hasCustomColorsStacking;
+        !pivotDimensions?.length;
 
-    // Color by category: only for single-series bar charts
-    const isSingleSeriesBar = supportsCustomColors && allSeries.length <= 1;
+    // Color by category: only for single-series non-stacked bar charts
+    const isSingleSeriesBar =
+        supportsCustomColors &&
+        allSeries.length <= 1 &&
+        !hasCustomColorsStacking;
 
     const colorByCategory = dirtyLayout?.colorByCategory ?? false;
     const customColorsEnabled =
@@ -359,6 +361,9 @@ export const Series: FC<Props> = ({ items }) => {
                                     xField={dirtyLayout?.xField}
                                     yFields={dirtyLayout?.yField ?? []}
                                     canColorByCategory={isSingleSeriesBar}
+                                    enforceSingleTarget={
+                                        hasCustomColorsStacking
+                                    }
                                     colorPalette={colorPalette}
                                     colorByCategory={colorByCategory}
                                     categoryColorOverrides={

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -1062,7 +1062,7 @@ describe('useCartesianChartConfig', () => {
         );
     });
 
-    test('should clear custom colors when stacking is enabled', () => {
+    test('should clear category colors but keep conditional formatting when stacking is enabled', () => {
         const initialParams = getSingleSeriesParams();
         const conditionalFormattings = [
             createConditionalFormattingConfigWithSingleColor('#ff0000', {
@@ -1115,7 +1115,70 @@ describe('useCartesianChartConfig', () => {
         expect(
             result.current.dirtyLayout?.categoryColorOverrides,
         ).toBeUndefined();
-        expect(result.current.validConfig.conditionalFormattings).toEqual([]);
+        // Stacked bar charts support conditional formatting, so configs survive
+        expect(result.current.validConfig.conditionalFormattings).toEqual(
+            conditionalFormattings,
+        );
+    });
+
+    test('should coerce conditional formatting to a single target when stacked', () => {
+        const initialParams = getSingleSeriesParams();
+        const multiMetricParams = {
+            ...initialParams,
+            stacking: StackType.NORMAL,
+            initialChartConfig: {
+                ...initialParams.initialChartConfig,
+                layout: {
+                    xField: 'orders_customer_id',
+                    yField: ['orders_total_order_amount', 'orders_order_count'],
+                },
+                eChartsConfig: {
+                    series: [
+                        {
+                            type: CartesianSeriesType.BAR,
+                            yAxisIndex: 0,
+                            encode: {
+                                xRef: { field: 'orders_customer_id' },
+                                yRef: {
+                                    field: 'orders_total_order_amount',
+                                },
+                            },
+                        },
+                        {
+                            type: CartesianSeriesType.BAR,
+                            yAxisIndex: 0,
+                            encode: {
+                                xRef: { field: 'orders_customer_id' },
+                                yRef: { field: 'orders_order_count' },
+                            },
+                        },
+                    ],
+                },
+                conditionalFormattings: [
+                    createConditionalFormattingConfigWithSingleColor(
+                        '#ff0000',
+                        { fieldId: 'orders_total_order_amount' },
+                    ),
+                    createConditionalFormattingConfigWithSingleColor(
+                        '#0000ff',
+                        { fieldId: 'orders_order_count' },
+                    ),
+                ],
+            },
+        };
+
+        const { result } = renderHook(
+            ({ params }) =>
+                // @ts-expect-error partially mock params for hook
+                useCartesianChartConfig(params),
+            { initialProps: { params: multiMetricParams } },
+        );
+
+        expect(
+            result.current.validConfig.conditionalFormattings.map(
+                (config) => config.target?.fieldId,
+            ),
+        ).toEqual(['orders_total_order_amount', 'orders_total_order_amount']);
     });
 
     test('should clear conditional formattings when chart becomes ineligible', () => {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -1115,7 +1115,6 @@ describe('useCartesianChartConfig', () => {
         expect(
             result.current.dirtyLayout?.categoryColorOverrides,
         ).toBeUndefined();
-        // Stacked bar charts support conditional formatting, so configs survive
         expect(result.current.validConfig.conditionalFormattings).toEqual(
             conditionalFormattings,
         );

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -1168,14 +1168,12 @@ describe('useCartesianChartConfig', () => {
         };
 
         const { result } = renderHook(
-            ({ params }) =>
-                // @ts-expect-error partially mock params for hook
-                useCartesianChartConfig(params),
+            ({ params }) => useCartesianChartConfig(params),
             { initialProps: { params: multiMetricParams } },
         );
 
         expect(
-            result.current.validConfig.conditionalFormattings.map(
+            result.current.validConfig.conditionalFormattings?.map(
                 (config) => config.target?.fieldId,
             ),
         ).toEqual(['orders_total_order_amount', 'orders_total_order_amount']);

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1279,8 +1279,8 @@ const useCartesianChartConfig = ({
         [dirtyEchartsConfig?.series, dirtyLayout?.stack],
     );
 
-    // Conditional formatting: non-stacked all-bar charts without pivots,
-    // regardless of metric count. Mixed bar/line charts are excluded since
+    // Conditional formatting: all-bar charts without pivots, regardless of
+    // metric count or stacking. Mixed bar/line charts are excluded since
     // formatting only renders on bars.
     const isConditionalFormattingEligible = useMemo(
         () =>
@@ -1288,22 +1288,21 @@ const useCartesianChartConfig = ({
             (dirtyEchartsConfig?.series ?? []).every(
                 (series) => series.type === CartesianSeriesType.BAR,
             ) &&
-            !pivotKeys?.length &&
-            !hasCustomColorsStacking,
-        [
-            dirtyChartType,
-            dirtyEchartsConfig?.series,
-            pivotKeys,
-            hasCustomColorsStacking,
-        ],
+            !pivotKeys?.length,
+        [dirtyChartType, dirtyEchartsConfig?.series, pivotKeys],
     );
 
-    // Color by category: only single-metric bar charts
+    // Color by category: only single-metric non-stacked bar charts
     const isColorByCategoryEligible = useMemo(
         () =>
             isConditionalFormattingEligible &&
+            !hasCustomColorsStacking &&
             (dirtyLayout?.yField?.length ?? 0) <= 1,
-        [isConditionalFormattingEligible, dirtyLayout?.yField],
+        [
+            isConditionalFormattingEligible,
+            hasCustomColorsStacking,
+            dirtyLayout?.yField,
+        ],
     );
 
     useEffect(() => {
@@ -1334,7 +1333,9 @@ const useCartesianChartConfig = ({
     }, [isConditionalFormattingEligible]);
 
     // Repair configs whose target no longer exists on the chart (e.g. the
-    // metric was swapped or removed) by pointing them at the first metric
+    // metric was swapped or removed) by pointing them at the first metric.
+    // Stacked charts additionally allow only a single target series, so all
+    // configs are coerced to the first config's target.
     useEffect(() => {
         if (!isConditionalFormattingEligible) return;
 
@@ -1343,15 +1344,7 @@ const useCartesianChartConfig = ({
         if (!firstYField) return;
 
         setConditionalFormattings((prev) => {
-            const hasOutdatedTargets = prev.some(
-                (config) =>
-                    !config.target?.fieldId ||
-                    !yFields.includes(config.target.fieldId),
-            );
-
-            if (!hasOutdatedTargets) return prev;
-
-            return prev.map((config) =>
+            const repairedConfigs = prev.map((config) =>
                 config.target?.fieldId &&
                 yFields.includes(config.target.fieldId)
                     ? config
@@ -1360,8 +1353,32 @@ const useCartesianChartConfig = ({
                           target: { fieldId: firstYField },
                       },
             );
+
+            const withSingleTarget = hasCustomColorsStacking
+                ? repairedConfigs.map((config, index) =>
+                      index === 0 ||
+                      config.target?.fieldId ===
+                          repairedConfigs[0].target?.fieldId
+                          ? config
+                          : {
+                                ...config,
+                                target: repairedConfigs[0].target,
+                            },
+                  )
+                : repairedConfigs;
+
+            const hasChanges = withSingleTarget.some(
+                (config, index) =>
+                    config.target?.fieldId !== prev[index].target?.fieldId,
+            );
+
+            return hasChanges ? withSingleTarget : prev;
         });
-    }, [isConditionalFormattingEligible, dirtyLayout?.yField]);
+    }, [
+        isConditionalFormattingEligible,
+        hasCustomColorsStacking,
+        dirtyLayout?.yField,
+    ]);
 
     const validConfig: CartesianChart = useMemo(() => {
         // Always use the dirtyLayout and dirtyEchartsConfig when possible, fallback to the empty config if not complete.

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1334,8 +1334,6 @@ const useCartesianChartConfig = ({
 
     // Repair configs whose target no longer exists on the chart (e.g. the
     // metric was swapped or removed) by pointing them at the first metric.
-    // Stacked charts additionally allow only a single target series, so all
-    // configs are coerced to the first config's target.
     useEffect(() => {
         if (!isConditionalFormattingEligible) return;
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -1,12 +1,15 @@
 import {
     CartesianSeriesType,
+    createConditionalFormattingConfigWithSingleColor,
     DimensionType,
     FieldType,
+    FilterOperator,
     TimeFrames,
     transformToPercentageStacking,
     type Dimension,
     type EChartsSeries,
     type Field,
+    type ItemsMap,
     type ResultRow,
     type Series,
 } from '@lightdash/common';
@@ -15,6 +18,7 @@ import timezonePlugin from 'dayjs/plugin/timezone';
 import utcPlugin from 'dayjs/plugin/utc';
 import { describe, expect, test, vi } from 'vitest';
 import {
+    applyConditionalFormattingToStackedSeries,
     applyLegendPlacementToGrid,
     filterSeriesWithNoData,
     getAxisDefaultMaxValue,
@@ -2367,5 +2371,153 @@ describe('relocateMarkLinesToVisibleSeries (PROD-7119)', () => {
 
         expect(result).toBe(series);
         expect(markLineData(result[1])).toHaveLength(0);
+    });
+});
+
+describe('applyConditionalFormattingToStackedSeries', () => {
+    const revenueField = {
+        compiledSql: '',
+        tablesReferences: [],
+        fieldType: FieldType.DIMENSION,
+        hidden: false,
+        label: 'Revenue',
+        name: 'revenue',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '',
+        type: DimensionType.NUMBER,
+    } as ItemsMap[string];
+    const costField = {
+        ...revenueField,
+        label: 'Cost',
+        name: 'cost',
+    } as ItemsMap[string];
+    const itemsMap: ItemsMap = {
+        orders_revenue: revenueField,
+        orders_cost: costField,
+    };
+
+    const belowThresholdRed = (fieldId: string) => {
+        const config = createConditionalFormattingConfigWithSingleColor(
+            '#ff0000',
+            { fieldId },
+        );
+        config.rules = [
+            {
+                id: 'r1',
+                operator: FilterOperator.LESS_THAN,
+                values: [100],
+            },
+        ];
+        return config;
+    };
+
+    const rawRows = [
+        { orders_category: 'a', orders_revenue: 50, orders_cost: 50 },
+        { orders_category: 'b', orders_revenue: 150, orders_cost: 50 },
+    ];
+
+    const mkStackedSeries = (fieldId: string): EChartsSeries =>
+        ({
+            type: CartesianSeriesType.BAR,
+            stack: 'stack-all-series',
+            color: '#123456',
+            encode: {
+                x: 'orders_category',
+                y: fieldId,
+                yRef: { field: fieldId },
+            },
+        }) as unknown as EChartsSeries;
+
+    test('normal stacks: colors matching per-item data and preserves rounded-corner itemStyle', () => {
+        const series = {
+            ...mkStackedSeries('orders_revenue'),
+            data: [
+                {
+                    value: ['a', 50],
+                    itemStyle: { borderRadius: [4, 4, 0, 0] },
+                },
+                { value: ['b', 150] },
+            ],
+        };
+
+        const [result] = applyConditionalFormattingToStackedSeries({
+            seriesList: [series],
+            rawRows,
+            itemsMap,
+            conditionalFormattings: [belowThresholdRed('orders_revenue')],
+        });
+
+        expect(result.data).toEqual([
+            {
+                value: ['a', 50],
+                itemStyle: { borderRadius: [4, 4, 0, 0], color: '#ff0000' },
+            },
+            { value: ['b', 150] },
+        ]);
+    });
+
+    test('normal stacks: untargeted series in the stack stays untouched', () => {
+        const series = {
+            ...mkStackedSeries('orders_cost'),
+            data: [{ value: ['a', 50] }, { value: ['b', 50] }],
+        };
+
+        const [result] = applyConditionalFormattingToStackedSeries({
+            seriesList: [series],
+            rawRows,
+            itemsMap,
+            conditionalFormattings: [belowThresholdRed('orders_revenue')],
+        });
+
+        expect(result.data).toEqual([
+            { value: ['a', 50] },
+            { value: ['b', 50] },
+        ]);
+    });
+
+    test('100% stacks: dataset-bound series get a callback evaluating raw values', () => {
+        const series = mkStackedSeries('orders_revenue');
+
+        const [result] = applyConditionalFormattingToStackedSeries({
+            seriesList: [series],
+            // Simulates 100% mode: the dataset holds normalized percentages,
+            // but evaluation uses the raw rows by index
+            rawRows,
+            itemsMap,
+            conditionalFormattings: [belowThresholdRed('orders_revenue')],
+        });
+
+        const colorFn = (
+            result.itemStyle as {
+                color: (params: { dataIndex: number }) => string;
+            }
+        ).color;
+        expect(colorFn({ dataIndex: 0 })).toBe('#ff0000');
+        expect(colorFn({ dataIndex: 1 })).toBe('#123456');
+    });
+
+    test('passes through non-stacked and non-bar series', () => {
+        const flatBar = {
+            type: CartesianSeriesType.BAR,
+            color: '#123456',
+            encode: { yRef: { field: 'orders_revenue' } },
+        } as unknown as EChartsSeries;
+        const line = {
+            type: CartesianSeriesType.LINE,
+            stack: 'stack-all-series',
+            color: '#123456',
+            encode: { yRef: { field: 'orders_cost' } },
+        } as unknown as EChartsSeries;
+
+        const result = applyConditionalFormattingToStackedSeries({
+            seriesList: [flatBar, line],
+            rawRows,
+            itemsMap,
+            conditionalFormattings: [belowThresholdRed('orders_revenue')],
+        });
+
+        expect(result[0]).toBe(flatBar);
+        expect(result[1]).toBe(line);
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2898,12 +2898,8 @@ export const transformStack100ByValueAxis = <T extends Record<string, unknown>>(
 };
 
 /**
- * Apply conditional formatting to stacked bar series. Normal stacks carry
- * per-item data (from the rounded-corner transform) aligned 1:1 with the raw
- * rows, so matching segments get a concrete per-item fill color. 100% stacks
- * stay dataset-bound with normalized values, so they get a series-level
- * color callback that resolves the raw row by data index — either way rules
- * evaluate raw metric values, not normalized percentages.
+ * Apply conditional formatting colors to stacked bar series, using raw row
+ * values for 100%-stack series via a color callback.
  */
 export const applyConditionalFormattingToStackedSeries = ({
     seriesList,
@@ -3410,9 +3406,8 @@ const useEchartsCartesianConfig = (
             !hasCustomColorsStacking;
         // Applies per bar series on all-bar charts: each config routes to its
         // target field, so multi-metric charts color each metric's bars
-        // independently. Stacked series are handled downstream (their data
-        // shape changes after the stack decoration), so only non-stacked
-        // series get the series-level color callback here.
+        // independently. Stacked series are handled downstream after stack
+        // decoration.
         const shouldApplyConditionalFormatting =
             series.length > 0 &&
             barSeries.length === series.length &&
@@ -3880,9 +3875,8 @@ const useEchartsCartesianConfig = (
                   )
                 : stackedSeriesWithColorAssignments;
 
-        // Conditional formatting on stacked bars evaluates against the raw
-        // padded rows (not the 100%-stack ratios) and runs before the stack
-        // totals are appended so the synthetic total series stays untouched
+        // Runs before stack totals are appended so the synthetic total
+        // series stays untouched
         const conditionalFormattings =
             validCartesianConfig?.conditionalFormattings;
         const shouldApplyStackConditionalFormatting =

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -60,6 +60,7 @@ import {
     valueFormatter,
     XAxisSortType,
     type CartesianChart,
+    type ConditionalFormattingConfig,
     type CustomDimension,
     type EChartsSeries,
     type EchartsLegend,
@@ -2896,6 +2897,78 @@ export const transformStack100ByValueAxis = <T extends Record<string, unknown>>(
     return { transformedResults, originalValues };
 };
 
+/**
+ * Apply conditional formatting to stacked bar series. Normal stacks carry
+ * per-item data (from the rounded-corner transform) aligned 1:1 with the raw
+ * rows, so matching segments get a concrete per-item fill color. 100% stacks
+ * stay dataset-bound with normalized values, so they get a series-level
+ * color callback that resolves the raw row by data index — either way rules
+ * evaluate raw metric values, not normalized percentages.
+ */
+export const applyConditionalFormattingToStackedSeries = ({
+    seriesList,
+    rawRows,
+    itemsMap,
+    conditionalFormattings,
+}: {
+    seriesList: EChartsSeries[];
+    rawRows: Record<string, unknown>[];
+    itemsMap: ItemsMap;
+    conditionalFormattings: ConditionalFormattingConfig[];
+}): EChartsSeries[] =>
+    seriesList.map((series) => {
+        if (series.type !== CartesianSeriesType.BAR || !series.stack) {
+            return series;
+        }
+
+        if (Array.isArray(series.data)) {
+            const data = series.data.map((item, rowIndex) => {
+                const conditionalColor = getCartesianConditionalFormattingColor(
+                    {
+                        itemsMap,
+                        conditionalFormattings,
+                        rowValues: rawRows[rowIndex] ?? {},
+                        series,
+                    },
+                );
+                if (!conditionalColor) return item;
+                const baseItem =
+                    item !== null && typeof item === 'object' && 'value' in item
+                        ? (item as {
+                              value: unknown;
+                              itemStyle?: Record<string, unknown>;
+                          })
+                        : { value: item, itemStyle: undefined };
+                return {
+                    ...baseItem,
+                    itemStyle: {
+                        ...(baseItem.itemStyle ?? {}),
+                        color: conditionalColor,
+                    },
+                };
+            });
+            return { ...series, data };
+        }
+
+        // Series colors are always assigned upstream; keep the type narrow
+        const fallbackColor = series.color;
+        if (!fallbackColor) return series;
+
+        return {
+            ...series,
+            itemStyle: {
+                ...(series.itemStyle ?? {}),
+                color: (params: { dataIndex: number }) =>
+                    getCartesianConditionalFormattingColor({
+                        itemsMap,
+                        conditionalFormattings,
+                        rowValues: rawRows[params.dataIndex] ?? {},
+                        series,
+                    }) ?? fallbackColor,
+            },
+        };
+    });
+
 // To hack the stack totals in echarts we need to create a fake series with the value 0 and display the total in the label
 export const getStackTotalSeries = (
     rows: Record<string, unknown>[],
@@ -3337,13 +3410,14 @@ const useEchartsCartesianConfig = (
             !hasCustomColorsStacking;
         // Applies per bar series on all-bar charts: each config routes to its
         // target field, so multi-metric charts color each metric's bars
-        // independently
+        // independently. Stacked series are handled downstream (their data
+        // shape changes after the stack decoration), so only non-stacked
+        // series get the series-level color callback here.
         const shouldApplyConditionalFormatting =
             series.length > 0 &&
             barSeries.length === series.length &&
             !pivotDimensions?.length &&
             !isColorByCategory &&
-            !hasCustomColorsStacking &&
             Boolean(conditionalFormattings?.length);
 
         const seriesColors = series.map((serie) => getSeriesColor(serie));
@@ -3397,7 +3471,10 @@ const useEchartsCartesianConfig = (
                         }),
                     };
 
-                    if (shouldApplyConditionalFormatting) {
+                    if (
+                        shouldApplyConditionalFormatting &&
+                        getValidStack(serie) === undefined
+                    ) {
                         return {
                             ...barConfig,
                             colorBy: 'data' as const,
@@ -3803,6 +3880,28 @@ const useEchartsCartesianConfig = (
                   )
                 : stackedSeriesWithColorAssignments;
 
+        // Conditional formatting on stacked bars evaluates against the raw
+        // padded rows (not the 100%-stack ratios) and runs before the stack
+        // totals are appended so the synthetic total series stays untouched
+        const conditionalFormattings =
+            validCartesianConfig?.conditionalFormattings;
+        const shouldApplyStackConditionalFormatting =
+            Boolean(conditionalFormattings?.length) &&
+            !pivotDimensions?.length &&
+            stackedSeriesWithColorAssignments.every(
+                (s) => s.type === CartesianSeriesType.BAR,
+            );
+
+        const seriesWithStackConditionalFormatting =
+            shouldApplyStackConditionalFormatting && conditionalFormattings
+                ? applyConditionalFormattingToStackedSeries({
+                      seriesList: seriesWithRoundedStacks,
+                      rawRows: paddedSortedResults,
+                      itemsMap,
+                      conditionalFormattings,
+                  })
+                : seriesWithRoundedStacks;
+
         // User-configured value-axis maxes; the value axis config lives in
         // eChartsConfig.yAxis for both orientations (flipped charts apply it
         // to the echarts x axis).
@@ -3815,10 +3914,10 @@ const useEchartsCartesianConfig = (
         });
 
         return [
-            ...seriesWithRoundedStacks,
+            ...seriesWithStackConditionalFormatting,
             ...getStackTotalSeries(
                 paddedSortedResults,
-                seriesWithRoundedStacks,
+                seriesWithStackConditionalFormatting,
                 itemsMap,
                 validCartesianConfig?.layout.flipAxes,
                 validCartesianConfigLegend,
@@ -3833,6 +3932,8 @@ const useEchartsCartesianConfig = (
         paddedSortedResults,
         dynamicRadius,
         itemsMap,
+        pivotDimensions,
+        validCartesianConfig?.conditionalFormattings,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,
         validCartesianConfig?.layout.connectNulls,


### PR DESCRIPTION
### Description

Slice 2 of the conditional formatting work (slice 1 — multi-metric non-stacked bars — shipped in #25301). Extends conditional formatting to **stacked and 100% stacked bar charts that stack multiple metrics**, per the design decisions confirmed with the requester:

- **Single target series per stack**: rules can only target one metric of the stack, bounding the legend-color conflict to a single stack layer. Changing any rule's target retargets all rules together, new rules follow the existing target, and the config hook coerces mixed targets (e.g. saved unstacked, then stacked) to the first config's target.
- **Fill override** for matching segments (the legend swatch keeps the base series color — accepted mismatch).
- **Rules evaluate raw metric values in 100% mode**, never the normalized percentages.
- **Pivoted (grouped) stacks stay excluded** — metrics-only stacks in v1.

### How it works

Normal stacks carry per-item `data` arrays from the rounded-corner transform (aligned 1:1 with the raw padded rows), so matching segments get a concrete per-item `itemStyle.color` composed with the existing border-radius entries. 100% stacks skip that transform and stay dataset-bound with normalized values, so they get a series-level color callback that resolves the raw row by `dataIndex`. The decoration runs before the synthetic stack-total series are appended, so totals are untouched.

Color-by-category remains restricted to single-metric non-stacked bars.

### How to test

1. Bar chart, 2+ metrics, Stacking → Stack: "Apply custom colors" appears; add a rule (e.g. `< 1500` → red) — only the targeted metric's segments recolor where the raw value matches; the other layer keeps its legend color; rounded corners intact.
2. Switch to 100%: segments render as shares, but the rule still colors by the **raw** value (segments with near-identical rendered heights color differently when their raw values straddle the threshold).
3. Non-stacked multi-metric and single-metric charts behave exactly as before.

Closes: PROD-8761
Relates: PROD-8191
Relates: #24040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
