### PR TITLE
feat(ai): edit knowledge documents

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2051,6 +2051,18 @@ export type AiAgentDocumentCreatedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentDocumentUpdatedEvent = BaseTrack & {
+    event: 'ai_agent_document.updated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string | null;
+        documentId: string;
+        contentChanged: boolean;
+        contentSizeBytes: number;
+    };
+};
+
 export type AiAgentDocumentDeletedEvent = BaseTrack & {
     event: 'ai_agent_document.deleted';
     userId: string;
@@ -2578,6 +2590,7 @@ type TypedEvent =
     | AiAgentDeletedEvent
     | AiAgentUpdatedEvent
     | AiAgentDocumentCreatedEvent
+    | AiAgentDocumentUpdatedEvent
     | AiAgentDocumentDeletedEvent
     | AiAgentPromptCreatedEvent
     | AiAgentPromptFeedbackEvent

--- a/packages/backend/src/ee/controllers/aiAgentScopedDocumentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentScopedDocumentController.ts
@@ -1,10 +1,12 @@
 import {
+    ApiAiAgentDocumentContentResponse,
     ApiAiAgentDocumentResponse,
     ApiAiAgentDocumentSummaryListResponse,
     ApiCreateAgentDocument,
     ApiErrorPayload,
     ApiSuccessEmpty,
     ApiUpdateAgentDocument,
+    ApiUpdateAgentDocumentContent,
     assertRegisteredAccount,
     type UUID,
 } from '@lightdash/common';
@@ -89,6 +91,64 @@ export class AiAgentScopedDocumentController extends BaseController {
             results: await this.getService().createDocument(
                 toSessionUser(req.account),
                 { projectUuid, agentUuid },
+                body,
+            ),
+        };
+    }
+
+    /**
+     * Read the full content of a knowledge document this agent can use.
+     * @summary Get agent document content
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{documentUuid}/content')
+    @OperationId('getAgentDocumentContent')
+    async getDocumentContent(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
+        @Path() documentUuid: UUID,
+    ): Promise<ApiAiAgentDocumentContentResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().getDocumentContent(
+                toSessionUser(req.account),
+                { projectUuid, agentUuid },
+                documentUuid,
+            ),
+        };
+    }
+
+    /**
+     * Replace the name and content of a knowledge document this agent can use.
+     * @summary Update agent document content
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{documentUuid}/content')
+    @OperationId('updateAgentDocumentContent')
+    async updateDocumentContent(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
+        @Path() documentUuid: UUID,
+        @Body() body: ApiUpdateAgentDocumentContent,
+    ): Promise<ApiAiAgentDocumentResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().updateDocumentContent(
+                toSessionUser(req.account),
+                { projectUuid, agentUuid },
+                documentUuid,
                 body,
             ),
         };

--- a/packages/backend/src/ee/models/AiAgentDocumentModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentDocumentModel.test.ts
@@ -151,6 +151,66 @@ describe('AiAgentDocumentModel agent scope', () => {
         });
     });
 
+    describe('updateContent', () => {
+        it('updates content within the owning organization and recomputes its byte size', async () => {
+            tracker.on.update(() => true).response(1);
+            tracker.on
+                .select(() => true)
+                .response([
+                    {
+                        ai_agent_document_uuid: DOCUMENT,
+                        organization_uuid: ORG,
+                        project_uuid: PROJECT,
+                        name: 'Updated metrics',
+                        original_filename: 'metrics.md',
+                        mime_type: 'text/markdown',
+                        content: '€',
+                        content_size_bytes: 3,
+                        always_include_in_context: false,
+                        summary: {
+                            description: 'Updated definitions',
+                            definedTerms: [],
+                            relatedExploreNames: [],
+                            useWhen: '',
+                            relevance: 'high',
+                            warning: null,
+                        },
+                        storage_key: 'storage-key',
+                        agent_access: [AGENT],
+                        created_by_user_uuid: null,
+                        updated_by_user_uuid: AGENT,
+                        created_at: new Date('2026-07-10T00:00:00Z'),
+                        updated_at: new Date('2026-07-10T01:00:00Z'),
+                    },
+                ]);
+
+            const document = await model.updateContent({
+                documentUuid: DOCUMENT,
+                organizationUuid: ORG,
+                name: 'Updated metrics',
+                content: '€',
+                summary: {
+                    description: 'Updated definitions',
+                    definedTerms: [],
+                    relatedExploreNames: [],
+                    useWhen: '',
+                    relevance: 'high',
+                    warning: null,
+                },
+                updatedByUserUuid: AGENT,
+            });
+
+            const [query] = tracker.history.update;
+            expect(normalize(query.sql)).toContain(
+                'where "ai_agent_document_uuid" = ? and "organization_uuid" = ?',
+            );
+            expect(query.bindings).toContain(DOCUMENT);
+            expect(query.bindings).toContain(ORG);
+            expect(query.bindings).toContain(3);
+            expect(document.contentSizeBytes).toBe(3);
+        });
+    });
+
     describe('updateAlwaysIncludeInContext', () => {
         it('updates only the selected document', async () => {
             tracker.on.update(() => true).response(1);

--- a/packages/backend/src/ee/models/AiAgentDocumentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentDocumentModel.ts
@@ -369,6 +369,40 @@ export class AiAgentDocumentModel {
         };
     }
 
+    async updateContent(args: {
+        documentUuid: string;
+        organizationUuid: string;
+        name: string;
+        content: string;
+        summary: AiAgentDocumentStructuredSummary;
+        updatedByUserUuid: string;
+    }): Promise<AiAgentDocument> {
+        const updated = await this.database(AiAgentDocumentTableName)
+            .where('ai_agent_document_uuid', args.documentUuid)
+            .andWhere('organization_uuid', args.organizationUuid)
+            .update({
+                name: args.name,
+                content: args.content,
+                content_size_bytes: Buffer.byteLength(args.content, 'utf8'),
+                summary: args.summary,
+                updated_by_user_uuid: args.updatedByUserUuid,
+                updated_at: this.database.fn.now(),
+            });
+        if (updated === 0) {
+            throw new NotFoundError(
+                `AI agent document ${args.documentUuid} not found`,
+            );
+        }
+
+        const document = await this.findOnQb(args.documentUuid, this.database);
+        if (!document) {
+            throw new NotFoundError(
+                `AI agent document ${args.documentUuid} not found`,
+            );
+        }
+        return document;
+    }
+
     async updateAlwaysIncludeInContext(args: {
         documentUuid: string;
         alwaysIncludeInContext: boolean;

--- a/packages/backend/src/ee/services/AiAgentDocumentService.ts
+++ b/packages/backend/src/ee/services/AiAgentDocumentService.ts
@@ -1,13 +1,16 @@
 import { subject } from '@casl/ability';
 import {
     AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
+    AI_AGENT_DOCUMENT_MAX_NAME_LENGTH,
     AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES,
     AiAgent,
     AiAgentDocument,
+    AiAgentDocumentContent,
     AiAgentDocumentSummary,
     ApiCreateAgentDocument,
     ApiCreateAiAgentDocument,
     ApiUpdateAgentDocument,
+    ApiUpdateAgentDocumentContent,
     CommercialFeatureFlags,
     Explore,
     ForbiddenError,
@@ -20,6 +23,7 @@ import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import {
     AiAgentDocumentCreatedEvent,
     AiAgentDocumentDeletedEvent,
+    AiAgentDocumentUpdatedEvent,
     LightdashAnalytics,
 } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -130,6 +134,34 @@ export class AiAgentDocumentService extends BaseService {
         }
     }
 
+    private async generateSummary(
+        user: SessionUser,
+        organizationUuid: string,
+        args: {
+            name: string;
+            content: string;
+            projectExplores: Explore[];
+        },
+    ): Promise<AiAgentDocument['summary']> {
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                organizationUuid,
+            );
+        return generateDocumentSummary(
+            {
+                ...getModel(copilotConfig, {
+                    enableReasoning: false,
+                    useFastModel: true,
+                }),
+                telemetry: {
+                    organizationUuid,
+                    userUuid: user.userUuid,
+                },
+            },
+            args,
+        );
+    }
+
     private async assertCopilotEnabled(user: SessionUser): Promise<void> {
         const flag = await this.commercialFeatureFlagModel.get({
             user,
@@ -225,6 +257,161 @@ export class AiAgentDocumentService extends BaseService {
         });
     }
 
+    async getDocumentContent(
+        user: SessionUser,
+        { projectUuid, agentUuid }: AiAgentDocumentScope,
+        documentUuid: string,
+    ): Promise<AiAgentDocumentContent> {
+        const organizationUuid = assertOrganizationUuid(user);
+        await this.assertCopilotEnabled(user);
+        this.assertCanViewDocuments(user, organizationUuid, projectUuid);
+        await this.aiAgentService.getAgent(user, agentUuid, projectUuid);
+
+        const content = await this.aiAgentDocumentModel.getContentForAgent({
+            organizationUuid,
+            agentUuid,
+            projectUuid,
+            documentUuid,
+        });
+        if (!content) {
+            throw new NotFoundError(
+                `AI agent document ${documentUuid} not found`,
+            );
+        }
+        return content;
+    }
+
+    async updateDocumentContent(
+        user: SessionUser,
+        { projectUuid, agentUuid }: AiAgentDocumentScope,
+        documentUuid: string,
+        body: ApiUpdateAgentDocumentContent,
+    ): Promise<AiAgentDocument> {
+        const organizationUuid = assertOrganizationUuid(user);
+        await this.assertCopilotEnabled(user);
+        this.assertCanManageDocuments(user, organizationUuid, projectUuid);
+        const agent = await this.aiAgentService.getAgent(
+            user,
+            agentUuid,
+            projectUuid,
+        );
+
+        const existing = await this.aiAgentDocumentModel.findAccessibleForAgent(
+            {
+                organizationUuid,
+                agentUuid,
+                projectUuid,
+                documentUuid,
+            },
+        );
+        if (!existing) {
+            throw new NotFoundError(
+                `AI agent document ${documentUuid} not found`,
+            );
+        }
+        this.assertCanManageDocuments(
+            user,
+            organizationUuid,
+            existing.projectUuid,
+        );
+
+        const name = body.name.trim();
+        if (name.length === 0) {
+            throw new ParameterError('Document name cannot be empty');
+        }
+        if (name.length > AI_AGENT_DOCUMENT_MAX_NAME_LENGTH) {
+            throw new ParameterError(
+                `Document name cannot exceed ${AI_AGENT_DOCUMENT_MAX_NAME_LENGTH} characters`,
+            );
+        }
+
+        const existingContent =
+            await this.aiAgentDocumentModel.getContentForAgent({
+                organizationUuid,
+                agentUuid,
+                projectUuid,
+                documentUuid,
+            });
+        if (!existingContent) {
+            throw new NotFoundError(
+                `AI agent document ${documentUuid} not found`,
+            );
+        }
+
+        const contentSizeBytes = Buffer.byteLength(body.content, 'utf8');
+        const contentChanged = body.content !== existingContent.content;
+        if (contentChanged) {
+            if (contentSizeBytes > AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES) {
+                throw new PayloadTooLargeError(
+                    `Content exceeds the ${AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES} byte limit.`,
+                    {
+                        contentSizeBytes,
+                        maxBytes: AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
+                    },
+                );
+            }
+
+            const existingTotal =
+                await this.aiAgentDocumentModel.getOrganizationContentSize(
+                    organizationUuid,
+                );
+            const projectedTotal =
+                existingTotal - existing.contentSizeBytes + contentSizeBytes;
+            if (projectedTotal > AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES) {
+                throw new PayloadTooLargeError(
+                    `Organization document quota of ${AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES} bytes would be exceeded`,
+                    {
+                        currentBytes: existingTotal,
+                        incomingBytes: contentSizeBytes,
+                        quotaBytes: AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES,
+                    },
+                );
+            }
+        }
+
+        let { summary } = existing;
+        if (contentChanged) {
+            const projectExplores = await this.getAgentExploresForSummarization(
+                user,
+                agent,
+            );
+            try {
+                summary = await this.generateSummary(user, organizationUuid, {
+                    name,
+                    content: body.content,
+                    projectExplores,
+                });
+            } catch (error) {
+                this.logger.error(
+                    `Failed to regenerate summary for document "${name}", keeping the existing summary: ${error}`,
+                );
+            }
+        }
+
+        const document = await this.aiAgentDocumentModel.updateContent({
+            documentUuid,
+            organizationUuid,
+            name,
+            content: body.content,
+            summary,
+            updatedByUserUuid: user.userUuid,
+        });
+
+        this.analytics.track<AiAgentDocumentUpdatedEvent>({
+            event: 'ai_agent_document.updated',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: existing.projectUuid,
+                documentId: documentUuid,
+                contentChanged,
+                contentSizeBytes,
+            },
+        });
+
+        return document;
+    }
+
     async updateDocument(
         user: SessionUser,
         { projectUuid, agentUuid }: AiAgentDocumentScope,
@@ -303,23 +490,9 @@ export class AiAgentDocumentService extends BaseService {
             body.originalFilename,
         );
 
-        const copilotConfig =
-            await this.orgAiCopilotConfigResolver.getCopilotConfig(
-                organizationUuid,
-            );
-        const modelOptions = {
-            ...getModel(copilotConfig, {
-                enableReasoning: false,
-                useFastModel: true,
-            }),
-            telemetry: {
-                organizationUuid,
-                userUuid: user.userUuid,
-            },
-        };
         let summary: AiAgentDocument['summary'];
         try {
-            summary = await generateDocumentSummary(modelOptions, {
+            summary = await this.generateSummary(user, organizationUuid, {
                 name: body.name,
                 content: body.content,
                 projectExplores: scope.projectExplores,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12393,6 +12393,60 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiAgentDocument.uuid-or-name-or-mimeType_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+                mimeType: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentDocumentContent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_AiAgentDocument.uuid-or-name-or-mimeType_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        content: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentDocumentContentResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentDocumentContent', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateAgentDocumentContent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                content: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiUpdateAgentDocument: {
         dataType: 'refAlias',
         type: {
@@ -51931,6 +51985,158 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentScopedDocumentController_getDocumentContent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        documentUuid: {
+            in: 'path',
+            name: 'documentUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/documents/:documentUuid/content',
+        ...fetchMiddlewares<RequestHandler>(AiAgentScopedDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentScopedDocumentController.prototype.getDocumentContent,
+        ),
+
+        async function AiAgentScopedDocumentController_getDocumentContent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentScopedDocumentController_getDocumentContent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentScopedDocumentController>(
+                        AiAgentScopedDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getDocumentContent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentScopedDocumentController_updateDocumentContent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        documentUuid: {
+            in: 'path',
+            name: 'documentUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiUpdateAgentDocumentContent',
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/documents/:documentUuid/content',
+        ...fetchMiddlewares<RequestHandler>(AiAgentScopedDocumentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentScopedDocumentController.prototype.updateDocumentContent,
+        ),
+
+        async function AiAgentScopedDocumentController_updateDocumentContent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentScopedDocumentController_updateDocumentContent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentScopedDocumentController>(
+                        AiAgentScopedDocumentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateDocumentContent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14020,6 +14020,64 @@
                 "type": "object",
                 "description": "Body of POST /api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents."
             },
+            "Pick_AiAgentDocument.uuid-or-name-or-mimeType_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "mimeType": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "uuid", "mimeType"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AiAgentDocumentContent": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_AiAgentDocument.uuid-or-name-or-mimeType_"
+                    },
+                    {
+                        "properties": {
+                            "content": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["content"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiAiAgentDocumentContentResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentDocumentContent"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiUpdateAgentDocumentContent": {
+                "properties": {
+                    "content": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["content", "name"],
+                "type": "object"
+            },
             "ApiUpdateAgentDocument": {
                 "properties": {
                     "alwaysIncludeInContext": {
@@ -46434,6 +46492,126 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ApiCreateAgentDocument"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/documents/{documentUuid}/content": {
+            "get": {
+                "operationId": "getAgentDocumentContent",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentDocumentContentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Read the full content of a knowledge document this agent can use.",
+                "summary": "Get agent document content",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "documentUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "updateAgentDocumentContent",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentDocumentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Replace the name and content of a knowledge document this agent can use.",
+                "summary": "Update agent document content",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "documentUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiUpdateAgentDocumentContent"
                             }
                         }
                     }

--- a/packages/common/src/ee/AiAgent/documentTypes.ts
+++ b/packages/common/src/ee/AiAgent/documentTypes.ts
@@ -1,4 +1,5 @@
 export const AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES = 20 * 1024;
+export const AI_AGENT_DOCUMENT_MAX_NAME_LENGTH = 255;
 export const AI_AGENT_DOCUMENT_ORG_QUOTA_BYTES = 5 * 1024 * 1024;
 
 export type AiAgentDocumentRelevance = 'high' | 'medium' | 'low' | 'none';
@@ -73,6 +74,11 @@ export type ApiCreateAgentDocument = {
 
 export type ApiUpdateAgentDocument = {
     alwaysIncludeInContext: boolean;
+};
+
+export type ApiUpdateAgentDocumentContent = {
+    name: string;
+    content: string;
 };
 
 export type ApiAiAgentDocumentResponse = {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -126,6 +126,7 @@
         "rehype-raw": "7.0.0",
         "rehype-sanitize": "6.0.0",
         "remark-emoji": "5.0.2",
+        "remark-frontmatter": "5.0.0",
         "remark-gfm": "4.0.1",
         "reselect": "5.1.1",
         "rudder-sdk-js": "2.9.1",

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
@@ -1,0 +1,330 @@
+import {
+    AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
+    AI_AGENT_DOCUMENT_MAX_NAME_LENGTH,
+    assertUnreachable,
+    type AiAgentDocumentSummary,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Center,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    Textarea,
+    TextInput,
+    useMantineColorScheme,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconDownload, IconEdit } from '@tabler/icons-react';
+import MDEditor from '@uiw/react-md-editor';
+import { useCallback, useMemo, useState } from 'react';
+import remarkFrontmatter from 'remark-frontmatter';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import useToaster from '../../../../hooks/toaster/useToaster';
+import { formatFileSize } from '../../../../utils/formatters';
+import {
+    mdEditorComponents,
+    rehypeRemoveHeaderLinks,
+    useMdEditorStyle,
+} from '../../../../utils/markdownUtils';
+import {
+    useAiAgentDocumentContent,
+    useUpdateAiAgentDocumentContent,
+} from '../hooks/useAiAgentDocuments';
+
+const MARKDOWN_REMARK_PLUGINS = [remarkFrontmatter];
+
+type LoadedDocumentModalProps = {
+    agentUuid: string;
+    content: string;
+    document: AiAgentDocumentSummary;
+    onClose: () => void;
+    projectUuid: string;
+};
+
+const LoadedDocumentModal = ({
+    agentUuid,
+    content,
+    document,
+    onClose,
+    projectUuid,
+}: LoadedDocumentModalProps) => {
+    const { colorScheme } = useMantineColorScheme();
+    const markdownStyle = useMdEditorStyle();
+    const updateDocument = useUpdateAiAgentDocumentContent(
+        projectUuid,
+        agentUuid,
+    );
+    const { showToastError } = useToaster();
+    const [mode, setMode] = useState<'view' | 'edit'>('view');
+    const initialValues = useMemo(
+        () => ({ name: document.name, content }),
+        [content, document.name],
+    );
+    const form = useForm({ initialValues });
+    const contentSizeBytes = new TextEncoder().encode(
+        form.values.content,
+    ).byteLength;
+    const contentTooLarge =
+        contentSizeBytes > AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES;
+    const isMarkdown = document.mimeType === 'text/markdown';
+
+    const handleDownload = useCallback(() => {
+        const blob = new Blob([form.values.content], {
+            type: `${document.mimeType};charset=utf-8`,
+        });
+        const url = URL.createObjectURL(blob);
+        const anchor = window.document.createElement('a');
+        anchor.href = url;
+        anchor.download = document.originalFilename;
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+    }, [document.mimeType, document.originalFilename, form.values.content]);
+
+    const handleCancelEdit = useCallback(() => {
+        form.setValues(initialValues);
+        form.resetDirty(initialValues);
+        setMode('view');
+    }, [form, initialValues]);
+
+    const handleSave = useCallback(async () => {
+        if (contentTooLarge) {
+            showToastError({
+                title: 'Document is too large',
+                subtitle: `Content exceeds the ${formatFileSize(
+                    AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES,
+                )} limit.`,
+            });
+            return;
+        }
+
+        const values = {
+            name: form.values.name.trim(),
+            content: form.values.content,
+        };
+        try {
+            await updateDocument.mutateAsync({
+                documentUuid: document.uuid,
+                body: values,
+            });
+            form.setValues(values);
+            form.resetDirty(values);
+            setMode('view');
+        } catch {
+            // The mutation hook shows the error; keep the editor open for retry.
+        }
+    }, [contentTooLarge, document.uuid, form, showToastError, updateDocument]);
+
+    const saveDisabled =
+        !form.isDirty() ||
+        form.values.name.trim().length === 0 ||
+        contentTooLarge;
+    const headerActions = (() => {
+        switch (mode) {
+            case 'view':
+                return (
+                    <Group gap="xs">
+                        <Button
+                            size="xs"
+                            variant="default"
+                            leftSection={<MantineIcon icon={IconDownload} />}
+                            onClick={handleDownload}
+                        >
+                            Download
+                        </Button>
+                        <Button
+                            size="xs"
+                            leftSection={<MantineIcon icon={IconEdit} />}
+                            onClick={() => setMode('edit')}
+                        >
+                            Edit
+                        </Button>
+                    </Group>
+                );
+            case 'edit':
+                return (
+                    <Group gap="xs">
+                        <Button
+                            size="xs"
+                            variant="default"
+                            disabled={updateDocument.isLoading}
+                            onClick={handleCancelEdit}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            size="xs"
+                            disabled={saveDisabled}
+                            loading={updateDocument.isLoading}
+                            onClick={() => void handleSave()}
+                        >
+                            Save
+                        </Button>
+                    </Group>
+                );
+            default:
+                return assertUnreachable(mode, 'Unknown document modal mode');
+        }
+    })();
+
+    return (
+        <MantineModal
+            opened
+            onClose={() => {
+                if (!updateDocument.isLoading) onClose();
+            }}
+            title={
+                mode === 'edit' ? 'Edit knowledge document' : form.values.name
+            }
+            fullScreen
+            headerActions={headerActions}
+            cancelLabel={false}
+            confirmBeforeClose={
+                !updateDocument.isLoading && mode === 'edit' && form.isDirty()
+            }
+            withCloseButton={!updateDocument.isLoading}
+        >
+            {mode === 'view' ? (
+                isMarkdown ? (
+                    <Box
+                        data-color-mode={colorScheme}
+                        h="100%"
+                        style={{ overflowY: 'auto' }}
+                    >
+                        <MDEditor.Markdown
+                            source={form.values.content}
+                            style={markdownStyle}
+                            components={mdEditorComponents}
+                            rehypeRewrite={rehypeRemoveHeaderLinks}
+                            remarkPlugins={MARKDOWN_REMARK_PLUGINS}
+                        />
+                    </Box>
+                ) : (
+                    <Text
+                        component="pre"
+                        fz="sm"
+                        ff="monospace"
+                        style={{
+                            whiteSpace: 'pre-wrap',
+                            overflowWrap: 'anywhere',
+                        }}
+                    >
+                        {form.values.content}
+                    </Text>
+                )
+            ) : (
+                <Stack gap="md" h="100%">
+                    <TextInput
+                        label="Name"
+                        required
+                        maxLength={AI_AGENT_DOCUMENT_MAX_NAME_LENGTH}
+                        {...form.getInputProps('name')}
+                    />
+                    {isMarkdown ? (
+                        <Box data-color-mode={colorScheme} flex={1} mih={0}>
+                            <MDEditor
+                                value={form.values.content}
+                                onChange={(value) =>
+                                    form.setFieldValue('content', value ?? '')
+                                }
+                                preview="live"
+                                previewOptions={{
+                                    components: mdEditorComponents,
+                                    rehypeRewrite: rehypeRemoveHeaderLinks,
+                                    remarkPlugins: MARKDOWN_REMARK_PLUGINS,
+                                }}
+                                height="calc(100dvh - 220px)"
+                                overflow={false}
+                            />
+                        </Box>
+                    ) : (
+                        <Textarea
+                            label="Content"
+                            autosize
+                            minRows={24}
+                            maxRows={40}
+                            styles={{ input: { fontFamily: 'monospace' } }}
+                            {...form.getInputProps('content')}
+                        />
+                    )}
+                    <Text
+                        size="xs"
+                        c={contentTooLarge ? 'red' : 'dimmed'}
+                        ta="right"
+                    >
+                        {formatFileSize(contentSizeBytes)} /{' '}
+                        {formatFileSize(AI_AGENT_DOCUMENT_MAX_CONTENT_BYTES)}
+                    </Text>
+                </Stack>
+            )}
+        </MantineModal>
+    );
+};
+
+type Props = {
+    agentUuid: string;
+    document: AiAgentDocumentSummary | null;
+    onClose: () => void;
+    projectUuid: string;
+};
+
+export const AiAgentKnowledgeDocumentModal = ({
+    agentUuid,
+    document,
+    onClose,
+    projectUuid,
+}: Props) => {
+    const documentContent = useAiAgentDocumentContent(
+        projectUuid,
+        agentUuid,
+        document?.uuid ?? null,
+    );
+
+    if (!document) return null;
+
+    if (documentContent.data) {
+        return (
+            <LoadedDocumentModal
+                key={document.uuid}
+                agentUuid={agentUuid}
+                content={documentContent.data.content}
+                document={document}
+                onClose={onClose}
+                projectUuid={projectUuid}
+            />
+        );
+    }
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title={document.name}
+            fullScreen
+            cancelLabel={false}
+        >
+            <Center h="100%">
+                {documentContent.isLoading ? (
+                    <Loader />
+                ) : (
+                    <Stack align="center" gap="xs">
+                        <Text size="sm" c="dimmed">
+                            Unable to load this document.
+                        </Text>
+                        <Button
+                            size="xs"
+                            variant="default"
+                            onClick={() => void documentContent.refetch()}
+                        >
+                            Try again
+                        </Button>
+                    </Stack>
+                )}
+            </Center>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
@@ -26,6 +26,7 @@ import MantineModal from '../../../../components/common/MantineModal';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { formatFileSize } from '../../../../utils/formatters';
 import {
+    markdownSanitizeRehypePlugins,
     mdEditorComponents,
     rehypeRemoveHeaderLinks,
     useMdEditorStyle,
@@ -199,6 +200,7 @@ const LoadedDocumentModal = ({
                             source={form.values.content}
                             style={markdownStyle}
                             components={mdEditorComponents}
+                            rehypePlugins={markdownSanitizeRehypePlugins}
                             rehypeRewrite={rehypeRemoveHeaderLinks}
                             remarkPlugins={MARKDOWN_REMARK_PLUGINS}
                         />
@@ -234,6 +236,8 @@ const LoadedDocumentModal = ({
                                 preview="live"
                                 previewOptions={{
                                     components: mdEditorComponents,
+                                    rehypePlugins:
+                                        markdownSanitizeRehypePlugins,
                                     rehypeRewrite: rehypeRemoveHeaderLinks,
                                     remarkPlugins: MARKDOWN_REMARK_PLUGINS,
                                 }}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -106,7 +106,7 @@ const getPendingActionModalConfig = (
         case 'enableFullContext':
             return {
                 title: 'Always include in context?',
-                description: `The full content of “${action.document.name}” will be added to every prompt. This uses more tokens and may increase response time.`,
+                description: `The full content of “${action.document.name}” will be added to every session. This uses more tokens and may increase response time.`,
                 confirmLabel: 'Always include',
                 variant: 'default',
             };
@@ -605,7 +605,7 @@ export const AiAgentKnowledgeFilesSection = ({
                                         <Switch
                                             size="xs"
                                             label="Always include in context"
-                                            description="Adds the full document to every prompt. Uses more tokens."
+                                            description="Adds the full document to every session. Uses more tokens."
                                             checked={
                                                 selectedDocument.alwaysIncludeInContext
                                             }

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -23,6 +23,7 @@ import {
     UnstyledButton,
 } from '@mantine-8/core';
 import {
+    IconEye,
     IconFileText,
     IconFolderOpen,
     IconTrash,
@@ -45,6 +46,7 @@ import {
 } from '../hooks/useAiAgentDocuments';
 import { AiAgentDocumentRelevanceCard } from './AiAgentDocumentRelevanceCard';
 import { AiAgentIcon } from './AiAgentIcon';
+import { AiAgentKnowledgeDocumentModal } from './AiAgentKnowledgeDocumentModal';
 import styles from './AiAgentKnowledgeFilesSection.module.css';
 
 const ACCEPT_ATTR =
@@ -138,6 +140,8 @@ export const AiAgentKnowledgeFilesSection = ({
     const [pendingAction, setPendingAction] = useState<PendingAction | null>(
         null,
     );
+    const [viewingDocument, setViewingDocument] =
+        useState<AiAgentDocumentSummary | null>(null);
 
     const effectiveSelectedId = useMemo(() => {
         if (selectedId && pendingUploads.some((p) => p.tempId === selectedId)) {
@@ -548,32 +552,52 @@ export const AiAgentKnowledgeFilesSection = ({
                                             </Text>
                                         </Stack>
                                         {selectedDocument && (
-                                            <Tooltip
-                                                label="Delete document"
-                                                position="left"
-                                                withArrow
-                                            >
-                                                <ActionIcon
-                                                    variant="subtle"
-                                                    color="red"
-                                                    loading={
-                                                        deleteDocument.isLoading &&
-                                                        deleteDocument.variables ===
-                                                            selectedDocument.uuid
-                                                    }
-                                                    onClick={() =>
-                                                        setPendingAction({
-                                                            type: 'delete',
-                                                            document:
-                                                                selectedDocument,
-                                                        })
-                                                    }
+                                            <Group gap={4} wrap="nowrap">
+                                                <Tooltip
+                                                    label="View and edit document"
+                                                    position="left"
+                                                    withArrow
                                                 >
-                                                    <MantineIcon
-                                                        icon={IconTrash}
-                                                    />
-                                                </ActionIcon>
-                                            </Tooltip>
+                                                    <ActionIcon
+                                                        variant="subtle"
+                                                        onClick={() =>
+                                                            setViewingDocument(
+                                                                selectedDocument,
+                                                            )
+                                                        }
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconEye}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                                <Tooltip
+                                                    label="Delete document"
+                                                    position="left"
+                                                    withArrow
+                                                >
+                                                    <ActionIcon
+                                                        variant="subtle"
+                                                        color="red"
+                                                        loading={
+                                                            deleteDocument.isLoading &&
+                                                            deleteDocument.variables ===
+                                                                selectedDocument.uuid
+                                                        }
+                                                        onClick={() =>
+                                                            setPendingAction({
+                                                                type: 'delete',
+                                                                document:
+                                                                    selectedDocument,
+                                                            })
+                                                        }
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconTrash}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                            </Group>
                                         )}
                                     </Group>
 
@@ -667,6 +691,12 @@ export const AiAgentKnowledgeFilesSection = ({
                     </Group>
                 )}
             </Paper>
+            <AiAgentKnowledgeDocumentModal
+                agentUuid={agentUuid}
+                document={viewingDocument}
+                onClose={() => setViewingDocument(null)}
+                projectUuid={projectUuid}
+            />
             {pendingAction && (
                 <MantineModal
                     opened

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
@@ -1,10 +1,12 @@
 import type {
+    ApiAiAgentDocumentContentResponse,
     ApiAiAgentDocumentResponse,
     ApiAiAgentDocumentSummaryListResponse,
     ApiCreateAgentDocument,
     ApiError,
     ApiSuccessEmpty,
     ApiUpdateAgentDocument,
+    ApiUpdateAgentDocumentContent,
 } from '@lightdash/common';
 import {
     useMutation,
@@ -37,6 +39,31 @@ const createDocument = async (
         version: 'v1',
         url: documentsUrl(projectUuid, agentUuid),
         method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+const getDocumentContent = async (
+    projectUuid: string,
+    agentUuid: string,
+    documentUuid: string,
+) =>
+    lightdashApi<ApiAiAgentDocumentContentResponse['results']>({
+        version: 'v1',
+        url: `${documentsUrl(projectUuid, agentUuid)}/${documentUuid}/content`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const updateDocumentContent = async (
+    projectUuid: string,
+    agentUuid: string,
+    documentUuid: string,
+    body: ApiUpdateAgentDocumentContent,
+) =>
+    lightdashApi<ApiAiAgentDocumentResponse['results']>({
+        version: 'v1',
+        url: `${documentsUrl(projectUuid, agentUuid)}/${documentUuid}/content`,
+        method: 'PATCH',
         body: JSON.stringify(body),
     });
 
@@ -100,6 +127,71 @@ export const useCreateAiAgentDocument = (
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to upload document',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useAiAgentDocumentContent = (
+    projectUuid: string,
+    agentUuid: string,
+    documentUuid: string | null,
+    options?: UseQueryOptions<
+        ApiAiAgentDocumentContentResponse['results'],
+        ApiError
+    >,
+) =>
+    useQuery<ApiAiAgentDocumentContentResponse['results'], ApiError>({
+        queryKey: [
+            AI_AGENT_DOCUMENTS_KEY,
+            projectUuid,
+            agentUuid,
+            'content',
+            documentUuid,
+        ],
+        queryFn: () => {
+            if (!documentUuid) {
+                throw new Error('Document uuid is required');
+            }
+            return getDocumentContent(projectUuid, agentUuid, documentUuid);
+        },
+        enabled: documentUuid !== null,
+        ...options,
+    });
+
+export const useUpdateAiAgentDocumentContent = (
+    projectUuid: string,
+    agentUuid: string,
+) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+    return useMutation<
+        ApiAiAgentDocumentResponse['results'],
+        ApiError,
+        { documentUuid: string; body: ApiUpdateAgentDocumentContent }
+    >({
+        mutationFn: ({ documentUuid, body }) =>
+            updateDocumentContent(projectUuid, agentUuid, documentUuid, body),
+        onSuccess: async (document) => {
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: [AI_AGENT_DOCUMENTS_KEY],
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: [
+                        AI_AGENT_DOCUMENTS_KEY,
+                        projectUuid,
+                        agentUuid,
+                        'content',
+                        document.uuid,
+                    ],
+                }),
+            ]);
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update document content',
                 apiError: error,
             });
         },

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentDocuments.ts
@@ -143,6 +143,7 @@ export const useAiAgentDocumentContent = (
     >,
 ) =>
     useQuery<ApiAiAgentDocumentContentResponse['results'], ApiError>({
+        ...options,
         queryKey: [
             AI_AGENT_DOCUMENTS_KEY,
             projectUuid,
@@ -156,8 +157,7 @@ export const useAiAgentDocumentContent = (
             }
             return getDocumentContent(projectUuid, agentUuid, documentUuid);
         },
-        enabled: documentUuid !== null,
-        ...options,
+        enabled: documentUuid !== null && (options?.enabled ?? true),
     });
 
 export const useUpdateAiAgentDocumentContent = (

--- a/packages/frontend/src/utils/markdownUtils.test.ts
+++ b/packages/frontend/src/utils/markdownUtils.test.ts
@@ -1,0 +1,45 @@
+import type { Root } from 'hast';
+import { unified } from 'unified';
+import { markdownSanitizeRehypePlugins } from './markdownUtils';
+
+describe('markdownSanitizeRehypePlugins', () => {
+    test('removes executable HTML while preserving safe elements', async () => {
+        const tree: Root = {
+            type: 'root',
+            children: [
+                {
+                    type: 'element',
+                    tagName: 'strong',
+                    properties: {},
+                    children: [{ type: 'text', value: 'Safe' }],
+                },
+                {
+                    type: 'element',
+                    tagName: 'img',
+                    properties: {
+                        src: 'x',
+                        onError: "fetch('/session')",
+                    },
+                    children: [],
+                },
+                {
+                    type: 'element',
+                    tagName: 'script',
+                    properties: {},
+                    children: [{ type: 'text', value: "fetch('/session')" }],
+                },
+            ],
+        };
+
+        const sanitized = await unified()
+            .use({ plugins: markdownSanitizeRehypePlugins })
+            .run(tree);
+        const serialized = JSON.stringify(sanitized);
+
+        expect(serialized).toContain('strong');
+        expect(serialized).toContain('img');
+        expect(serialized).not.toContain('onError');
+        expect(serialized).not.toContain('script');
+        expect(serialized).not.toContain("fetch('/session')");
+    });
+});

--- a/packages/frontend/src/utils/markdownUtils.tsx
+++ b/packages/frontend/src/utils/markdownUtils.tsx
@@ -1,5 +1,18 @@
-import { rem, useMantineTheme } from '@mantine-8/core';
+import {
+    Divider,
+    rem,
+    Title,
+    useMantineTheme,
+    type MantineStyleProp,
+} from '@mantine-8/core';
 import type MarkdownPreview from '@uiw/react-markdown-preview';
+import type MDEditor from '@uiw/react-md-editor';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import type { PluggableList } from 'unified';
+
+export const markdownSanitizeRehypePlugins = [
+    [rehypeSanitize, defaultSchema],
+] satisfies PluggableList;
 
 /**
  * Removes header auto-linking when rendering markdown via ReactMarkdownPreview.
@@ -16,6 +29,49 @@ export const rehypeRemoveHeaderLinks: React.ComponentProps<
     ) {
         parent.children = parent.children.slice(1);
     }
+};
+
+const HEADER_STYLES = {
+    border: 0,
+} satisfies MantineStyleProp;
+/**
+ * Component overrides for MDEditor.Markdown to match Lightdash design system.
+ * Provides consistent styling for markdown headers and dividers.
+ */
+export const mdEditorComponents: React.ComponentProps<
+    typeof MDEditor.Markdown
+>['components'] = {
+    hr: () => <Divider color="ldGray.4" my="sm" />,
+    h1: ({ children }) => (
+        <Title order={1} style={HEADER_STYLES}>
+            {children}
+        </Title>
+    ),
+    h2: ({ children }) => (
+        <Title order={2} style={HEADER_STYLES}>
+            {children}
+        </Title>
+    ),
+    h3: ({ children }) => (
+        <Title order={3} style={HEADER_STYLES}>
+            {children}
+        </Title>
+    ),
+    h4: ({ children }) => (
+        <Title order={4} style={HEADER_STYLES}>
+            {children}
+        </Title>
+    ),
+    h5: ({ children }) => (
+        <Title order={5} style={HEADER_STYLES}>
+            {children}
+        </Title>
+    ),
+    h6: ({ children }) => (
+        <Title order={6} style={HEADER_STYLES}>
+            {children}
+        </Title>
+    ),
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1362,6 +1362,9 @@ importers:
       remark-emoji:
         specifier: 5.0.2
         version: 5.0.2
+      remark-frontmatter:
+        specifier: 5.0.0
+        version: 5.0.0
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
@@ -10870,6 +10873,9 @@ packages:
   fastq@1.11.0:
     resolution: {integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fb-watchman@2.0.1:
     resolution: {integrity: sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==}
 
@@ -11032,6 +11038,10 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formdata-node@4.4.1:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
@@ -12986,6 +12996,9 @@ packages:
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
   mdast-util-gfm-autolink-literal@0.1.3:
     resolution: {integrity: sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==}
 
@@ -13096,6 +13109,9 @@ packages:
 
   micromark-core-commonmark@2.0.2:
     resolution: {integrity: sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@0.5.7:
     resolution: {integrity: sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==}
@@ -15208,6 +15224,9 @@ packages:
   remark-emoji@5.0.2:
     resolution: {integrity: sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==}
     engines: {node: '>=18'}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
   remark-gfm@1.0.0:
     resolution: {integrity: sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==}
@@ -29006,6 +29025,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fb-watchman@2.0.1:
     dependencies:
       bser: 2.1.1
@@ -29235,6 +29258,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  format@0.2.2: {}
 
   formdata-node@4.4.1:
     dependencies:
@@ -31653,6 +31678,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@0.1.3:
     dependencies:
       ccount: 1.1.0
@@ -31892,6 +31928,13 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.1
 
@@ -34409,6 +34452,15 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       node-emoji: 2.2.0
       unified: 11.0.5
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@1.0.0:
     dependencies:


### PR DESCRIPTION
Lets users inspect and update an AI agent's uploaded knowledge documents without deleting and re-uploading them.

- Adds agent-scoped content read/update endpoints with existing access checks
- Enforces document and organization quotas and refreshes the AI summary after content edits
- Adds a fullscreen viewer/editor with rendered Markdown, plain-text support, downloads, and unsaved-change protection
- Parses Markdown frontmatter without rendering it while preserving the raw source
- Keeps always-in-context documents current on the agent's next message

This revives the useful UI from #25042 on the newer agent-scoped document APIs.

### Testing
- Common, backend, and frontend fast typechecks
- Targeted backend model tests
- Targeted lint and formatting across touched packages
- Live API checks for read/update, cross-agent isolation, and name validation
- Frontmatter rendering check
- Claude Fable advisor review

Closes PROD-8646