### PR TITLE
refactor(backend): introduce QueryComposer and adopt it in the sync compile path

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -117,8 +117,6 @@ import {
     maybeOverrideDbtConnection,
     maybeOverrideWarehouseConnection,
     maybeReplaceFieldsInChartVersion,
-    mergeReservedDefinitions,
-    mergeReservedValues,
     mergeWarehouseCredentials,
     MetricQuery,
     MissingWarehouseCredentialsError,
@@ -151,7 +149,6 @@ import {
     RequestMethod,
     ResolvedProjectColorPalette,
     resolveQueryTimezone,
-    resolveReservedParameterValues,
     ResultRow,
     SavedChartDAO,
     SavedChartsInfoForDashboardAvailableFilters,
@@ -268,20 +265,13 @@ import { compileMetricQuery } from '../../queryCompiler';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { traceSpan } from '../../tracing/tracing';
 import { CachedWarehouse, ProjectAdapter } from '../../types';
-import {
-    runWorkerThread,
-    wrapSentryTransaction,
-    wrapSentryTransactionSync,
-} from '../../utils';
+import { runWorkerThread, wrapSentryTransaction } from '../../utils';
 import { buildCacheHash, getCacheUserUuid } from '../../utils/cacheUtils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
-import { updateExploreWithDateZoom } from '../../utils/QueryBuilder/dateZoom';
-import {
-    CompiledQuery,
-    MetricQueryBuilder,
-} from '../../utils/QueryBuilder/MetricQueryBuilder';
+import { CompiledQuery } from '../../utils/QueryBuilder/MetricQueryBuilder';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
+import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
@@ -4105,64 +4095,24 @@ export class ProjectService extends BaseService {
          */
         applyDateZoomToFilters?: boolean;
     }): Promise<CompiledQuery> {
-        // Fold reserved definitions in so custom SQL referencing them compiles; a
-        // same-named user parameter wins (shadows the reserved one).
-        const parameterDefinitionsWithReserved: ParameterDefinitions =
-            mergeReservedDefinitions(availableParameterDefinitions);
-        const availableParameters = Object.keys(
-            parameterDefinitionsWithReserved,
-        );
-
-        const {
-            explore: exploreWithOverride,
-            dateZoomApplied,
-            dateZoomTargetFieldId,
-        } = updateExploreWithDateZoom(
-            explore,
-            metricQuery,
-            warehouseSqlBuilder,
-            availableParameters,
-            dateZoom,
-        );
-
-        // Resolve reserved values from the query context (date zoom reflects the selected
-        // grain whenever a zoom reaches the query); a same-named user value wins.
-        const parametersWithReserved: ParametersValuesMap = mergeReservedValues(
-            parameters,
-            resolveReservedParameterValues({ dateZoom }),
-        );
-
-        const compiledMetricQuery = compileMetricQuery({
-            explore: exploreWithOverride,
-            metricQuery,
-            warehouseSqlBuilder,
-            availableParameters,
-        });
-
-        const queryBuilder = new MetricQueryBuilder({
-            explore: exploreWithOverride,
-            compiledMetricQuery,
-            warehouseSqlBuilder,
-            intrinsicUserAttributes,
-            userAttributes,
-            timezone,
-            parameters: parametersWithReserved,
-            parameterDefinitions: parameterDefinitionsWithReserved,
-            pivotConfiguration,
-            pivotDimensions,
-            continueOnError,
-            originalExplore: dateZoom ? explore : undefined,
-            dateZoomFilterTargetFieldId:
-                applyDateZoomToFilters && dateZoomApplied
-                    ? dateZoomTargetFieldId
-                    : undefined,
-            useTimezoneAwareDateTrunc,
-            columnTimezone,
-        });
-
-        return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>
-            queryBuilder.compileQuery(),
-        );
+        return new QueryComposer(
+            { metricQuery, pivotConfiguration },
+            {
+                explore,
+                warehouseSqlBuilder,
+                intrinsicUserAttributes,
+                userAttributes,
+                timezone,
+                availableParameterDefinitions,
+                parameters,
+                dateZoom,
+                pivotDimensions,
+                continueOnError,
+                useTimezoneAwareDateTrunc,
+                columnTimezone,
+                applyDateZoomToFilters,
+            },
+        ).compile();
     }
 
     /**
@@ -4290,36 +4240,33 @@ export class ProjectService extends BaseService {
             organizationUuid: account.organization.organizationUuid,
         });
 
-        const compiledQuery = await ProjectService._compileQuery({
-            metricQuery,
-            explore,
-            warehouseSqlBuilder,
-            intrinsicUserAttributes,
-            userAttributes,
-            timezone,
-            parameters: combinedParameters,
-            availableParameterDefinitions,
-            pivotConfiguration,
-            pivotDimensions,
-            continueOnError: true, // Return SQL even with compilation errors for debugging
-            useTimezoneAwareDateTrunc,
-            columnTimezone: getColumnTimezone(warehouseCredentials),
-        });
-
-        // Generate pivot query if pivot configuration is provided
-        let pivotQuery: string | undefined;
-        if (pivotConfiguration) {
-            const pivotQueryBuilder = new PivotQueryBuilder(
-                compiledQuery.query,
-                pivotConfiguration,
+        const queryComposer = new QueryComposer(
+            { metricQuery, pivotConfiguration },
+            {
+                explore,
                 warehouseSqlBuilder,
-                metricQuery.limit,
-                compiledQuery.fields,
-            );
-            pivotQuery = pivotQueryBuilder.toSql({
-                columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
-            });
-        }
+                intrinsicUserAttributes,
+                userAttributes,
+                timezone,
+                availableParameterDefinitions,
+                parameters: combinedParameters,
+                dateZoom: undefined,
+                pivotDimensions,
+                continueOnError: true, // Return SQL even with compilation errors for debugging
+                useTimezoneAwareDateTrunc,
+                columnTimezone: getColumnTimezone(warehouseCredentials),
+                applyDateZoomToFilters: undefined,
+            },
+        );
+
+        const compiledQuery = queryComposer.compile();
+
+        // Include pivot query only when a pivot configuration was provided
+        const pivotQuery = pivotConfiguration
+            ? queryComposer.getSql({
+                  columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+              })
+            : undefined;
 
         return {
             ...compiledQuery,

--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -1,5 +1,6 @@
 <summary>
 SQL generation and transformation utilities for Lightdash queries.
+One facade: QueryComposer (orchestrates context prep + the builders below to own metric SQL generation end-to-end).
 Four builders: MetricQueryBuilder (metrics/dimensions with joins), PivotQueryBuilder (flat → pivot table with row/column indexes), SqlQueryBuilder (SQL charts with filtering), TotalQueryBuilder (source query → grand/row/column/subtotal query transform).
 PivotQueryBuilder does NOT pivot data — it generates SQL that tags each row with `row_index` and `column_index` metadata via DENSE_RANK(). The actual pivoting happens downstream in AsyncQueryService.runQueryAndTransformRows.
 
@@ -8,7 +9,35 @@ This file covers SQL generation only. For the end-to-end pivot pipeline (config 
 
 <howToUse>
 
-**MetricQueryBuilder** — builds the base SQL from an Explore + MetricQuery (dimensions, metrics, filters, joins, table calculations). Handles fan-out protection via CTEs and period-over-period comparisons.
+**QueryComposer** — the facade to reach for when you have a `MetricQuery` (+ optional `PivotConfiguration`) and want SQL. It owns the context prep internally — reserved-parameter merge, date-zoom explore rewrite, `compileMetricQuery` — then orchestrates `MetricQueryBuilder` and `PivotQueryBuilder`. It does not generate SQL itself. Prefer this over wiring the builders by hand. Construct it directly at the call site.
+
+```typescript
+import { QueryComposer } from './QueryComposer';
+
+const composer = new QueryComposer(
+    { metricQuery, pivotConfiguration }, // pivotConfiguration: undefined for a flat query
+    {
+        explore,
+        warehouseSqlBuilder,
+        intrinsicUserAttributes,
+        userAttributes,
+        timezone,
+        availableParameterDefinitions,
+        parameters,
+        dateZoom,
+        pivotDimensions,
+        continueOnError,
+        useTimezoneAwareDateTrunc,
+        columnTimezone,
+        applyDateZoomToFilters,
+    },
+);
+
+const compiled = composer.compile(); // memoized CompiledQuery (base SQL, fields, warnings, params)
+const sql = composer.getSql({ columnLimit }); // PivotQueryBuilder-wrapped when pivotConfiguration is set, else base
+```
+
+**MetricQueryBuilder** — builds the base SQL from an Explore + MetricQuery (dimensions, metrics, filters, joins, table calculations). Handles fan-out protection via CTEs and period-over-period comparisons. Usually driven via `QueryComposer` rather than constructed directly.
 
 ```typescript
 import { MetricQueryBuilder } from './MetricQueryBuilder';
@@ -114,6 +143,7 @@ graph TD
 
 <links>
 
+- @/packages/backend/src/utils/QueryBuilder/QueryComposer.ts — Facade that owns metric SQL generation end-to-end
 - @/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts — Query execution and pivot result streaming
 - @/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts — PivotQueryBuilder tests (all CTE paths)
 - @/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts — MetricQueryBuilder tests

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
@@ -1,0 +1,77 @@
+import {
+    PivotConfiguration,
+    SortByDirection,
+    VizAggregationOptions,
+    VizIndexType,
+} from '@lightdash/common';
+import {
+    EXPLORE,
+    INTRINSIC_USER_ATTRIBUTES,
+    METRIC_QUERY,
+    QUERY_BUILDER_UTC_TIMEZONE,
+    warehouseClientMock,
+} from './MetricQueryBuilder.mock';
+import { QueryComposer, QueryComposerContext } from './QueryComposer';
+
+const CONTEXT: QueryComposerContext = {
+    explore: EXPLORE,
+    warehouseSqlBuilder: warehouseClientMock,
+    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+    userAttributes: {},
+    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+    availableParameterDefinitions: {},
+    parameters: {},
+    dateZoom: undefined,
+    pivotDimensions: undefined,
+    continueOnError: undefined,
+    useTimezoneAwareDateTrunc: undefined,
+    columnTimezone: undefined,
+    applyDateZoomToFilters: undefined,
+};
+
+const PIVOT_CONFIGURATION: PivotConfiguration = {
+    indexColumn: [{ reference: 'table1_dim1', type: VizIndexType.CATEGORY }],
+    valuesColumns: [
+        {
+            reference: 'table1_metric1',
+            aggregation: VizAggregationOptions.SUM,
+        },
+    ],
+    groupByColumns: undefined,
+    sortBy: [{ reference: 'table1_dim1', direction: SortByDirection.ASC }],
+};
+
+describe('QueryComposer', () => {
+    it('compiles a metric query and returns the base SQL via getSql when there is no pivot', () => {
+        const composer = new QueryComposer(
+            { metricQuery: METRIC_QUERY, pivotConfiguration: undefined },
+            CONTEXT,
+        );
+
+        const compiled = composer.compile();
+
+        expect(compiled.query).toMatchSnapshot();
+        expect(Object.keys(compiled.fields)).toEqual(
+            expect.arrayContaining(['table1_dim1', 'table1_metric1']),
+        );
+
+        // Without a pivot configuration, getSql returns the compiled base query.
+        expect(composer.getSql({ columnLimit: 100 })).toBe(compiled.query);
+    });
+
+    it('wraps the base query with the pivot query when a pivot configuration is set', () => {
+        const composer = new QueryComposer(
+            {
+                metricQuery: METRIC_QUERY,
+                pivotConfiguration: PIVOT_CONFIGURATION,
+            },
+            CONTEXT,
+        );
+
+        const sql = composer.getSql({ columnLimit: 100 });
+
+        // The pivot SQL wraps (and therefore differs from) the base query.
+        expect(sql).not.toBe(composer.compile().query);
+        expect(sql).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -1,0 +1,173 @@
+import {
+    mergeReservedDefinitions,
+    mergeReservedValues,
+    resolveReservedParameterValues,
+    type DateZoom,
+    type Explore,
+    type IntrinsicUserAttributes,
+    type MetricQuery,
+    type ParameterDefinitions,
+    type ParametersValuesMap,
+    type PivotConfiguration,
+    type UserAttributeValueMap,
+    type WarehouseSqlBuilder,
+} from '@lightdash/common';
+import { compileMetricQuery } from '../../queryCompiler';
+import { wrapSentryTransactionSync } from '../../utils';
+import { updateExploreWithDateZoom } from './dateZoom';
+import { CompiledQuery, MetricQueryBuilder } from './MetricQueryBuilder';
+import { PivotQueryBuilder } from './PivotQueryBuilder';
+
+/** What to compile: the metric query and, optionally, how to pivot it. */
+export type QueryComposerDefinition = {
+    metricQuery: MetricQuery;
+    pivotConfiguration: PivotConfiguration | undefined;
+};
+
+/** Raw inputs the composer needs to prepare context and build SQL. */
+export type QueryComposerContext = {
+    explore: Explore;
+    warehouseSqlBuilder: WarehouseSqlBuilder;
+    intrinsicUserAttributes: IntrinsicUserAttributes;
+    userAttributes: UserAttributeValueMap;
+    timezone: string;
+    availableParameterDefinitions: ParameterDefinitions;
+    parameters: ParametersValuesMap | undefined;
+    dateZoom: DateZoom | undefined;
+    pivotDimensions: string[] | undefined;
+    continueOnError: boolean | undefined;
+    useTimezoneAwareDateTrunc: boolean | undefined;
+    columnTimezone: string | undefined;
+    applyDateZoomToFilters: boolean | undefined;
+};
+
+/**
+ * Facade that owns metric SQL generation end-to-end. It prepares the query
+ * context internally (reserved-parameter merge, date-zoom explore rewrite,
+ * metric-query compilation) and orchestrates MetricQueryBuilder and
+ * PivotQueryBuilder — it does not generate SQL itself.
+ */
+export class QueryComposer {
+    private readonly definition: QueryComposerDefinition;
+
+    private readonly context: QueryComposerContext;
+
+    private compiledQuery: CompiledQuery | undefined;
+
+    constructor(
+        definition: QueryComposerDefinition,
+        context: QueryComposerContext,
+    ) {
+        this.definition = definition;
+        this.context = context;
+    }
+
+    /** Compile the metric query to base SQL. Memoized. */
+    compile(): CompiledQuery {
+        if (this.compiledQuery) {
+            return this.compiledQuery;
+        }
+
+        const { metricQuery, pivotConfiguration } = this.definition;
+        const {
+            explore,
+            warehouseSqlBuilder,
+            intrinsicUserAttributes,
+            userAttributes,
+            timezone,
+            availableParameterDefinitions,
+            parameters,
+            dateZoom,
+            pivotDimensions,
+            continueOnError,
+            useTimezoneAwareDateTrunc,
+            columnTimezone,
+            applyDateZoomToFilters,
+        } = this.context;
+
+        // Fold reserved definitions in so custom SQL referencing them compiles; a
+        // same-named user parameter wins (shadows the reserved one).
+        const parameterDefinitionsWithReserved: ParameterDefinitions =
+            mergeReservedDefinitions(availableParameterDefinitions);
+        const availableParameters = Object.keys(
+            parameterDefinitionsWithReserved,
+        );
+
+        const {
+            explore: exploreWithOverride,
+            dateZoomApplied,
+            dateZoomTargetFieldId,
+        } = updateExploreWithDateZoom(
+            explore,
+            metricQuery,
+            warehouseSqlBuilder,
+            availableParameters,
+            dateZoom,
+        );
+
+        // Resolve reserved values from the query context (date zoom reflects the
+        // selected grain whenever a zoom reaches the query); a same-named user
+        // value wins.
+        const parametersWithReserved: ParametersValuesMap = mergeReservedValues(
+            parameters,
+            resolveReservedParameterValues({ dateZoom }),
+        );
+
+        const compiledMetricQuery = compileMetricQuery({
+            explore: exploreWithOverride,
+            metricQuery,
+            warehouseSqlBuilder,
+            availableParameters,
+        });
+
+        const queryBuilder = new MetricQueryBuilder({
+            explore: exploreWithOverride,
+            compiledMetricQuery,
+            warehouseSqlBuilder,
+            intrinsicUserAttributes,
+            userAttributes,
+            timezone,
+            parameters: parametersWithReserved,
+            parameterDefinitions: parameterDefinitionsWithReserved,
+            pivotConfiguration,
+            pivotDimensions,
+            continueOnError,
+            originalExplore: dateZoom ? explore : undefined,
+            dateZoomFilterTargetFieldId:
+                applyDateZoomToFilters && dateZoomApplied
+                    ? dateZoomTargetFieldId
+                    : undefined,
+            useTimezoneAwareDateTrunc,
+            columnTimezone,
+        });
+
+        this.compiledQuery = wrapSentryTransactionSync(
+            'QueryBuilder.buildQuery',
+            {},
+            () => queryBuilder.compileQuery(),
+        );
+        return this.compiledQuery;
+    }
+
+    /**
+     * SQL for the query — PivotQueryBuilder-wrapped when a pivot config is set,
+     * otherwise the base query.
+     */
+    getSql({ columnLimit }: { columnLimit: number }): string {
+        const compiledQuery = this.compile();
+        const { metricQuery, pivotConfiguration } = this.definition;
+
+        if (!pivotConfiguration) {
+            return compiledQuery.query;
+        }
+
+        const pivotQueryBuilder = new PivotQueryBuilder(
+            compiledQuery.query,
+            pivotConfiguration,
+            this.context.warehouseSqlBuilder,
+            metricQuery.limit,
+            compiledQuery.fields,
+        );
+        return pivotQueryBuilder.toSql({ columnLimit });
+    }
+}

--- a/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`QueryComposer > compiles a metric query and returns the base SQL via getSql when there is no pivot 1`] = `
+"WITH metrics AS (
+SELECT
+  "table1".dim1 AS "table1_dim1",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM "db"."schema"."table1" AS "table1"
+
+GROUP BY 1
+)
+SELECT
+  *,
+  "table1_dim1" + "table1_metric1" AS "calc3"
+FROM metrics
+ORDER BY "table1_metric1" DESC
+LIMIT 10"
+`;
+
+exports[`QueryComposer > wraps the base query with the pivot query when a pivot configuration is set 1`] = `
+"WITH original_query AS (WITH metrics AS ( SELECT "table1".dim1 AS "table1_dim1", MAX("table1".number_column) AS "table1_metric1" FROM "db"."schema"."table1" AS "table1" GROUP BY 1 ) SELECT *, "table1_dim1" + "table1_metric1" AS "calc3" FROM metrics ORDER BY "table1_metric1" DESC),
+group_by_query AS (SELECT "table1_dim1", sum("table1_metric1") AS "table1_metric1_sum" FROM original_query group by "table1_dim1")
+SELECT * FROM group_by_query ORDER BY "table1_dim1" ASC LIMIT 10"
+`;


### PR DESCRIPTION
Closes: PROD-8773

### Description:

Introduces a `QueryComposer` facade (`packages/backend/src/utils/QueryBuilder/QueryComposer.ts`) that owns metric SQL generation end-to-end — reserved-parameter merge, date-zoom explore rewrite, `compileMetricQuery` → `MetricQueryBuilder`, and pivot wrapping via `PivotQueryBuilder` — exposing `compile()` and `getSql()`. It's adopted in the synchronous compile path (`ProjectService._compileQuery` and `compileQuery`), deleting the inline `MetricQueryBuilder`/`PivotQueryBuilder` wiring. This is a pure structural refactor: the SQL output is byte-identical (all existing builder golden snapshots stay green, and the `_compileQuery` tests now pass through the composer). Adds a focused `QueryComposer` test suite (non-pivot + pivot, snapshot-asserted) and documents the facade in the QueryBuilder `CLAUDE.md`. Part of the QueryComposer facade rebuild (parent PROD-8696); the async execution path is migrated in follow-up tickets.