### PR TITLE
fix(custom-roles): clarify role scope selection

### DIFF
--- a/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.module.css
+++ b/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.module.css
@@ -20,6 +20,88 @@
     flex-direction: column;
 }
 
+.roleLevelOptions {
+    width: 100%;
+}
+
+.roleLevelOption {
+    flex: 1 1 280px;
+    min-width: min(100%, 280px);
+    padding: var(--mantine-spacing-md);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-body);
+    transition:
+        border-color 150ms ease,
+        box-shadow 150ms ease;
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.roleLevelOption:hover:not(:disabled) {
+    border-color: var(--mantine-color-blue-outline);
+
+    @mixin dark {
+        border-color: var(--mantine-color-blue-outline);
+    }
+}
+
+.roleLevelOption[data-selected='true'] {
+    border-color: var(--mantine-color-blue-outline);
+    box-shadow: 0 0 0 1px var(--mantine-color-blue-outline);
+
+    @mixin dark {
+        border-color: var(--mantine-color-blue-outline);
+    }
+}
+
+.roleLevelOption:disabled {
+    cursor: not-allowed;
+}
+
+.roleLevelIcon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    flex: 0 0 40px;
+    border-radius: var(--mantine-radius-md);
+    color: var(--mantine-color-ldGray-6);
+    background-color: var(--mantine-color-ldGray-0);
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-4);
+        background-color: var(--mantine-color-ldDark-5);
+    }
+}
+
+.roleLevelOption[data-selected='true'] .roleLevelIcon {
+    color: var(--mantine-color-blue-filled);
+}
+
+.roleLevelIndicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    flex: 0 0 24px;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: 50%;
+    color: var(--mantine-color-blue-filled);
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldDark-3);
+    }
+}
+
+.roleLevelIndicator[data-selected='true'] {
+    border-color: transparent;
+}
+
 .permissionsCard {
     display: flex;
     flex-direction: column;

--- a/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
@@ -5,17 +5,19 @@ import {
     Flex,
     Group,
     Input,
-    SegmentedControl,
     Stack,
     Text,
     Textarea,
     TextInput,
+    UnstyledButton,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import {
     IconAlertTriangleFilled,
+    IconBuilding,
     IconCircleCheckFilled,
     IconCircleXFilled,
+    IconFolder,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
@@ -68,6 +70,28 @@ const dependencyStatusItems = [
     key: DependencyStatus;
     icon: typeof IconCircleCheckFilled;
     color: string;
+}>;
+
+const roleLevelOptions = [
+    {
+        value: 'project',
+        title: 'Project role',
+        description:
+            'Assigned per project. A user or group can hold different project roles on different projects.',
+        icon: IconFolder,
+    },
+    {
+        value: 'organization',
+        title: 'Organization role',
+        description:
+            'Grants access to organization-wide admin settings, applied across the whole org. Any project-scoped permissions you add here will apply to every project.',
+        icon: IconBuilding,
+    },
+] as const satisfies Array<{
+    value: RoleLevel;
+    title: string;
+    description: string;
+    icon: typeof IconFolder;
 }>;
 
 /**
@@ -151,7 +175,7 @@ export const RoleBuilder: FC<Props> = ({
     const isLevelDisabled = isWorking || mode === 'edit' || levelLocked;
     const levelHint =
         mode === 'edit'
-            ? "Type can't be changed after creation."
+            ? "Role scope can't be changed after creation."
             : levelLocked
               ? levelLockedHint
               : undefined;
@@ -167,6 +191,105 @@ export const RoleBuilder: FC<Props> = ({
                 <Stack gap="xs" className={styles.contentStack}>
                     <SettingsCard>
                         <Stack gap="md">
+                            <Stack gap="xs">
+                                <Stack gap="two">
+                                    <Input.Label>Role scope</Input.Label>
+                                    <Text fz="sm" c="dimmed">
+                                        Choose where this role can be assigned.
+                                        This can't be changed after the role is
+                                        created.
+                                    </Text>
+                                    {levelHint && (
+                                        <Text fz="xs" c="dimmed">
+                                            {levelHint}
+                                        </Text>
+                                    )}
+                                </Stack>
+                                <Group
+                                    gap="md"
+                                    align="stretch"
+                                    className={styles.roleLevelOptions}
+                                >
+                                    {roleLevelOptions.map((option) => {
+                                        const isSelected =
+                                            form.values.level === option.value;
+
+                                        return (
+                                            <UnstyledButton
+                                                key={option.value}
+                                                className={
+                                                    styles.roleLevelOption
+                                                }
+                                                data-selected={isSelected}
+                                                aria-pressed={isSelected}
+                                                disabled={isLevelDisabled}
+                                                onClick={() =>
+                                                    handleLevelChange(
+                                                        option.value,
+                                                    )
+                                                }
+                                            >
+                                                <Group
+                                                    align="flex-start"
+                                                    justify="space-between"
+                                                    wrap="nowrap"
+                                                    gap="md"
+                                                >
+                                                    <Group
+                                                        align="flex-start"
+                                                        wrap="nowrap"
+                                                        gap="md"
+                                                    >
+                                                        <Box
+                                                            className={
+                                                                styles.roleLevelIcon
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                icon={
+                                                                    option.icon
+                                                                }
+                                                                size="md"
+                                                            />
+                                                        </Box>
+                                                        <Stack gap="xs">
+                                                            <Text fw={600}>
+                                                                {option.title}
+                                                            </Text>
+                                                            <Text
+                                                                fz="sm"
+                                                                c="dimmed"
+                                                                lh={1.45}
+                                                            >
+                                                                {
+                                                                    option.description
+                                                                }
+                                                            </Text>
+                                                        </Stack>
+                                                    </Group>
+                                                    <Box
+                                                        className={
+                                                            styles.roleLevelIndicator
+                                                        }
+                                                        data-selected={
+                                                            isSelected
+                                                        }
+                                                    >
+                                                        {isSelected ? (
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconCircleCheckFilled
+                                                                }
+                                                                size="md"
+                                                            />
+                                                        ) : null}
+                                                    </Box>
+                                                </Group>
+                                            </UnstyledButton>
+                                        );
+                                    })}
+                                </Group>
+                            </Stack>
                             <TextInput
                                 label="Role name"
                                 placeholder="e.g., Finance Analyst"
@@ -181,29 +304,6 @@ export const RoleBuilder: FC<Props> = ({
                                 disabled={isWorking}
                                 {...form.getInputProps('description')}
                             />
-                            <Stack gap="two">
-                                <Input.Label>Type</Input.Label>
-                                <SegmentedControl
-                                    data={[
-                                        {
-                                            value: 'project',
-                                            label: 'Project',
-                                        },
-                                        {
-                                            value: 'organization',
-                                            label: 'Organization',
-                                        },
-                                    ]}
-                                    disabled={isLevelDisabled}
-                                    value={form.values.level}
-                                    onChange={handleLevelChange}
-                                />
-                                {levelHint && (
-                                    <Text fz="xs" c="dimmed">
-                                        {levelHint}
-                                    </Text>
-                                )}
-                            </Stack>
                         </Stack>
                     </SettingsCard>
 

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -483,12 +483,12 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
                             c={form.errors.scopes ? 'red' : 'default'}
                             fz="sm"
                         >
-                            Select at least one scope for this role
+                            Select at least one permission for this role
                         </Text>
                     </Stack>
 
                     <TextInput
-                        placeholder="Search scopes by name or group..."
+                        placeholder="Search permissions by name or group..."
                         w={300}
                         leftSection={
                             <MantineIcon icon={IconSearch} size="sm" />
@@ -499,7 +499,11 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
                 </Group>
                 <Group justify="space-between">
                     <Text fz="sm" c="dimmed">
-                        {selectedCount} of {totalScopes} scopes selected
+                        {selectedCount} of {totalScopes}{' '}
+                        <Text span fw={600} inherit>
+                            {level}
+                        </Text>{' '}
+                        permissions selected
                     </Text>
                     <Group gap="xs">
                         <Button
@@ -525,7 +529,7 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
             {filteredScopes.length === 0 ? (
                 <Paper p="xl" style={{ flexShrink: 0 }}>
                     <Text ta="center" fz="sm">
-                        No scopes found matching your search.
+                        No permissions found matching your search.
                     </Text>
                 </Paper>
             ) : (
@@ -584,7 +588,7 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
                                 />
                             ) : (
                                 <Text ta="center" c="dimmed" fz="sm">
-                                    Select a group to view its scopes
+                                    Select a group to view its permissions
                                 </Text>
                             )}
                         </Flex>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8620/improve-custom-role-builder-ux-to-clarify-the-difference-between-org

## Screenshot

<img width="2808" height="1918" alt="CleanShot 2026-07-09 at 14 58 55@2x" src="https://github.com/user-attachments/assets/aa551461-0702-4079-bd3b-7e5a4a66c545" />


## Summary

Clarifies the custom role builder by making role scope the first decision in the form and explaining how project and organization roles differ.

### Role scope selector

- Replaces the segmented control with two selectable cards for **Project role** and **Organization role**.
- Keeps the selected state restrained: neutral card background, blue outline, selected-only blue icon treatment, and a check indicator.
- Moves role scope above role name so admins choose the assignment boundary before naming the role.
- Uses the requested organization-role copy to explain that project-scoped permissions apply to every project for organization roles.

Before:
`Role type` segmented control below role name/description

After:
`Role scope` cards first, then role name/description

### Permission copy

- Uses “permissions” in the permission picker UI instead of exposing internal “scopes” wording.
- Updates the selected count to include the current role scope, for example: `3 of 93 project permissions selected`, with the scope label emphasized.

## Regression analysis

- Create, edit, and duplicate flows still submit the existing `level` and `scopes` values through `RoleBuilder`.
- The role scope cards call the same `handleLevelChange` path as the previous segmented control.
- Permission selection behavior is unchanged; only visible copy changes in `ScopeSelector`.
- No backend/API surface touched.

## Test plan

- [x] `pnpm -F frontend exec oxfmt src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.module.css src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx --check`
- [x] `pnpm -F frontend typecheck:fast`
- [x] `pnpm -F frontend lint` passed with 0 errors and 3 unrelated existing AI-copilot warnings.
- [x] `git diff --check`

No UI tests added per request.
