### PR TITLE
fix(ai): run data-apps sandbox on a BYO org's own Anthropic key

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
@@ -58,6 +58,10 @@ const makePayload = (): AppBuildFromSourceJobPayload => ({
 
 const REGISTRY_HOSTS = ['registry.npmjs.org'];
 
+// Sentinel copilot config the mocked resolver returns and createSandbox is
+// asserted to receive — verifies the org-resolved config is threaded through.
+const COPILOT_CONFIG = { sentinel: 'copilot' } as never;
+
 const CUSTOM_DEPS: AppVersionDependencies = {
     custom: [{ name: 'react-query', version: '^5.0.0' }],
     lockfileHash: 'abc123',
@@ -106,7 +110,9 @@ function buildService(
         promoteService: {} as never,
         externalConnectionModel: {} as never,
         sandboxRegistryModel: {} as never,
-        orgAiCopilotConfigResolver: {} as never,
+        orgAiCopilotConfigResolver: {
+            getClaudeCodeConfig: vi.fn().mockResolvedValue(COPILOT_CONFIG),
+        } as never,
     });
 
     const service = raw as unknown as ServiceWithPrivates;
@@ -210,6 +216,7 @@ describe('AppGenerateService.runBuildFromSourcePipeline', () => {
                 'app-uuid-1',
                 'org-uuid-1',
                 'proj-uuid-1',
+                COPILOT_CONFIG,
                 [],
             );
             // No dep restore or install should have happened
@@ -230,6 +237,7 @@ describe('AppGenerateService.runBuildFromSourcePipeline', () => {
                 'app-uuid-1',
                 'org-uuid-1',
                 'proj-uuid-1',
+                COPILOT_CONFIG,
                 REGISTRY_HOSTS,
             );
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -114,7 +114,10 @@ import { type ExternalConnectionModel } from '../../models/ExternalConnectionMod
 import type { SandboxRegistryModel } from '../../models/SandboxRegistryModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
-import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
+import {
+    OrgAiCopilotConfigResolver,
+    type CopilotConfig,
+} from '../ai/OrgAiCopilotConfigResolver';
 import {
     getAiCallTelemetry,
     getLanguageModelAttribution,
@@ -457,8 +460,8 @@ export class AppGenerateService extends BaseService {
         );
     }
 
-    private getAnthropicApiKey(): string {
-        const key = this.lightdashConfig.ai.copilot.providers.anthropic?.apiKey;
+    private static getAnthropicApiKey(copilot: CopilotConfig): string {
+        const key = copilot.providers.anthropic?.apiKey;
         if (!key) {
             throw new MissingConfigError(
                 'Anthropic API key is not configured (ANTHROPIC_API_KEY)',
@@ -471,11 +474,14 @@ export class AppGenerateService extends BaseService {
      * Resolves the env vars passed to the `claude` CLI in the sandbox: the
      * Bedrock block (reusing the copilot's BEDROCK_* config) when configured,
      * otherwise the Anthropic API key. Throws MissingConfigError when neither
-     * is set.
+     * is set. `copilot` is the org-resolved config (BYO key when the org brings
+     * one), so a BYO org runs on its own key rather than the instance key.
      */
-    private getClaudeCodeEnv(): Record<string, string> {
-        return buildClaudeCodeEnv(this.lightdashConfig.ai.copilot, () =>
-            this.getAnthropicApiKey(),
+    private static getClaudeCodeEnv(
+        copilot: CopilotConfig,
+    ): Record<string, string> {
+        return buildClaudeCodeEnv(copilot, () =>
+            AppGenerateService.getAnthropicApiKey(copilot),
         );
     }
 
@@ -580,13 +586,16 @@ export class AppGenerateService extends BaseService {
         };
     }
 
-    private buildSandboxSpec(extraEgressHosts: string[] = []): SandboxSpec {
+    private buildSandboxSpec(
+        copilot: CopilotConfig,
+        extraEgressHosts: string[] = [],
+    ): SandboxSpec {
         return {
             templateRef: this.getSandboxTemplateRef(),
             timeoutMs: 60 * 60 * 1000,
             egress: {
                 allow: [
-                    ...claudeCodeAllowedHosts(this.lightdashConfig.ai.copilot),
+                    ...claudeCodeAllowedHosts(copilot),
                     ...extraEgressHosts,
                 ],
             },
@@ -1291,6 +1300,7 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
         organizationUuid: string,
         projectUuid: string,
+        copilot: CopilotConfig,
         extraEgressHosts: string[] = [],
     ): Promise<{
         sandboxUuid: string;
@@ -1298,7 +1308,7 @@ export class AppGenerateService extends BaseService {
         durationMs: number;
     }> {
         const start = performance.now();
-        const spec = this.buildSandboxSpec(extraEgressHosts);
+        const spec = this.buildSandboxSpec(copilot, extraEgressHosts);
         this.logger.info(
             `App ${appUuid}: launching sandbox from template ${spec.templateRef} (provider=${this.lightdashConfig.appRuntime.sandboxProvider})`,
         );
@@ -1346,12 +1356,13 @@ export class AppGenerateService extends BaseService {
     private async resumeSandbox(
         sandboxUuid: string,
         appUuid: string,
+        copilot: CopilotConfig,
         extraEgressHosts: string[] = [],
     ): Promise<{ sandbox: SandboxHandle; durationMs: number }> {
         const start = performance.now();
         const sandbox = await this.getSandboxManager().resume({
             sandboxUuid,
-            spec: this.buildSandboxSpec(extraEgressHosts),
+            spec: this.buildSandboxSpec(copilot, extraEgressHosts),
         });
         const durationMs = AppGenerateService.elapsed(start);
         this.logger.info(
@@ -1505,6 +1516,7 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         s3Client: S3Client,
         bucket: string,
+        copilot: CopilotConfig,
         extraEgressHosts: string[] = [],
     ): Promise<{
         sandbox: SandboxHandle;
@@ -1520,6 +1532,7 @@ export class AppGenerateService extends BaseService {
                 const result = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
+                    copilot,
                     extraEgressHosts,
                 );
                 durations.resumeMs = result.durationMs;
@@ -1541,6 +1554,7 @@ export class AppGenerateService extends BaseService {
             appUuid,
             organizationUuid,
             projectUuid,
+            copilot,
             extraEgressHosts,
         );
         durations.sandboxMs = createResult.durationMs;
@@ -2864,10 +2878,14 @@ export class AppGenerateService extends BaseService {
         }
 
         let claudeCodeEnv: Record<string, string>;
+        let copilot: CopilotConfig;
         let s3Client: S3Client;
         let bucket: string;
         try {
-            claudeCodeEnv = this.getClaudeCodeEnv();
+            copilot = await this.orgAiCopilotConfigResolver.getClaudeCodeConfig(
+                payload.organizationUuid,
+            );
+            claudeCodeEnv = AppGenerateService.getClaudeCodeEnv(copilot);
             ({ client: s3Client, bucket } = this.getS3Client());
         } catch (error) {
             // Config errors (missing/incomplete provider, E2B, or S3 setup) carry
@@ -2936,6 +2954,7 @@ export class AppGenerateService extends BaseService {
                         projectUuid,
                         s3Client,
                         bucket,
+                        copilot,
                         registryHosts,
                     );
                     sandbox = acquired.sandbox;
@@ -2947,6 +2966,7 @@ export class AppGenerateService extends BaseService {
                         appUuid,
                         payload.organizationUuid,
                         projectUuid,
+                        copilot,
                         registryHosts,
                     );
                     sandbox = result.sandbox;
@@ -3002,6 +3022,7 @@ export class AppGenerateService extends BaseService {
                 const result = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
+                    copilot,
                     registryHosts,
                 );
                 sandbox = result.sandbox;
@@ -4657,9 +4678,14 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         if (app.sandbox_id) {
             let sandbox: SandboxHandle | null = null;
             try {
+                const copilot =
+                    await this.orgAiCopilotConfigResolver.getClaudeCodeConfig(
+                        app.organization_uuid,
+                    );
                 const resumed = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
+                    copilot,
                 );
                 sandbox = resumed.sandbox;
                 await this.resyncSandboxFromS3(
@@ -4678,6 +4704,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                     sandbox,
                     appUuid,
                     sourceVersion,
+                    copilot,
                 );
             } catch (error) {
                 // A half-synced sandbox would corrupt the next iteration —
@@ -4867,10 +4894,11 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         sandbox: SandboxHandle,
         appUuid: string,
         sourceVersion: number,
+        copilot: CopilotConfig,
     ): Promise<void> {
         let claudeCodeEnv: Record<string, string>;
         try {
-            claudeCodeEnv = this.getClaudeCodeEnv();
+            claudeCodeEnv = AppGenerateService.getClaudeCodeEnv(copilot);
         } catch (error) {
             this.logger.warn(
                 `App ${appUuid}: skipping restore FYI — ${getErrorMessage(error)}`,
@@ -7526,6 +7554,10 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     ): Promise<void> {
         const { appUuid, version, organizationUuid, projectUuid } = payload;
         const { client, bucket } = this.getS3Client();
+        const copilot =
+            await this.orgAiCopilotConfigResolver.getClaudeCodeConfig(
+                organizationUuid,
+            );
 
         // Look up the version's custom dependency set once — null means the
         // build uses the template set only (no install step).
@@ -7562,6 +7594,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 appUuid,
                 organizationUuid,
                 projectUuid,
+                copilot,
                 registryHosts,
             );
             sandbox = result.sandbox;

--- a/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
+++ b/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
@@ -174,6 +174,7 @@ describe('OrgAiCopilotConfigResolver', () => {
         orgKeys?: AiOrgProviderApiKeys | null;
         modelVisibility?: AiOrgModelVisibility | null;
         accessibleModelIds?: string[] | null;
+        instanceConfig?: CopilotConfig;
     };
 
     const makeResolver = ({
@@ -181,10 +182,11 @@ describe('OrgAiCopilotConfigResolver', () => {
         orgKeys = { openai: 'org-openai-key' },
         modelVisibility = null,
         accessibleModelIds = null,
+        instanceConfig = baseConfig,
     }: ResolverOptions) =>
         new OrgAiCopilotConfigResolver({
             lightdashConfig: {
-                ai: { copilot: baseConfig },
+                ai: { copilot: instanceConfig },
             } as LightdashConfig,
             aiOrganizationSettingsModel: {
                 findDecryptedProviderApiKeys: vi
@@ -225,6 +227,67 @@ describe('OrgAiCopilotConfigResolver', () => {
             flagEnabled: true,
         }).getCopilotConfig('org-uuid');
         expect(result.providers.openai?.apiKey).toBe('org-openai-key');
+    });
+
+    describe('getClaudeCodeConfig', () => {
+        it('returns the instance config unchanged without an organization uuid', async () => {
+            const result = await makeResolver({
+                flagEnabled: true,
+                instanceConfig: bothProvidersConfig,
+            }).getClaudeCodeConfig(null);
+            expect(result.defaultProvider).toBe('openai');
+            expect(result.providers.anthropic?.apiKey).toBe(
+                'instance-anthropic-key',
+            );
+        });
+
+        it('returns the instance config unchanged when the feature flag is off', async () => {
+            const result = await makeResolver({
+                flagEnabled: false,
+                orgKeys: { anthropic: 'org-anthropic-key' },
+                instanceConfig: bothProvidersConfig,
+            }).getClaudeCodeConfig('org-uuid');
+            expect(result.defaultProvider).toBe('openai');
+            expect(result.providers.anthropic?.apiKey).toBe(
+                'instance-anthropic-key',
+            );
+        });
+
+        it('returns the instance config unchanged when the org has no keys', async () => {
+            const result = await makeResolver({
+                flagEnabled: true,
+                orgKeys: null,
+                instanceConfig: bothProvidersConfig,
+            }).getClaudeCodeConfig('org-uuid');
+            expect(result.providers.anthropic?.apiKey).toBe(
+                'instance-anthropic-key',
+            );
+        });
+
+        it('runs a BYO org on its own Anthropic key and forces the Anthropic provider', async () => {
+            const result = await makeResolver({
+                flagEnabled: true,
+                orgKeys: { anthropic: 'org-anthropic-key' },
+                instanceConfig: bothProvidersConfig,
+            }).getClaudeCodeConfig('org-uuid');
+            expect(result.defaultProvider).toBe('anthropic');
+            expect(result.providers.anthropic?.apiKey).toBe(
+                'org-anthropic-key',
+            );
+        });
+
+        it('never leaks the instance Anthropic key to a BYO org that only keyed OpenAI', async () => {
+            const result = await makeResolver({
+                flagEnabled: true,
+                orgKeys: { openai: 'org-openai-key' },
+                instanceConfig: bothProvidersConfig,
+            }).getClaudeCodeConfig('org-uuid');
+            // Anthropic is stripped, so key resolution fails loudly rather than
+            // silently billing the instance — the sandbox can't run a Claude
+            // turn on the instance key.
+            expect(result.providers.anthropic).toBeUndefined();
+            expect(result.defaultProvider).toBe('anthropic');
+        });
     });
 
     describe('resolveEffectiveModelVisibilityForOrg', () => {

--- a/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.ts
+++ b/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.ts
@@ -139,6 +139,41 @@ export class OrgAiCopilotConfigResolver {
     }
 
     /**
+     * Copilot config for the data-apps sandbox (the `claude` CLI). Claude Code
+     * supports only Anthropic and Bedrock, and Bedrock is instance infra (never
+     * BYO) — so a BYO org must run the sandbox on its own Anthropic key. This
+     * forces Anthropic and drops any instance Anthropic key the org didn't
+     * bring, so the sandbox can never silently fall back to the instance key (a
+     * billing + data-governance leak). With no usable org Anthropic key the
+     * config carries none and key resolution fails only where a Claude turn
+     * needs it — not for key-less sandbox work (dependency builds, restores).
+     * Non-BYO orgs get the instance config unchanged.
+     */
+    async getClaudeCodeConfig(
+        organizationUuid: string | null | undefined,
+    ): Promise<CopilotConfig> {
+        const base = this.lightdashConfig.ai.copilot;
+        if (!organizationUuid) return base;
+        if (!(await this.isEnabled(organizationUuid))) return base;
+        const orgKeys =
+            await this.aiOrganizationSettingsModel.findDecryptedProviderApiKeys(
+                organizationUuid,
+            );
+        if (!orgKeys) return base;
+        const overlaid = overlayOrgProviderApiKeys(base, orgKeys);
+        return {
+            ...overlaid,
+            defaultProvider: 'anthropic',
+            providers: {
+                ...overlaid.providers,
+                anthropic: orgKeys.anthropic
+                    ? overlaid.providers.anthropic
+                    : undefined,
+            },
+        };
+    }
+
+    /**
      * Org overrides for model LISTINGS (visibility settings + which hidden
      * models the org's own Anthropic key unlocks). Both are null unless the
      * feature flag is on AND the org has at least one BYO key, so deleting


### PR DESCRIPTION
## What & why

Data-app generation runs the `claude` CLI inside a sandbox. Its API key was resolved from the **instance** config (`lightdashConfig.ai.copilot` → `ANTHROPIC_API_KEY`, or instance Bedrock) regardless of whether the org brings its own AI provider key.

For a BYO-key org this is a **billing + data-governance leak**: their prompts and data flow through the instance provider account they didn't choose, and the instance gets billed. This is the same class of leak already closed for auxiliary AI (thread titles, follow-ups, AI Router, Slack routing, compaction). Data apps were missed — only the pre-generation **clarifier** honored BYOK (`getCopilotConfig`); the actual generation, dependency build, and version-restore paths all used the instance key.

## The fix

- **`OrgAiCopilotConfigResolver.getClaudeCodeConfig(orgUuid)`** — a sandbox-specific resolver. Reuses the existing `overlayOrgProviderApiKeys`, then:
  - **Forces `defaultProvider: 'anthropic'`** — a BYO org is never routed through instance Bedrock.
  - **Strips the instance Anthropic key** when the org didn't bring its own, so the sandbox can never silently fall back to it. The config carries no Anthropic key in that case, and key resolution fails loudly **only where a Claude turn actually needs it** — key-less sandbox work (dependency builds, restores) still runs.
- **`AppGenerateService`** — threads the org-resolved `CopilotConfig` through every sandbox touchpoint (`getClaudeCodeEnv`, `buildSandboxSpec`, `createSandbox`, `resumeSandbox`, `acquireSandbox`, `notifyClaudeOfRestore`) so the **env (the key) and the egress allowlist always agree**. Resolved once at each of the three entry points (`runPipeline`, `restoreVersion`, `runBuildFromSourcePipeline`), all of which already had `organizationUuid` in scope.

## Who is affected

| Case | Before | After |
|------|--------|-------|
| **No BYOK** (org uses instance key) | instance key | **unchanged** — instance key, same provider (Anthropic or Bedrock) |
| **BYOK, Anthropic key** | leaked to instance key | runs on the **org's own Anthropic key** |
| **BYOK, OpenAI-only key** | leaked to instance Anthropic key | **refused** with a clear `MissingConfigError` at generation time |

The OpenAI-only-BYOK case can't run data apps at all — Claude Code only supports Anthropic and Bedrock, and Bedrock is instance infrastructure (never BYO). Refusing loudly is the correct posture vs. silently charging the instance key. Such an org can't have functioning data apps anyway.

## Testing

- `pnpm -F backend typecheck:fast` — clean
- 130 tests pass across the full `AppGenerateService` suite + resolver
- 5 new `getClaudeCodeConfig` tests covering the isolation cases, including *"never leaks the instance Anthropic key to a BYO org that only keyed OpenAI"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
