### PR TITLE
feat(backend): harden metadata DB pool against Postgres failover/restart

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -112,6 +112,10 @@ export const lightdashConfigMock: LightdashConfig = {
         maxConnections: undefined,
         minConnections: undefined,
         allowMissingMigrations: false,
+        keepAlive: true,
+        keepAliveInitialDelayMillis: 10000,
+        connectionTimeoutMillis: 10000,
+        queryTimeoutMillis: undefined,
     },
     intercom: {
         appId: '',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1307,6 +1307,10 @@ export type LightdashConfig = {
         maxConnections: number | undefined;
         minConnections: number | undefined;
         allowMissingMigrations: boolean;
+        keepAlive: boolean;
+        keepAliveInitialDelayMillis: number;
+        connectionTimeoutMillis: number;
+        queryTimeoutMillis: number | undefined;
     };
     allowMultiOrgs: boolean;
     maxPayloadSize: string;
@@ -2349,6 +2353,18 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable('PGMINCONNECTIONS'),
             allowMissingMigrations:
                 process.env.ALLOW_MISSING_MIGRATIONS === 'true',
+            keepAlive: process.env.PGKEEPALIVE !== 'false',
+            keepAliveInitialDelayMillis:
+                getIntegerFromEnvironmentVariable(
+                    'PGKEEPALIVEINITIALDELAYMILLIS',
+                ) ?? 10000,
+            connectionTimeoutMillis:
+                getIntegerFromEnvironmentVariable(
+                    'PGCONNECTIONTIMEOUTMILLIS',
+                ) ?? 10000,
+            queryTimeoutMillis: getIntegerFromEnvironmentVariable(
+                'PGQUERYTIMEOUTMILLIS',
+            ),
         },
         auth: {
             pat: {

--- a/packages/backend/src/knexfile.ts
+++ b/packages/backend/src/knexfile.ts
@@ -10,6 +10,17 @@ const CONNECTION = lightdashConfig.database.connectionUri
     ? parse(lightdashConfig.database.connectionUri)
     : {};
 
+const connection = {
+    ...CONNECTION,
+    keepAlive: lightdashConfig.database.keepAlive,
+    keepAliveInitialDelayMillis:
+        lightdashConfig.database.keepAliveInitialDelayMillis,
+    connectionTimeoutMillis: lightdashConfig.database.connectionTimeoutMillis,
+    ...(lightdashConfig.database.queryTimeoutMillis !== undefined
+        ? { query_timeout: lightdashConfig.database.queryTimeoutMillis }
+        : {}),
+};
+
 export const DEFAULT_DB_MAX_CONNECTIONS = 10;
 
 // Condition to be removed once we require Postgres vector extension
@@ -17,7 +28,7 @@ const hasEnterpriseLicense = !!lightdashConfig.license.licenseKey;
 
 const development: Knex.Config<Knex.PgConnectionConfig> = {
     client: 'pg',
-    connection: CONNECTION,
+    connection,
     pool: {
         min: lightdashConfig.database.minConnections || 0,
         max:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Thanks for maintaining Lightdash! Small backwards-compatible change to the metadata DB pool.

Closes: #25368

### Description:

After the metadata Postgres briefly drops and recovers (RDS failover, reboot, network blip), the backend doesn't recover on its own: `/api/v1/health` stays `200` while real requests hang and 504. Only a restart fixes it. The pool in `knexfile.ts` uses knex defaults with no pg `keepAlive` or connect/query timeouts, so black-holed sockets sit checked-out for hours (OS keepalive default) and never get reaped.

This adds conservative liveness hardening to the metadata connection, all env-overridable:

- `keepAlive` on by default (`PGKEEPALIVE=false` to disable), delay via `PGKEEPALIVEINITIALDELAYMILLIS` (default `10000`)
- `connectionTimeoutMillis` default `10000` via `PGCONNECTIONTIMEOUTMILLIS`
- `query_timeout` opt-in / off by default via `PGQUERYTIMEOUTMILLIS`, so migrations and long queries are untouched unless set

No behavior change unless these are set, apart from `keepAlive` now defaulting on. Verified with `pnpm -F backend typecheck` and `parseConfig.test.ts`.
