### PR TITLE
feat(totals): gate totals on query success and show loading skeletons

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -232,6 +232,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
         showSubtotalsExpanded,
         showRowGrouping,
         updateColumnProperty,
+        isCalculatingColumnTotals,
+        isCalculatingRowTotals,
+        isCalculatingSubtotals,
     } = visualizationConfig.chartConfig;
 
     const onColumnWidthChange =
@@ -325,6 +328,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 }
                                 onColumnWidthChange={onColumnWidthChange}
                                 parameters={parameters}
+                                isColumnTotalsLoading={
+                                    isCalculatingColumnTotals
+                                }
+                                isRowTotalsLoading={isCalculatingRowTotals}
+                                isSubtotalsLoading={isCalculatingSubtotals}
                                 {...rest}
                             />
                         ) : (
@@ -347,6 +355,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 }
                                 onColumnWidthChange={onColumnWidthChange}
                                 parameters={parameters}
+                                isColumnTotalsLoading={
+                                    isCalculatingColumnTotals
+                                }
+                                isRowTotalsLoading={isCalculatingRowTotals}
+                                isSubtotalsLoading={isCalculatingSubtotals}
                                 {...rest}
                             />
                         )}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -28,7 +28,13 @@ import {
     type SortField,
 } from '@lightdash/common';
 import { Box, Menu, type BoxProps } from '@mantine-8/core';
-import { Button, Group, useMantineColorScheme, Text } from '@mantine/core';
+import {
+    Button,
+    Group,
+    Skeleton,
+    Text,
+    useMantineColorScheme,
+} from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import {
     flexRender,
@@ -171,6 +177,12 @@ type PivotTableProps = BoxProps & // TODO: remove this
          * `showSubtotals` is true (subtotals always group).
          */
         showRowGrouping?: boolean;
+        /** Column-total footer cells render a loading skeleton while their async query is in flight. */
+        isColumnTotalsLoading?: boolean;
+        /** Row-total cells render a loading skeleton while their async query is in flight. */
+        isRowTotalsLoading?: boolean;
+        /** Subtotal cells render a loading skeleton while their async query is in flight. */
+        isSubtotalsLoading?: boolean;
         columnProperties?: Record<string, ColumnProperties>;
         isMinimal: boolean;
         isDashboard?: boolean;
@@ -202,6 +214,9 @@ const PivotTable: FC<PivotTableProps> = ({
     showSubtotals = false,
     showSubtotalsExpanded = false,
     showRowGrouping = false,
+    isColumnTotalsLoading = false,
+    isRowTotalsLoading = false,
+    isSubtotalsLoading = false,
     columnProperties = {},
     isMinimal = false,
     isDashboard = false,
@@ -545,6 +560,20 @@ const PivotTable: FC<PivotTableProps> = ({
                                     return null;
                                 }
 
+                                if (
+                                    subtotalValue === undefined &&
+                                    isSubtotalsLoading &&
+                                    isNumericItem(item)
+                                ) {
+                                    return (
+                                        <Skeleton
+                                            height={16}
+                                            width="min(60%, 50px)"
+                                            ml="auto"
+                                        />
+                                    );
+                                }
+
                                 return (
                                     <Text span fw={600}>
                                         {formatItemValue(
@@ -580,6 +609,7 @@ const PivotTable: FC<PivotTableProps> = ({
         frozenLayout,
         rowNumberWidth,
         parameters,
+        isSubtotalsLoading,
     ]);
 
     // Minimum table width so auto columns don't get squeezed to zero
@@ -2038,7 +2068,14 @@ const PivotTable: FC<PivotTableProps> = ({
                                                 )
                                             )
                                         ) : cell.getIsPlaceholder() ||
-                                          isBlankMergeDataCell ? null : (
+                                          isBlankMergeDataCell ? null : isRowTotal &&
+                                          isRowTotalsLoading ? (
+                                            <Skeleton
+                                                height={16}
+                                                width="min(60%, 50px)"
+                                                ml="auto"
+                                            />
+                                        ) : (
                                             flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext(),
@@ -2177,6 +2214,18 @@ const PivotTable: FC<PivotTableProps> = ({
                                             )}
                                         >
                                             {value.formatted}
+                                        </Table.CellHead>
+                                    ) : isColumnTotalsLoading ? (
+                                        <Table.CellHead
+                                            key={`column-total-${totalRowIndex}-${totalColIndex}`}
+                                            withAlignRight
+                                            isMinimal={isMinimal}
+                                        >
+                                            <Skeleton
+                                                height={16}
+                                                width="min(60%, 50px)"
+                                                ml="auto"
+                                            />
                                         </Table.CellHead>
                                     ) : (
                                         <Table.Cell

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -229,7 +229,7 @@ const getDataAndColumns = ({
                     cell: (info) => getFormattedValueCell(info, parameters),
 
                     footer: () => {
-                        if (totals?.[itemId]) {
+                        if (totals?.[itemId] !== undefined) {
                             return formatItemValue(
                                 item,
                                 totals[itemId],

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -4,13 +4,14 @@ import {
     isCustomDimension,
     isDimension,
     isField,
+    isNumericItem,
     normalizePivotMatchRaw,
     type ItemsMap,
     type ParametersValuesMap,
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
-import { Text } from '@mantine/core';
+import { Skeleton, Text } from '@mantine/core';
 import { captureException } from '@sentry/react';
 import type { CellContext } from '@tanstack/react-table';
 import {
@@ -35,7 +36,9 @@ type Args = {
     getFieldLabelOverride: (key: string) => string | undefined;
     columnOrder: string[];
     totals?: Record<string, number>;
+    totalsLoading?: boolean;
     groupedSubtotals?: Record<string, Record<string, number>[]>;
+    subtotalsLoading?: boolean;
     parameters?: ParametersValuesMap;
 };
 
@@ -156,7 +159,9 @@ const getDataAndColumns = ({
     getFieldLabelOverride,
     columnOrder,
     totals,
+    totalsLoading,
     groupedSubtotals,
+    subtotalsLoading,
     parameters,
 }: Args): Array<TableHeader | TableColumn> => {
     // Deduplicate columnOrder to prevent duplicate columns if the same field appears multiple times
@@ -223,15 +228,26 @@ const getDataAndColumns = ({
                     ),
                     cell: (info) => getFormattedValueCell(info, parameters),
 
-                    footer: () =>
-                        totals?.[itemId]
-                            ? formatItemValue(
-                                  item,
-                                  totals[itemId],
-                                  false,
-                                  parameters,
-                              )
-                            : null,
+                    footer: () => {
+                        if (totals?.[itemId]) {
+                            return formatItemValue(
+                                item,
+                                totals[itemId],
+                                false,
+                                parameters,
+                            );
+                        }
+                        if (totalsLoading && isNumericItem(item)) {
+                            return (
+                                <Skeleton
+                                    height={16}
+                                    width="min(60%, 50px)"
+                                    ml="auto"
+                                />
+                            );
+                        }
+                        return null;
+                    },
                     meta: {
                         item,
                         labelOverride: headerOverride,
@@ -276,6 +292,20 @@ const getDataAndColumns = ({
 
                             if (subtotalValue === null) {
                                 return null;
+                            }
+
+                            if (
+                                subtotalValue === undefined &&
+                                subtotalsLoading &&
+                                isNumericItem(item)
+                            ) {
+                                return (
+                                    <Skeleton
+                                        height={16}
+                                        width="min(60%, 50px)"
+                                        ml="auto"
+                                    />
+                                );
                             }
 
                             return (

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -8,6 +8,7 @@ import {
     isNumericItem,
     isTableCalculation,
     itemsInMetricQuery,
+    QueryHistoryStatus,
     type ColumnProperties,
     type ConditionalFormattingConfig,
     type ConditionalFormattingMinMaxMap,
@@ -223,14 +224,21 @@ const useTableConfig = (
     }, [dimensions.length, numUnpivotedDimensions]);
 
     const projectUuid = useProjectUuid();
+    // Only request totals once the initial query has succeeded — a queryUuid can
+    // exist for a query that errored, and totals against that are meaningless.
+    const isInitialQueryReady =
+        resultsData?.queryStatus === QueryHistoryStatus.READY;
     const canFetchAsyncTotals =
-        !!resultsData?.queryUuid && !!tableChartConfig?.showColumnCalculation;
-    const { data: asyncTotals } = useAsyncCalculateTotal({
-        projectUuid,
-        sourceQueryUuid: resultsData?.queryUuid,
-        enabled: canFetchAsyncTotals,
-        invalidateCache,
-    });
+        isInitialQueryReady &&
+        !!resultsData?.queryUuid &&
+        !!tableChartConfig?.showColumnCalculation;
+    const { data: asyncTotals, isFetching: isCalculatingColumnTotals } =
+        useAsyncCalculateTotal({
+            projectUuid,
+            sourceQueryUuid: resultsData?.queryUuid,
+            enabled: canFetchAsyncTotals,
+            invalidateCache,
+        });
 
     // Index dimension field ids the warehouse row-total query groups by — the
     // worker keys each rendered row's total by these. Row totals are exclusively
@@ -244,26 +252,29 @@ const useTableConfig = (
             : [indexColumn.reference];
     }, [resultsData?.pivotDetails?.indexColumn]);
     const canFetchAsyncRowTotals =
+        isInitialQueryReady &&
         !!resultsData?.queryUuid &&
         !!tableChartConfig?.showRowCalculation &&
         !!resultsData?.pivotDetails;
-    const { data: asyncRowTotals } = useAsyncCalculateRowTotal({
-        projectUuid,
-        sourceQueryUuid: resultsData?.queryUuid,
-        indexFieldIds: rowTotalIndexFieldIds,
-        enabled: canFetchAsyncRowTotals,
-        invalidateCache,
-    });
+    const { data: asyncRowTotals, isFetching: isCalculatingRowTotals } =
+        useAsyncCalculateRowTotal({
+            projectUuid,
+            sourceQueryUuid: resultsData?.queryUuid,
+            indexFieldIds: rowTotalIndexFieldIds,
+            enabled: canFetchAsyncRowTotals,
+            invalidateCache,
+        });
 
-    const { data: groupedSubtotals } = useAsyncCalculateSubtotals({
-        projectUuid,
-        sourceQueryUuid: resultsData?.queryUuid,
-        dimensions: resultsData?.metricQuery?.dimensions,
-        columnOrder,
-        pivotDimensions,
-        enabled: showSubtotals && canUseSubtotals,
-        invalidateCache,
-    });
+    const { data: groupedSubtotals, isFetching: isCalculatingSubtotals } =
+        useAsyncCalculateSubtotals({
+            projectUuid,
+            sourceQueryUuid: resultsData?.queryUuid,
+            dimensions: resultsData?.metricQuery?.dimensions,
+            columnOrder,
+            pivotDimensions,
+            enabled: isInitialQueryReady && showSubtotals && canUseSubtotals,
+            invalidateCache,
+        });
 
     const columns = useMemo(() => {
         if (!selectedItemIds || !itemsMap) {
@@ -284,7 +295,9 @@ const useTableConfig = (
             getColumnWidth,
             columnOrder,
             totals: asyncTotals,
+            totalsLoading: isCalculatingColumnTotals,
             groupedSubtotals,
+            subtotalsLoading: isCalculatingSubtotals,
             parameters,
         });
     }, [
@@ -298,7 +311,9 @@ const useTableConfig = (
         getColumnWidth,
         getFieldLabelOverride,
         asyncTotals,
+        isCalculatingColumnTotals,
         groupedSubtotals,
+        isCalculatingSubtotals,
         parameters,
     ]);
     const worker = useWorker(createWorker);
@@ -687,6 +702,9 @@ const useTableConfig = (
             isPivotResultStale,
             canUseSubtotals,
             groupedSubtotals,
+            isCalculatingColumnTotals,
+            isCalculatingRowTotals,
+            isCalculatingSubtotals,
             rowLimit,
             setRowLimit,
         }),
@@ -731,6 +749,9 @@ const useTableConfig = (
             isPivotResultStale,
             canUseSubtotals,
             groupedSubtotals,
+            isCalculatingColumnTotals,
+            isCalculatingRowTotals,
+            isCalculatingSubtotals,
             rowLimit,
             setRowLimit,
         ],

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -12,6 +12,7 @@ import {
     isMetric,
     isNumericItem,
     isResultValue,
+    QueryHistoryStatus,
     renderRichTextTemplate,
     renderTemplatedUrl,
     type AdditionalMetric,
@@ -26,7 +27,7 @@ import {
     type ResultValue,
     type TableCalculation,
 } from '@lightdash/common';
-import { Group, Tooltip } from '@mantine/core';
+import { Group, Skeleton, Tooltip } from '@mantine/core';
 import { IconExclamationCircle } from '@tabler/icons-react';
 import { type CellContext } from '@tanstack/react-table';
 import omit from 'lodash/omit';
@@ -601,16 +602,26 @@ export const useColumns = (): TableColumn[] => {
     const sourceQueryUuid = unpivotedEnabled
         ? unpivotedQueryResults.queryUuid
         : queryResults.queryUuid;
+    const sourceQueryStatus = unpivotedEnabled
+        ? unpivotedQueryResults.queryStatus
+        : queryResults.queryStatus;
+    // Only request totals once the source query has succeeded
+    const isInitialQueryReady = sourceQueryStatus === QueryHistoryStatus.READY;
     const hasMetricFields = !!resultsMetricQuery?.metrics.length;
     // The results table has no explicit "Show column totals" setting, so the
     // `column_totals` project default decides whether the totals query runs
     const totalsEnabledByDefault = useColumnTotalsEnabledByDefault(projectUuid);
-    const { data: totals } = useAsyncCalculateTotal({
-        projectUuid,
-        sourceQueryUuid,
-        enabled: !!sourceQueryUuid && hasMetricFields && totalsEnabledByDefault,
-        invalidateCache: validQueryArgs?.invalidateCache,
-    });
+    const { data: totals, isFetching: isCalculatingTotals } =
+        useAsyncCalculateTotal({
+            projectUuid,
+            sourceQueryUuid,
+            enabled:
+                isInitialQueryReady &&
+                !!sourceQueryUuid &&
+                hasMetricFields &&
+                totalsEnabledByDefault,
+            invalidateCache: validQueryArgs?.invalidateCache,
+        });
 
     return useMemo(() => {
         if (hasNoActiveFields) {
@@ -674,16 +685,27 @@ export const useColumns = (): TableColumn[] => {
                             timezone,
                         );
                     },
-                    footer: () =>
-                        totals?.[fieldId]
-                            ? formatItemValue(
-                                  item,
-                                  totals[fieldId],
-                                  false,
-                                  parameters,
-                                  timezone,
-                              )
-                            : null,
+                    footer: () => {
+                        if (totals?.[fieldId]) {
+                            return formatItemValue(
+                                item,
+                                totals[fieldId],
+                                false,
+                                parameters,
+                                timezone,
+                            );
+                        }
+                        if (isCalculatingTotals && isNumericItem(item)) {
+                            return (
+                                <Skeleton
+                                    height={16}
+                                    width="min(60%, 50px)"
+                                    ml="auto"
+                                />
+                            );
+                        }
+                        return null;
+                    },
                     meta: {
                         item,
                         draggable: true,
@@ -749,6 +771,7 @@ export const useColumns = (): TableColumn[] => {
         invalidActiveItems,
         sorts,
         totals,
+        isCalculatingTotals,
         exploreData,
         parameters,
         timezone,

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -686,7 +686,7 @@ export const useColumns = (): TableColumn[] => {
                         );
                     },
                     footer: () => {
-                        if (totals?.[fieldId]) {
+                        if (totals?.[fieldId] !== undefined) {
                             return formatItemValue(
                                 item,
                                 totals[fieldId],


### PR DESCRIPTION
Closes: PROD-8691

### Description:
The frontend now only requests column, row and subtotal totals once the initial results query has succeeded (reaches `READY`), instead of firing whenever a query UUID exists — so a query that errored no longer triggers a totals request. While an async totals query is in flight, the affected total cells render a loading skeleton instead of an empty cell, covering the explorer results-table footer and the table visualisation's column-totals footer, row-total columns and subtotal cells across both flat and pivoted layouts.


https://github.com/user-attachments/assets/66e6f4e0-08fd-4cd2-a660-b5365e61bb8a

