### PR TITLE
feat: allow embed viewers to add their own dashboard filters

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2538,6 +2538,7 @@ const models: TsoaRoute.Models = {
                 dashboardFiltersInteractivity: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        canAddFilters: { dataType: 'boolean' },
                         hidden: { dataType: 'boolean' },
                         allowedFilters: {
                             dataType: 'union',
@@ -3712,6 +3713,9 @@ const models: TsoaRoute.Models = {
                                 dashboardFiltersInteractivity: {
                                     dataType: 'nestedObjectLiteral',
                                     nestedProperties: {
+                                        canAddFilters: {
+                                            dataType: 'boolean',
+                                        },
                                         hidden: { dataType: 'boolean' },
                                         allowedFilters: {
                                             dataType: 'union',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2537,6 +2537,9 @@
                     },
                     "dashboardFiltersInteractivity": {
                         "properties": {
+                            "canAddFilters": {
+                                "type": "boolean"
+                            },
                             "hidden": {
                                 "type": "boolean"
                             },
@@ -3827,6 +3830,9 @@
                                     },
                                     "dashboardFiltersInteractivity": {
                                         "properties": {
+                                            "canAddFilters": {
+                                                "type": "boolean"
+                                            },
                                             "hidden": {
                                                 "type": "boolean"
                                             },

--- a/packages/common/src/ee/embed/index.test.ts
+++ b/packages/common/src/ee/embed/index.test.ts
@@ -1,0 +1,157 @@
+import {
+    canAddDashboardFiltersInEmbed,
+    EmbedJwtSchema,
+    FilterInteractivityValues,
+    type DashboardFilterInteractivityOptions,
+} from './index';
+
+const baseJwt = {
+    content: {
+        type: 'dashboard' as const,
+        dashboardUuid: 'dashboard-uuid',
+    },
+    exp: 1234567890,
+};
+
+describe('EmbedJwtSchema canAddFilters', () => {
+    it('accepts a dashboard JWT with canAddFilters set', () => {
+        const result = EmbedJwtSchema.parse({
+            ...baseJwt,
+            content: {
+                ...baseJwt.content,
+                dashboardFiltersInteractivity: {
+                    enabled: FilterInteractivityValues.all,
+                    canAddFilters: true,
+                },
+            },
+        });
+
+        expect(
+            result.content.type === 'dashboard' &&
+                'dashboardFiltersInteractivity' in result.content &&
+                result.content.dashboardFiltersInteractivity?.canAddFilters,
+        ).toBe(true);
+    });
+
+    it('accepts a dashboard JWT that omits canAddFilters', () => {
+        const result = EmbedJwtSchema.parse({
+            ...baseJwt,
+            content: {
+                ...baseJwt.content,
+                dashboardFiltersInteractivity: {
+                    enabled: FilterInteractivityValues.all,
+                },
+            },
+        });
+
+        expect(
+            result.content.type === 'dashboard' &&
+                'dashboardFiltersInteractivity' in result.content &&
+                result.content.dashboardFiltersInteractivity?.canAddFilters,
+        ).toBeUndefined();
+    });
+});
+
+describe('canAddDashboardFiltersInEmbed', () => {
+    const cases: Array<{
+        name: string;
+        options: DashboardFilterInteractivityOptions | undefined;
+        expected: boolean;
+    }> = [
+        {
+            name: 'undefined options',
+            options: undefined,
+            expected: false,
+        },
+        {
+            name: 'none, flag on',
+            options: {
+                enabled: FilterInteractivityValues.none,
+                canAddFilters: true,
+            },
+            expected: false,
+        },
+        {
+            name: 'none, flag off',
+            options: {
+                enabled: FilterInteractivityValues.none,
+                canAddFilters: false,
+            },
+            expected: false,
+        },
+        {
+            name: 'none, flag undefined',
+            options: { enabled: FilterInteractivityValues.none },
+            expected: false,
+        },
+        {
+            name: 'some with empty allowedFilters, flag on',
+            options: {
+                enabled: FilterInteractivityValues.some,
+                allowedFilters: [],
+                canAddFilters: true,
+            },
+            expected: false,
+        },
+        {
+            name: 'some with empty allowedFilters, flag off',
+            options: {
+                enabled: FilterInteractivityValues.some,
+                allowedFilters: [],
+                canAddFilters: false,
+            },
+            expected: false,
+        },
+        {
+            name: 'some with allowedFilters, flag on',
+            options: {
+                enabled: FilterInteractivityValues.some,
+                allowedFilters: ['filter-1'],
+                canAddFilters: true,
+            },
+            expected: true,
+        },
+        {
+            name: 'some with allowedFilters, flag off',
+            options: {
+                enabled: FilterInteractivityValues.some,
+                allowedFilters: ['filter-1'],
+                canAddFilters: false,
+            },
+            expected: false,
+        },
+        {
+            name: 'some with allowedFilters, flag undefined',
+            options: {
+                enabled: FilterInteractivityValues.some,
+                allowedFilters: ['filter-1'],
+            },
+            expected: false,
+        },
+        {
+            name: 'all, flag on',
+            options: {
+                enabled: FilterInteractivityValues.all,
+                canAddFilters: true,
+            },
+            expected: true,
+        },
+        {
+            name: 'all, flag off',
+            options: {
+                enabled: FilterInteractivityValues.all,
+                canAddFilters: false,
+            },
+            expected: false,
+        },
+        {
+            name: 'all, flag undefined',
+            options: { enabled: FilterInteractivityValues.all },
+            expected: false,
+        },
+    ];
+
+    it.each(cases)('$name -> $expected', ({ options, expected }) => {
+        expect(canAddDashboardFiltersInEmbed(options)).toBe(expected);
+    });
+});

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -51,6 +51,9 @@ export const DashboardFilterInteractivityOptionsSchema = z.object({
     // Nullish because we have python clients that serialize None to null
     allowedFilters: z.array(z.string()).nullish(),
     hidden: z.boolean().optional(),
+    // Lets embed viewers add their own temporary filters via the filter bar.
+    // Only effective when filter interactivity is enabled.
+    canAddFilters: z.boolean().optional(),
 });
 
 export type DashboardFilterInteractivityOptions = z.infer<
@@ -203,6 +206,9 @@ export type CommonEmbedJwtContent = {
         allowedFilters?: string[] | null;
         // Should the filters be rendered hidden or visible in the UI
         hidden?: boolean;
+        // Lets embed viewers add their own temporary filters via the filter bar.
+        // Only effective when filter interactivity is enabled.
+        canAddFilters?: boolean;
     };
     parameterInteractivity?: {
         enabled: boolean;
@@ -361,6 +367,15 @@ export function isFilterInteractivityEnabled(
                 `Unknown FilterInteractivityValue ${filterInteractivityValue}`,
             );
     }
+}
+
+export function canAddDashboardFiltersInEmbed(
+    filterInteractivityOptions?: DashboardFilterInteractivityOptions,
+): boolean {
+    return (
+        !!isFilterInteractivityEnabled(filterInteractivityOptions) &&
+        filterInteractivityOptions?.canAddFilters === true
+    );
 }
 
 export function isParameterInteractivityEnabled(

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
@@ -1,4 +1,5 @@
 import {
+    canAddDashboardFiltersInEmbed,
     isParameterInteractivityEnabled,
     type Dashboard,
     type InteractivityOptions,
@@ -42,6 +43,9 @@ const EmbedDashboardFilterBar: FC<Props> = ({
     const parametersEnabled = isParameterInteractivityEnabled(
         dashboard.parameterInteractivity,
     );
+    const canAddFilters =
+        shouldShowFilters &&
+        canAddDashboardFiltersInEmbed(dashboard.dashboardFiltersInteractivity);
 
     const totalFiltersCount = shouldShowFilters
         ? dashboardFilters.dimensions.length +
@@ -62,7 +66,7 @@ const EmbedDashboardFilterBar: FC<Props> = ({
 
     // Interactivity may be enabled with nothing to show (hidden filters, or
     // none defined) — render nothing rather than an empty padded row
-    if (!dashboard.canDateZoom && !isCollapsible) {
+    if (!dashboard.canDateZoom && !isCollapsible && !canAddFilters) {
         return null;
     }
 
@@ -97,7 +101,9 @@ const EmbedDashboardFilterBar: FC<Props> = ({
                 gap="sm"
                 style={{ flex: 1, minWidth: 0 }}
             >
-                {shouldShowFilters && <EmbedDashboardFilters />}
+                {shouldShowFilters && (
+                    <EmbedDashboardFilters canAddFilters={canAddFilters} />
+                )}
                 {parametersEnabled && <EmbedDashboardParameters />}
             </Group>
 

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
@@ -1,17 +1,43 @@
+import { getItemId, type DashboardFilterRule } from '@lightdash/common';
 import { Button, Flex, Tooltip } from '@mantine-8/core';
 import { IconRotate2 } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import FiltersProvider from '../../../../../components/common/Filters/FiltersProvider';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import ActiveFilters from '../../../../../features/dashboardFilters/ActiveFilters';
+import AddFilterButton from '../../../../../features/dashboardFilters/AddFilterButton';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
+import useTracking from '../../../../../providers/Tracking/useTracking';
+import { EventName } from '../../../../../types/Events';
 import { embedContractClass } from '../../styles/embedClassContract';
 
-const EmbedDashboardFilters: FC = () => {
+type Props = {
+    canAddFilters?: boolean;
+};
+
+const EmbedDashboardFilters: FC<Props> = ({ canAddFilters = false }) => {
+    const { track } = useTracking();
     const [openPopoverId, setPopoverId] = useState<string>();
 
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const activeTab = useDashboardContext((c) => c.activeTab);
+    const allFilters = useDashboardContext((c) => c.allFilters);
+    const allFilterableFieldsMap = useDashboardContext(
+        (c) => c.allFilterableFieldsMap,
+    );
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const filterableFieldsByTileUuid = useDashboardContext(
+        (c) => c.filterableFieldsByTileUuid,
+    );
+    const addDimensionDashboardFilter = useDashboardContext(
+        (c) => c.addDimensionDashboardFilter,
+    );
+    const addMetricDashboardFilter = useDashboardContext(
+        (c) => c.addMetricDashboardFilter,
+    );
+    const allFilterableMetrics = useDashboardContext(
+        (c) => c.allFilterableMetrics,
+    );
 
     const haveFiltersChanged = useDashboardContext(
         (c) =>
@@ -35,16 +61,65 @@ const EmbedDashboardFilters: FC = () => {
         setPopoverId(undefined);
     }, []);
 
-    const showResetFiltersButton = haveFiltersChanged;
+    const handleSaveNew = useCallback(
+        (value: DashboardFilterRule) => {
+            track({
+                name: EventName.ADD_FILTER_CLICKED,
+                properties: {
+                    mode: 'embed',
+                },
+            });
 
-    // FIXME fieldsWithSuggestions is required
+            const isMetricFilter = allFilterableMetrics?.some(
+                (m) => getItemId(m) === value.target.fieldId,
+            );
+            if (isMetricFilter) {
+                addMetricDashboardFilter(value, true);
+            } else {
+                addDimensionDashboardFilter(value, true);
+            }
+        },
+        [
+            addDimensionDashboardFilter,
+            addMetricDashboardFilter,
+            allFilterableMetrics,
+            track,
+        ],
+    );
+
+    // AddFilterButton renders its own attached reset button once filters have
+    // changed, so the standalone reset pill below would duplicate it.
+    const showResetFiltersButton = !canAddFilters && haveFiltersChanged;
+
     return (
         <FiltersProvider
             projectUuid={projectUuid}
-            itemsMap={{}}
+            itemsMap={allFilterableFieldsMap}
             startOfWeek={undefined}
+            dashboardFilters={allFilters}
+            dashboardTiles={dashboardTiles}
+            filterableFieldsByTileUuid={filterableFieldsByTileUuid}
+            activeTabUuid={activeTab?.uuid}
         >
             <Flex gap="xs" wrap="wrap" w="100%" justify="flex-start">
+                {canAddFilters && (
+                    <AddFilterButton
+                        isEditMode={false}
+                        activeTabUuid={activeTab?.uuid}
+                        openPopoverId={openPopoverId}
+                        onPopoverOpen={handlePopoverOpen}
+                        onPopoverClose={handlePopoverClose}
+                        onSave={handleSaveNew}
+                        onResetDashboardFilters={resetDashboardFilters}
+                        triggerClassName={embedContractClass(
+                            'ld-dashboard-add-filter',
+                        )}
+                        dropdownClassName={embedContractClass(
+                            'ld-dashboard-add-filter-dropdown',
+                        )}
+                        unsavedFiltersTooltip="Filters you add are not saved"
+                    />
+                )}
                 {showResetFiltersButton && (
                     // TODO: create a common component for this
                     <Tooltip label="Reset all filters" withinPortal>

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.test.ts
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.test.ts
@@ -172,4 +172,21 @@ describe('EmbedCodeSnippet Language Helpers', () => {
             expect(languageUndefined(SnippetLanguage.GO)).toBe('None');
         });
     });
+
+    // dashboardFiltersInteractivity.canAddFilters is substituted into the
+    // generated snippets via languageBoolean, same as the `hidden` field.
+    describe('languageBoolean for canAddFilters', () => {
+        it('formats true/false per language', () => {
+            expect(languageBoolean(SnippetLanguage.NODE, true)).toBe('true');
+            expect(languageBoolean(SnippetLanguage.PYTHON, true)).toBe('True');
+            expect(languageBoolean(SnippetLanguage.GO, false)).toBe('false');
+        });
+
+        it('defaults to false when canAddFilters is not set', () => {
+            const canAddFilters: boolean | undefined = undefined;
+            expect(
+                languageBoolean(SnippetLanguage.NODE, canAddFilters ?? false),
+            ).toBe('false');
+        });
+    });
 });

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -690,6 +690,7 @@ const data = {
             enabled: "{{dashboardFiltersInteractivityEnabled}}",
             allowedFilters: {{dashboardFiltersInteractivityAllowedFilters}},
             hidden: {{dashboardFiltersInteractivityHidden}},
+            canAddFilters: {{dashboardFiltersInteractivityCanAddFilters}},
         },
         parameterInteractivity: {
             enabled: {{canChangeParameters}},
@@ -730,6 +731,7 @@ data = {
             "enabled": "{{dashboardFiltersInteractivityEnabled}}",
             "allowedFilters": {{dashboardFiltersInteractivityAllowedFilters}},
             "hidden": {{dashboardFiltersInteractivityHidden}},
+            "canAddFilters": {{dashboardFiltersInteractivityCanAddFilters}},
         },
         "parameterInteractivity": {
             "enabled": {{canChangeParameters}},
@@ -780,6 +782,7 @@ func main() {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
                 Hidden bool \`json:"hidden"\`
+                CanAddFilters bool \`json:"canAddFilters"\`
             } \`json:"dashboardFiltersInteractivity"\`
             ParameterInteractivity struct {
                 Enabled bool \`json:"enabled"\`
@@ -816,6 +819,7 @@ func main() {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
                 Hidden bool \`json:"hidden"\`
+                CanAddFilters bool \`json:"canAddFilters"\`
             } \`json:"dashboardFiltersInteractivity"\`
             ParameterInteractivity struct {
                 Enabled bool \`json:"enabled"\`
@@ -836,10 +840,12 @@ func main() {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
                 Hidden bool \`json:"hidden"\`
+                CanAddFilters bool \`json:"canAddFilters"\`
             }{
                 Enabled: "{{dashboardFiltersInteractivityEnabled}}",
                 AllowedFilters: []string{{{dashboardFiltersInteractivityAllowedFilters}}},
                 Hidden: {{dashboardFiltersInteractivityHidden}},
+                CanAddFilters: {{dashboardFiltersInteractivityCanAddFilters}},
             },
             ParameterInteractivity: struct {
                 Enabled bool \`json:"enabled"\`
@@ -1031,6 +1037,7 @@ const data = {
             enabled: "{{dashboardFiltersInteractivityEnabled}}",
             allowedFilters: {{dashboardFiltersInteractivityAllowedFilters}},
             hidden: {{dashboardFiltersInteractivityHidden}},
+            canAddFilters: {{dashboardFiltersInteractivityCanAddFilters}},
         },
         parameterInteractivity: {
             enabled: {{canChangeParameters}},
@@ -1070,6 +1077,7 @@ data = {
             "enabled": "{{dashboardFiltersInteractivityEnabled}}",
             "allowedFilters": {{dashboardFiltersInteractivityAllowedFilters}},
             "hidden": {{dashboardFiltersInteractivityHidden}},
+            "canAddFilters": {{dashboardFiltersInteractivityCanAddFilters}},
         },
         "parameterInteractivity": {
             "enabled": {{canChangeParameters}},
@@ -1118,6 +1126,7 @@ func main() {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
                 Hidden bool \`json:"hidden"\`
+                CanAddFilters bool \`json:"canAddFilters"\`
             } \`json:"dashboardFiltersInteractivity"\`
             ParameterInteractivity struct {
                 Enabled bool \`json:"enabled"\`
@@ -1153,6 +1162,7 @@ func main() {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
                 Hidden bool \`json:"hidden"\`
+                CanAddFilters bool \`json:"canAddFilters"\`
             } \`json:"dashboardFiltersInteractivity"\`
             ParameterInteractivity struct {
                 Enabled bool \`json:"enabled"\`
@@ -1173,10 +1183,12 @@ func main() {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
                 Hidden bool \`json:"hidden"\`
+                CanAddFilters bool \`json:"canAddFilters"\`
             }{
                 Enabled: "{{dashboardFiltersInteractivityEnabled}}",
                 AllowedFilters: []string{{{dashboardFiltersInteractivityAllowedFilters}}},
                 Hidden: {{dashboardFiltersInteractivityHidden}},
+                CanAddFilters: {{dashboardFiltersInteractivityCanAddFilters}},
             },
             ParameterInteractivity: struct {
                 Enabled bool \`json:"enabled"\`
@@ -1346,6 +1358,14 @@ const getBackendCodeSnippet = (
                         language,
                         data.content.dashboardFiltersInteractivity?.hidden ??
                             false,
+                    ),
+                )
+                .replace(
+                    '{{dashboardFiltersInteractivityCanAddFilters}}',
+                    languageBoolean(
+                        language,
+                        data.content.dashboardFiltersInteractivity
+                            ?.canAddFilters ?? false,
                     ),
                 )
                 .replace(

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
@@ -108,10 +108,12 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
             enabled: newEnabledValue,
             allowedFilters: newAllowedFilters,
             hidden: newHiddenValue,
+            canAddFilters: newCanAddFiltersValue,
         }: {
             enabled?: FilterInteractivityValues;
             allowedFilters?: string[];
             hidden?: boolean;
+            canAddFilters?: boolean;
         }) => {
             const enabled = getFilterInteractivityValue(
                 newEnabledValue ?? interactivityOptions.enabled,
@@ -139,12 +141,17 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                 enabled,
                 allowedFilters,
                 hidden: newHiddenValue ?? interactivityOptions.hidden ?? false,
+                canAddFilters:
+                    newCanAddFiltersValue ??
+                    interactivityOptions.canAddFilters ??
+                    false,
             });
         },
         [
             interactivityOptions.enabled,
             interactivityOptions.allowedFilters,
             interactivityOptions.hidden,
+            interactivityOptions.canAddFilters,
             onInteractivityOptionsChange,
         ],
     );
@@ -182,7 +189,6 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                                 FilterInteractivityValues.all,
                             ),
                             value: FilterInteractivityValues.all,
-                            disabled: dashboardFilters?.length === 0,
                         },
                     ]}
                     size="xs"
@@ -214,6 +220,35 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                 onChange={(event) => {
                     setInteractivityOptions({
                         hidden: event.currentTarget.checked,
+                    });
+                }}
+            />
+            <Switch
+                size="sm"
+                checked={interactivityOptions.canAddFilters ?? false}
+                disabled={
+                    getFilterInteractivityValue(
+                        interactivityOptions.enabled,
+                    ) === FilterInteractivityValues.none
+                }
+                label={
+                    <Group gap="xs">
+                        <Text inherit>Users can add their own filters</Text>
+                        <Tooltip
+                            label="Filters added by viewers are temporary and only last for the current session. This also requires the dashboard's 'Add filter' button to be visible to viewers."
+                            withArrow
+                            withinPortal
+                            multiline
+                            maw="300px"
+                            position="right"
+                        >
+                            <MantineIcon icon={IconInfoCircle} size="sm" />
+                        </Tooltip>
+                    </Group>
+                }
+                onChange={(event) => {
+                    setInteractivityOptions({
+                        canAddFilters: event.currentTarget.checked,
                     });
                 }}
             />

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -125,6 +125,7 @@ const EmbedPreviewDashboardForm: FC<{
             dashboardFiltersInteractivity: {
                 enabled: FilterInteractivityValues.none,
                 hidden: false,
+                canAddFilters: false,
             },
             parameterInteractivity: {
                 enabled: false,
@@ -161,6 +162,9 @@ const EmbedPreviewDashboardForm: FC<{
                         hidden:
                             values.dashboardFiltersInteractivity?.hidden ??
                             false,
+                        canAddFilters:
+                            values.dashboardFiltersInteractivity
+                                ?.canAddFilters ?? false,
                         ...(values.dashboardFiltersInteractivity?.enabled ===
                         FilterInteractivityValues.some
                             ? {

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.test.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.test.ts
@@ -21,10 +21,12 @@ describe('embed class contract', () => {
             'ld-dashboard-header',
             'ld-dashboard-filters',
             'ld-dashboard-filter',
+            'ld-dashboard-add-filter',
             'ld-dashboard-date-zoom',
             'ld-dashboard-parameters',
             'ld-dashboard-parameter',
             'ld-dashboard-filter-dropdown',
+            'ld-dashboard-add-filter-dropdown',
             'ld-dashboard-date-zoom-dropdown',
             'ld-dashboard-parameter-dropdown',
         ]);

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
@@ -22,10 +22,12 @@ export const EMBED_CLASS_CONTRACT = [
     'ld-dashboard-header',
     'ld-dashboard-filters',
     'ld-dashboard-filter', // each filter pill
+    'ld-dashboard-add-filter',
     'ld-dashboard-date-zoom',
     'ld-dashboard-parameters',
     'ld-dashboard-parameter', // each parameter pill
     'ld-dashboard-filter-dropdown', // portalled
+    'ld-dashboard-add-filter-dropdown', // portalled
     'ld-dashboard-date-zoom-dropdown', // portalled
     'ld-dashboard-parameter-dropdown', // portalled
 ] as const satisfies readonly `ld-${EmbedSurface}-${string}`[];

--- a/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
@@ -24,6 +24,14 @@ type Props = {
     onPopoverClose: () => void;
     onSave: (value: DashboardFilterRule) => void;
     onResetDashboardFilters: () => void;
+    /** Public class contract hooks — set only by embed wrappers, never in the main app. */
+    triggerClassName?: string;
+    dropdownClassName?: string;
+    /**
+     * Overrides the view-mode tooltip on the trigger button. Pass `null` to
+     * hide it entirely. Defaults to the app's "edit mode" copy.
+     */
+    unsavedFiltersTooltip?: string | null;
 };
 
 const AddFilterButton: FC<Props> = ({
@@ -34,6 +42,9 @@ const AddFilterButton: FC<Props> = ({
     onPopoverClose,
     onSave,
     onResetDashboardFilters,
+    triggerClassName,
+    dropdownClassName,
+    unsavedFiltersTooltip,
 }) => {
     const popoverId = useId();
     const isAddFilterDisabled = useDashboardContext(
@@ -106,6 +117,19 @@ const AddFilterButton: FC<Props> = ({
     const showResetFiltersButton = !isEditMode && haveFiltersChanged;
     const hasAttachedButton = showResetFiltersButton || isEditMode;
 
+    const tooltipLabel =
+        unsavedFiltersTooltip === undefined ? (
+            <Text fz="xs">
+                Only filters added in{' '}
+                <Text span fw={600}>
+                    'edit'
+                </Text>{' '}
+                mode will be saved
+            </Text>
+        ) : unsavedFiltersTooltip === null ? null : (
+            <Text fz="xs">{unsavedFiltersTooltip}</Text>
+        );
+
     if (isAddFilterDisabled && !isEditMode) {
         if (showResetFiltersButton)
             return (
@@ -151,25 +175,21 @@ const AddFilterButton: FC<Props> = ({
                 offset={1}
                 arrowOffset={14}
                 withinPortal
+                classNames={{ dropdown: dropdownClassName }}
             >
                 <Popover.Target>
                     <Tooltip
-                        disabled={isPopoverOpen || isEditMode}
+                        disabled={
+                            isPopoverOpen || isEditMode || tooltipLabel === null
+                        }
                         position="top-start"
                         withinPortal
                         offset={0}
                         arrowOffset={16}
-                        label={
-                            <Text fz="xs">
-                                Only filters added in{' '}
-                                <Text span fw={600}>
-                                    'edit'
-                                </Text>{' '}
-                                mode will be saved
-                            </Text>
-                        }
+                        label={tooltipLabel}
                     >
                         <Button
+                            className={triggerClassName}
                             size="xs"
                             variant="default"
                             radius={100}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-6982/allow-adding-filters-in-embedded-dashboard-visualizations

## Summary

Embedded dashboard viewers can interact with existing dashboard filters (per `dashboardFiltersInteractivity`) but could not **add new filters**. This PR adds an opt-in `canAddFilters?: boolean` flag inside the embed JWT's `dashboardFiltersInteractivity` options. When set (and filter interactivity is enabled — `'all'`, or `'some'` with a non-empty `allowedFilters`), the embed filter bar renders the **Add filter** button so viewers can add **temporary, session-only** filters over any filterable field in the dashboard's explores.

```ts
dashboardFiltersInteractivity: {
    enabled: 'all',
    canAddFilters: true,
}
```

## Behavior notes

- **Temporary-only**: viewer-added filters live in session state (and the existing temp-filter deep-link param); a fresh embed URL starts clean.
- **Backwards compatible**: old JWTs without the field behave exactly as before (button hidden); JWT schema violations are log-only, so no token breakage.
- **No backend query-path change**: the server already accepts new in-explore filter rules whenever filter interactivity is enabled (the SDK's programmatic filter injection depends on this), and value autocomplete already supports dynamically-generated filter ids. Like the existing `allowedFilters` whitelist, `canAddFilters` is client-side gating; server-side enforcement is unchanged and out of scope here.
- Metric filters in the picker remain gated by the `metric-dashboard-filters` feature flag.

<img width="1034" height="638" alt="image" src="https://github.com/user-attachments/assets/bca11caf-69e0-405c-ac9e-ef38fbaaa0b1" />
