### PR TITLE
feat(mcp): server-side session segmentation for activity grouping

### DIFF
--- a/packages/backend/src/database/pagination/index.ts
+++ b/packages/backend/src/database/pagination/index.ts
@@ -6,9 +6,16 @@ import {
 import { Knex } from 'knex';
 
 export default class KnexPaginate {
+    /**
+     * `countQuery`, when provided, is used for the total count instead of the
+     * data query. It must return the same number of rows — use it when the
+     * data query carries expensive computed columns (e.g. window functions)
+     * that don't affect the row count.
+     */
     static async paginate<TRecord extends {}, TResult>(
         query: Knex.QueryBuilder<TRecord, TResult>,
         paginateArgs?: KnexPaginateArgs,
+        countQuery?: Knex.QueryBuilder,
     ): Promise<KnexPaginatedData<TResult>> {
         if (paginateArgs) {
             const { page, pageSize } = paginateArgs;
@@ -26,7 +33,7 @@ export default class KnexPaginate {
                 WITH count_cte AS (?)
                 SELECT count(*) as count FROM count_cte
             `,
-                [query.clone().clear('limit').clear('offset')],
+                [(countQuery ?? query).clone().clear('limit').clear('offset')],
             );
             const dataPromise = query.clone().offset(offset).limit(pageSize);
             const [countData, data] = await Promise.all([

--- a/packages/backend/src/ee/models/McpToolCallModel.ts
+++ b/packages/backend/src/ee/models/McpToolCallModel.ts
@@ -47,7 +47,7 @@ const STATS_RECENT_ERRORS_LIMIT = 5;
 // A session left open across sittings is split into display segments at
 // this inactivity gap, so old calls aren't hoisted out of their
 // chronological neighborhood when the session resumes days later
-const SESSION_SEGMENT_INACTIVITY_GAP = '1 hour';
+const SESSION_SEGMENT_INACTIVITY_GAP_HOURS = 1;
 
 const capToolArgs = (args: object): object => {
     const serialized = JSON.stringify(args);
@@ -194,16 +194,19 @@ export class McpToolCallModel {
             .with('filtered_calls', filteredCalls)
             .with(
                 'gapped_calls',
-                this.database.raw(`
+                this.database.raw(
+                    `
                     SELECT *,
                         CASE
                             WHEN created_at - lag(created_at) OVER (
                                 PARTITION BY session_block_key ORDER BY created_at
-                            ) > interval '${SESSION_SEGMENT_INACTIVITY_GAP}'
+                            ) > make_interval(hours => ?)
                             THEN 1 ELSE 0
                         END AS gap_start
                     FROM filtered_calls
-                `),
+                `,
+                    [SESSION_SEGMENT_INACTIVITY_GAP_HOURS],
+                ),
             )
             .with(
                 'segmented_calls',
@@ -379,9 +382,12 @@ export class McpToolCallModel {
             ]);
         }
 
+        // Counting the un-joined base query skips the window-function passes
+        // (and the 1:1 display joins) the count doesn't need
         const { data, pagination } = await KnexPaginate.paginate(
             query,
             paginateArgs,
+            this.buildActivityQuery(organizationUuid, filters),
         );
 
         return {

--- a/packages/backend/src/ee/models/McpToolCallModel.ts
+++ b/packages/backend/src/ee/models/McpToolCallModel.ts
@@ -44,6 +44,11 @@ const STATS_TOP_TOOLS_LIMIT = 6;
 const STATS_AGENTS_LIMIT = 6;
 const STATS_RECENT_ERRORS_LIMIT = 5;
 
+// A session left open across sittings is split into display segments at
+// this inactivity gap, so old calls aren't hoisted out of their
+// chronological neighborhood when the session resumes days later
+const SESSION_SEGMENT_INACTIVITY_GAP = '1 hour';
+
 const capToolArgs = (args: object): object => {
     const serialized = JSON.stringify(args);
     if (serialized.length <= MAX_TOOL_ARGS_BYTES) {
@@ -160,18 +165,104 @@ export class McpToolCallModel {
         return query;
     }
 
+    /**
+     * Wraps the filtered calls in a window-function CTE chain that assigns
+     * each call to a display block (its session id, or a shared no-session
+     * block), splits blocks into segments on inactivity gaps, and anchors
+     * each segment at its latest (or earliest, for asc) call. Ordering by
+     * the anchor keeps segments contiguous in the stream while sessionless
+     * calls stay in their chronological position. The final CTE is aliased
+     * back to the tool-call table name so the caller's joins and selects
+     * work unchanged.
+     */
+    private buildSessionGroupedQuery(
+        organizationUuid: string,
+        filters: McpActivityFilters | undefined,
+        direction: 'asc' | 'desc',
+    ): Knex.QueryBuilder {
+        const filteredCalls = this.buildActivityQuery(organizationUuid, filters)
+            .select(`${McpToolCallTableName}.*`)
+            .select(
+                this.database.raw(
+                    `COALESCE(${McpToolCallTableName}.mcp_session_id::text, 'no-session') AS session_block_key`,
+                ),
+            );
+
+        const anchorFn = direction === 'asc' ? 'min' : 'max';
+
+        return this.database
+            .with('filtered_calls', filteredCalls)
+            .with(
+                'gapped_calls',
+                this.database.raw(`
+                    SELECT *,
+                        CASE
+                            WHEN created_at - lag(created_at) OVER (
+                                PARTITION BY session_block_key ORDER BY created_at
+                            ) > interval '${SESSION_SEGMENT_INACTIVITY_GAP}'
+                            THEN 1 ELSE 0
+                        END AS gap_start
+                    FROM filtered_calls
+                `),
+            )
+            .with(
+                'segmented_calls',
+                this.database.raw(`
+                    SELECT *,
+                        sum(gap_start) OVER (
+                            PARTITION BY session_block_key ORDER BY created_at
+                        ) AS session_segment
+                    FROM gapped_calls
+                `),
+            )
+            .with(
+                'session_blocks',
+                this.database.raw(`
+                    SELECT *,
+                        ${anchorFn}(created_at) OVER (
+                            PARTITION BY session_block_key, session_segment
+                        ) AS session_anchor_at,
+                        (count(*) OVER (
+                            PARTITION BY session_block_key, session_segment
+                        ))::int AS session_call_count,
+                        (count(*) FILTER (WHERE status = 'error') OVER (
+                            PARTITION BY session_block_key, session_segment
+                        ))::int AS session_error_count
+                    FROM segmented_calls
+                `),
+            )
+            .from({ [McpToolCallTableName]: 'session_blocks' });
+    }
+
     async findActivityPaginated({
         organizationUuid,
         paginateArgs,
         filters,
         sort,
+        groupBySession = false,
     }: {
         organizationUuid: string;
         paginateArgs?: KnexPaginateArgs;
         filters?: McpActivityFilters;
         sort?: McpActivitySort;
+        groupBySession?: boolean;
     }): Promise<KnexPaginatedData<McpActivityItem[]>> {
-        const query = this.buildActivityQuery(organizationUuid, filters)
+        const sortColumn =
+            sort?.field === 'durationMs' ? 'duration_ms' : 'created_at';
+        const direction = sort?.direction ?? 'desc';
+        // Session grouping reorders rows around segment anchors, which only
+        // makes sense for the time sort
+        const isSessionGrouped = groupBySession && sortColumn === 'created_at';
+
+        const query = (
+            isSessionGrouped
+                ? this.buildSessionGroupedQuery(
+                      organizationUuid,
+                      filters,
+                      direction,
+                  )
+                : this.buildActivityQuery(organizationUuid, filters)
+        )
             .leftJoin(
                 UserTableName,
                 `${UserTableName}.user_uuid`,
@@ -216,6 +307,9 @@ export class McpToolCallModel {
                     auth_type: string;
                     protocol_version: string | null;
                     mcp_session_id: string | null;
+                    session_group_key?: string;
+                    session_call_count?: number;
+                    session_error_count?: number;
                 }[]
             >([
                 `${McpToolCallTableName}.mcp_tool_call_uuid`,
@@ -242,19 +336,48 @@ export class McpToolCallModel {
                 `${McpToolCallTableName}.mcp_session_id`,
             ]);
 
-        const sortColumn =
-            sort?.field === 'durationMs' ? 'duration_ms' : 'created_at';
-        // uuid tie-breaker keeps pagination stable when sort values collide
-        void query.orderBy([
-            {
-                column: `${McpToolCallTableName}.${sortColumn}`,
-                order: sort?.direction ?? 'desc',
-            },
-            {
-                column: `${McpToolCallTableName}.mcp_tool_call_uuid`,
-                order: 'asc',
-            },
-        ]);
+        if (isSessionGrouped) {
+            void query.select(
+                this.database.raw(
+                    `${McpToolCallTableName}.session_block_key || ':' || ${McpToolCallTableName}.session_segment AS session_group_key`,
+                ),
+                `${McpToolCallTableName}.session_call_count`,
+                `${McpToolCallTableName}.session_error_count`,
+            );
+            // Anchor ordering keeps each segment's calls contiguous;
+            // block-key tie-break keeps whole segments intact when anchors
+            // collide
+            void query.orderBy([
+                {
+                    column: `${McpToolCallTableName}.session_anchor_at`,
+                    order: direction,
+                },
+                {
+                    column: `${McpToolCallTableName}.session_block_key`,
+                    order: 'asc',
+                },
+                {
+                    column: `${McpToolCallTableName}.created_at`,
+                    order: direction,
+                },
+                {
+                    column: `${McpToolCallTableName}.mcp_tool_call_uuid`,
+                    order: 'asc',
+                },
+            ]);
+        } else {
+            // uuid tie-breaker keeps pagination stable when sort values collide
+            void query.orderBy([
+                {
+                    column: `${McpToolCallTableName}.${sortColumn}`,
+                    order: direction,
+                },
+                {
+                    column: `${McpToolCallTableName}.mcp_tool_call_uuid`,
+                    order: 'asc',
+                },
+            ]);
+        }
 
         const { data, pagination } = await KnexPaginate.paginate(
             query,
@@ -293,6 +416,14 @@ export class McpToolCallModel {
                 authType: row.auth_type,
                 protocolVersion: row.protocol_version,
                 sessionId: row.mcp_session_id,
+                sessionGroup:
+                    row.session_group_key !== undefined
+                        ? {
+                              key: row.session_group_key,
+                              callCount: row.session_call_count ?? 0,
+                              errorCount: row.session_error_count ?? 0,
+                          }
+                        : null,
             })),
             pagination,
         };

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -592,6 +592,7 @@ export class AiAgentAdminService extends BaseService {
                 paginateArgs,
                 filters: scopedFilters,
                 sort,
+                groupBySession: true,
             });
 
         return { data: { toolCalls: data }, pagination };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12468,8 +12468,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -13128,8 +13128,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -15276,13 +15276,13 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                tableName:
+                                                                                                fieldType:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15365,6 +15365,12 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
+                                                                                                                                operator:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 tableName:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15372,12 +15378,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                                 fieldRef:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
@@ -15674,13 +15674,13 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    tableName:
+                                                                                                    fieldType:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -15778,13 +15778,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -15869,6 +15869,130 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -15918,6 +16042,12 @@ const models: TsoaRoute.Models = {
                                                                                                                         'boolean',
                                                                                                                     required: true,
                                                                                                                 },
+                                                                                                            operator:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             tableName:
                                                                                                                 {
                                                                                                                     dataType:
@@ -15925,12 +16055,6 @@ const models: TsoaRoute.Models = {
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                             fieldRef:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
@@ -15978,130 +16102,6 @@ const models: TsoaRoute.Models = {
                                                                                 required: true,
                                                                             },
                                                                         },
-                                                                    required: true,
-                                                                },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -16271,17 +16271,17 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                    required: true,
+                                                },
                                                 name: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
                                                 uuid: {
                                                     dataType: 'string',
-                                                    required: true,
-                                                },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -16502,11 +16502,6 @@ const models: TsoaRoute.Models = {
                                                                     'nestedObjectLiteral',
                                                                 nestedProperties:
                                                                     {
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
                                                                         kind: {
                                                                             dataType:
                                                                                 'union',
@@ -16548,6 +16543,11 @@ const models: TsoaRoute.Models = {
                                                                                         ],
                                                                                     },
                                                                                 ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
                                                                             required: true,
                                                                         },
                                                                     },
@@ -16755,13 +16755,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -16928,13 +16928,13 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                tableName:
+                                                                                fieldType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
+                                                                                tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -23509,11 +23509,32 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    McpActivitySessionGroup: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                errorCount: { dataType: 'double', required: true },
+                callCount: { dataType: 'double', required: true },
+                key: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     McpActivityItem: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                sessionGroup: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'McpActivitySessionGroup' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 sessionId: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14082,7 +14082,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -14721,7 +14721,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16749,10 +16749,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -16763,8 +16763,8 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "tableName",
                                                                         "fieldType",
+                                                                        "tableName",
                                                                         "label",
                                                                         "name"
                                                                     ],
@@ -16786,13 +16786,13 @@
                                                                                     "required": {
                                                                                         "type": "boolean"
                                                                                     },
+                                                                                    "operator": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldRef": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "operator": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
@@ -16801,9 +16801,9 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "required",
+                                                                                    "operator",
                                                                                     "tableName",
                                                                                     "fieldRef",
-                                                                                    "operator",
                                                                                     "fieldId"
                                                                                 ],
                                                                                 "type": "object"
@@ -16919,10 +16919,10 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldType": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
@@ -16933,8 +16933,8 @@
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "tableName",
                                                                                     "fieldType",
+                                                                                    "tableName",
                                                                                     "label",
                                                                                     "name"
                                                                                 ],
@@ -16977,19 +16977,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17030,6 +17030,66 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldFilterType",
+                                                                                "fieldValueType",
+                                                                                "table",
+                                                                                "fieldType",
+                                                                                "fieldId",
+                                                                                "label",
+                                                                                "description",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "requiredFilters": {
@@ -17043,13 +17103,13 @@
                                                                                         "required": {
                                                                                             "type": "boolean"
                                                                                         },
+                                                                                        "operator": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "tableName": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldRef": {
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "operator": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
@@ -17058,9 +17118,9 @@
                                                                                     },
                                                                                     "required": [
                                                                                         "required",
+                                                                                        "operator",
                                                                                         "tableName",
                                                                                         "fieldRef",
-                                                                                        "operator",
                                                                                         "fieldId"
                                                                                     ],
                                                                                     "type": "object"
@@ -17091,66 +17151,6 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "fieldValueType",
-                                                                                "caseSensitiveFilters",
-                                                                                "isFromJoinedTable",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "label",
-                                                                                "fieldId",
-                                                                                "description",
-                                                                                "name"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -17161,8 +17161,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "explore",
                                                                     "fields",
+                                                                    "explore",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -17273,16 +17273,16 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
+                                                    },
                                                     "name": {
                                                         "type": "string"
                                                     },
                                                     "uuid": {
                                                         "type": "string"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
@@ -17290,9 +17290,9 @@
                                                     "warnings",
                                                     "href",
                                                     "slug",
+                                                    "status",
                                                     "name",
-                                                    "uuid",
-                                                    "status"
+                                                    "uuid"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17360,9 +17360,6 @@
                                                     "steps": {
                                                         "items": {
                                                             "properties": {
-                                                                "label": {
-                                                                    "type": "string"
-                                                                },
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
@@ -17372,11 +17369,14 @@
                                                                         "compile",
                                                                         "stage"
                                                                     ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
                                                                 }
                                                             },
                                                             "required": [
-                                                                "label",
-                                                                "kind"
+                                                                "kind",
+                                                                "label"
                                                             ],
                                                             "type": "object"
                                                         },
@@ -17455,20 +17455,20 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
                                                     "slug",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17521,10 +17521,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -17535,8 +17535,8 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "tableName",
                                                                         "fieldType",
+                                                                        "tableName",
                                                                         "label",
                                                                         "name"
                                                                     ],
@@ -23734,8 +23734,34 @@
                 "type": "string",
                 "enum": ["success", "error"]
             },
+            "McpActivitySessionGroup": {
+                "properties": {
+                    "errorCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "callCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "key": {
+                        "type": "string"
+                    }
+                },
+                "required": ["errorCount", "callCount", "key"],
+                "type": "object",
+                "description": "Server-computed display group for session-grouped activity: a session\nsplit into segments on 1h inactivity gaps (sessionless calls chunk the\nsame way under a shared no-session block). Counts cover the whole\nsegment, not just the loaded page. Null when the query isn't\nsession-grouped (e.g. sorted by duration)."
+            },
             "McpActivityItem": {
                 "properties": {
+                    "sessionGroup": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/McpActivitySessionGroup"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "sessionId": {
                         "type": "string",
                         "nullable": true
@@ -23826,6 +23852,7 @@
                     }
                 },
                 "required": [
+                    "sessionGroup",
                     "sessionId",
                     "protocolVersion",
                     "authType",

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -94,6 +94,19 @@ export type McpActivitySort = {
     direction: 'asc' | 'desc';
 };
 
+/**
+ * Server-computed display group for session-grouped activity: a session
+ * split into segments on 1h inactivity gaps (sessionless calls chunk the
+ * same way under a shared no-session block). Counts cover the whole
+ * segment, not just the loaded page. Null when the query isn't
+ * session-grouped (e.g. sorted by duration).
+ */
+export type McpActivitySessionGroup = {
+    key: string;
+    callCount: number;
+    errorCount: number;
+};
+
 export type McpActivityItem = {
     uuid: string;
     createdAt: string;
@@ -121,6 +134,7 @@ export type McpActivityItem = {
     authType: string;
     protocolVersion: string | null;
     sessionId: string | null;
+    sessionGroup: McpActivitySessionGroup | null;
 };
 
 export type McpActivitySummary = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/mcpActivitySessionRows.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/mcpActivitySessionRows.ts
@@ -20,56 +20,70 @@ export type McpCallRow = {
 export type McpActivityRow = McpSessionHeaderRow | McpCallRow;
 
 type SessionGroup = {
-    sessionId: string | null;
+    key: string;
     calls: McpActivityItem[];
 };
 
-// Contiguous runs only: a session whose calls interleave in time with
-// another session's shows as separate blocks. Exact grouping needs
-// server-side session pagination.
-const groupContiguousBySession = (calls: McpActivityItem[]): SessionGroup[] =>
+// The server emits session-grouped queries with segments already
+// contiguous, so grouping consecutive keys reconstructs them exactly;
+// rows without a server group (e.g. from older cached pages) fall back
+// to standalone one-call groups
+const getGroupKey = (call: McpActivityItem): string =>
+    call.sessionGroup?.key ?? `call:${call.uuid}`;
+
+const groupConsecutiveByKey = (calls: McpActivityItem[]): SessionGroup[] =>
     calls.reduce<SessionGroup[]>((groups, call) => {
+        const key = getGroupKey(call);
         const lastGroup = groups[groups.length - 1];
-        if (lastGroup && lastGroup.sessionId === call.sessionId) {
+        if (lastGroup && lastGroup.key === key) {
             lastGroup.calls.push(call);
             return groups;
         }
-        return [...groups, { sessionId: call.sessionId, calls: [call] }];
+        return [...groups, { key, calls: [call] }];
     }, []);
-
-// Keyed by the first call's uuid so keys stay stable while infinite scroll
-// appends older pages (a run only ever grows at its tail).
-const getGroupKey = (group: SessionGroup): string =>
-    `${group.sessionId ?? 'no-session'}:${group.calls[0].uuid}`;
 
 export const buildSessionRows = (
     calls: McpActivityItem[],
     collapsedGroups: ReadonlySet<string>,
 ): McpActivityRow[] =>
-    groupContiguousBySession(calls).flatMap<McpActivityRow>((group) => {
-        const groupKey = getGroupKey(group);
+    groupConsecutiveByKey(calls).flatMap<McpActivityRow>((group) => {
+        const [firstCall] = group.calls;
+        const { sessionGroup, sessionId } = firstCall;
+        const callCount = sessionGroup?.callCount ?? group.calls.length;
+        // A lone sessionless call reads better as a plain chronological row
+        // than as a one-call "No session ID" group
+        const isHeaderless =
+            !sessionGroup || (sessionId === null && callCount === 1);
+        if (isHeaderless) {
+            return group.calls.map<McpCallRow>((call) => ({
+                type: 'call',
+                groupKey: group.key,
+                call,
+            }));
+        }
         const latestCall = group.calls.reduce((latest, call) =>
             call.createdAt > latest.createdAt ? call : latest,
         );
         const header: McpSessionHeaderRow = {
             type: 'session',
-            groupKey,
-            sessionId: group.sessionId,
+            groupKey: group.key,
+            sessionId,
             clientName: latestCall.clientName,
             clientVersion: latestCall.clientVersion,
-            callCount: group.calls.length,
-            errorCount: group.calls.filter((call) => call.status === 'error')
-                .length,
+            callCount,
+            errorCount:
+                sessionGroup?.errorCount ??
+                group.calls.filter((call) => call.status === 'error').length,
             latestCallAt: latestCall.createdAt,
         };
-        if (collapsedGroups.has(groupKey)) {
+        if (collapsedGroups.has(group.key)) {
             return [header];
         }
         return [
             header,
             ...group.calls.map<McpCallRow>((call) => ({
                 type: 'call',
-                groupKey,
+                groupKey: group.key,
                 call,
             })),
         ];


### PR DESCRIPTION
## Summary

Moves session grouping into SQL so it's exact (stacked on #25334). The activity query now orders calls by *session segments*: each call belongs to a block (its session id, or a shared no-session block), blocks split into segments on 1-hour inactivity gaps, and each segment anchors at its latest call.

This fixes the two limitations of client-side grouping:

- **Interleaved sessions no longer fragment** — a segment's calls are contiguous in the stream even when other activity overlaps them in time.
- **A session resumed days later renders as two separately placed segments** sharing the same session id, instead of hoisting old calls out of their chronological neighborhood. Sessionless calls keep their exact chronological position.

## Implementation

- `McpToolCallModel.buildSessionGroupedQuery`: CTE chain (block key → gap detection via `lag` → running-sum segment numbering → per-segment anchor/counts via window functions), with the final CTE aliased back to the tool-call table name so existing joins, selects, and `KnexPaginate` work unchanged
- Each row carries `sessionGroup: { key, callCount, errorCount }` — server-computed totals for the whole segment, so headers show true counts even when a segment spans page boundaries
- Grouping is opt-in per query: the activity endpoint enables it (time sort only); stats `recentErrors` keeps flat chronological order
- Frontend groups by the server key instead of run-contiguity, and a lone sessionless call renders as a plain row instead of a one-call group

## Testing

Validated the SQL directly and end-to-end in the dev app with a seeded session spanning two sittings 3 days apart: the return sitting renders at the top (2 calls · 1 error), the first sitting renders at its 3-days-ago position (3 calls), both labeled with the same session id. Typecheck, lint, and backend tests pass.

Relates: ZAP-602

🤖 Generated with [Claude Code](https://claude.com/claude-code)