### PR TITLE
fix: post Slack MCP OAuth login prompt once per user+server

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -229,6 +229,7 @@ export type AiMcpOAuthCredentialPayload = {
     resourceMetadata?: Record<string, unknown>;
     authorizationServerMetadata?: Record<string, unknown>;
     lastError?: string;
+    slackLoginPromptedAt?: string;
 };
 
 export type AiMcpCredentialPayload =

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6049,6 +6049,19 @@ export class AiAgentService extends BaseService {
         await Promise.all(
             loginServers.map(async ({ serverName, serverUuid, mcpServer }) => {
                 try {
+                    const existingCredential =
+                        await this.aiAgentModel.getCredential(
+                            serverUuid,
+                            'user',
+                            { userUuid: user.userUuid },
+                        );
+                    if (
+                        existingCredential?.credentials.type === 'oauth' &&
+                        existingCredential.credentials.slackLoginPromptedAt
+                    ) {
+                        return;
+                    }
+
                     const authorizationUrl = await this.startMcpOAuthConnection(
                         user,
                         prompt.projectUuid,
@@ -6089,6 +6102,25 @@ export class AiAgentService extends BaseService {
                             },
                         ],
                     });
+
+                    const promptedCredential =
+                        await this.aiAgentModel.getCredential(
+                            serverUuid,
+                            'user',
+                            { userUuid: user.userUuid },
+                        );
+                    if (promptedCredential?.credentials.type === 'oauth') {
+                        await this.aiAgentModel.upsertCredential({
+                            serverUuid,
+                            scope: 'user',
+                            userUuid: user.userUuid,
+                            actorUserUuid: user.userUuid,
+                            credentials: {
+                                ...promptedCredential.credentials,
+                                slackLoginPromptedAt: new Date().toISOString(),
+                            },
+                        });
+                    }
                 } catch (error) {
                     Logger.error(
                         `Failed to post Slack MCP OAuth login message for ${mcpServer.name}`,

--- a/packages/backend/src/ee/services/AiAgentService/ackReactionLifecycle.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/ackReactionLifecycle.test.ts
@@ -37,6 +37,8 @@ const buildService = () => {
     };
     const aiAgentModel = {
         findSlackPrompt: vi.fn().mockResolvedValue(buildSlackPrompt()),
+        getCredential: vi.fn().mockResolvedValue(undefined),
+        upsertCredential: vi.fn().mockResolvedValue(undefined),
     };
     const service = new AiAgentService({
         slackClient,
@@ -238,5 +240,48 @@ describe('AiAgentService :eyes: ack reaction lifecycle', () => {
                 text: 'GitHub MCP needs you to log in before I can use it.',
             }),
         );
+    });
+
+    it('records the prompted timestamp after posting so it only fires once', async () => {
+        const { service, aiAgentModel, webClient } = buildService();
+        vi.spyOn(service, 'startMcpOAuthConnection').mockResolvedValue(
+            'https://oauth.example/mcp-1',
+        );
+        aiAgentModel.getCredential.mockResolvedValue({
+            credentials: { type: 'oauth', connectionStatus: 'not_connected' },
+        });
+
+        await postMcpOAuthLoginMessages(service);
+
+        expect(webClient.chat.postEphemeral).toHaveBeenCalledTimes(1);
+        expect(aiAgentModel.upsertCredential).toHaveBeenCalledWith(
+            expect.objectContaining({
+                serverUuid: 'mcp-1',
+                scope: 'user',
+                userUuid: 'user-1',
+                credentials: expect.objectContaining({
+                    type: 'oauth',
+                    slackLoginPromptedAt: expect.any(String),
+                }),
+            }),
+        );
+    });
+
+    it('does not re-post when the user was already prompted for the server', async () => {
+        const { service, aiAgentModel, webClient } = buildService();
+        const startOAuth = vi.spyOn(service, 'startMcpOAuthConnection');
+        aiAgentModel.getCredential.mockResolvedValue({
+            credentials: {
+                type: 'oauth',
+                connectionStatus: 'not_connected',
+                slackLoginPromptedAt: '2026-01-01T00:00:00.000Z',
+            },
+        });
+
+        await postMcpOAuthLoginMessages(service);
+
+        expect(startOAuth).not.toHaveBeenCalled();
+        expect(webClient.chat.postEphemeral).not.toHaveBeenCalled();
+        expect(aiAgentModel.upsertCredential).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Problem

When an AI agent uses an OAuth MCP server (e.g. Linear, Attio) that the user hasn't connected, the backend posts a Slack ephemeral prompt — *"X MCP needs you to log in before I can use it"* — with a **Log in** button. That prompt was re-posted on **every prompt turn** for as long as the server stayed `not_connected`, spamming the thread.

## Fix

Record a per-user `slackLoginPromptedAt` timestamp on the OAuth credential payload after the prompt is posted, and skip re-posting once it's set. The check + write are scoped to the `user` credential (matching `startMcpOAuthConnection`).

- **Read**: before posting, load the user's credential for the server; if `slackLoginPromptedAt` is already set, skip.
- **Write**: after posting, stamp `slackLoginPromptedAt`. `startMcpOAuthConnection` runs first and persists the in-flight OAuth payload, so we read-modify-write to preserve `codeVerifier`/`state`.

## Why it self-resets ("unless I ask again")

The flag lives in the credential payload. All status writes (`updateMcpServerRuntimeState`) **spread** the existing payload, so the flag survives turn-to-turn. Only `disconnectOAuthConnection` writes a fresh payload — clearing the flag — so if the user disconnects (or connects and later drops), the prompt can appear once again.

## Regression analysis

- **Slack MCP-OAuth users**: was spammed every turn → now prompted once. This is the intended behavior change.
- **Connected servers**: unaffected — `getSlackMcpOAuthLoginServers` already filters to `not_connected`, so connected servers never prompt.
- **Web app**: unaffected — this path only fires for `isSlackPrompt`.
- **Non-OAuth (bearer) servers**: unaffected — the prompt path is OAuth-only.

## Caveat

These are Slack *ephemeral* messages — there's no API to delete one after posting, so an already-posted prompt won't vanish; this stops it multiplying. Making it disappear on connect would require switching to a real (non-ephemeral) message we can `chat.delete`.

## Testing

`packages/backend/src/ee/services/AiAgentService/ackReactionLifecycle.test.ts` — added coverage that the timestamp is stamped after posting and that a server with `slackLoginPromptedAt` set is not re-posted. `pnpm -F backend typecheck:fast` + the suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wDcAp8AGS5Bov2fac1otr
