### PR TITLE
fix(agents): scope knowledge documents to project and agent

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentScopedDocumentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentScopedDocumentController.ts
@@ -1,10 +1,11 @@
 import {
     ApiAiAgentDocumentResponse,
     ApiAiAgentDocumentSummaryListResponse,
-    ApiCreateAiAgentDocument,
+    ApiCreateAgentDocument,
     ApiErrorPayload,
     ApiSuccessEmpty,
     assertRegisteredAccount,
+    type UUID,
 } from '@lightdash/common';
 import {
     Body,
@@ -14,7 +15,6 @@ import {
     OperationId,
     Path,
     Post,
-    Query,
     Request,
     Response,
     Route,
@@ -30,41 +30,41 @@ import {
 import { BaseController } from '../../controllers/baseController';
 import { type AiAgentDocumentService } from '../services/AiAgentDocumentService';
 
-@Route('/api/v1/aiAgents/documents')
+@Route('/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents')
 @Response<ApiErrorPayload>('default', 'Error')
-export class AiAgentDocumentController extends BaseController {
+export class AiAgentScopedDocumentController extends BaseController {
     private getService(): AiAgentDocumentService {
         return this.services.getAiAgentDocumentService<AiAgentDocumentService>();
     }
 
     /**
-     * List every knowledge document in the organization.
-     * @summary List AI agent documents
+     * List the knowledge documents this agent can use: the organization level
+     * documents plus the ones granted to this agent in this project.
+     * @summary List agent documents
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/')
-    @OperationId('listAiAgentDocuments')
+    @OperationId('listAgentDocuments')
     async listDocuments(
         @Request() req: express.Request,
-        @Query() projectUuid?: string,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
     ): Promise<ApiAiAgentDocumentSummaryListResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await this.getService().listOrganizationDocuments(
+            results: await this.getService().listDocuments(
                 toSessionUser(req.account),
-                { projectUuid: projectUuid ?? undefined },
+                { projectUuid, agentUuid },
             ),
         };
     }
 
     /**
-     * Create a knowledge document. The projectUuid and agentAccess body fields
-     * are deprecated: scope the document by creating it on the agent route
-     * instead. Without them the document is available to every agent.
-     * @summary Create AI agent document
+     * Create a knowledge document scoped to this project and agent.
+     * @summary Create agent document
      */
     @Middlewares([
         allowApiKeyAuthentication,
@@ -73,25 +73,28 @@ export class AiAgentDocumentController extends BaseController {
     ])
     @SuccessResponse('201', 'Created')
     @Post('/')
-    @OperationId('createAiAgentDocument')
+    @OperationId('createAgentDocument')
     async createDocument(
         @Request() req: express.Request,
-        @Body() body: ApiCreateAiAgentDocument,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
+        @Body() body: ApiCreateAgentDocument,
     ): Promise<ApiAiAgentDocumentResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(201);
         return {
             status: 'ok',
-            results: await this.getService().createOrganizationDocument(
+            results: await this.getService().createDocument(
                 toSessionUser(req.account),
+                { projectUuid, agentUuid },
                 body,
             ),
         };
     }
 
     /**
-     * Delete a knowledge document anywhere in the organization.
-     * @summary Delete AI agent document
+     * Delete a knowledge document this agent can use.
+     * @summary Delete agent document
      */
     @Middlewares([
         allowApiKeyAuthentication,
@@ -100,14 +103,17 @@ export class AiAgentDocumentController extends BaseController {
     ])
     @SuccessResponse('200', 'Success')
     @Delete('/{documentUuid}')
-    @OperationId('deleteAiAgentDocument')
+    @OperationId('deleteAgentDocument')
     async deleteDocument(
         @Request() req: express.Request,
-        @Path() documentUuid: string,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
+        @Path() documentUuid: UUID,
     ): Promise<ApiSuccessEmpty> {
         assertRegisteredAccount(req.account);
-        await this.getService().deleteOrganizationDocument(
+        await this.getService().deleteDocument(
             toSessionUser(req.account),
+            { projectUuid, agentUuid },
             documentUuid,
         );
         this.setStatus(200);

--- a/packages/backend/src/ee/database/migrations/20260518124758_add_ai_agent_document.ts
+++ b/packages/backend/src/ee/database/migrations/20260518124758_add_ai_agent_document.ts
@@ -99,6 +99,10 @@ export async function up(knex: Knex): Promise<void> {
         );
     }
 
+    // Note added after this migration shipped: absence of access rows is not a
+    // wildcard. An agent sees a document only when project_uuid is null (org
+    // level) or an access row grants it. The ai_agent_uuid comment below states
+    // the original semantics and is left as-is to match databases already migrated.
     if (!(await knex.schema.hasTable(AiAgentDocumentAccessTableName))) {
         await knex.schema.createTable(
             AiAgentDocumentAccessTableName,

--- a/packages/backend/src/ee/models/AiAgentDocumentModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentDocumentModel.test.ts
@@ -1,0 +1,130 @@
+import { knex } from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { AiAgentDocumentModel } from './AiAgentDocumentModel';
+
+const ORG = '11111111-1111-4111-8111-111111111111';
+const PROJECT = '22222222-2222-4222-8222-222222222222';
+const AGENT = '33333333-3333-4333-8333-333333333333';
+const DOCUMENT = '44444444-4444-4444-8444-444444444444';
+
+/** Collapse whitespace so the assertions read against a single line of SQL. */
+const normalize = (sql: string) => sql.replace(/\s+/g, ' ').toLowerCase();
+
+describe('AiAgentDocumentModel agent scope', () => {
+    let tracker: Tracker;
+    const database = knex({ client: MockClient });
+    const model = new AiAgentDocumentModel({ database });
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    const capture = async (
+        run: () => Promise<unknown>,
+    ): Promise<{ sql: string; bindings: unknown[] }> => {
+        tracker.on.select(() => true).response([]);
+        await run();
+        const [query] = tracker.history.select;
+        return { sql: normalize(query.sql), bindings: query.bindings };
+    };
+
+    describe('findAllForAgent', () => {
+        it('only treats a document as org level when it has no project AND no grants', async () => {
+            const { sql } = await capture(() =>
+                model.findAllForAgent({
+                    organizationUuid: ORG,
+                    agentUuid: AGENT,
+                    projectUuid: PROJECT,
+                }),
+            );
+
+            // Org level branch: both conditions, never project_uuid is null alone
+            expect(sql).toContain(
+                '(("ai_agent_document"."project_uuid" is null and not exists',
+            );
+        });
+
+        it('requires an explicit grant for a project document', async () => {
+            const { sql } = await capture(() =>
+                model.findAllForAgent({
+                    organizationUuid: ORG,
+                    agentUuid: AGENT,
+                    projectUuid: PROJECT,
+                }),
+            );
+
+            expect(sql).toContain(
+                'exists ( select 1 from "ai_agent_document_access"',
+            );
+            expect(sql).toContain('access.ai_agent_uuid = ?');
+        });
+
+        it('scopes the organization filter outside the OR group so it cannot be bypassed', async () => {
+            const { sql, bindings } = await capture(() =>
+                model.findAllForAgent({
+                    organizationUuid: ORG,
+                    agentUuid: AGENT,
+                    projectUuid: PROJECT,
+                }),
+            );
+
+            // The org predicate must be ANDed with a parenthesised scope group.
+            // If the OR ever escapes its parentheses, every document in every
+            // organization matches. This is the regression this file exists for.
+            expect(sql).toMatch(/"organization_uuid" = \? and \(\(/);
+            expect(bindings).toContain(ORG);
+            expect(bindings).toContain(AGENT);
+            expect(bindings).toContain(PROJECT);
+        });
+
+        it('never matches a project document when the agent has no project', async () => {
+            const { sql, bindings } = await capture(() =>
+                model.findAllForAgent({
+                    organizationUuid: ORG,
+                    agentUuid: AGENT,
+                    projectUuid: null,
+                }),
+            );
+
+            expect(bindings).not.toContain(PROJECT);
+            // Granted branch still allows a granted document with no project
+            expect(sql).toContain('"ai_agent_document"."project_uuid" is null');
+        });
+    });
+
+    describe('shared predicate', () => {
+        it('findAccessibleForAgent scopes by document, organization and agent', async () => {
+            const { sql, bindings } = await capture(() =>
+                model.findAccessibleForAgent({
+                    organizationUuid: ORG,
+                    agentUuid: AGENT,
+                    projectUuid: PROJECT,
+                    documentUuid: DOCUMENT,
+                }),
+            );
+
+            expect(sql).toMatch(/"organization_uuid" = \? and \(\(/);
+            expect(bindings).toContain(DOCUMENT);
+            expect(bindings).toContain(AGENT);
+        });
+
+        it('getContentForAgent applies the same project scope as listing', async () => {
+            const { sql, bindings } = await capture(() =>
+                model.getContentForAgent({
+                    organizationUuid: ORG,
+                    agentUuid: AGENT,
+                    projectUuid: PROJECT,
+                    documentUuid: DOCUMENT,
+                }),
+            );
+
+            // Without the project scope an agent could read a document it cannot list
+            expect(bindings).toContain(PROJECT);
+            expect(sql).toMatch(/"organization_uuid" = \? and \(\(/);
+        });
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentDocumentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentDocumentModel.ts
@@ -72,6 +72,9 @@ export class AiAgentDocumentModel {
         return row ? mapRowToDocument(row) : undefined;
     }
 
+    /**
+     * @deprecated Serves the deprecated organization-wide routes. Use findAllForAgent.
+     */
     async findAllForOrganization(args: {
         organizationUuid: string;
         projectUuid?: string | null;
@@ -99,6 +102,9 @@ export class AiAgentDocumentModel {
         return rows.map(mapRowToSummary);
     }
 
+    /**
+     * @deprecated Serves the deprecated organization-wide routes. Use findAccessibleForAgent.
+     */
     async find(uuid: string): Promise<AiAgentDocument | undefined> {
         const row = await this.baseSelect()
             .where(`${AiAgentDocumentTableName}.ai_agent_document_uuid`, uuid)
@@ -106,6 +112,9 @@ export class AiAgentDocumentModel {
         return row ? mapRowToDocument(row) : undefined;
     }
 
+    /**
+     * @deprecated Serves the deprecated organization-wide routes. Use findAccessibleForAgent.
+     */
     async get(uuid: string): Promise<AiAgentDocument> {
         const doc = await this.find(uuid);
         if (!doc) {
@@ -178,20 +187,12 @@ export class AiAgentDocumentModel {
 
     private static agentAccessSubquery(qb: Knex, agentUuid: string) {
         return qb.raw(
-            `(
-                NOT EXISTS (
-                    SELECT 1 FROM ?? AS access
-                    WHERE access.ai_agent_document_uuid = ??.ai_agent_document_uuid
-                )
-                OR EXISTS (
-                    SELECT 1 FROM ?? AS access
-                    WHERE access.ai_agent_document_uuid = ??.ai_agent_document_uuid
-                      AND access.ai_agent_uuid = ?
-                )
+            `EXISTS (
+                SELECT 1 FROM ?? AS access
+                WHERE access.ai_agent_document_uuid = ??.ai_agent_document_uuid
+                  AND access.ai_agent_uuid = ?
             )`,
             [
-                AiAgentDocumentAccessTableName,
-                AiAgentDocumentTableName,
                 AiAgentDocumentAccessTableName,
                 AiAgentDocumentTableName,
                 agentUuid,
@@ -199,46 +200,105 @@ export class AiAgentDocumentModel {
         );
     }
 
+    private static noAgentAccessSubquery(qb: Knex) {
+        return qb.raw(
+            `NOT EXISTS (
+                SELECT 1 FROM ?? AS access
+                WHERE access.ai_agent_document_uuid = ??.ai_agent_document_uuid
+            )`,
+            [AiAgentDocumentAccessTableName, AiAgentDocumentTableName],
+        );
+    }
+
+    /**
+     * A document is org level, and so reaches every agent, only when it has no
+     * project and no grants. Access rows always restrict; having none is not a
+     * wildcard, so a project document nobody was granted reaches no agent.
+     */
+    private static agentScope(
+        qb: Knex,
+        agentUuid: string,
+        projectUuid: string | null,
+    ) {
+        return (builder: Knex.QueryBuilder) => {
+            void builder.where((orgLevel) => {
+                void orgLevel
+                    .whereNull(`${AiAgentDocumentTableName}.project_uuid`)
+                    .andWhere(AiAgentDocumentModel.noAgentAccessSubquery(qb));
+            });
+            void builder.orWhere((granted) => {
+                void granted
+                    .where(
+                        AiAgentDocumentModel.agentAccessSubquery(qb, agentUuid),
+                    )
+                    .andWhere((inScope) => {
+                        void inScope.whereNull(
+                            `${AiAgentDocumentTableName}.project_uuid`,
+                        );
+                        if (projectUuid) {
+                            void inScope.orWhere(
+                                `${AiAgentDocumentTableName}.project_uuid`,
+                                projectUuid,
+                            );
+                        }
+                    });
+            });
+        };
+    }
+
     async findAllForAgent(args: {
         organizationUuid: string;
         agentUuid: string;
         projectUuid: string | null;
     }): Promise<AiAgentDocumentSummary[]> {
-        const query = this.baseSelect()
+        const rows = await this.baseSelect()
             .where(
                 `${AiAgentDocumentTableName}.organization_uuid`,
                 args.organizationUuid,
             )
             .andWhere(
-                AiAgentDocumentModel.agentAccessSubquery(
+                AiAgentDocumentModel.agentScope(
                     this.database,
                     args.agentUuid,
+                    args.projectUuid,
                 ),
-            );
+            )
+            .orderBy(`${AiAgentDocumentTableName}.created_at`, 'desc');
 
-        if (args.projectUuid) {
-            void query.andWhere((builder) => {
-                void builder
-                    .whereNull(`${AiAgentDocumentTableName}.project_uuid`)
-                    .orWhere(
-                        `${AiAgentDocumentTableName}.project_uuid`,
-                        args.projectUuid!,
-                    );
-            });
-        } else {
-            void query.whereNull(`${AiAgentDocumentTableName}.project_uuid`);
-        }
-
-        const rows = await query.orderBy(
-            `${AiAgentDocumentTableName}.created_at`,
-            'desc',
-        );
         return rows.map(mapRowToSummary);
+    }
+
+    async findAccessibleForAgent(args: {
+        organizationUuid: string;
+        agentUuid: string;
+        projectUuid: string | null;
+        documentUuid: string;
+    }): Promise<AiAgentDocument | undefined> {
+        const row = await this.baseSelect()
+            .where(
+                `${AiAgentDocumentTableName}.ai_agent_document_uuid`,
+                args.documentUuid,
+            )
+            .andWhere(
+                `${AiAgentDocumentTableName}.organization_uuid`,
+                args.organizationUuid,
+            )
+            .andWhere(
+                AiAgentDocumentModel.agentScope(
+                    this.database,
+                    args.agentUuid,
+                    args.projectUuid,
+                ),
+            )
+            .first();
+
+        return row ? mapRowToDocument(row) : undefined;
     }
 
     async getContentForAgent(args: {
         organizationUuid: string;
         agentUuid: string;
+        projectUuid: string | null;
         documentUuid: string;
     }): Promise<AiAgentDocumentContent | undefined> {
         const row = await this.database(AiAgentDocumentTableName)
@@ -257,9 +317,10 @@ export class AiAgentDocumentModel {
                 args.organizationUuid,
             )
             .andWhere(
-                AiAgentDocumentModel.agentAccessSubquery(
+                AiAgentDocumentModel.agentScope(
                     this.database,
                     args.agentUuid,
+                    args.projectUuid,
                 ),
             )
             .first();

--- a/packages/backend/src/ee/services/AiAgentDocumentService.ts
+++ b/packages/backend/src/ee/services/AiAgentDocumentService.ts
@@ -2,17 +2,20 @@ import { subject } from '@casl/ability';
 import {
     AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
     AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES,
+    AiAgent,
     AiAgentDocument,
     AiAgentDocumentSummary,
+    ApiCreateAgentDocument,
     ApiCreateAiAgentDocument,
     CommercialFeatureFlags,
     Explore,
     ForbiddenError,
+    NotFoundError,
     ParameterError,
     PayloadTooLargeError,
     type SessionUser,
 } from '@lightdash/common';
-import { v4 as uuidv4 } from 'uuid';
+import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import {
     AiAgentDocumentCreatedEvent,
     AiAgentDocumentDeletedEvent,
@@ -62,6 +65,11 @@ const normalizeMimeType = (mimeType: string, filename: string): string => {
     );
 };
 
+export type AiAgentDocumentScope = {
+    projectUuid: string;
+    agentUuid: string;
+};
+
 type AiAgentDocumentServiceDependencies = {
     analytics: LightdashAnalytics;
     aiAgentDocumentModel: AiAgentDocumentModel;
@@ -100,34 +108,18 @@ export class AiAgentDocumentService extends BaseService {
      * Build the explore context used to ground the summary generator. Mirrors
      * what the agent itself sees at conversation time: filtered by the
      * agent's tags AND the user's attributes via
-     * AiAgentService.getAvailableExplores. If the upload isn't bound to an
-     * agent, falls back to all explores in the project.
+     * AiAgentService.getAvailableExplores.
      */
-    private async getProjectExploresForSummarization(
+    private async getAgentExploresForSummarization(
         user: SessionUser,
-        body: ApiCreateAiAgentDocument,
+        agent: AiAgent,
     ): Promise<Explore[]> {
-        const primaryAgentUuid = body.agentAccess?.[0];
         try {
-            if (primaryAgentUuid) {
-                const agent = await this.aiAgentService.getAgent(
-                    user,
-                    primaryAgentUuid,
-                );
-                return await this.aiAgentService.getAvailableExplores(
-                    user,
-                    agent.projectUuid,
-                    agent.tags,
-                );
-            }
-            if (body.projectUuid) {
-                return await this.aiAgentService.getAvailableExplores(
-                    user,
-                    body.projectUuid,
-                    null,
-                );
-            }
-            return [];
+            return await this.aiAgentService.getAvailableExplores(
+                user,
+                agent.projectUuid,
+                agent.tags,
+            );
         } catch (e) {
             this.logger.warn(
                 'Failed to fetch project explores for document summarization',
@@ -150,7 +142,7 @@ export class AiAgentDocumentService extends BaseService {
     private assertCanViewDocuments(
         user: SessionUser,
         organizationUuid: string,
-        projectUuid: string | null = null,
+        projectUuid: string | null,
     ): void {
         const ability = this.createAuditedAbility(user);
         if (
@@ -166,10 +158,15 @@ export class AiAgentDocumentService extends BaseService {
         }
     }
 
+    /**
+     * A document with no project is org-wide: the project-level rule cannot
+     * match a subject without a projectUuid, so managing it needs org-level
+     * permission.
+     */
     private assertCanManageDocuments(
         user: SessionUser,
         organizationUuid: string,
-        projectUuid: string | null = null,
+        projectUuid: string | null,
     ): void {
         const ability = this.createAuditedAbility(user);
         if (
@@ -187,51 +184,56 @@ export class AiAgentDocumentService extends BaseService {
 
     async listDocuments(
         user: SessionUser,
-        { projectUuid }: { projectUuid?: string | null } = {},
+        { projectUuid, agentUuid }: AiAgentDocumentScope,
     ): Promise<AiAgentDocumentSummary[]> {
         const organizationUuid = assertOrganizationUuid(user);
         await this.assertCopilotEnabled(user);
-        this.assertCanViewDocuments(
-            user,
+        this.assertCanViewDocuments(user, organizationUuid, projectUuid);
+        // Throws if the agent does not exist in this project
+        await this.aiAgentService.getAgent(user, agentUuid, projectUuid);
+
+        return this.aiAgentDocumentModel.findAllForAgent({
             organizationUuid,
-            projectUuid ?? null,
-        );
-        return this.aiAgentDocumentModel.findAllForOrganization({
-            organizationUuid,
+            agentUuid,
             projectUuid,
         });
     }
 
-    private async getDocument(
-        user: SessionUser,
-        documentUuid: string,
-    ): Promise<AiAgentDocument> {
-        const organizationUuid = assertOrganizationUuid(user);
-        await this.assertCopilotEnabled(user);
-        const document = await this.aiAgentDocumentModel.get(documentUuid);
-        if (document.organizationUuid !== organizationUuid) {
-            throw new ForbiddenError();
-        }
-        this.assertCanViewDocuments(
-            user,
-            organizationUuid,
-            document.projectUuid,
-        );
-        return document;
-    }
-
     async createDocument(
         user: SessionUser,
-        body: ApiCreateAiAgentDocument,
+        { projectUuid, agentUuid }: AiAgentDocumentScope,
+        body: ApiCreateAgentDocument,
     ): Promise<AiAgentDocument> {
         const organizationUuid = assertOrganizationUuid(user);
         await this.assertCopilotEnabled(user);
-        this.assertCanManageDocuments(
+        this.assertCanManageDocuments(user, organizationUuid, projectUuid);
+        const agent = await this.aiAgentService.getAgent(
             user,
-            organizationUuid,
-            body.projectUuid ?? null,
+            agentUuid,
+            projectUuid,
+        );
+        const projectExplores = await this.getAgentExploresForSummarization(
+            user,
+            agent,
         );
 
+        return this.persistDocument(user, organizationUuid, body, {
+            projectUuid,
+            agentUuids: [agentUuid],
+            projectExplores,
+        });
+    }
+
+    private async persistDocument(
+        user: SessionUser,
+        organizationUuid: string,
+        body: ApiCreateAgentDocument,
+        scope: {
+            projectUuid: string | null;
+            agentUuids: string[];
+            projectExplores: Explore[];
+        },
+    ): Promise<AiAgentDocument> {
         const contentBytes = Buffer.byteLength(body.content, 'utf8');
         if (contentBytes > AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES) {
             throw new PayloadTooLargeError(
@@ -263,10 +265,6 @@ export class AiAgentDocumentService extends BaseService {
             body.originalFilename,
         );
 
-        const projectExplores = await this.getProjectExploresForSummarization(
-            user,
-            body,
-        );
         const copilotConfig =
             await this.orgAiCopilotConfigResolver.getCopilotConfig(
                 organizationUuid,
@@ -286,7 +284,7 @@ export class AiAgentDocumentService extends BaseService {
             summary = await generateDocumentSummary(modelOptions, {
                 name: body.name,
                 content: body.content,
-                projectExplores,
+                projectExplores: scope.projectExplores,
             });
         } catch (error) {
             this.logger.error(
@@ -301,14 +299,14 @@ export class AiAgentDocumentService extends BaseService {
 
         const document = await this.aiAgentDocumentModel.create({
             organizationUuid,
-            projectUuid: body.projectUuid ?? null,
+            projectUuid: scope.projectUuid,
             name: body.name,
             originalFilename: body.originalFilename,
             mimeType,
             content: body.content,
             summary,
             storageKey,
-            agentUuids: body.agentAccess ?? [],
+            agentUuids: scope.agentUuids,
             createdByUserUuid: user.userUuid,
         });
 
@@ -321,7 +319,7 @@ export class AiAgentDocumentService extends BaseService {
                 documentId: document.uuid,
                 mimeType: document.mimeType,
                 contentSizeBytes: contentBytes,
-                agentAccessCount: body.agentAccess?.length ?? 0,
+                agentAccessCount: document.agentAccess.length,
             },
         });
 
@@ -330,12 +328,176 @@ export class AiAgentDocumentService extends BaseService {
 
     async deleteDocument(
         user: SessionUser,
+        { projectUuid, agentUuid }: AiAgentDocumentScope,
         documentUuid: string,
     ): Promise<void> {
-        const existing = await this.getDocument(user, documentUuid);
+        const organizationUuid = assertOrganizationUuid(user);
+        await this.assertCopilotEnabled(user);
+        this.assertCanManageDocuments(user, organizationUuid, projectUuid);
+        await this.aiAgentService.getAgent(user, agentUuid, projectUuid);
+
+        const existing = await this.aiAgentDocumentModel.findAccessibleForAgent(
+            {
+                organizationUuid,
+                agentUuid,
+                projectUuid,
+                documentUuid,
+            },
+        );
+        if (!existing) {
+            throw new NotFoundError(
+                `AI agent document ${documentUuid} not found`,
+            );
+        }
+        // An org-wide document outranks the path's project scope
         this.assertCanManageDocuments(
             user,
-            existing.organizationUuid,
+            organizationUuid,
+            existing.projectUuid,
+        );
+
+        await this.aiAgentDocumentModel.delete(documentUuid);
+
+        this.analytics.track<AiAgentDocumentDeletedEvent>({
+            event: 'ai_agent_document.deleted',
+            userId: user.userUuid,
+            properties: {
+                organizationId: existing.organizationUuid,
+                projectId: existing.projectUuid,
+                documentId: documentUuid,
+            },
+        });
+    }
+
+    /**
+     * @deprecated Serves GET /api/v1/aiAgents/documents. Use listDocuments.
+     */
+    async listOrganizationDocuments(
+        user: SessionUser,
+        { projectUuid }: { projectUuid?: string | null } = {},
+    ): Promise<AiAgentDocumentSummary[]> {
+        const organizationUuid = assertOrganizationUuid(user);
+        await this.assertCopilotEnabled(user);
+        this.assertCanViewDocuments(
+            user,
+            organizationUuid,
+            projectUuid ?? null,
+        );
+        return this.aiAgentDocumentModel.findAllForOrganization({
+            organizationUuid,
+            projectUuid,
+        });
+    }
+
+    /**
+     * Resolve the summarization explores from the request body rather than the
+     * route, mirroring the pre-deprecation behaviour.
+     * @deprecated Serves POST /api/v1/aiAgents/documents.
+     */
+    private async getBodyScopeExploresForSummarization(
+        user: SessionUser,
+        body: ApiCreateAiAgentDocument,
+        agent: AiAgent | null,
+    ): Promise<Explore[]> {
+        if (agent) {
+            return this.getAgentExploresForSummarization(user, agent);
+        }
+        if (!body.projectUuid) {
+            return [];
+        }
+        try {
+            return await this.aiAgentService.getAvailableExplores(
+                user,
+                body.projectUuid,
+                null,
+            );
+        } catch (e) {
+            this.logger.warn(
+                'Failed to fetch project explores for document summarization',
+                { error: e },
+            );
+            return [];
+        }
+    }
+
+    /**
+     * Resolve every agentAccess entry through the org-filtered agent lookup, so
+     * an unknown or foreign agent fails the request instead of the FK, and a
+     * wrong-project agent cannot be persisted as an access row nothing reads.
+     * @deprecated Serves POST /api/v1/aiAgents/documents.
+     */
+    private async resolveBodyScopeAgents(
+        user: SessionUser,
+        body: ApiCreateAiAgentDocument,
+    ): Promise<AiAgent[]> {
+        const agentAccess = body.agentAccess ?? [];
+        const { projectUuid } = body;
+        return Promise.all(
+            agentAccess.map(async (agentUuid) => {
+                const agent = await this.aiAgentService.getAgent(
+                    user,
+                    agentUuid,
+                );
+                if (projectUuid && agent.projectUuid !== projectUuid) {
+                    throw new ParameterError(
+                        `Agent ${agentUuid} does not belong to project ${projectUuid}.`,
+                    );
+                }
+                return agent;
+            }),
+        );
+    }
+
+    /**
+     * @deprecated Serves POST /api/v1/aiAgents/documents. Use createDocument.
+     */
+    async createOrganizationDocument(
+        user: SessionUser,
+        body: ApiCreateAiAgentDocument,
+    ): Promise<AiAgentDocument> {
+        const organizationUuid = assertOrganizationUuid(user);
+        await this.assertCopilotEnabled(user);
+        this.assertCanManageDocuments(
+            user,
+            organizationUuid,
+            body.projectUuid ?? null,
+        );
+
+        const agents = await this.resolveBodyScopeAgents(user, body);
+        const projectExplores = await this.getBodyScopeExploresForSummarization(
+            user,
+            body,
+            agents[0] ?? null,
+        );
+
+        return this.persistDocument(user, organizationUuid, body, {
+            projectUuid: body.projectUuid ?? null,
+            agentUuids: agents.map((agent) => agent.uuid),
+            projectExplores,
+        });
+    }
+
+    /**
+     * The path param stays a plain string: tightening it to a uuid pattern is a
+     * breaking OpenAPI change, so reject a malformed uuid here instead.
+     * @deprecated Serves DELETE /api/v1/aiAgents/documents/{documentUuid}. Use deleteDocument.
+     */
+    async deleteOrganizationDocument(
+        user: SessionUser,
+        documentUuid: string,
+    ): Promise<void> {
+        const organizationUuid = assertOrganizationUuid(user);
+        await this.assertCopilotEnabled(user);
+        if (!isValidUuid(documentUuid)) {
+            throw new ParameterError(`Invalid document uuid: ${documentUuid}`);
+        }
+        const existing = await this.aiAgentDocumentModel.get(documentUuid);
+        if (existing.organizationUuid !== organizationUuid) {
+            throw new ForbiddenError();
+        }
+        this.assertCanManageDocuments(
+            user,
+            organizationUuid,
             existing.projectUuid,
         );
         await this.aiAgentDocumentModel.delete(documentUuid);

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -2054,6 +2054,7 @@ export class AiAgentToolsService extends BaseService {
                     await this.aiAgentDocumentModel.getContentForAgent({
                         organizationUuid: context.organizationUuid,
                         agentUuid: context.agentUuid,
+                        projectUuid: context.projectUuid,
                         documentUuid: args.documentUuid,
                     });
                 if (!content) {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -135,6 +135,8 @@ import { AiAgentController } from './../ee/controllers/aiAgentController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiAgentDocumentController } from './../ee/controllers/aiAgentDocumentController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AiAgentScopedDocumentController } from './../ee/controllers/aiAgentScopedDocumentController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiController } from './../ee/controllers/aiController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiRouterController } from './../ee/controllers/aiRouterController';
@@ -12357,6 +12359,20 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCreateAgentDocument: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                content: { dataType: 'string', required: true },
+                mimeType: { dataType: 'string', required: true },
+                originalFilename: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCreateAiAgentDocument: {
         dataType: 'refAlias',
         type: {
@@ -12468,8 +12484,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -13128,8 +13144,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -15012,11 +15028,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -15074,11 +15090,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -15115,11 +15131,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15134,11 +15150,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15153,11 +15169,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15172,11 +15188,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15321,6 +15337,29 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -15359,13 +15398,13 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
-                                                                                                                                required:
+                                                                                                                                fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
-                                                                                                                                            'boolean',
+                                                                                                                                            'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                operator:
+                                                                                                                                fieldId:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
@@ -15377,16 +15416,16 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                fieldRef:
+                                                                                                                                operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                fieldId:
+                                                                                                                                required:
                                                                                                                                     {
                                                                                                                                         dataType:
-                                                                                                                                            'string',
+                                                                                                                                            'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                             },
@@ -15411,29 +15450,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         dataType:
                                                                                                                             'string',
                                                                                                                     },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15485,11 +15501,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15556,21 +15572,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -15580,15 +15581,30 @@ const models: TsoaRoute.Models = {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'success',
+                                                                                                    'error',
                                                                                                 ],
                                                                                             },
                                                                                             {
                                                                                                 dataType:
                                                                                                     'enum',
                                                                                                 enums: [
-                                                                                                    'error',
+                                                                                                    'success',
                                                                                                 ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
                                                                                             },
                                                                                             {
                                                                                                 dataType:
@@ -15722,11 +15738,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15741,11 +15757,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15760,11 +15776,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15807,11 +15823,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15850,25 +15866,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15913,57 +15910,18 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 fieldValueType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldId:
+                                                                                fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15984,6 +15942,45 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -15991,6 +15988,25 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -16036,24 +16052,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            operator:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16066,6 +16064,24 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            operator:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                         },
                                                                                                 },
                                                                                             },
@@ -16075,12 +16091,6 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -16089,6 +16099,12 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -16132,17 +16148,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -16276,14 +16292,14 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                             },
                                         },
                                         {
@@ -16294,11 +16310,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16313,11 +16329,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16332,11 +16348,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16351,11 +16367,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16428,6 +16444,18 @@ const models: TsoaRoute.Models = {
                                                                                 ],
                                                                             required: true,
                                                                         },
+                                                                        isPrimary:
+                                                                            {
+                                                                                dataType:
+                                                                                    'boolean',
+                                                                                required: true,
+                                                                            },
+                                                                        projectDbtSourceUuid:
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
                                                                         repository:
                                                                             {
                                                                                 dataType:
@@ -16446,18 +16474,6 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         },
                                                                                     ],
-                                                                                required: true,
-                                                                            },
-                                                                        isPrimary:
-                                                                            {
-                                                                                dataType:
-                                                                                    'boolean',
-                                                                                required: true,
-                                                                            },
-                                                                        projectDbtSourceUuid:
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
                                                                                 required: true,
                                                                             },
                                                                         name: {
@@ -16482,77 +16498,6 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'union',
                                                     subSchemas: [
                                                         { dataType: 'boolean' },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: [null],
@@ -16640,6 +16585,77 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16671,6 +16687,12 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -16678,12 +16700,6 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
-                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16723,11 +16739,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16788,11 +16804,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16807,11 +16823,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16824,10 +16840,6 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'union',
                                                     subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
@@ -16835,6 +16847,10 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16853,11 +16869,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16874,6 +16890,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16954,25 +16989,6 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 type: {
                                                                     dataType:
                                                                         'union',
@@ -16982,14 +16998,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
@@ -17015,11 +17031,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17034,11 +17050,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17053,11 +17069,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17072,11 +17088,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17091,11 +17107,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -34449,7 +34465,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34459,7 +34475,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34469,7 +34485,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34482,7 +34498,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -51722,6 +51738,219 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'generateTooltip',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentScopedDocumentController_listDocuments: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/documents',
+        ...fetchMiddlewares<RequestHandler>(AiAgentScopedDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentScopedDocumentController.prototype.listDocuments,
+        ),
+
+        async function AiAgentScopedDocumentController_listDocuments(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentScopedDocumentController_listDocuments,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentScopedDocumentController>(
+                        AiAgentScopedDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listDocuments',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentScopedDocumentController_createDocument: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiCreateAgentDocument',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/documents',
+        ...fetchMiddlewares<RequestHandler>(AiAgentScopedDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentScopedDocumentController.prototype.createDocument,
+        ),
+
+        async function AiAgentScopedDocumentController_createDocument(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentScopedDocumentController_createDocument,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentScopedDocumentController>(
+                        AiAgentScopedDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createDocument',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentScopedDocumentController_deleteDocument: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        documentUuid: {
+            in: 'path',
+            name: 'documentUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.delete(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/documents/:documentUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentScopedDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentScopedDocumentController.prototype.deleteDocument,
+        ),
+
+        async function AiAgentScopedDocumentController_deleteDocument(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentScopedDocumentController_deleteDocument,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentScopedDocumentController>(
+                        AiAgentScopedDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteDocument',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13973,17 +13973,38 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ApiCreateAgentDocument": {
+                "properties": {
+                    "content": {
+                        "type": "string"
+                    },
+                    "mimeType": {
+                        "type": "string"
+                    },
+                    "originalFilename": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["content", "mimeType", "originalFilename", "name"],
+                "type": "object",
+                "description": "Body of POST /api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents."
+            },
             "ApiCreateAiAgentDocument": {
                 "properties": {
                     "agentAccess": {
                         "items": {
                             "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "deprecated": true
                     },
                     "projectUuid": {
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "content": {
                         "type": "string"
@@ -13999,7 +14020,8 @@
                     }
                 },
                 "required": ["content", "mimeType", "originalFilename", "name"],
-                "type": "object"
+                "type": "object",
+                "description": "Body of POST /api/v1/aiAgents/documents. Both scope fields are deprecated:\nscope now comes from the agent-scoped route path. Once they are removed this\nendpoint only creates organization level documents."
             },
             "AiAgentModelConfig": {
                 "properties": {
@@ -14082,7 +14104,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -14721,7 +14743,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16625,8 +16647,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16684,8 +16706,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -16719,8 +16741,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16775,6 +16797,11 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -16783,28 +16810,28 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "operator": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "required",
-                                                                                    "operator",
-                                                                                    "tableName",
                                                                                     "fieldRef",
-                                                                                    "fieldId"
+                                                                                    "fieldId",
+                                                                                    "tableName",
+                                                                                    "operator",
+                                                                                    "required"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -16815,11 +16842,6 @@
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -16849,8 +16871,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16891,15 +16913,15 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "status": {
                                                                             "type": "string",
                                                                             "enum": [
-                                                                                "success",
-                                                                                "error"
+                                                                                "error",
+                                                                                "success"
                                                                             ]
+                                                                        },
+                                                                        "error": {
+                                                                            "type": "string"
                                                                         },
                                                                         "results": {
                                                                             "items": {
@@ -16963,8 +16985,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16998,8 +17020,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "not_found"
                                                         ]
                                                     }
@@ -17026,10 +17048,6 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
-                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -17044,31 +17062,31 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "table": {
+                                                                                "fieldFilterType": {
                                                                                     "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
                                                                                 },
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
+                                                                                        "metric",
+                                                                                        "dimension"
                                                                                     ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
@@ -17077,18 +17095,22 @@
                                                                             "required": [
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
-                                                                                "fieldFilterType",
                                                                                 "fieldValueType",
-                                                                                "table",
+                                                                                "fieldFilterType",
+                                                                                "description",
                                                                                 "fieldType",
+                                                                                "table",
                                                                                 "fieldId",
                                                                                 "label",
-                                                                                "description",
                                                                                 "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
+                                                                    },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -17100,41 +17122,41 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
-                                                                                        },
-                                                                                        "operator": {
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
+                                                                                        },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
-                                                                                        "required",
-                                                                                        "operator",
-                                                                                        "tableName",
                                                                                         "fieldRef",
-                                                                                        "fieldId"
+                                                                                        "fieldId",
+                                                                                        "tableName",
+                                                                                        "operator",
+                                                                                        "required"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
                                                                                 "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
                                                                             },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -17144,8 +17166,8 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
@@ -17160,8 +17182,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "rationale",
                                                                     "fields",
+                                                                    "rationale",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -17175,10 +17197,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -17186,8 +17208,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -17278,10 +17300,10 @@
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
-                                                    "name": {
+                                                    "uuid": {
                                                         "type": "string"
                                                     },
-                                                    "uuid": {
+                                                    "name": {
                                                         "type": "string"
                                                     }
                                                 },
@@ -17291,8 +17313,8 @@
                                                     "href",
                                                     "slug",
                                                     "status",
-                                                    "name",
-                                                    "uuid"
+                                                    "uuid",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17326,15 +17348,15 @@
                                                                     "type": "string",
                                                                     "nullable": true
                                                                 },
-                                                                "repository": {
-                                                                    "type": "string",
-                                                                    "nullable": true
-                                                                },
                                                                 "isPrimary": {
                                                                     "type": "boolean"
                                                                 },
                                                                 "projectDbtSourceUuid": {
                                                                     "type": "string"
+                                                                },
+                                                                "repository": {
+                                                                    "type": "string",
+                                                                    "nullable": true
                                                                 },
                                                                 "name": {
                                                                     "type": "string"
@@ -17343,9 +17365,9 @@
                                                             "required": [
                                                                 "projectSubPath",
                                                                 "branch",
-                                                                "repository",
                                                                 "isPrimary",
                                                                 "projectDbtSourceUuid",
+                                                                "repository",
                                                                 "name"
                                                             ],
                                                             "type": "object"
@@ -17355,32 +17377,6 @@
                                                     },
                                                     "needsDbtSourceSelection": {
                                                         "type": "boolean",
-                                                        "nullable": true
-                                                    },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "read",
-                                                                        "edit",
-                                                                        "search",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
                                                         "nullable": true
                                                     },
                                                     "previewUrl": {
@@ -17410,6 +17406,32 @@
                                                         ],
                                                         "nullable": true
                                                     },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "search",
+                                                                        "read",
+                                                                        "edit",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17429,9 +17451,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
+                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -17481,8 +17503,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -17494,9 +17516,9 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -17508,6 +17530,10 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17544,23 +17570,19 @@
                                                                 },
                                                                 "type": "array"
                                                             },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "dimension",
                                                                     "metric",
+                                                                    "dimension",
                                                                     null
                                                                 ],
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "fields",
                                                             "searchQuery",
+                                                            "fields",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -17568,8 +17590,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -34731,22 +34753,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -44376,7 +44398,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3350.0",
+        "version": "0.3352.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -46218,6 +46240,166 @@
                 ]
             }
         },
+        "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents": {
+            "get": {
+                "operationId": "listAgentDocuments",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentDocumentSummaryListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List the knowledge documents this agent can use: the organization level\ndocuments plus the ones granted to this agent in this project.",
+                "summary": "List agent documents",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "createAgentDocument",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentDocumentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Create a knowledge document scoped to this project and agent.",
+                "summary": "Create agent document",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCreateAgentDocument"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents/{documentUuid}": {
+            "delete": {
+                "operationId": "deleteAgentDocument",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete a knowledge document this agent can use.",
+                "summary": "Delete agent document",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "documentUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
         "/api/v1/aiAgents/documents": {
             "get": {
                 "operationId": "listAiAgentDocuments",
@@ -46243,6 +46425,8 @@
                         }
                     }
                 },
+                "description": "List every knowledge document in the organization.",
+                "summary": "List AI agent documents",
                 "security": [],
                 "parameters": [
                     {
@@ -46279,6 +46463,8 @@
                         }
                     }
                 },
+                "description": "Create a knowledge document. The projectUuid and agentAccess body fields\nare deprecated: scope the document by creating it on the agent route\ninstead. Without them the document is available to every agent.",
+                "summary": "Create AI agent document",
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -46318,6 +46504,8 @@
                         }
                     }
                 },
+                "description": "Delete a knowledge document anywhere in the organization.",
+                "summary": "Delete AI agent document",
                 "security": [],
                 "parameters": [
                     {

--- a/packages/common/src/ee/AiAgent/documentTypes.ts
+++ b/packages/common/src/ee/AiAgent/documentTypes.ts
@@ -38,19 +38,32 @@ export type AiAgentDocumentContent = Pick<
     content: string;
 };
 
+/**
+ * Body of POST /api/v1/aiAgents/documents. Both scope fields are deprecated:
+ * scope now comes from the agent-scoped route path. Once they are removed this
+ * endpoint only creates organization level documents.
+ */
 export type ApiCreateAiAgentDocument = {
     name: string;
     originalFilename: string;
     mimeType: string;
     content: string;
+    /**
+     * @deprecated Use POST /api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents, which takes the project from the path
+     */
     projectUuid?: string | null;
+    /**
+     * @deprecated Use POST /api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents, which takes the agent from the path
+     */
     agentAccess?: string[];
 };
 
-export type ApiUpdateAiAgentDocument = {
-    name?: string;
-    projectUuid?: string | null;
-    agentAccess?: string[];
+/** Body of POST /api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents. */
+export type ApiCreateAgentDocument = {
+    name: string;
+    originalFilename: string;
+    mimeType: string;
+    content: string;
 };
 
 export type ApiAiAgentDocumentResponse = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -1,7 +1,4 @@
-import {
-    AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
-    type AiAgentDocumentSummary,
-} from '@lightdash/common';
+import { AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -80,20 +77,12 @@ export const AiAgentKnowledgeFilesSection = ({
     agentUuid,
     projectUuid,
 }: Props) => {
-    const { data: documents, isLoading } = useAiAgentDocuments();
-    const createDocument = useCreateAiAgentDocument();
-    const deleteDocument = useDeleteAiAgentDocument();
+    const { data, isLoading } = useAiAgentDocuments(projectUuid, agentUuid);
+    const createDocument = useCreateAiAgentDocument(projectUuid, agentUuid);
+    const deleteDocument = useDeleteAiAgentDocument(projectUuid, agentUuid);
     const { showToastError } = useToaster();
 
-    const accessibleDocuments = useMemo<AiAgentDocumentSummary[]>(
-        () =>
-            (documents ?? []).filter(
-                (doc) =>
-                    doc.agentAccess.length === 0 ||
-                    doc.agentAccess.includes(agentUuid),
-            ),
-        [documents, agentUuid],
-    );
+    const documents = useMemo(() => data ?? [], [data]);
 
     const [pendingUploads, setPendingUploads] = useState<PendingUpload[]>([]);
     const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -102,14 +91,11 @@ export const AiAgentKnowledgeFilesSection = ({
         if (selectedId && pendingUploads.some((p) => p.tempId === selectedId)) {
             return selectedId;
         }
-        if (
-            selectedId &&
-            accessibleDocuments.some((doc) => doc.uuid === selectedId)
-        ) {
+        if (selectedId && documents.some((doc) => doc.uuid === selectedId)) {
             return selectedId;
         }
-        return accessibleDocuments[0]?.uuid ?? null;
-    }, [accessibleDocuments, pendingUploads, selectedId]);
+        return documents[0]?.uuid ?? null;
+    }, [documents, pendingUploads, selectedId]);
 
     const selectedPending = useMemo(
         () =>
@@ -121,10 +107,9 @@ export const AiAgentKnowledgeFilesSection = ({
         () =>
             selectedPending
                 ? null
-                : (accessibleDocuments.find(
-                      (doc) => doc.uuid === effectiveSelectedId,
-                  ) ?? null),
-        [accessibleDocuments, effectiveSelectedId, selectedPending],
+                : (documents.find((doc) => doc.uuid === effectiveSelectedId) ??
+                  null),
+        [documents, effectiveSelectedId, selectedPending],
     );
 
     const handleFiles = useCallback(
@@ -183,8 +168,6 @@ export const AiAgentKnowledgeFilesSection = ({
                         originalFilename: file.name,
                         mimeType: normalizeMimeType(file),
                         content,
-                        agentAccess: [agentUuid],
-                        projectUuid,
                     });
                     setSelectedId((current) =>
                         current === pending.tempId ? created.uuid : current,
@@ -198,13 +181,11 @@ export const AiAgentKnowledgeFilesSection = ({
                 }
             }
         },
-        [agentUuid, createDocument, projectUuid, showToastError],
+        [createDocument, showToastError],
     );
 
     const isEmpty =
-        !isLoading &&
-        pendingUploads.length === 0 &&
-        accessibleDocuments.length === 0;
+        !isLoading && pendingUploads.length === 0 && documents.length === 0;
 
     return (
         <Stack gap="md">
@@ -329,7 +310,7 @@ export const AiAgentKnowledgeFilesSection = ({
                                                 </Skeleton>
                                             ),
                                         })),
-                                        ...accessibleDocuments.map((doc) => ({
+                                        ...documents.map((doc) => ({
                                             id: doc.uuid,
                                             name: doc.name,
                                             sizeBytes: doc.contentSizeBytes,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
@@ -1,7 +1,7 @@
 import type {
     ApiAiAgentDocumentResponse,
     ApiAiAgentDocumentSummaryListResponse,
-    ApiCreateAiAgentDocument,
+    ApiCreateAgentDocument,
     ApiError,
     ApiSuccessEmpty,
 } from '@lightdash/common';
@@ -16,52 +16,69 @@ import useToaster from '../../../../hooks/toaster/useToaster';
 
 const AI_AGENT_DOCUMENTS_KEY = 'aiAgentDocuments';
 
-const listDocuments = async () =>
+const documentsUrl = (projectUuid: string, agentUuid: string) =>
+    `/projects/${projectUuid}/aiAgents/${agentUuid}/documents`;
+
+const listDocuments = async (projectUuid: string, agentUuid: string) =>
     lightdashApi<ApiAiAgentDocumentSummaryListResponse['results']>({
         version: 'v1',
-        url: `/aiAgents/documents`,
+        url: documentsUrl(projectUuid, agentUuid),
         method: 'GET',
         body: undefined,
     });
 
-const createDocument = async (body: ApiCreateAiAgentDocument) =>
+const createDocument = async (
+    projectUuid: string,
+    agentUuid: string,
+    body: ApiCreateAgentDocument,
+) =>
     lightdashApi<ApiAiAgentDocumentResponse['results']>({
         version: 'v1',
-        url: `/aiAgents/documents`,
+        url: documentsUrl(projectUuid, agentUuid),
         method: 'POST',
         body: JSON.stringify(body),
     });
 
-const deleteDocument = async (documentUuid: string) =>
+const deleteDocument = async (
+    projectUuid: string,
+    agentUuid: string,
+    documentUuid: string,
+) =>
     lightdashApi<ApiSuccessEmpty['results']>({
         version: 'v1',
-        url: `/aiAgents/documents/${documentUuid}`,
+        url: `${documentsUrl(projectUuid, agentUuid)}/${documentUuid}`,
         method: 'DELETE',
         body: undefined,
     });
 
 export const useAiAgentDocuments = (
+    projectUuid: string,
+    agentUuid: string,
     options?: UseQueryOptions<
         ApiAiAgentDocumentSummaryListResponse['results'],
         ApiError
     >,
 ) =>
     useQuery<ApiAiAgentDocumentSummaryListResponse['results'], ApiError>({
-        queryKey: [AI_AGENT_DOCUMENTS_KEY],
-        queryFn: listDocuments,
+        queryKey: [AI_AGENT_DOCUMENTS_KEY, projectUuid, agentUuid],
+        queryFn: () => listDocuments(projectUuid, agentUuid),
         ...options,
     });
 
-export const useCreateAiAgentDocument = () => {
+export const useCreateAiAgentDocument = (
+    projectUuid: string,
+    agentUuid: string,
+) => {
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
     return useMutation<
         ApiAiAgentDocumentResponse['results'],
         ApiError,
-        ApiCreateAiAgentDocument
+        ApiCreateAgentDocument
     >({
-        mutationFn: createDocument,
+        mutationFn: (body) => createDocument(projectUuid, agentUuid, body),
         onSuccess: async () => {
+            // Org level documents appear under every agent, so invalidate them all
             await queryClient.invalidateQueries({
                 queryKey: [AI_AGENT_DOCUMENTS_KEY],
             });
@@ -75,12 +92,17 @@ export const useCreateAiAgentDocument = () => {
     });
 };
 
-export const useDeleteAiAgentDocument = () => {
+export const useDeleteAiAgentDocument = (
+    projectUuid: string,
+    agentUuid: string,
+) => {
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
     return useMutation<ApiSuccessEmpty['results'], ApiError, string>({
-        mutationFn: deleteDocument,
+        mutationFn: (documentUuid) =>
+            deleteDocument(projectUuid, agentUuid, documentUuid),
         onSuccess: async () => {
+            // Org level documents appear under every agent, so invalidate them all
             await queryClient.invalidateQueries({
                 queryKey: [AI_AGENT_DOCUMENTS_KEY],
             });


### PR DESCRIPTION
Knowledge documents were served only from a root-level route that returned every document in the organization, with the agent filter running client-side. The browser received documents belonging to other agents.

## Agent-scoped route

```
/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents
```

Both scopes come from the path. Listing reuses `findAllForAgent` — the same query the agent runtime uses to resolve its own documents — so the settings UI and the agent see the same set. The frontend moves to it.

The root route keeps working. Its `projectUuid` and `agentAccess` body fields are deprecated in favour of the path; once they go, it creates organization-level documents.

## Scope semantics

A document is organization level, and reaches every agent, only when it has **no project and no grants**. Access rows always restrict — having none is not a wildcard.

`getContentForAgent` applied the access check without a project scope, which only worked under the old wildcard rule. It now shares the listing predicate, so an agent can read every document it can list.

Deleting through the agent route requires the document to be in scope for that agent; another agent's document returns 404. Deletion re-asserts `manage` against the document's own scope, so an organization-level document still needs organization-level permission.

## Notes for reviewers

- A project-scoped document with no grants is now visible to no agent. Only the API could create that shape; the UI always sent `agentAccess`. Accepted, no backfill.
- The root `GET` still returns every document summary in the organization to any viewer, without a per-agent check. Pre-existing behaviour, deliberately kept — this route is becoming the organization-level endpoint.
- `agentScope` is covered by tests because it is a security boundary any organization member can reach: a collapsed `OR` group would expose every document in every organization.

Relates: ZAP-606
Relates: #25099