### PR TITLE
feat(charts): persist legend selection state in saved charts

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5649,6 +5649,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                selected: { ref: 'Record_string.boolean_' },
                 placement: { ref: 'LegendPlacement' },
                 icon: {
                     dataType: 'union',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6289,6 +6289,10 @@
             },
             "EchartsLegend": {
                 "properties": {
+                    "selected": {
+                        "$ref": "#/components/schemas/Record_string.boolean_",
+                        "description": "Legend entries toggled off by name. Missing entries default to visible."
+                    },
                     "placement": {
                         "$ref": "#/components/schemas/LegendPlacement",
                         "description": "High-level placement preset. Overrides orient/top/right/bottom/left\nwhen set to an outside value."

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -1176,6 +1176,10 @@
                     "description": "Right position",
                     "type": "string"
                 },
+                "selected": {
+                    "$ref": "#/$defs/Record_string.boolean_",
+                    "description": "Legend entries toggled off by name. Missing entries default to visible."
+                },
                 "show": {
                     "description": "Show the legend",
                     "type": "boolean"
@@ -2556,6 +2560,14 @@
                 }
             },
             "required": ["value", "field"],
+            "type": "object"
+        },
+        "Record_string.boolean_": {
+            "additionalProperties": {
+                "type": "boolean"
+            },
+            "description": "Construct a type with a set of properties K of type T",
+            "properties": {},
             "type": "object"
         },
         "Record_string.ColumnProperties_": {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -623,6 +623,8 @@ export type EchartsLegend = {
     /** High-level placement preset. Overrides orient/top/right/bottom/left
      * when set to an outside value. */
     placement?: LegendPlacement;
+    /** Legend entries toggled off by name. Missing entries default to visible. */
+    selected?: Record<string, boolean>;
 };
 
 export type EchartsGrid = {

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -7,10 +7,15 @@ import { IconChartBarOff } from '@tabler/icons-react';
 import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
 import { memo, useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import useEchartsCartesianConfig from '../../hooks/echarts/useEchartsCartesianConfig';
-import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
+import {
+    getDisabledLegendEntries,
+    useLegendDoubleClickSelection,
+    type LegendSelection,
+} from '../../hooks/echarts/useLegendDoubleClickSelection';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import EChartsReact from '../EChartsReactWrapper';
+import { isCartesianVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 
 type EchartsBaseClickEvent = {
@@ -139,10 +144,37 @@ const SimpleChart: FC<SimpleChartProps> = memo(
             itemsMap,
             resultsData,
             resolvedTimezone,
+            visualizationConfig,
+            isEditMode,
         } = useVisualizationContext();
 
+        const cartesianChartConfig = isCartesianVisualizationConfig(
+            visualizationConfig,
+        )
+            ? visualizationConfig.chartConfig
+            : undefined;
+
+        const persistLegendSelection = useCallback(
+            (selected: LegendSelection) => {
+                if (!isEditMode || !cartesianChartConfig) return;
+                const { selected: previousSelected, ...legend } =
+                    cartesianChartConfig.dirtyEchartsConfig?.legend ?? {};
+                const disabledEntries = getDisabledLegendEntries(selected);
+                if (!disabledEntries && !previousSelected) return;
+                cartesianChartConfig.setLegend(
+                    disabledEntries
+                        ? { ...legend, selected: disabledEntries }
+                        : legend,
+                );
+            },
+            [isEditMode, cartesianChartConfig],
+        );
+
         const { selectedLegends, onLegendChange } =
-            useLegendDoubleClickSelection();
+            useLegendDoubleClickSelection(
+                cartesianChartConfig?.dirtyEchartsConfig?.legend?.selected,
+                persistLegendSelection,
+            );
         const eChartsOptions = useEchartsCartesianConfig(
             selectedLegends,
             props.isInDashboard,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -2095,6 +2095,17 @@ describe('mergeLegendSettings', () => {
         });
     });
 
+    test('returns defaults when config is empty', () => {
+        const result = mergeLegendSettings({}, selected, series);
+        expect(result).toMatchObject({
+            show: true,
+            type: 'scroll',
+            orient: 'horizontal',
+            top: 0,
+            selected,
+        });
+    });
+
     test('passes through user orient/position when placement is unset', () => {
         const result = mergeLegendSettings(
             { orient: 'vertical', right: '10', top: '20' },

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -417,7 +417,7 @@ export const mergeLegendSettings = <
     series: EChartsSeries[],
 ): Record<string, unknown> => {
     const normalizedConfig = removeEmptyProperties(legendConfig);
-    if (!normalizedConfig) {
+    if (!normalizedConfig || Object.keys(normalizedConfig).length === 0) {
         return {
             show: series.length > 1,
             type: 'scroll',

--- a/packages/frontend/src/hooks/echarts/useLegendDoubleClickSelection.test.ts
+++ b/packages/frontend/src/hooks/echarts/useLegendDoubleClickSelection.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+    getDisabledLegendEntries,
+    useLegendDoubleClickSelection,
+} from './useLegendDoubleClickSelection';
+
+describe('useLegendDoubleClickSelection', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('defaults to an empty selection', () => {
+        const { result } = renderHook(() => useLegendDoubleClickSelection());
+
+        expect(result.current.selectedLegends).toEqual({});
+    });
+
+    test('seeds selection from initial value', () => {
+        const { result } = renderHook(() =>
+            useLegendDoubleClickSelection({ '5 quarters ago': false }),
+        );
+
+        expect(result.current.selectedLegends).toEqual({
+            '5 quarters ago': false,
+        });
+    });
+
+    test('single click applies the echarts selection after the double-click delay and notifies onChange', () => {
+        const onChange = vi.fn();
+        const { result } = renderHook(() =>
+            useLegendDoubleClickSelection(undefined, onChange),
+        );
+
+        act(() => {
+            result.current.onLegendChange({
+                name: 'a',
+                selected: { a: false, b: true },
+            });
+        });
+        act(() => {
+            vi.advanceTimersByTime(400);
+        });
+
+        expect(result.current.selectedLegends).toEqual({ a: false, b: true });
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith({ a: false, b: true });
+    });
+
+    test('double click solos the clicked legend and notifies onChange once', () => {
+        const onChange = vi.fn();
+        const { result } = renderHook(() =>
+            useLegendDoubleClickSelection(undefined, onChange),
+        );
+
+        act(() => {
+            result.current.onLegendChange({
+                name: 'a',
+                selected: { a: false, b: true, c: true },
+            });
+            result.current.onLegendChange({
+                name: 'a',
+                selected: { a: true, b: true, c: true },
+            });
+        });
+        act(() => {
+            vi.advanceTimersByTime(400);
+        });
+
+        expect(result.current.selectedLegends).toEqual({
+            a: true,
+            b: false,
+            c: false,
+        });
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith({ a: true, b: false, c: false });
+    });
+});
+
+describe('getDisabledLegendEntries', () => {
+    test('keeps only disabled entries', () => {
+        expect(
+            getDisabledLegendEntries({ a: true, b: false, c: false }),
+        ).toEqual({ b: false, c: false });
+    });
+
+    test('returns undefined when nothing is disabled', () => {
+        expect(getDisabledLegendEntries({ a: true, b: true })).toBeUndefined();
+        expect(getDisabledLegendEntries({})).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/hooks/echarts/useLegendDoubleClickSelection.ts
+++ b/packages/frontend/src/hooks/echarts/useLegendDoubleClickSelection.ts
@@ -5,12 +5,30 @@ export type LegendClickEvent = {
     selected: Record<string, boolean>;
 };
 
+export type LegendSelection = Record<string, boolean>;
+
+/** Entries toggled off in the legend, or undefined when everything is visible.
+ * Missing keys default to visible in echarts, so this is the minimal state to persist. */
+export const getDisabledLegendEntries = (
+    selected: LegendSelection,
+): LegendSelection | undefined => {
+    const disabledEntries = Object.entries(selected).filter(
+        ([, isSelected]) => !isSelected,
+    );
+    return disabledEntries.length > 0
+        ? Object.fromEntries(disabledEntries)
+        : undefined;
+};
+
 const DOUBLE_CLICK_DELAY = 300;
 
-export const useLegendDoubleClickSelection = () => {
-    const [selectedLegends, setSelectedLegends] = useState<
-        Record<string, boolean>
-    >({});
+export const useLegendDoubleClickSelection = (
+    initialSelection?: LegendSelection,
+    onChange?: (selected: LegendSelection) => void,
+) => {
+    const [selectedLegends, setSelectedLegends] = useState<LegendSelection>(
+        initialSelection ?? {},
+    );
     const legendClicksRef = useRef<
         Record<
             string,
@@ -21,17 +39,29 @@ export const useLegendDoubleClickSelection = () => {
         >
     >({});
 
-    const overrideSelectAllLegends = useCallback((params: LegendClickEvent) => {
-        setSelectedLegends(
-            Object.fromEntries(
-                Object.keys(params.selected).map((key) => [key, true]),
-            ),
-        );
+    // Ref keeps onLegendChange referentially stable so echarts event bindings don't churn
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+
+    const applySelection = useCallback((selected: LegendSelection) => {
+        setSelectedLegends(selected);
+        onChangeRef.current?.(selected);
     }, []);
+
+    const overrideSelectAllLegends = useCallback(
+        (params: LegendClickEvent) => {
+            applySelection(
+                Object.fromEntries(
+                    Object.keys(params.selected).map((key) => [key, true]),
+                ),
+            );
+        },
+        [applySelection],
+    );
 
     const overrideSelectSingleLegend = useCallback(
         (params: LegendClickEvent) => {
-            setSelectedLegends(
+            applySelection(
                 Object.fromEntries(
                     Object.keys(params.selected).map((key) => [
                         key,
@@ -40,7 +70,7 @@ export const useLegendDoubleClickSelection = () => {
                 ),
             );
         },
-        [],
+        [applySelection],
     );
 
     const onLegendChange = useCallback(
@@ -71,7 +101,7 @@ export const useLegendDoubleClickSelection = () => {
             } else {
                 const timeoutId = setTimeout(() => {
                     delete legendClicksRef.current[params.name];
-                    setSelectedLegends(params.selected);
+                    applySelection(params.selected);
                 }, DOUBLE_CLICK_DELAY + 50);
                 legendClicksRef.current[params.name] = {
                     singleClickTimeout: timeoutId,
@@ -79,7 +109,7 @@ export const useLegendDoubleClickSelection = () => {
                 };
             }
         },
-        [overrideSelectAllLegends, overrideSelectSingleLegend],
+        [applySelection, overrideSelectAllLegends, overrideSelectSingleLegend],
     );
 
     return { selectedLegends, onLegendChange };


### PR DESCRIPTION
## Description

Clicking a legend entry to disable a series in the chart editor now persists that state when the chart is saved. The disabled series stays visible in the legend (greyed out), so viewers can still toggle it back on — but the chart defaults to the saved selection on every load (explore view, saved chart view, dashboards).

### How it works

- New optional `selected` field on `EchartsLegend` (`Record<string, boolean>` keyed by legend entry name, mirroring the echarts `legend.selected` option). No migration needed — it rides along in the saved chart config JSON and in chart-as-code YAML.
- `useLegendDoubleClickSelection` now seeds its state from the saved config and notifies an `onChange` callback when the user toggles entries.
- In edit mode, `SimpleChart` writes the disabled entries back into the chart config via `setLegend`, marking the chart as having unsaved changes. Only `false` entries are stored, so series that appear later (e.g. new quarters in a pivoted chart) default to visible. Re-enabling everything removes the key.
- Outside edit mode (view page, dashboards) legend toggling stays ephemeral, as before.
- Fixed a latent quirk in `mergeLegendSettings`: an empty `legend: {}` config now gets the same defaults (`show`, `type: 'scroll'`) as a missing legend config.

Scoped to cartesian charts; pie/funnel keep their current ephemeral behavior.

## Testing

- Unit tests for the hook seeding/`onChange`, the disabled-entries filter, and the `mergeLegendSettings` empty-config default.
- Verified end-to-end locally: toggle series off in editor → save → reload → series greyed out and hidden; viewer can re-toggle without persisting; re-enable + save removes the key from config.

Closes: PROD-5137
Closes: #3321
