### PR TITLE
refactor(backend): adopt QueryComposer in pre-aggregation DuckDB path

### DIFF
--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -2,17 +2,27 @@ import { DimensionType, type WarehouseClient } from '@lightdash/common';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
 import Logger from '../../../logging/logger';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
-import { ProjectService } from '../../../services/ProjectService/ProjectService';
 import {
     metricQueryMock,
     preAggregateExplore,
 } from '../../../services/ProjectService/ProjectService.mock';
 import { warehouseClientMock } from '../../../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { QueryComposer } from '../../../utils/QueryBuilder/QueryComposer';
 import { type PreAggregateModel } from '../../models/PreAggregateModel';
 import {
     PreAggregationDuckDbClient,
     PreAggregationDuckDbResolveReason,
 } from './PreAggregationDuckDbClient';
+
+vi.mock('../../../utils/QueryBuilder/QueryComposer', () => ({
+    QueryComposer: vi.fn(
+        function MockQueryComposer(this: { getSql: () => string }) {
+            this.getSql = vi.fn().mockReturnValue('SELECT * FROM test');
+        },
+    ),
+}));
+
+const QueryComposerMock = vi.mocked(QueryComposer);
 
 describe('PreAggregationDuckDbClient', () => {
     const getClient = ({
@@ -103,11 +113,12 @@ describe('PreAggregationDuckDbClient', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        vi.spyOn(ProjectService, '_compileQuery').mockResolvedValue({
-            query: 'SELECT * FROM test',
-        } as unknown as Awaited<
-            ReturnType<typeof ProjectService._compileQuery>
-        >);
+        QueryComposerMock.mockImplementation(function MockQueryComposer(this: {
+            getSql: () => string;
+        }) {
+            this.getSql = vi.fn().mockReturnValue('SELECT * FROM test');
+            return this;
+        } as unknown as () => QueryComposer);
     });
 
     afterEach(() => {
@@ -164,7 +175,8 @@ describe('PreAggregationDuckDbClient', () => {
             query: 'SELECT * FROM test',
             warehouseClient: warehouseClientMock,
         });
-        expect(ProjectService._compileQuery).toHaveBeenCalledWith(
+        expect(QueryComposerMock).toHaveBeenCalledWith(
+            expect.anything(),
             expect.objectContaining({
                 explore: expect.objectContaining({
                     name: '__preagg__valid_explore__rollup',
@@ -265,7 +277,8 @@ describe('PreAggregationDuckDbClient', () => {
 
         await client.resolve(baseResolveArgs);
 
-        expect(ProjectService._compileQuery).toHaveBeenCalledWith(
+        expect(QueryComposerMock).toHaveBeenCalledWith(
+            expect.anything(),
             expect.objectContaining({
                 explore: expect.objectContaining({
                     tables: expect.objectContaining({
@@ -305,7 +318,8 @@ describe('PreAggregationDuckDbClient', () => {
 
         await client.resolve(baseResolveArgs);
 
-        expect(ProjectService._compileQuery).toHaveBeenCalledWith(
+        expect(QueryComposerMock).toHaveBeenCalledWith(
+            expect.anything(),
             expect.objectContaining({
                 explore: expect.objectContaining({
                     tables: expect.objectContaining({

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -27,10 +27,9 @@ import Logger from '../../../logging/logger';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import type PrometheusMetrics from '../../../prometheus/PrometheusMetrics';
 import { type PreAggregationRoute } from '../../../services/AsyncQueryService/types';
-import { ProjectService } from '../../../services/ProjectService/ProjectService';
 import { traceSpan } from '../../../tracing/tracing';
 import { wrapSentryTransaction } from '../../../utils';
-import { PivotQueryBuilder } from '../../../utils/QueryBuilder/PivotQueryBuilder';
+import { QueryComposer } from '../../../utils/QueryBuilder/QueryComposer';
 import { type PreAggregateModel } from '../../models/PreAggregateModel';
 import {
     getDuckdbPreAggregateSqlTable,
@@ -348,43 +347,43 @@ export class PreAggregationDuckDbClient {
             args.startOfWeek,
         );
 
-        const fullQuery = await traceSpan(
+        const queryComposer = new QueryComposer(
+            {
+                metricQuery: args.metricQuery,
+                pivotConfiguration: args.pivotConfiguration,
+            },
+            {
+                explore: patchedPreAggExplore,
+                warehouseSqlBuilder,
+                intrinsicUserAttributes:
+                    args.userAccessControls.intrinsicUserAttributes,
+                userAttributes: args.userAccessControls.userAttributes,
+                timezone: args.timezone,
+                availableParameterDefinitions:
+                    args.availableParameterDefinitions,
+                parameters: args.parameters,
+                dateZoom: args.dateZoom,
+                pivotDimensions: undefined,
+                // Pre-agg pivots against the source query's persisted fields,
+                // not the pre-agg explore's freshly compiled ones.
+                pivotItemsMap: args.fieldsMap,
+                continueOnError: undefined,
+                useTimezoneAwareDateTrunc: args.useTimezoneAwareDateTrunc,
+                columnTimezone: undefined,
+                applyDateZoomToFilters: undefined,
+            },
+        );
+
+        const query = traceSpan(
             {
                 op: 'function',
                 name: 'preagg.compileQuery',
             },
             () =>
-                ProjectService._compileQuery({
-                    metricQuery: args.metricQuery,
-                    explore: patchedPreAggExplore,
-                    warehouseSqlBuilder,
-                    intrinsicUserAttributes:
-                        args.userAccessControls.intrinsicUserAttributes,
-                    userAttributes: args.userAccessControls.userAttributes,
-                    timezone: args.timezone,
-                    dateZoom: args.dateZoom,
-                    parameters: args.parameters,
-                    availableParameterDefinitions:
-                        args.availableParameterDefinitions,
-                    pivotConfiguration: args.pivotConfiguration,
-                    useTimezoneAwareDateTrunc: args.useTimezoneAwareDateTrunc,
+                queryComposer.getSql({
+                    columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
                 }),
         );
-
-        let { query } = fullQuery;
-        if (args.pivotConfiguration) {
-            const pivotQueryBuilder = new PivotQueryBuilder(
-                fullQuery.query,
-                args.pivotConfiguration,
-                warehouseSqlBuilder,
-                args.metricQuery.limit,
-                args.fieldsMap,
-            );
-
-            query = pivotQueryBuilder.toSql({
-                columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
-            });
-        }
 
         const warehouseClient = this.getOrCreateWarehouseClient();
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4107,6 +4107,7 @@ export class ProjectService extends BaseService {
                 parameters,
                 dateZoom,
                 pivotDimensions,
+                pivotItemsMap: undefined,
                 continueOnError,
                 useTimezoneAwareDateTrunc,
                 columnTimezone,
@@ -4252,6 +4253,7 @@ export class ProjectService extends BaseService {
                 parameters: combinedParameters,
                 dateZoom: undefined,
                 pivotDimensions,
+                pivotItemsMap: undefined,
                 continueOnError: true, // Return SQL even with compilation errors for debugging
                 useTimezoneAwareDateTrunc,
                 columnTimezone: getColumnTimezone(warehouseCredentials),

--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -26,6 +26,10 @@ const composer = new QueryComposer(
         parameters,
         dateZoom,
         pivotDimensions,
+        // pivotItemsMap overrides the itemsMap the pivot resolves against
+        // (defaults to the freshly compiled fields) — pre-agg passes the
+        // source query's persisted fields.
+        pivotItemsMap,
         continueOnError,
         useTimezoneAwareDateTrunc,
         columnTimezone,

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
@@ -23,6 +23,7 @@ const CONTEXT: QueryComposerContext = {
     parameters: {},
     dateZoom: undefined,
     pivotDimensions: undefined,
+    pivotItemsMap: undefined,
     continueOnError: undefined,
     useTimezoneAwareDateTrunc: undefined,
     columnTimezone: undefined,

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -5,6 +5,7 @@ import {
     type DateZoom,
     type Explore,
     type IntrinsicUserAttributes,
+    type ItemsMap,
     type MetricQuery,
     type ParameterDefinitions,
     type ParametersValuesMap,
@@ -35,6 +36,12 @@ export type QueryComposerContext = {
     parameters: ParametersValuesMap | undefined;
     dateZoom: DateZoom | undefined;
     pivotDimensions: string[] | undefined;
+    /**
+     * itemsMap the pivot resolves field metadata against. Defaults to the
+     * freshly compiled fields when undefined; pre-agg supplies the source
+     * query's persisted fields instead.
+     */
+    pivotItemsMap: ItemsMap | undefined;
     continueOnError: boolean | undefined;
     useTimezoneAwareDateTrunc: boolean | undefined;
     columnTimezone: string | undefined;
@@ -166,7 +173,7 @@ export class QueryComposer {
             pivotConfiguration,
             this.context.warehouseSqlBuilder,
             metricQuery.limit,
-            compiledQuery.fields,
+            this.context.pivotItemsMap ?? compiledQuery.fields,
         );
         return pivotQueryBuilder.toSql({ columnLimit });
     }


### PR DESCRIPTION
Closes: PROD-8776
Relates: PROD-8696

### Description:

Migrates `PreAggregationDuckDbClient` to build its DuckDB query through `QueryComposer` instead of hand-wiring `ProjectService._compileQuery` + a manual `PivotQueryBuilder`, so pre-agg shares the same SQL-generation path as everything else. Adds an optional `pivotItemsMap` to `QueryComposerContext` so the pivot resolves field metadata against the source query's persisted fields (defaulting to the freshly compiled fields otherwise), and drops the direct `ProjectService` dependency from the EE client. The emitted SQL is byte-identical to the previous hand-wired path for both the plain and pivot cases. Existing pre-agg and `QueryComposer` unit tests were updated to mock/pass through the new seam; typecheck and lint are clean.