### PR TITLE
fix: correct oversized 'edit' emphasis in dashboard filter tooltip

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
@@ -121,7 +121,7 @@ const AddFilterButton: FC<Props> = ({
         unsavedFiltersTooltip === undefined ? (
             <Text fz="xs">
                 Only filters added in{' '}
-                <Text span fw={600}>
+                <Text span fz="xs" fw={600}>
                     'edit'
                 </Text>{' '}
                 mode will be saved


### PR DESCRIPTION
### Description:
The nested Mantine <Text span> around 'edit' did not inherit the outer fz="xs", so it reset to the default md (16px) size and rendered much larger than the surrounding tooltip text. Add fz="xs" to the span so only the font weight distinguishes it.

Before:

<img width="349" height="159" alt="before" src="https://github.com/user-attachments/assets/8856f779-6ced-4c63-bdb2-08bad806129f" />

After:
<img width="349" height="159" alt="after" src="https://github.com/user-attachments/assets/9eba4167-ef55-46ab-a9e2-86c0ba798caf" />
