### PR TITLE
feat(tables): use 3-dot icon for column header context menus

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -19,7 +19,7 @@ import {
 } from '@lightdash/common';
 import { ActionIcon, Box, Group, Menu, Text } from '@mantine-8/core';
 import {
-    IconChevronDown,
+    IconDots,
     IconFilter,
     IconPencil,
     IconTimelineEvent,
@@ -410,8 +410,9 @@ const ColumnHeaderContextMenu: FC<HeaderProps> = ({ header }) => {
                                 variant="light"
                                 bg="transparent"
                                 color="ldGray.6"
+                                aria-label="Context menu"
                             >
-                                <MantineIcon icon={IconChevronDown} />
+                                <MantineIcon icon={IconDots} />
                             </ActionIcon>
                         </Menu.Target>
 

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataHeaderContextMenu.tsx
@@ -6,7 +6,7 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { ActionIcon, Flex, Menu, Text } from '@mantine-8/core';
-import { IconCheck, IconChevronDown } from '@tabler/icons-react';
+import { IconCheck, IconDots } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import {
     getSortDirectionOrder,
@@ -113,8 +113,13 @@ const UnderlyingDataHeaderContextMenu: FC<
                 {iconSort ? <MantineIcon icon={iconSort} /> : <div />}
                 <Menu withinPortal withArrow shadow="md">
                     <Menu.Target>
-                        <ActionIcon size="xs" variant="light" bg="transparent">
-                            <MantineIcon icon={IconChevronDown} />
+                        <ActionIcon
+                            size="xs"
+                            variant="light"
+                            bg="transparent"
+                            aria-label="Context menu"
+                        >
+                            <MantineIcon icon={IconDots} />
                         </ActionIcon>
                     </Menu.Target>
 

--- a/packages/frontend/src/components/SimpleTable/DashboardHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardHeaderContextMenu.tsx
@@ -5,7 +5,7 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { ActionIcon, Flex, Menu, Text } from '@mantine-8/core';
-import { IconCheck, IconChevronDown } from '@tabler/icons-react';
+import { IconCheck, IconDots } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import {
@@ -124,8 +124,13 @@ const DashboardHeaderContextMenu: FC<HeaderProps & { tileUuid: string }> = ({
                 }
                 <Menu withinPortal withArrow shadow="md">
                     <Menu.Target>
-                        <ActionIcon size="xs" variant="light" bg="transparent">
-                            <MantineIcon icon={IconChevronDown} />
+                        <ActionIcon
+                            size="xs"
+                            variant="light"
+                            bg="transparent"
+                            aria-label="Context menu"
+                        >
+                            <MantineIcon icon={IconDots} />
                         </ActionIcon>
                     </Menu.Target>
 


### PR DESCRIPTION
## Description

A chevron in a table column header conventionally signals sort, so users didn't realize it opened a context menu and missed the "Edit format", filter, and quick calculation actions behind it.

This swaps the chevron for the standard 3-dot context menu icon (the convention we use for context menus everywhere else) and adds an accessible `aria-label="Context menu"`, in all three table header menus that shared the chevron:

- Explore results table (`ColumnHeaderContextMenu`) — the one from the ticket
- Underlying data modal (`UnderlyingDataHeaderContextMenu`)
- Dashboard table tiles (`DashboardHeaderContextMenu`)

## Testing

Verified in the app: the 3 dots render on each column header in the explore results table (including narrow columns), the menu opens with all options intact, and the "Edit format" journey from the ticket works end to end.

Closes: PROD-8708
