### PR TITLE
chore(backend): mark service methods only used by deprecated routes as deprecated

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -302,6 +302,7 @@ export class EmbedService extends BaseService {
         return this.getConfig(account, projectUuid);
     }
 
+    /** @deprecated Superseded by updateConfig (PATCH /api/v1/embed/{projectUuid}/config). */
     async updateDashboards(
         account: SessionAccount,
         projectUuid: string,
@@ -1462,6 +1463,7 @@ export class EmbedService extends BaseService {
         });
     }
 
+    /** @deprecated Only used by the deprecated embed chart-and-results endpoint; use executeAsyncDashboardTileQuery instead. */
     async getChartAndResults(
         projectUuid: string,
         account: AnonymousAccount,
@@ -1766,6 +1768,7 @@ export class EmbedService extends BaseService {
         };
     }
 
+    /** @deprecated Superseded by AsyncQueryService.executeAsyncCalculateTotalFromQueryHistory. */
     async calculateTotalFromSavedChart(
         account: AnonymousAccount,
         projectUuid: string,
@@ -1847,7 +1850,7 @@ export class EmbedService extends BaseService {
         }
     }
 
-    /** @deprecated Superseded by the V2 calculate-total path (kind 'columnSubtotal'). */
+    /** @deprecated Superseded by AsyncQueryService.executeAsyncCalculateTotalFromQueryHistory (kind 'columnSubtotal'). */
     async calculateSubtotalsFromSavedChart(
         account: AnonymousAccount,
         projectUuid: string,
@@ -1985,6 +1988,7 @@ export class EmbedService extends BaseService {
     /**
      * Calculate totals from a raw metric query in embed context.
      * This is used when exploring data directly (not from a saved chart).
+     * @deprecated Superseded by AsyncQueryService.executeAsyncCalculateTotalFromQueryHistory.
      */
     async calculateTotalFromQuery(
         account: AnonymousAccount,
@@ -2064,7 +2068,7 @@ export class EmbedService extends BaseService {
     /**
      * Calculate subtotals from a raw metric query in embed context.
      * This is used when exploring data directly (not from a saved chart).
-     * @deprecated Superseded by the V2 calculate-total path (kind 'columnSubtotal').
+     * @deprecated Superseded by AsyncQueryService.executeAsyncCalculateTotalFromQueryHistory (kind 'columnSubtotal').
      */
     async calculateSubtotalsFromQuery(
         account: AnonymousAccount,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7137,7 +7137,7 @@ export class AsyncQueryService extends ProjectService {
         return rows[0];
     }
 
-    /** @deprecated Superseded by the V2 calculate-total path (kind 'columnSubtotal'). */
+    /** @deprecated Superseded by executeAsyncCalculateTotalFromQueryHistory (kind 'columnSubtotal'). */
     async calculateMetricQuerySubtotals({
         account,
         projectUuid,
@@ -7244,6 +7244,7 @@ export class AsyncQueryService extends ProjectService {
         return SubtotalsCalculator.formatSubtotalEntries(subtotalsEntries);
     }
 
+    /** @deprecated Superseded by executeAsyncCalculateTotalFromQueryHistory. */
     async calculateTotalFromSavedChart(
         account: Account,
         chartUuid: string,
@@ -7356,6 +7357,7 @@ export class AsyncQueryService extends ProjectService {
         }
     }
 
+    /** @deprecated Superseded by executeAsyncCalculateTotalFromQueryHistory. */
     async calculateTotalFromQuery(
         account: Account,
         projectUuid: string,

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -746,6 +746,7 @@ export class CatalogService<
         };
     }
 
+    /** @deprecated Only used by the deprecated table metadata endpoint, which will be removed without replacement. */
     async getMetadata(user: SessionUser, projectUuid: string, table: string) {
         // Right now we return the full cached explore based on name
         // We could extract some data to only return what we need instead
@@ -1303,6 +1304,7 @@ export class CatalogService<
         return metrics[0];
     }
 
+    /** @deprecated Only used by deprecated metrics tree endpoints; use getMetricsTreeDetails instead. */
     async getMetricsTree(
         user: SessionUser,
         projectUuid: string,
@@ -1394,6 +1396,7 @@ export class CatalogService<
         }
     }
 
+    /** @deprecated Only used by the deprecated create-edge endpoint; use updateMetricsTree instead. */
     async createMetricsTreeEdge(
         user: SessionUser,
         projectUuid: string,
@@ -1684,6 +1687,7 @@ export class CatalogService<
         return getTypeValidSegmentDimensions(allDimensions);
     }
 
+    /** @deprecated Only used by the deprecated delete-edge endpoint; use updateMetricsTree instead. */
     async deleteMetricsTreeEdge(
         user: SessionUser,
         projectUuid: string,

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -986,6 +986,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
 
     /**
      * Get the YAML file for an explore's base table
+     * @deprecated Only used by the deprecated explore files endpoint; use getFileOrDirectory instead.
      */
     async getFileForExplore(
         user: SessionUser,
@@ -1102,6 +1103,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
 
     /**
      * Create a pull request with arbitrary file changes
+     * @deprecated Only used by the deprecated file-change PR endpoint; use createPullRequestFromBranch instead.
      */
     async createPullRequestWithFileChange(
         user: SessionUser,

--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -53,6 +53,7 @@ export class GroupsService extends BaseService {
         return featureFlag.enabled;
     }
 
+    /** @deprecated Only used by the deprecated add-user-to-group endpoint; use update with the full member set instead. */
     async addGroupMember(
         user: SessionUser,
         member: GroupMembership,
@@ -101,6 +102,7 @@ export class GroupsService extends BaseService {
         return groupMembership;
     }
 
+    /** @deprecated Only used by the deprecated remove-user-from-group endpoint; use update with the full member set instead. */
     async removeGroupMember(
         user: SessionUser,
         member: GroupMembership,
@@ -263,6 +265,7 @@ export class GroupsService extends BaseService {
         return updatedGroup;
     }
 
+    /** @deprecated Only used by the deprecated group members endpoint; use get with includeMembers instead. */
     async getGroupMembers(
         user: SessionUser,
         groupUuid: string,
@@ -290,6 +293,7 @@ export class GroupsService extends BaseService {
         return group.members;
     }
 
+    /** @deprecated Only used by the deprecated group project access endpoint; use RolesService.upsertProjectGroupRoleAssignment instead. */
     async addProjectAccess(
         user: SessionUser,
         { groupUuid, projectUuid, role }: ProjectGroupAccess,
@@ -345,6 +349,7 @@ export class GroupsService extends BaseService {
         };
     }
 
+    /** @deprecated Only used by the deprecated group project access endpoint; use RolesService.deleteProjectRoleAssignment instead. */
     async removeProjectAccess(
         user: SessionUser,
         {
@@ -398,6 +403,7 @@ export class GroupsService extends BaseService {
         return removed;
     }
 
+    /** @deprecated Only used by the deprecated group project access endpoint; use RolesService.updateProjectRoleAssignment instead. */
     async updateProjectAccess(
         user: SessionUser,
         {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -554,6 +554,7 @@ export class OrganizationService extends BaseService {
         });
     }
 
+    /** @deprecated Only used by the deprecated get-member-by-uuid endpoint; use getUsers instead. */
     async getMemberByUuid(
         user: SessionUser,
         memberUuid: string,
@@ -585,6 +586,7 @@ export class OrganizationService extends BaseService {
         return member;
     }
 
+    /** @deprecated Only used by the deprecated get-member-by-email endpoint; use getUsers instead. */
     async getMemberByEmail(
         user: SessionUser,
         email: string,
@@ -617,6 +619,7 @@ export class OrganizationService extends BaseService {
         return member;
     }
 
+    /** @deprecated Only used by the deprecated update-member endpoint; use RolesService.upsertOrganizationUserRoleAssignment instead. */
     async updateMember(
         authenticatedUser: SessionUser,
         memberUserUuid: string,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4637,6 +4637,7 @@ export class ProjectService extends BaseService {
         }
     }
 
+    /** @deprecated Only used by the deprecated runUnderlyingDataQuery endpoint; use AsyncQueryService.executeAsyncUnderlyingDataQuery instead. */
     async runUnderlyingDataQuery(
         account: Account,
         metricQuery: MetricQuery,
@@ -4777,6 +4778,7 @@ export class ProjectService extends BaseService {
         };
     }
 
+    /** @deprecated Only used by the deprecated chart-and-results endpoint; use AsyncQueryService.executeAsyncDashboardChartQuery instead. */
     async getChartAndResults({
         account,
         chartUuid,
@@ -5885,6 +5887,7 @@ export class ProjectService extends BaseService {
         };
     }
 
+    /** @deprecated Only used by the deprecated SQL runner results endpoint; use AsyncQueryService.getAsyncQueryResults instead. */
     async getFileStream(
         user: SessionUser,
         projectUuid: string,
@@ -7819,6 +7822,7 @@ export class ProjectService extends BaseService {
         }
     }
 
+    /** @deprecated Only used by the deprecated project access endpoint; use RolesService.getProjectRoleAssignments instead. */
     async getProjectMemberAccess(
         user: SessionUser,
         projectUuid: string,
@@ -7915,6 +7919,7 @@ export class ProjectService extends BaseService {
             );
     }
 
+    /** @deprecated Only used by the deprecated project access endpoint; use RolesService.upsertProjectUserRoleAssignment instead. */
     async updateProjectAccess(
         user: SessionUser,
         projectUuid: string,
@@ -8069,6 +8074,7 @@ export class ProjectService extends BaseService {
         });
     }
 
+    /** @deprecated Only used by the deprecated project access endpoint; use RolesService.deleteProjectRoleAssignment instead. */
     async deleteProjectAccess(
         user: SessionUser,
         projectUuid: string,
@@ -8147,6 +8153,7 @@ export class ProjectService extends BaseService {
         return [...savedQueries, ...savedSqlCharts];
     }
 
+    /** @deprecated Only used by the deprecated chart summaries endpoint. */
     async getChartSummaries(
         user: SessionUser,
         projectUuid: string,
@@ -8820,6 +8827,7 @@ export class ProjectService extends BaseService {
         );
     }
 
+    /** @deprecated Only used by the deprecated custom metrics endpoint, which will be removed without replacement. */
     async getCustomMetrics(
         user: SessionUser,
         projectUuid: string,

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -1057,6 +1057,7 @@ export class RolesService extends BaseService {
         });
     }
 
+    /** @deprecated Only used by the deprecated remove-scope endpoint; use updateRole with scopes.remove instead. */
     async removeScopeFromRole(
         account: Account,
         roleUuid: string,

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -657,6 +657,7 @@ export class SavedSqlService
         await this.savedSqlModel.permanentDelete(savedSqlUuid);
     }
 
+    /** @deprecated Superseded by AsyncQueryService.executeAsyncSqlQuery. */
     async getResultJobFromSql(
         user: SessionUser,
         projectUuid: string,
@@ -698,6 +699,7 @@ export class SavedSqlService
         return { jobId };
     }
 
+    /** @deprecated Superseded by AsyncQueryService.executeAsyncSqlQuery with pivotConfiguration. */
     async getResultJobFromSqlPivotQuery(
         user: SessionUser,
         projectUuid: string,
@@ -762,6 +764,7 @@ export class SavedSqlService
         return { jobId };
     }
 
+    /** @deprecated Superseded by AsyncQueryService.executeAsyncSqlChartQuery. */
     async getSqlChartResultJob(
         user: SessionUser,
         projectUuid: string,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1332,6 +1332,7 @@ export class SchedulerService extends BaseService {
         }
     }
 
+    /** @deprecated Only used by the deprecated scheduler jobs endpoint, which will be removed without replacement. */
     async getScheduledJobs(
         user: SessionUser,
         schedulerUuid: string,
@@ -1382,6 +1383,7 @@ export class SchedulerService extends BaseService {
         await this.schedulerModel.updateGsheetExportProgress(jobId, progress);
     }
 
+    /** @deprecated Only used by the deprecated scheduler logs endpoint; use getSchedulerRuns instead. */
     async getSchedulerLogs(
         user: SessionUser,
         projectUuid: string,


### PR DESCRIPTION
Closes: n/a — no Linear ticket or GitHub issue for this change

### Description:

Audited every deprecated API route (`@Deprecated()` / `getDeprecatedRouteMiddleware`) across the backend controllers and added a one-line `@deprecated` JSDoc to the ~35 service methods whose only callers are those deprecated routes, so IDEs and lint flag any new usage. Where a replacement exists, each annotation names the new service method to use (e.g. `AsyncQueryService.executeAsyncSqlQuery`, `RolesService.upsertProjectUserRoleAssignment`, `CatalogService.updateMetricsTree`); methods behind routes sunsetting without replacement are marked as such. Methods also called by live code paths (e.g. `runSqlQuery` via FunnelService, `runExploreQuery` via postgres wire, `AsyncQueryService.download` via scheduler tasks) were deliberately left untouched. Comment-only change — no runtime behavior, API surface, or generated spec changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)