### PR TITLE
fix: remove navbar height offset on embedded AI agent pages

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -19,7 +19,6 @@ import {
     type ImperativePanelHandle,
 } from 'react-resizable-panels';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { clearPreview } from '../../store/aiArtifactSlice';
 import {
@@ -36,6 +35,7 @@ interface Props extends PropsWithChildren {
     Header?: React.ReactNode;
     isAgentSidebarCollapsed?: boolean;
     setIsAgentSidebarCollapsed?: (isAgentSidebarCollapsed: boolean) => void;
+    isEmbed?: boolean;
 }
 
 export const AiAgentPageLayout: React.FC<Props> = ({
@@ -44,6 +44,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
     children,
     setIsAgentSidebarCollapsed,
     isAgentSidebarCollapsed,
+    isEmbed = false,
 }) => {
     const dispatch = useAiAgentStoreDispatch();
     const sidebarPanelRef = useRef<ImperativePanelHandle>(null);
@@ -81,8 +82,9 @@ export const AiAgentPageLayout: React.FC<Props> = ({
 
     return (
         <div
-            className={styles.workspace}
-            style={{ height: `calc(100vh - ${NAVBAR_HEIGHT}px)` }}
+            className={`${styles.workspace} ${
+                isEmbed ? styles.workspaceEmbed : ''
+            }`}
         >
             <PanelGroup
                 direction="horizontal"

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
@@ -113,6 +113,7 @@
     flex: 1;
     min-height: 0;
     overflow: hidden;
+    height: calc(100vh - var(--navbar-height));
 
     @mixin light {
         background-color: var(--mantine-color-white);
@@ -121,6 +122,11 @@
     @mixin dark {
         background-color: var(--mantine-color-dark-8);
     }
+}
+
+/* Embed pages render without the app navbar */
+.workspaceEmbed {
+    height: 100vh;
 }
 
 .floatingArtifactRegion {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -204,6 +204,7 @@ const AgentPage = () => {
 
     return (
         <AiAgentPageLayout
+            isEmbed={isEmbed}
             setIsAgentSidebarCollapsed={setIsAgentSidebarCollapsed}
             isAgentSidebarCollapsed={isAgentSidebarCollapsed}
             Sidebar={

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentsNotAuthorizedPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentsNotAuthorizedPage.tsx
@@ -20,7 +20,7 @@ const AiAgentsNotAuthorizedPage: FC = () => {
     const isEmbed = isEmbedAiAgentRoute();
 
     return (
-        <AiAgentPageLayout>
+        <AiAgentPageLayout isEmbed={isEmbed}>
             <Center h="80%">
                 <Stack align="center" maw="480px">
                     <Box pos="relative">


### PR DESCRIPTION
## Summary

Fixes a ~50px gray band at the bottom of the embedded AI agent page. `AiAgentPageLayout` sized its workspace as `calc(100vh - NAVBAR_HEIGHT)`, but embed routes render without the app navbar, so the last 50px of the iframe showed the page body's gray background below the chat/artifact panels.

## Changes

- Moved the workspace height from an inline `style` prop into the CSS module, using the shared `--navbar-height` var.
- Added a `.workspaceEmbed` variant (`height: 100vh`) applied via a new optional `isEmbed` prop on `AiAgentPageLayout`.
- `AgentPage` and `AiAgentsNotAuthorizedPage` (both reachable under `/embed/...`) now pass their existing `isEmbed` flag. The non-embed consumers (`AgentsWelcome`, `AgentsRouterPage`) keep the navbar offset — no behavior change in the main app.

## Testing

- Verified in the embed showcase app: the embed now fills the iframe to the bottom edge, and the standalone `/projects/.../ai-agents` pages are unaffected.
- Frontend typecheck and lint pass.

Closes: https://linear.app/lightdash/issue/SPK-539/ui-improvement-weird-bottom-padding-on-ai-embed

