### PR TITLE
feat(backend): add totals support to QueryComposer + migrate calculate-total path

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3438,6 +3438,7 @@ export class AsyncQueryService extends ProjectService {
         parameters,
         projectUuid,
         pivotConfiguration,
+        totalConfiguration,
         pivotDimensions,
         userAttributeOverrides,
         materializationRole,
@@ -3456,6 +3457,7 @@ export class AsyncQueryService extends ProjectService {
         | 'projectUuid'
         | 'userAttributeOverrides'
         | 'materializationRole'
+        | 'totalConfiguration'
     > & {
         warehouseSqlBuilder: WarehouseSqlBuilder;
         explore: Explore;
@@ -3518,7 +3520,7 @@ export class AsyncQueryService extends ProjectService {
             preloadedProjectTimezone,
         });
 
-        const fullQuery = await ProjectService._compileQuery({
+        const queryComposer = ProjectService._createQueryComposer({
             metricQuery,
             explore,
             warehouseSqlBuilder,
@@ -3530,11 +3532,17 @@ export class AsyncQueryService extends ProjectService {
             parameters,
             availableParameterDefinitions,
             pivotConfiguration,
+            totalConfiguration,
             pivotDimensions: pivotDimensions ?? metricQuery.pivotDimensions,
             useTimezoneAwareDateTrunc,
             columnTimezone,
             applyDateZoomToFilters,
         });
+
+        const fullQuery = queryComposer.compile();
+        const effectiveMetricQuery = queryComposer.getMetricQuery();
+        const effectivePivotConfiguration =
+            queryComposer.getPivotConfiguration();
 
         const resolvedMetricOverrides =
             getMetricOverridesWithPopInheritance(metricQuery);
@@ -3563,7 +3571,7 @@ export class AsyncQueryService extends ProjectService {
             }),
         );
 
-        const responseMetricQuery = metricQuery;
+        const responseMetricQuery = effectiveMetricQuery;
 
         return {
             sql: fullQuery.query,
@@ -3575,6 +3583,7 @@ export class AsyncQueryService extends ProjectService {
             ),
             usedParameters: fullQuery.usedParameters,
             responseMetricQuery,
+            effectivePivotConfiguration,
             userAccessControls: { userAttributes, intrinsicUserAttributes },
             availableParameterDefinitions,
             resolvedTimezone,
@@ -4335,6 +4344,7 @@ export class AsyncQueryService extends ProjectService {
             userAttributeOverrides,
             materializationRole,
             dashboardFilters,
+            totalConfiguration,
         }: ExecuteAsyncMetricQueryArgs,
         organizationUuid: string,
     ): Promise<ApiExecuteAsyncMetricQueryResults> {
@@ -4436,6 +4446,7 @@ export class AsyncQueryService extends ProjectService {
             missingParameterReferences,
             usedParameters,
             responseMetricQuery,
+            effectivePivotConfiguration,
             userAccessControls,
             availableParameterDefinitions,
             resolvedTimezone,
@@ -4450,6 +4461,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             pivotConfiguration,
+            totalConfiguration,
             userAttributeOverrides,
             materializationRole,
             columnTimezone: getColumnTimezone(warehouseCredentials),
@@ -4459,6 +4471,8 @@ export class AsyncQueryService extends ProjectService {
         });
         const prepareMs = Date.now() - prepareStart;
 
+        const effectiveMetricQuery = responseMetricQuery;
+
         const queryTagsWithUserAttributes =
             AsyncQueryService.addUserAttributeQueryTags(
                 queryTags,
@@ -4467,13 +4481,13 @@ export class AsyncQueryService extends ProjectService {
 
         const requestParameters: ExecuteAsyncMetricQueryRequestParams = {
             context,
-            query: metricQuery,
+            query: effectiveMetricQuery,
             parameters: combinedParameters,
             dateZoom,
         };
 
         const routingDecision = this.getPreAggregationRoutingDecision({
-            metricQuery,
+            metricQuery: effectiveMetricQuery,
             explore,
             context,
             forceWarehouse: usePreAggregateCache === false,
@@ -4493,7 +4507,7 @@ export class AsyncQueryService extends ProjectService {
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 account,
-                metricQuery,
+                metricQuery: effectiveMetricQuery,
                 projectUuid,
                 organizationUuid,
                 explore,
@@ -4509,7 +4523,7 @@ export class AsyncQueryService extends ProjectService {
                 timezone: resolvedTimezone,
                 displayTimezone,
                 useTimezoneAwareDateTrunc,
-                pivotConfiguration,
+                pivotConfiguration: effectivePivotConfiguration,
                 warehouseCredentials,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
@@ -4567,13 +4581,6 @@ export class AsyncQueryService extends ProjectService {
             this.projectModel.getSummary(projectUuid),
         ]);
 
-        const { metricQuery, pivotConfiguration } = new TotalQueryBuilder({
-            metricQuery: source.metricQuery,
-            pivotConfiguration: source.pivotConfiguration,
-            kind,
-            subtotalDimensions,
-        }).compileQuery();
-
         // Reuse the source's parameter values so the totals query sees the
         // same parameter context as the original. The execution path
         // re-combines these against project defaults.
@@ -4592,8 +4599,9 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 projectUuid,
                 context: QueryExecutionContext.CALCULATE_TOTAL,
-                metricQuery,
-                pivotConfiguration,
+                metricQuery: source.metricQuery,
+                pivotConfiguration: source.pivotConfiguration ?? undefined,
+                totalConfiguration: { kind, subtotalDimensions },
                 parameters: sourceParameters,
                 dateZoom: sourceDateZoom,
                 invalidateCache,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -23,6 +23,7 @@ import {
     type UserAttributeValueMap,
 } from '@lightdash/common';
 import type { DbProjectParameter } from '../../database/entities/projectParameters';
+import type { TotalConfiguration } from '../../utils/QueryBuilder/QueryComposer';
 
 export type CommonAsyncQueryArgs = {
     account: Account;
@@ -81,6 +82,11 @@ export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
     pivotConfiguration?: PivotConfiguration;
     materializationRole?: UserAccessControls;
     dashboardFilters?: DashboardFilters;
+    /**
+     * Collapse the query into a totals grain (calculate-total path only).
+     * Mutually exclusive with `dashboardFilters`.
+     */
+    totalConfiguration?: TotalConfiguration;
 };
 
 export type ExecuteAsyncSavedChartQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -271,7 +271,10 @@ import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLi
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { CompiledQuery } from '../../utils/QueryBuilder/MetricQueryBuilder';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
-import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
+import {
+    QueryComposer,
+    TotalConfiguration,
+} from '../../utils/QueryBuilder/QueryComposer';
 import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
@@ -4057,7 +4060,7 @@ export class ProjectService extends BaseService {
         });
     }
 
-    static async _compileQuery({
+    static _createQueryComposer({
         metricQuery,
         explore,
         warehouseSqlBuilder,
@@ -4068,6 +4071,7 @@ export class ProjectService extends BaseService {
         parameters,
         availableParameterDefinitions,
         pivotConfiguration,
+        totalConfiguration,
         pivotDimensions,
         continueOnError,
         useTimezoneAwareDateTrunc,
@@ -4084,6 +4088,11 @@ export class ProjectService extends BaseService {
         parameters?: ParametersValuesMap;
         availableParameterDefinitions: ParameterDefinitions;
         pivotConfiguration?: PivotConfiguration;
+        /**
+         * When set, the composer collapses the source query into this totals
+         * grain before compiling (calculate-total path only).
+         */
+        totalConfiguration?: TotalConfiguration;
         pivotDimensions?: string[];
         continueOnError?: boolean;
         useTimezoneAwareDateTrunc?: boolean;
@@ -4094,9 +4103,9 @@ export class ProjectService extends BaseService {
          * Only safe on the underlying-data path where filters are solely click-filters.
          */
         applyDateZoomToFilters?: boolean;
-    }): Promise<CompiledQuery> {
+    }): QueryComposer {
         return new QueryComposer(
-            { metricQuery, pivotConfiguration },
+            { metricQuery, pivotConfiguration, totalConfiguration },
             {
                 explore,
                 warehouseSqlBuilder,
@@ -4112,7 +4121,13 @@ export class ProjectService extends BaseService {
                 columnTimezone,
                 applyDateZoomToFilters,
             },
-        ).compile();
+        );
+    }
+
+    static async _compileQuery(
+        args: Parameters<typeof ProjectService._createQueryComposer>[0],
+    ): Promise<CompiledQuery> {
+        return ProjectService._createQueryComposer(args).compile();
     }
 
     /**

--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -15,7 +15,11 @@ This file covers SQL generation only. For the end-to-end pivot pipeline (config 
 import { QueryComposer } from './QueryComposer';
 
 const composer = new QueryComposer(
-    { metricQuery, pivotConfiguration }, // pivotConfiguration: undefined for a flat query
+    {
+        metricQuery,
+        pivotConfiguration, // undefined for a flat query
+        totalConfiguration, // undefined unless building a totals query (see below)
+    },
     {
         explore,
         warehouseSqlBuilder,
@@ -36,6 +40,17 @@ const composer = new QueryComposer(
 const compiled = composer.compile(); // memoized CompiledQuery (base SQL, fields, warnings, params)
 const sql = composer.getSql({ columnLimit }); // PivotQueryBuilder-wrapped when pivotConfiguration is set, else base
 ```
+
+**Totals mode.** Set `totalConfiguration: { kind, subtotalDimensions }` on the
+definition to build a totals query. The composer collapses the source
+`metricQuery` + `pivotConfiguration` into the requested grain
+(`grandTotal`/`columnTotal`/`rowTotal`/`columnSubtotal`) via `TotalQueryBuilder`
+before compiling. `getMetricQuery()` / `getPivotConfiguration()` return the
+**effective (collapsed)** query, so routing / request echo / response use it
+rather than the source. Date zoom stays inert here — it targets the source
+query's dimensions, which the collapsed totals query typically no longer selects.
+This is what the calculate-total path (`executeAsyncCalculateTotalFromQueryHistory`)
+uses instead of hand-collapsing at the call site.
 
 **MetricQueryBuilder** — builds the base SQL from an Explore + MetricQuery (dimensions, metrics, filters, joins, table calculations). Handles fan-out protection via CTEs and period-over-period comparisons. Usually driven via `QueryComposer` rather than constructed directly.
 

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
@@ -1,4 +1,5 @@
 import {
+    MetricQuery,
     PivotConfiguration,
     SortByDirection,
     VizAggregationOptions,
@@ -11,7 +12,11 @@ import {
     QUERY_BUILDER_UTC_TIMEZONE,
     warehouseClientMock,
 } from './MetricQueryBuilder.mock';
-import { QueryComposer, QueryComposerContext } from './QueryComposer';
+import {
+    QueryComposer,
+    QueryComposerContext,
+    TotalConfiguration,
+} from './QueryComposer';
 
 const CONTEXT: QueryComposerContext = {
     explore: EXPLORE,
@@ -38,6 +43,30 @@ const PIVOT_CONFIGURATION: PivotConfiguration = {
         },
     ],
     groupByColumns: undefined,
+    sortBy: [{ reference: 'table1_dim1', direction: SortByDirection.ASC }],
+};
+
+// Pivoted source: index on table1_dim1, pivot (groupBy) on table1_shared,
+// value on table1_metric1. Supports every totals grain.
+const TOTALS_SOURCE_METRIC_QUERY: MetricQuery = {
+    exploreName: 'table1',
+    dimensions: ['table1_dim1', 'table1_shared'],
+    metrics: ['table1_metric1'],
+    filters: {},
+    sorts: [{ fieldId: 'table1_dim1', descending: false }],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const TOTALS_SOURCE_PIVOT_CONFIGURATION: PivotConfiguration = {
+    indexColumn: { reference: 'table1_dim1', type: VizIndexType.CATEGORY },
+    valuesColumns: [
+        {
+            reference: 'table1_metric1',
+            aggregation: VizAggregationOptions.SUM,
+        },
+    ],
+    groupByColumns: [{ reference: 'table1_shared' }],
     sortBy: [{ reference: 'table1_dim1', direction: SortByDirection.ASC }],
 };
 
@@ -73,5 +102,30 @@ describe('QueryComposer', () => {
         // The pivot SQL wraps (and therefore differs from) the base query.
         expect(sql).not.toBe(composer.compile().query);
         expect(sql).toMatchSnapshot();
+    });
+
+    describe('totalConfiguration', () => {
+        const CASES: Array<TotalConfiguration> = [
+            { kind: 'grandTotal', subtotalDimensions: undefined },
+            { kind: 'columnTotal', subtotalDimensions: undefined },
+            { kind: 'rowTotal', subtotalDimensions: undefined },
+            { kind: 'columnSubtotal', subtotalDimensions: ['table1_dim1'] },
+        ];
+
+        it.each(CASES)(
+            'collapses the source query into the totals grain for kind "$kind"',
+            ({ kind, subtotalDimensions }) => {
+                const composer = new QueryComposer(
+                    {
+                        metricQuery: TOTALS_SOURCE_METRIC_QUERY,
+                        pivotConfiguration: TOTALS_SOURCE_PIVOT_CONFIGURATION,
+                        totalConfiguration: { kind, subtotalDimensions },
+                    },
+                    CONTEXT,
+                );
+
+                expect(composer.getSql({ columnLimit: 100 })).toMatchSnapshot();
+            },
+        );
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -17,11 +17,27 @@ import { wrapSentryTransactionSync } from '../../utils';
 import { updateExploreWithDateZoom } from './dateZoom';
 import { CompiledQuery, MetricQueryBuilder } from './MetricQueryBuilder';
 import { PivotQueryBuilder } from './PivotQueryBuilder';
+import { TotalQueryBuilder, TotalQueryKind } from './TotalQueryBuilder';
+
+/**
+ * Turns the source query into a totals query. When set on the definition, the
+ * composer collapses `metricQuery` + `pivotConfiguration` into the requested
+ * grain (grand/row/column/subtotal) via `TotalQueryBuilder` before compiling.
+ */
+export type TotalConfiguration = {
+    kind: TotalQueryKind;
+    // Required only for `columnSubtotal`; undefined for every other kind.
+    subtotalDimensions: string[] | undefined;
+};
 
 /** What to compile: the metric query and, optionally, how to pivot it. */
 export type QueryComposerDefinition = {
     metricQuery: MetricQuery;
-    pivotConfiguration: PivotConfiguration | undefined;
+    pivotConfiguration?: PivotConfiguration;
+    // When set, the composer builds the totals query for this grain instead of
+    // the source query. Mutually exclusive with dashboard filters (totals only
+    // arrive from the internal calculate-total path, which never sets them).
+    totalConfiguration?: TotalConfiguration;
 };
 
 /** Raw inputs the composer needs to prepare context and build SQL. */
@@ -54,6 +70,13 @@ export class QueryComposer {
 
     private compiledQuery: CompiledQuery | undefined;
 
+    private effectiveDefinition:
+        | {
+              metricQuery: MetricQuery;
+              pivotConfiguration: PivotConfiguration | undefined;
+          }
+        | undefined;
+
     constructor(
         definition: QueryComposerDefinition,
         context: QueryComposerContext,
@@ -62,13 +85,57 @@ export class QueryComposer {
         this.context = context;
     }
 
+    /**
+     * The query the composer actually compiles: the totals-collapsed query when
+     * a `totalConfiguration` is set, otherwise the source query. Memoized.
+     */
+    private getEffectiveDefinition(): {
+        metricQuery: MetricQuery;
+        pivotConfiguration: PivotConfiguration | undefined;
+    } {
+        if (this.effectiveDefinition) {
+            return this.effectiveDefinition;
+        }
+
+        const { metricQuery, pivotConfiguration, totalConfiguration } =
+            this.definition;
+
+        if (!totalConfiguration) {
+            this.effectiveDefinition = { metricQuery, pivotConfiguration };
+            return this.effectiveDefinition;
+        }
+
+        this.effectiveDefinition = new TotalQueryBuilder({
+            metricQuery,
+            pivotConfiguration: pivotConfiguration ?? null,
+            kind: totalConfiguration.kind,
+            subtotalDimensions: totalConfiguration.subtotalDimensions,
+        }).compileQuery();
+        return this.effectiveDefinition;
+    }
+
+    /** The effective (totals-collapsed) metric query the composer compiles. */
+    getMetricQuery(): MetricQuery {
+        return this.getEffectiveDefinition().metricQuery;
+    }
+
+    /** The effective (totals-collapsed) pivot configuration, if any. */
+    getPivotConfiguration(): PivotConfiguration | undefined {
+        return this.getEffectiveDefinition().pivotConfiguration;
+    }
+
     /** Compile the metric query to base SQL. Memoized. */
     compile(): CompiledQuery {
         if (this.compiledQuery) {
             return this.compiledQuery;
         }
 
-        const { metricQuery, pivotConfiguration } = this.definition;
+        const { metricQuery, pivotConfiguration } =
+            this.getEffectiveDefinition();
+        // Date zoom targets the source query's dimensions; it rewrites the
+        // explore, not the metric query, and stays inert when the collapsed
+        // totals query doesn't select the zoom dimension.
+        const sourceMetricQuery = this.definition.metricQuery;
         const {
             explore,
             warehouseSqlBuilder,
@@ -99,7 +166,7 @@ export class QueryComposer {
             dateZoomTargetFieldId,
         } = updateExploreWithDateZoom(
             explore,
-            metricQuery,
+            sourceMetricQuery,
             warehouseSqlBuilder,
             availableParameters,
             dateZoom,
@@ -155,7 +222,8 @@ export class QueryComposer {
      */
     getSql({ columnLimit }: { columnLimit: number }): string {
         const compiledQuery = this.compile();
-        const { metricQuery, pivotConfiguration } = this.definition;
+        const { metricQuery, pivotConfiguration } =
+            this.getEffectiveDefinition();
 
         if (!pivotConfiguration) {
             return compiledQuery.query;

--- a/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
@@ -17,6 +17,40 @@ ORDER BY "table1_metric1" DESC
 LIMIT 10"
 `;
 
+exports[`QueryComposer > totalConfiguration > collapses the source query into the totals grain for kind "'columnSubtotal'" 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1",
+  "table1".shared AS "table1_shared",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM "db"."schema"."table1" AS "table1"
+
+GROUP BY 1,2
+ORDER BY "table1_metric1" DESC
+LIMIT 500"
+`;
+
+exports[`QueryComposer > totalConfiguration > collapses the source query into the totals grain for kind "'columnTotal'" 1`] = `
+"WITH original_query AS (SELECT "table1".shared AS "table1_shared", MAX("table1".number_column) AS "table1_metric1" FROM "db"."schema"."table1" AS "table1" GROUP BY 1 ORDER BY "table1_metric1" DESC),
+group_by_query AS (SELECT "table1_shared", sum("table1_metric1") AS "table1_metric1_sum" FROM original_query group by "table1_shared"),
+pivot_query AS (SELECT g."table1_shared" AS "table1_shared", g."table1_metric1_sum" AS "table1_metric1_sum", 1 AS "row_index", DENSE_RANK() OVER (ORDER BY g."table1_shared" ASC) AS "column_index" FROM group_by_query g),
+filtered_rows AS (SELECT * FROM pivot_query WHERE "row_index" <= 500)
+SELECT "table1_shared", "table1_metric1_sum", "row_index", "column_index", total_columns FROM (SELECT p.*, SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY "table1_shared" ORDER BY "table1_shared") AS "__grp_rn" FROM filtered_rows f) p) pivoted WHERE "column_index" <= 100 order by "row_index", "column_index""
+`;
+
+exports[`QueryComposer > totalConfiguration > collapses the source query into the totals grain for kind "'grandTotal'" 1`] = `
+"SELECT
+  MAX("table1".number_column) AS "table1_metric1"
+FROM "db"."schema"."table1" AS "table1"
+
+LIMIT 1"
+`;
+
+exports[`QueryComposer > totalConfiguration > collapses the source query into the totals grain for kind "'rowTotal'" 1`] = `
+"WITH original_query AS (SELECT "table1".dim1 AS "table1_dim1", MAX("table1".number_column) AS "table1_metric1" FROM "db"."schema"."table1" AS "table1" GROUP BY 1 ORDER BY "table1_metric1" DESC),
+group_by_query AS (SELECT "table1_dim1", sum("table1_metric1") AS "table1_metric1_sum" FROM original_query group by "table1_dim1")
+SELECT * FROM group_by_query ORDER BY "table1_dim1" ASC LIMIT 500"
+`;
+
 exports[`QueryComposer > wraps the base query with the pivot query when a pivot configuration is set 1`] = `
 "WITH original_query AS (WITH metrics AS ( SELECT "table1".dim1 AS "table1_dim1", MAX("table1".number_column) AS "table1_metric1" FROM "db"."schema"."table1" AS "table1" GROUP BY 1 ) SELECT *, "table1_dim1" + "table1_metric1" AS "calc3" FROM metrics ORDER BY "table1_metric1" DESC),
 group_by_query AS (SELECT "table1_dim1", sum("table1_metric1") AS "table1_metric1_sum" FROM original_query group by "table1_dim1")


### PR DESCRIPTION
Closes: PROD-8774

### Description:

Adds an optional `totalConfiguration` to `QueryComposer` that collapses the source `metricQuery` + `pivotConfiguration` into the requested totals grain (grand/row/column/subtotal) via the existing `TotalQueryBuilder` before compiling, exposing the effective (collapsed) query through `getMetricQuery()` / `getPivotConfiguration()` so routing, request echo, storage and response all key off it. Migrates `executeAsyncCalculateTotalFromQueryHistory` to pass `totalConfiguration` into the prepare step so the single composer applies the collapse, instead of hand-assembling the totals query at the call site — `ProjectService._createQueryComposer` is extracted so `prepareMetricQueryAsyncQueryArgs` can read the effective query off that one composer. The date-zoom rewrite deliberately runs on the uncollapsed source query and stays inert when the collapsed totals query doesn't select the zoom dimension, keeping emitted SQL unchanged. Adds per-kind `QueryComposer` snapshot tests and documents totals mode in the QueryBuilder `CLAUDE.md`. Part of the QueryComposer facade rebuild (parent PROD-8696).