### PR TITLE
fix(docker): pin dbt 1.12 pre-releases, unbreaking image builds

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -146,13 +146,14 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-duckdb~=1.10.0" \
     && ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11 \
     && python3 -m venv /usr/local/dbt1.12 \
+# dbt 1.12 has no stable PyPI release yet: pin latest pre-releases, and skip
+# dbt-databricks (no release compatible with dbt-core 1.12)
     && /usr/local/dbt1.12/bin/pip install \
-    "dbt-core~=1.12.0" \
+    "dbt-core==1.12.0rc1" \
     "dbt-postgres~=1.10.0" \
     "dbt-redshift~=1.10.0" \
-    "dbt-snowflake~=1.12.0" \
-    "dbt-bigquery~=1.12.0" \
-    "dbt-databricks~=1.12.0" \
+    "dbt-snowflake==1.12.0b2" \
+    "dbt-bigquery==1.12.0b1" \
     "dbt-trino~=1.10.0" \
     "dbt-clickhouse~=1.9.0" \
     "dbt-athena~=1.10.0" \

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -145,13 +145,14 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-athena~=1.10.0" \
     && ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11 \
     && python3 -m venv /usr/local/dbt1.12 \
+# dbt 1.12 has no stable PyPI release yet: pin latest pre-releases, and skip
+# dbt-databricks (no release compatible with dbt-core 1.12)
     && /usr/local/dbt1.12/bin/pip install \
-    "dbt-core~=1.12.0" \
+    "dbt-core==1.12.0rc1" \
     "dbt-postgres~=1.10.0" \
     "dbt-redshift~=1.10.0" \
-    "dbt-snowflake~=1.12.0" \
-    "dbt-bigquery~=1.12.0" \
-    "dbt-databricks~=1.12.0" \
+    "dbt-snowflake==1.12.0b2" \
+    "dbt-bigquery==1.12.0b1" \
     "dbt-trino~=1.10.0" \
     "dbt-clickhouse~=1.9.0" \
     "dbt-athena~=1.10.0" \

--- a/sandboxes/ai-writeback/e2b.Dockerfile
+++ b/sandboxes/ai-writeback/e2b.Dockerfile
@@ -67,13 +67,14 @@ RUN python3 -m venv /usr/local/dbt1.8 \
         "dbt-athena~=1.10.0" \
         "dbt-duckdb~=1.10.0" \
     && python3 -m venv /usr/local/dbt1.12 \
+# dbt 1.12 has no stable PyPI release yet: pin latest pre-releases, and skip
+# dbt-databricks (no release compatible with dbt-core 1.12)
     && /usr/local/dbt1.12/bin/pip install --no-cache-dir \
-        "dbt-core~=1.12.0" \
+        "dbt-core==1.12.0rc1" \
         "dbt-postgres~=1.10.0" \
         "dbt-redshift~=1.10.0" \
-        "dbt-snowflake~=1.12.0" \
-        "dbt-bigquery~=1.12.0" \
-        "dbt-databricks~=1.12.0" \
+        "dbt-snowflake==1.12.0b2" \
+        "dbt-bigquery==1.12.0b1" \
         "dbt-trino~=1.10.0" \
         "dbt-clickhouse~=1.9.0" \
         "dbt-athena~=1.10.0" \


### PR DESCRIPTION
## Problem

Every Docker image build — including all preview environment deploys — has been failing since #25313 merged:

```
ERROR: No matching distribution found for dbt-core~=1.12.0
```

dbt Core 1.12 has **no stable release on PyPI**: the latest stable is 1.11.12, and the 1.12 line only has `1.12.0b1–b3` and `1.12.0rc1` (rc1 published 2026-07-07). pip never selects pre-releases for a `~=` spec, so the `dbt1.12` venv install in `dockerfile`, `dockerfile-prs`, and `sandboxes/ai-writeback/e2b.Dockerfile` can't succeed. `dbt-snowflake~=1.12.0` and `dbt-bigquery~=1.12.0` are unsatisfiable for the same reason.

## Fix

Pin the latest available pre-releases explicitly (pip accepts explicit pre-release pins):

- `dbt-core==1.12.0rc1`
- `dbt-snowflake==1.12.0b2`
- `dbt-bigquery==1.12.0b1`

and **drop `dbt-databricks` from the 1.12 venv**: no dbt-databricks release is compatible with dbt-core 1.12 (their 1.12.1 requires `dbt-core<1.11.12`), so it made the set unresolvable. Databricks projects selecting dbt 1.12 will fail with adapter-not-found until dbt-databricks ships a compatible release — same outcome as today, where the image doesn't build at all.

These pins should be bumped to `~=1.12.0` (and databricks restored) once the stable releases ship.

## Verification

- Full pin set resolves via `pip install --dry-run` on Python 3.11 (same as the bookworm base image): core 1.12.0rc1, snowflake 1.12.0b2, bigquery 1.12.0b1, postgres/redshift/trino/athena/duckdb 1.10.x, clickhouse 1.9.3.
- `docker buildx build --check` on the edited `dockerfile` produces warnings identical to main (no new parse/lint issues).

Relates: PROD-7486

deploy-preview
