### PR TITLE
fix(scheduler): enforce AI agent space access on AI-augmented deliveries

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -71,6 +71,7 @@ import {
     getWebAiChartConfig,
     GITHUB_MCP_SERVER_NAME,
     GITHUB_MCP_SERVER_URL,
+    hasAiAgentAccessToSpace,
     InsufficientGitPermissionsError,
     isAiWritebackRunInProgress,
     isGitProjectType,
@@ -1455,10 +1456,7 @@ export class AiAgentService extends BaseService {
         agent: AiAgent,
         spaceUuid: string,
     ) {
-        if (
-            agent.spaceAccess.length > 0 &&
-            !agent.spaceAccess.includes(spaceUuid)
-        ) {
+        if (!hasAiAgentAccessToSpace(agent, spaceUuid)) {
             throw new ForbiddenError(
                 'AI agent is not available in the embedded space',
             );
@@ -1505,8 +1503,7 @@ export class AiAgentService extends BaseService {
         return agents.filter(
             (agent) =>
                 agent.uuid === tokenAgentUuid &&
-                (agent.spaceAccess.length === 0 ||
-                    agent.spaceAccess.includes(spaceUuid)),
+                hasAiAgentAccessToSpace(agent, spaceUuid),
         );
     }
 

--- a/packages/backend/src/ee/services/SchedulerAiAugmentationService/SchedulerAiAugmentationService.ts
+++ b/packages/backend/src/ee/services/SchedulerAiAugmentationService/SchedulerAiAugmentationService.ts
@@ -3,6 +3,7 @@ import {
     assertUnreachable,
     CreateSchedulerAndTargets,
     ForbiddenError,
+    hasAiAgentAccessToSpace,
     hasSchedulerUuid,
     isChartScheduler,
     isDashboardChartTileType,
@@ -79,7 +80,8 @@ export class SchedulerAiAugmentationService {
     // augmentation is rejected with a 4xx at write time rather than failing
     // (or running unentitled) on every scheduled fire: copilot entitlement,
     // non-empty instructions, the agent pinned to the scheduler's project,
-    // and access to the pinned source thread.
+    // the agent's space access covering the delivered content, and access to
+    // the pinned source thread.
     async upsertAugmentation(
         user: SessionUser,
         schedulerUuid: string,
@@ -99,11 +101,19 @@ export class SchedulerAiAugmentationService {
             );
         }
         if (augmentation.type === 'agent') {
-            await this.aiAgentService.getAgent(
+            const agent = await this.aiAgentService.getAgent(
                 user,
                 augmentation.agentUuid,
                 resource.projectUuid,
             );
+            if (
+                resource.spaceUuid !== null &&
+                !hasAiAgentAccessToSpace(agent, resource.spaceUuid)
+            ) {
+                throw new ParameterError(
+                    `AI agent "${agent.name}" does not have access to the space containing this delivery's content`,
+                );
+            }
             if (augmentation.sourceThreadUuid) {
                 await this.aiAgentService.validateThreadContextAccess(user, {
                     threadUuid: augmentation.sourceThreadUuid,
@@ -152,7 +162,7 @@ export class SchedulerAiAugmentationService {
 
         switch (augmentation.type) {
             case 'agent': {
-                const { organizationUuid } =
+                const { organizationUuid, projectUuid, spaceUuid } =
                     await this.schedulerService.getSchedulerProjectContext(
                         scheduler,
                     );
@@ -161,6 +171,24 @@ export class SchedulerAiAugmentationService {
                         createdBy,
                         organizationUuid,
                     );
+                // Re-checked per fire (not just at write time) because the
+                // agent's space access can change after the schedule is saved,
+                // and an unsaved "send now" never goes through upsert. Failing
+                // here degrades to a partial failure on the delivery instead
+                // of a confusing "content not found" agent summary.
+                const agent = await this.aiAgentService.getAgent(
+                    creator,
+                    augmentation.agentUuid,
+                    projectUuid,
+                );
+                if (
+                    spaceUuid !== null &&
+                    !hasAiAgentAccessToSpace(agent, spaceUuid)
+                ) {
+                    throw new ForbiddenError(
+                        `AI agent "${agent.name}" does not have access to the space containing this delivery's content`,
+                    );
+                }
                 return this.aiAgentService.generateScheduledReport(creator, {
                     agentUuid: augmentation.agentUuid,
                     prompt: augmentation.prompt,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -175,18 +175,22 @@ export class SchedulerService extends BaseService {
 
     public async getSchedulerProjectContext(
         scheduler: Scheduler | CreateSchedulerAndTargets,
-    ): Promise<{ projectUuid: string; organizationUuid: string }> {
+    ): Promise<{
+        projectUuid: string;
+        organizationUuid: string;
+        spaceUuid: string | null;
+    }> {
         if (isChartScheduler(scheduler)) {
-            const { projectUuid, organizationUuid } =
+            const { projectUuid, organizationUuid, spaceUuid } =
                 await this.savedChartModel.getSummary(scheduler.savedChartUuid);
-            return { projectUuid, organizationUuid };
+            return { projectUuid, organizationUuid, spaceUuid };
         }
         if (isDashboardScheduler(scheduler)) {
-            const { projectUuid, organizationUuid } =
+            const { projectUuid, organizationUuid, spaceUuid } =
                 await this.dashboardModel.getByIdOrSlug(
                     scheduler.dashboardUuid,
                 );
-            return { projectUuid, organizationUuid };
+            return { projectUuid, organizationUuid, spaceUuid };
         }
         if (isSqlChartScheduler(scheduler)) {
             const sqlChart = await this.savedSqlModel.getByUuid(
@@ -196,6 +200,7 @@ export class SchedulerService extends BaseService {
             return {
                 projectUuid: sqlChart.project.projectUuid,
                 organizationUuid: sqlChart.organization.organizationUuid,
+                spaceUuid: sqlChart.space.uuid,
             };
         }
         if (isAppScheduler(scheduler)) {
@@ -206,6 +211,7 @@ export class SchedulerService extends BaseService {
             return {
                 projectUuid: app.project_uuid,
                 organizationUuid: app.organization_uuid,
+                spaceUuid: null,
             };
         }
         throw new ParameterError('Invalid scheduler type');
@@ -290,7 +296,11 @@ export class SchedulerService extends BaseService {
         sendNow: boolean = false,
     ): Promise<{
         scheduler: Scheduler;
-        resource: { projectUuid: string; organizationUuid: string };
+        resource: {
+            projectUuid: string;
+            organizationUuid: string;
+            spaceUuid: string | null;
+        };
     }> {
         // admins can manage all scheduled deliveries,
         // everyone below can only manage their own scheduled deliveries
@@ -349,7 +359,11 @@ export class SchedulerService extends BaseService {
         schedulerUuid: string,
     ): Promise<{
         scheduler: Scheduler;
-        resource: { projectUuid: string; organizationUuid: string };
+        resource: {
+            projectUuid: string;
+            organizationUuid: string;
+            spaceUuid: string | null;
+        };
     }> {
         return this.checkUserCanUpdateSchedulerResource(user, schedulerUuid);
     }

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -205,6 +205,13 @@ export type AiAgentSummary = Pick<
     | 'version'
 >;
 
+// An empty spaceAccess list means the agent is unrestricted (all spaces).
+export const hasAiAgentAccessToSpace = (
+    agent: Pick<AiAgent, 'spaceAccess'>,
+    spaceUuid: string,
+): boolean =>
+    agent.spaceAccess.length === 0 || agent.spaceAccess.includes(spaceUuid);
+
 export type AiAgentUser = {
     uuid: string;
     name: string;

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormAiInput.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormAiInput.tsx
@@ -1,4 +1,7 @@
-import { type SchedulerAiAugmentation } from '@lightdash/common';
+import {
+    hasAiAgentAccessToSpace,
+    type SchedulerAiAugmentation,
+} from '@lightdash/common';
 import {
     Box,
     Group,
@@ -8,7 +11,7 @@ import {
     Text,
     Textarea,
 } from '@mantine-8/core';
-import { type FC } from 'react';
+import { useEffect, type FC } from 'react';
 import { AiAgentIcon } from '../../../../ee/features/aiCopilot/components/AiAgentIcon';
 import { useAiAgentButtonVisibility } from '../../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useProjectAiAgents } from '../../../../ee/features/aiCopilot/hooks/useProjectAiAgents';
@@ -18,13 +21,21 @@ import { useSchedulerFormContext } from './schedulerFormContext';
 
 type Props = {
     projectUuid: string | undefined;
+    /** Space of the delivered chart/dashboard; agents are not filtered while undefined (loading) */
+    resourceSpaceUuid: string | undefined;
     /** Skip the panel chrome and leading icon when the host surface already provides them */
     bare?: boolean;
 };
 
 // Renders nothing unless AI is available for this project. Turning it on makes
 // the delivery message AI-written; picking an agent is an optional upgrade.
-export const SchedulerFormAiInput: FC<Props> = ({ projectUuid, bare }) => {
+// Agents whose space access doesn't cover the delivered content are hidden —
+// at delivery time they can't fetch it and produce a broken summary.
+export const SchedulerFormAiInput: FC<Props> = ({
+    projectUuid,
+    resourceSpaceUuid,
+    bare,
+}) => {
     const form = useSchedulerFormContext();
     const isAiVisible = useAiAgentButtonVisibility();
     const { data: agentsData } = useProjectAiAgents({
@@ -33,12 +44,39 @@ export const SchedulerFormAiInput: FC<Props> = ({ projectUuid, bare }) => {
         options: { enabled: isAiVisible },
     });
 
+    const augmentation = form.values.aiAugmentation;
+    const { setFieldValue } = form;
+
+    // A saved agent may have lost access to the content's space since the
+    // schedule was created; downgrade so the hidden selection isn't silently
+    // re-saved and rejected by the backend.
+    useEffect(() => {
+        if (
+            augmentation?.type === 'agent' &&
+            agentsData !== undefined &&
+            resourceSpaceUuid !== undefined &&
+            !agentsData.some(
+                (agent) =>
+                    agent.uuid === augmentation.agentUuid &&
+                    hasAiAgentAccessToSpace(agent, resourceSpaceUuid),
+            )
+        ) {
+            setFieldValue('aiAugmentation', {
+                type: 'fast_model',
+                prompt: augmentation.prompt,
+            });
+        }
+    }, [augmentation, agentsData, resourceSpaceUuid, setFieldValue]);
+
     if (!isAiVisible) {
         return null;
     }
 
-    const agents = agentsData ?? [];
-    const augmentation = form.values.aiAugmentation;
+    const agents = (agentsData ?? []).filter(
+        (agent) =>
+            resourceSpaceUuid === undefined ||
+            hasAiAgentAccessToSpace(agent, resourceSpaceUuid),
+    );
     const isEnabled = augmentation !== null;
     const selectedAgentUuid =
         augmentation?.type === 'agent' ? augmentation.agentUuid : null;

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -26,6 +26,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import DocumentationHelpButton from '../../../components/DocumentationHelpButton';
 import { useAiAgentButtonVisibility } from '../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useSavedQuery } from '../../../hooks/useSavedQuery';
 import { useSchedulerFormModal } from '../hooks/useSchedulerFormModal';
 import {
     getVisibleSections,
@@ -114,6 +115,17 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
         initialFormValues,
     });
 
+    // The AI agent selector filters by the delivered content's space. For
+    // dashboards the space comes with the form-modal's dashboard query; for
+    // charts we fetch the chart here (alerts have no AI section, so skip).
+    const { data: savedChart } = useSavedQuery({
+        uuidOrSlug: isChart && !isThresholdAlert ? resourceUuid : undefined,
+        projectUuid,
+    });
+    const resourceSpaceUuid = isChart
+        ? savedChart?.spaceUuid
+        : dashboard?.spaceUuid;
+
     const sections = useMemo(
         () =>
             getVisibleSections({
@@ -185,7 +197,13 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
             case 'message':
                 return <SchedulerMessageSection />;
             case 'ai':
-                return <SchedulerFormAiInput projectUuid={projectUuid} bare />;
+                return (
+                    <SchedulerFormAiInput
+                        projectUuid={projectUuid}
+                        resourceSpaceUuid={resourceSpaceUuid}
+                        bare
+                    />
+                );
             case 'alert':
                 return (
                     <SchedulerAlertSection


### PR DESCRIPTION
## Problem

The "AI agent (optional)" selector on scheduled deliveries listed every agent in the project, including agents whose space access doesn't cover the delivered dashboard/chart. At delivery time the agent can't fetch the content and recipients get a confusing "I can't find the dashboard" summary.

## Changes

- **Common**: new `hasAiAgentAccessToSpace(agent, spaceUuid)` predicate (empty `spaceAccess` = all spaces), reused by the existing embed checks.
- **Backend (write time)**: `upsertAugmentation` rejects an agent whose space access doesn't cover the scheduler resource's space, so API-created schedules fail with a 400 instead of shipping broken summaries. `getSchedulerProjectContext` now also returns the resource's `spaceUuid`.
- **Backend (delivery time)**: `runForDelivery` re-checks before generating the report — covers inline "send now" augmentations and agents that lose access after the schedule is saved. Failure degrades to the existing partial-failure path with a clear message.
- **Frontend**: the agent selector only shows agents with access to the delivered content's space; a saved selection that lost access is downgraded to the agentless summary.

Closes: PROD-8766
Closes: #25350
