### PR TITLE
fix(ai-agent): stop blocked/errored runSql from poisoning message history

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6542,6 +6542,116 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         );
     }
 
+    // Final safety net over the fully-assembled history: any assistant
+    // `tool-call` with no following `tool-result` makes the provider reject the
+    // whole request (400 "tool_use ids were found without tool_result blocks").
+    // `buildToolCallTurnMessages` backfills prior-prompt orphans, but a blocked
+    // sibling on the *current* prompt (e.g. a guardrail-tripped runSql whose
+    // result never persisted) can still dangle. Backfill a synthetic result for
+    // every dangling call, EXCEPT the trailing approved-but-unexecuted call(s):
+    // the AI SDK only resumes tool-approval-responses found in the LAST message
+    // (see `collectToolApprovals`), so those must stay result-less to re-execute.
+    static backfillDanglingToolResults(
+        history: ModelMessage[],
+    ): ModelMessage[] {
+        const approvalIdToToolCallId = new Map<string, string>();
+        for (const message of history) {
+            if (
+                message.role === 'assistant' &&
+                typeof message.content !== 'string'
+            ) {
+                for (const part of message.content) {
+                    if (part.type === 'tool-approval-request') {
+                        approvalIdToToolCallId.set(
+                            part.approvalId,
+                            part.toolCallId,
+                        );
+                    }
+                }
+            }
+        }
+
+        // The resume input the SDK is about to execute: approval-responses in
+        // the last message whose tool-call it will run. Leave these dangling.
+        const pendingResumeToolCallIds = new Set<string>();
+        const lastMessage = history.at(-1);
+        if (lastMessage?.role === 'tool') {
+            for (const part of lastMessage.content) {
+                if (part.type === 'tool-approval-response') {
+                    const toolCallId = approvalIdToToolCallId.get(
+                        part.approvalId,
+                    );
+                    if (toolCallId) {
+                        pendingResumeToolCallIds.add(toolCallId);
+                    }
+                }
+            }
+        }
+
+        const resolvedToolCallIds = new Set<string>();
+        for (const message of history) {
+            if (message.role === 'tool') {
+                for (const part of message.content) {
+                    if (part.type === 'tool-result') {
+                        resolvedToolCallIds.add(part.toolCallId);
+                    }
+                }
+            }
+        }
+
+        const backfilled: ModelMessage[] = [];
+        for (let i = 0; i < history.length; i += 1) {
+            const message = history[i];
+            backfilled.push(message);
+
+            const danglingCalls =
+                message.role === 'assistant' &&
+                typeof message.content !== 'string'
+                    ? message.content.filter(
+                          (part): part is ToolCallPart =>
+                              part.type === 'tool-call' &&
+                              !resolvedToolCallIds.has(part.toolCallId) &&
+                              !pendingResumeToolCallIds.has(part.toolCallId),
+                      )
+                    : [];
+
+            if (danglingCalls.length > 0) {
+                // Keep an approval-response that belongs to this turn ahead of
+                // the synthetic result, mirroring buildToolCallTurnMessages.
+                const next = history[i + 1];
+                if (
+                    next?.role === 'tool' &&
+                    next.content.some(
+                        (part) => part.type === 'tool-approval-response',
+                    )
+                ) {
+                    backfilled.push(next);
+                    i += 1;
+                }
+
+                for (const part of danglingCalls) {
+                    backfilled.push({
+                        role: 'tool',
+                        content: [
+                            {
+                                type: 'tool-result',
+                                toolCallId: part.toolCallId,
+                                toolName: part.toolName,
+                                output: {
+                                    type: 'json',
+                                    value: 'Tool result unavailable.',
+                                },
+                            },
+                        ],
+                    } satisfies ToolModelMessage);
+                    resolvedToolCallIds.add(part.toolCallId);
+                }
+            }
+        }
+
+        return backfilled;
+    }
+
     async getChatHistoryFromThreadMessages(
         // TODO: move getThreadMessages to AiAgentModel and improve types
         // also, it should be called through a service method...
@@ -6662,7 +6772,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             }),
         );
 
-        const history = messagesWithToolCalls.flat();
+        const history = AiAgentService.backfillDanglingToolResults(
+            messagesWithToolCalls.flat(),
+        );
 
         if (!options.compaction) {
             if (history.length === 0) {

--- a/packages/backend/src/ee/services/AiAgentService/sqlApprovalReconstruction.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/sqlApprovalReconstruction.test.ts
@@ -4,9 +4,7 @@ type Row = Parameters<
     typeof AiAgentService.buildToolCallTurnMessages
 >[0][number];
 
-type History = Parameters<
-    typeof AiAgentService.backfillDanglingToolResults
->[0];
+type History = Parameters<typeof AiAgentService.backfillDanglingToolResults>[0];
 
 const call = (toolCallId: string, sql: string) =>
     ({ toolCallId, toolName: 'runSql', toolArgs: { sql } }) as Row['toolCall'];
@@ -236,8 +234,7 @@ describe('AiAgentService SQL-approval history reconstruction', () => {
                 (m) =>
                     m.role === 'tool' &&
                     content(m).some(
-                        (p) =>
-                            p.type === 'tool-result' && p.toolCallId === 'C',
+                        (p) => p.type === 'tool-result' && p.toolCallId === 'C',
                     ),
             ),
         ).toBe(false);

--- a/packages/backend/src/ee/services/AiAgentService/sqlApprovalReconstruction.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/sqlApprovalReconstruction.test.ts
@@ -4,6 +4,10 @@ type Row = Parameters<
     typeof AiAgentService.buildToolCallTurnMessages
 >[0][number];
 
+type History = Parameters<
+    typeof AiAgentService.backfillDanglingToolResults
+>[0];
+
 const call = (toolCallId: string, sql: string) =>
     ({ toolCallId, toolName: 'runSql', toolArgs: { sql } }) as Row['toolCall'];
 
@@ -137,6 +141,106 @@ describe('AiAgentService SQL-approval history reconstruction', () => {
             toolCallId: 'tc1',
             output: { type: 'json', value: 'Tool result unavailable.' },
         });
+    });
+
+    it('backfillDanglingToolResults leaves valid history untouched', () => {
+        const history = [
+            { role: 'user', content: 'hi' },
+            {
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'tool-call',
+                        toolCallId: 'tc1',
+                        toolName: 'runSql',
+                        input: {},
+                    },
+                ],
+            },
+            {
+                role: 'tool',
+                content: [
+                    {
+                        type: 'tool-result',
+                        toolCallId: 'tc1',
+                        toolName: 'runSql',
+                        output: { type: 'json', value: '1 row' },
+                    },
+                ],
+            },
+        ] as unknown as History;
+
+        expect(AiAgentService.backfillDanglingToolResults(history)).toEqual(
+            history,
+        );
+    });
+
+    it('backfillDanglingToolResults backfills a blocked mid-history call but keeps the trailing resume input dangling', () => {
+        const approvalPair = (id: string) => [
+            {
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'tool-call',
+                        toolCallId: id,
+                        toolName: 'runSql',
+                        input: {},
+                    },
+                    {
+                        type: 'tool-approval-request',
+                        approvalId: `sql-approval:${id}`,
+                        toolCallId: id,
+                    },
+                ],
+            },
+            {
+                role: 'tool',
+                content: [
+                    {
+                        type: 'tool-approval-response',
+                        approvalId: `sql-approval:${id}`,
+                        approved: true,
+                    },
+                ],
+            },
+        ];
+
+        // A = blocked earlier in the turn (no result), C = trailing resume input.
+        const history = [
+            ...approvalPair('A'),
+            ...approvalPair('C'),
+        ] as unknown as History;
+
+        const out = AiAgentService.backfillDanglingToolResults(history);
+
+        // A's approval-response is followed by a synthetic result.
+        expect(content(out[1])[0].type).toBe('tool-approval-response');
+        expect(out[2]).toMatchObject({
+            role: 'tool',
+            content: [
+                {
+                    type: 'tool-result',
+                    toolCallId: 'A',
+                    output: { type: 'json', value: 'Tool result unavailable.' },
+                },
+            ],
+        });
+        // C (the trailing resume input) stays result-less and last.
+        const last = out[out.length - 1];
+        expect(content(last)[0]).toMatchObject({
+            type: 'tool-approval-response',
+            approvalId: 'sql-approval:C',
+        });
+        expect(
+            out.some(
+                (m) =>
+                    m.role === 'tool' &&
+                    content(m).some(
+                        (p) =>
+                            p.type === 'tool-result' && p.toolCallId === 'C',
+                    ),
+            ),
+        ).toBe(false);
     });
 
     it('hasUnresolvedSqlApproval is true only for a decided, result-less call', () => {

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -231,9 +231,8 @@ describe('getRunSql', () => {
         });
 
         it('persists a success result for an approved query', async () => {
-            const { dependencies, output } = runNativeResume(
-                'select 1 as answer',
-            );
+            const { dependencies, output } =
+                runNativeResume('select 1 as answer');
 
             const resolved = await output;
             expect(resolved.metadata?.status).toBe('success');

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -1,4 +1,4 @@
-import { type AiWebAppPrompt } from '@lightdash/common';
+import { type AiWebAppPrompt, type SlackPrompt } from '@lightdash/common';
 import { getRunSql } from './runSql';
 
 type RunSqlTool = ReturnType<typeof getRunSql>;
@@ -42,13 +42,27 @@ const makePrompt = (): AiWebAppPrompt => ({
     modelConfig: null,
 });
 
+const makeSlackPrompt = (): SlackPrompt => ({
+    ...makePrompt(),
+    response_slack_ts: 'response-ts',
+    slackUserId: 'slack-user',
+    slackChannelId: 'slack-channel',
+    promptSlackTs: 'prompt-ts',
+    slackThreadTs: 'thread-ts',
+});
+
 const makeTool = ({
     autoApproveSql = false,
     autoApproveSqlUserUuid = null,
     waitForSqlApproval = vi.fn().mockResolvedValue('approved'),
     recordSqlApproval = vi.fn().mockResolvedValue(true),
     maxQueryLimit = 5000,
-}: MakeToolOptions = {}) => {
+    useSlackStreamCard = false,
+    prompt = makePrompt(),
+}: MakeToolOptions & {
+    useSlackStreamCard?: boolean;
+    prompt?: AiWebAppPrompt | SlackPrompt;
+} = {}) => {
     const dependencies = {
         updateProgress: vi.fn().mockResolvedValue(undefined),
         runSqlJob: vi.fn().mockResolvedValue({
@@ -56,7 +70,7 @@ const makeTool = ({
             columns: ['answer'],
             rowCount: 1,
         }),
-        getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+        getPrompt: vi.fn().mockResolvedValue(prompt),
         sendFile: vi.fn().mockResolvedValue(undefined),
         updateSlackMessage: vi.fn().mockResolvedValue(undefined),
         siteUrl: 'https://lightdash.example',
@@ -67,6 +81,7 @@ const makeTool = ({
         autoApproveSql,
         autoApproveSqlUserUuid,
         maxQueryLimit,
+        useSlackStreamCard,
     };
 
     return {
@@ -176,5 +191,58 @@ describe('getRunSql', () => {
         expect(output.result).toContain('forbidden functions');
         expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(dependencies.runSqlJob).not.toHaveBeenCalled();
+    });
+
+    // On the native-approval (modern Slack) path, execute only runs as a resume
+    // of a previously-approved call, so it must persist its own result — even
+    // when the SQL is blocked/rejected. Otherwise the tool_use is left with no
+    // tool_result and the resumed request 400s. (ZAP-601)
+    describe('native-approval resume persists a result for every outcome', () => {
+        const runNativeResume = (sql: string, toolCallId = 'tool-call-1') => {
+            const { tool, dependencies } = makeTool({
+                useSlackStreamCard: true,
+                prompt: makeSlackPrompt(),
+            });
+            return {
+                dependencies,
+                output: tool.execute!(
+                    { sql, limit: 500 },
+                    { messages: [], toolCallId },
+                ) as Promise<RunSqlOutput>,
+            };
+        };
+
+        it('persists an error result for a guardrail-blocked query', async () => {
+            const { dependencies, output } = runNativeResume(
+                'SELECT * FROM INFORMATION_SCHEMA.COLUMNS',
+            );
+
+            const resolved = await output;
+            expect(resolved.metadata?.status).toBe('error');
+            expect(resolved.result).toContain('information_schema');
+            expect(dependencies.storeToolResults).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    promptUuid: 'prompt-uuid',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'runSql',
+                    result: resolved.result,
+                }),
+            ]);
+        });
+
+        it('persists a success result for an approved query', async () => {
+            const { dependencies, output } = runNativeResume(
+                'select 1 as answer',
+            );
+
+            const resolved = await output;
+            expect(resolved.metadata?.status).toBe('success');
+            expect(dependencies.storeToolResults).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    toolCallId: 'tool-call-1',
+                    result: resolved.result,
+                }),
+            ]);
+        });
     });
 });

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -123,24 +123,6 @@ export const getRunSql = ({
         toModelOutput: toolDefinition.toModelOutput,
         needsApproval: usesNativeApproval,
         execute: async ({ sql, limit }, { toolCallId }) => {
-            if (sqlApprovalTimedOut) {
-                return {
-                    result: 'A previous SQL approval timed out in this response. Do not call runSql again in this response; tell the user the SQL was not approved and ask them to retry when ready.',
-                    metadata: { status: 'timeout' },
-                };
-            }
-
-            // Pre-section errors (bad SQL shape) — no Slack message exists
-            // yet, just return the error to the agent.
-            try {
-                validateSelectOnly(sql);
-            } catch (e) {
-                return {
-                    result: toolErrorHandler(e, 'Error running SQL query.'),
-                    metadata: { status: 'error' },
-                };
-            }
-
             const prompt = await getPrompt();
             const isSlack = isSlackPrompt(prompt);
             const slackAutoApproved =
@@ -156,10 +138,14 @@ export const getRunSql = ({
             // When execute runs as a RESUME of a previously-suspended approval,
             // onStepFinish won't persist the result (the tool call was made in a
             // prior run), so we persist it here. Otherwise the call is left
-            // result-less — which re-triggers execution on later turns and
-            // shows a stale approval card on the web. A resume is identified
-            // either by the native path, or (when "don't ask again" flipped the
-            // thread to auto-approve) by the decision already being recorded.
+            // result-less — which re-triggers execution on later turns, shows a
+            // stale approval card on the web, and (worse) leaves the tool_use
+            // with no following tool_result so the resumed request 400s. Every
+            // early return below therefore routes through persistResumeResult so
+            // blocked/rejected/timed-out calls still store a real result. A
+            // resume is identified either by the native path, or (when "don't
+            // ask again" flipped the thread to auto-approve) by the decision
+            // already being recorded.
             let isResumeExecution = isNativeApprovalPath;
             const persistResumeResult = async <
                 T extends { result: string; metadata: AnyType },
@@ -181,6 +167,24 @@ export const getRunSql = ({
                 }
                 return output;
             };
+
+            if (sqlApprovalTimedOut) {
+                return persistResumeResult({
+                    result: 'A previous SQL approval timed out in this response. Do not call runSql again in this response; tell the user the SQL was not approved and ask them to retry when ready.',
+                    metadata: { status: 'timeout' },
+                });
+            }
+
+            // Pre-section errors (bad SQL shape) — no Slack message exists
+            // yet, just return the error to the agent.
+            try {
+                validateSelectOnly(sql);
+            } catch (e) {
+                return persistResumeResult({
+                    result: toolErrorHandler(e, 'Error running SQL query.'),
+                    metadata: { status: 'error' },
+                });
+            }
 
             // Render a runSql state INTO the bot's existing progress message
             // (the bolt-gif "Thinking…" message at response_slack_ts). One
@@ -233,18 +237,18 @@ export const getRunSql = ({
                         : await waitForSqlApproval(toolCallId);
                 if (decision === 'rejected') {
                     await renderState({ kind: 'rejected', sql });
-                    return {
+                    return await persistResumeResult({
                         result: 'User rejected this SQL execution. Do not retry the same query; ask the user what they would like instead.',
                         metadata: { status: 'rejected' },
-                    };
+                    });
                 }
                 if (decision === 'timeout') {
                     sqlApprovalTimedOut = true;
                     await renderState({ kind: 'timeout', sql });
-                    return {
+                    return await persistResumeResult({
                         result: 'SQL approval timed out after 5 minutes with no response. The user may have stepped away — acknowledge politely and wait for them to re-ask.',
                         metadata: { status: 'timeout' },
-                    };
+                    });
                 }
 
                 if (isSlack) {


### PR DESCRIPTION
### Description:

When a `runSql` tool call goes through SQL approval but its result is never persisted (guardrail-blocked e.g. `information_schema`, user-rejected, or approval-timeout), the DB row is left with an approval decision but a `null` result. On resume, history rebuilt from the DB emits that `tool_use` with no following `tool_result`, so the Anthropic Messages API rejects the whole request with a **400** ("tool_use ids were found without tool_result blocks") and the user sees the generic *"Something went wrong"*. Stored history stays poisoned, so every retry fails the same way.

Two combining fixes:

1. **Source fix — `runSql.ts`:** hoist the resume-detection + `persistResumeResult` setup above the early returns (approval-timeout short-circuit, `validateSelectOnly` error, rejected, timeout) so *every* `execute` outcome on a resume stores a real `tool_result`. Removes the corruption at the source.

2. **Defense-in-depth — `AiAgentService.ts`:** after assembling the message history, backfill a synthetic `tool_result` for any assistant `tool_use` with no following `tool_result` — **except** the trailing approved-but-unexecuted call(s). The AI SDK's `collectToolApprovals` only resumes `tool-approval-response`s found in the **last** message, so those must stay result-less to re-execute; everything else is backfilled. A missing result can never 400 the request again.

Tests added for both: `runSql` persisting a result on a native-approval resume (blocked + success), and `backfillDanglingToolResults` backfilling a blocked mid-turn call while keeping the trailing resume input dangling.