### PR TITLE
fix: stop dashboard promotion from resolving slugs to the wrong project

### DIFF
--- a/packages/backend/src/controllers/dashboardController.ts
+++ b/packages/backend/src/controllers/dashboardController.ts
@@ -21,6 +21,7 @@ import {
     OperationId,
     Path,
     Post,
+    Query,
     Request,
     Response,
     Route,
@@ -45,6 +46,7 @@ export class DashboardController extends BaseController {
      * Promote dashboard to its upstream project
      * @summary Promote dashboard
      * @param dashboardUuidOrSlug uuid or slug for the dashboard to run
+     * @param projectUuid project to resolve a slug in, required when the slug exists in multiple projects (e.g. preview projects)
      * @param req express request
      */
     @Middlewares([
@@ -58,6 +60,7 @@ export class DashboardController extends BaseController {
     async promoteDashboard(
         @Path() dashboardUuidOrSlug: UuidOrSlug,
         @Request() req: express.Request,
+        @Query() projectUuid?: UUID,
     ): Promise<ApiPromoteDashboardResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -68,6 +71,7 @@ export class DashboardController extends BaseController {
                 .promoteDashboard(
                     toSessionUser(req.account),
                     dashboardUuidOrSlug,
+                    { projectUuid },
                 ),
         };
     }
@@ -76,6 +80,7 @@ export class DashboardController extends BaseController {
      * Get diff from dashboard to promote
      * @summary Get dashboard promotion diff
      * @param dashboardUuidOrSlug uuid or slug for the dashboard to check diff
+     * @param projectUuid project to resolve a slug in, required when the slug exists in multiple projects (e.g. preview projects)
      * @param req express request
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -85,6 +90,7 @@ export class DashboardController extends BaseController {
     async promoteDashboardDiff(
         @Path() dashboardUuidOrSlug: UuidOrSlug,
         @Request() req: express.Request,
+        @Query() projectUuid?: UUID,
     ): Promise<ApiPromotionChangesResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -95,6 +101,7 @@ export class DashboardController extends BaseController {
                 .getPromoteDashboardDiff(
                     toSessionUser(req.account),
                     dashboardUuidOrSlug,
+                    { projectUuid },
                 ),
         };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -78736,6 +78736,7 @@ export function RegisterRoutes(app: Router) {
             ref: 'UuidOrSlug',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: { in: 'query', name: 'projectUuid', ref: 'UUID' },
     };
     app.post(
         '/api/v1/dashboards/:dashboardUuidOrSlug/promote',
@@ -78797,6 +78798,7 @@ export function RegisterRoutes(app: Router) {
             ref: 'UuidOrSlug',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: { in: 'query', name: 'projectUuid', ref: 'UUID' },
     };
     app.get(
         '/api/v1/dashboards/:dashboardUuidOrSlug/promoteDiff',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -66867,6 +66867,15 @@
                         "schema": {
                             "$ref": "#/components/schemas/UuidOrSlug"
                         }
+                    },
+                    {
+                        "description": "project to resolve a slug in, required when the slug exists in multiple projects (e.g. preview projects)",
+                        "in": "query",
+                        "name": "projectUuid",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
                     }
                 ]
             }
@@ -66908,6 +66917,15 @@
                         "required": true,
                         "schema": {
                             "$ref": "#/components/schemas/UuidOrSlug"
+                        }
+                    },
+                    {
+                        "description": "project to resolve a slug in, required when the slug exists in multiple projects (e.g. preview projects)",
+                        "in": "query",
+                        "name": "projectUuid",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
                         }
                     }
                 ]

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -718,8 +718,10 @@ export class DashboardModel {
         slug,
         slugs,
         projectUuid,
+        organizationUuid,
     }: {
         projectUuid?: string;
+        organizationUuid?: string;
         slug?: string;
         slugs?: string[];
     }): Promise<
@@ -738,7 +740,7 @@ export class DashboardModel {
             )
             .whereNull(`${DashboardsTableName}.deleted_at`);
 
-        if (projectUuid) {
+        if (projectUuid || organizationUuid) {
             void query
                 .innerJoin(SpaceTableName, function spaceJoin() {
                     this.on(
@@ -751,8 +753,24 @@ export class DashboardModel {
                     'projects',
                     `${SpaceTableName}.project_id`,
                     'projects.project_id',
+                );
+        }
+
+        if (projectUuid) {
+            void query.where('projects.project_uuid', projectUuid);
+        }
+
+        if (organizationUuid) {
+            void query
+                .leftJoin(
+                    OrganizationTableName,
+                    `${OrganizationTableName}.organization_id`,
+                    'projects.organization_id',
                 )
-                .where('projects.project_uuid', projectUuid);
+                .where(
+                    `${OrganizationTableName}.organization_uuid`,
+                    organizationUuid,
+                );
         }
 
         if (slug) {

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -1302,6 +1302,7 @@ describe('PromoteService promoting and mutating changes', () => {
         const changes = await service.getPromoteDashboardDiff(
             userWithPromotePermissions,
             dashboardWithOnlySqlTile.uuid,
+            { projectUuid: promotedDashboardWithSqlTile.projectUuid },
         );
 
         expect(changes.sqlCharts).toEqual([
@@ -1383,9 +1384,136 @@ describe('PromoteService promoting and mutating changes', () => {
             service.getPromoteDashboardDiff(
                 userWithoutPromotePermissions,
                 dashboardWithoutTiles.uuid,
+                { projectUuid: promotedDashboard.projectUuid },
             ),
         ).rejects.toThrow(
             /You do not have the right access permissions on the origin space and dashboard/,
+        );
+    });
+
+    test('getPromoteDashboardDiff rejects an unscoped slug matching multiple dashboards', async () => {
+        (dashboardModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [
+                { uuid: 'dashboard-uuid-1' },
+                { uuid: 'dashboard-uuid-2' },
+            ],
+        );
+
+        await expect(
+            service.getPromoteDashboardDiff(
+                userWithPromotePermissions,
+                'duplicated-slug',
+            ),
+        ).rejects.toThrow(/Multiple dashboards match slug 'duplicated-slug'/);
+
+        expect(dashboardModel.find).toHaveBeenCalledWith({
+            slug: 'duplicated-slug',
+            organizationUuid: user.organizationUuid,
+        });
+        expect(dashboardModel.getByIdOrSlug).not.toHaveBeenCalled();
+    });
+
+    test('getPromoteDashboardDiff throws not found for an unscoped slug with no matches', async () => {
+        (dashboardModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [],
+        );
+
+        await expect(
+            service.getPromoteDashboardDiff(
+                userWithPromotePermissions,
+                'unknown-slug',
+            ),
+        ).rejects.toThrow(/Dashboard not found/);
+    });
+
+    test('getPromoteDashboardDiff resolves an unscoped slug that is unique within the organization', async () => {
+        const dashboardWithoutTiles = {
+            ...promotedDashboard.dashboard,
+            tiles: [],
+        };
+
+        (dashboardModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [{ uuid: dashboardWithoutTiles.uuid }],
+        );
+        (
+            dashboardModel.getByIdOrSlug as import('vitest').Mock
+        ).mockImplementationOnce(async () => dashboardWithoutTiles);
+        (dashboardModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [existingUpstreamDashboard.dashboard],
+        );
+        (spaceModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [existingUpstreamDashboard.space],
+        );
+
+        await expect(
+            service.getPromoteDashboardDiff(
+                userWithAbilities([{ subject: 'Project', action: ['view'] }]),
+                dashboardWithoutTiles.slug,
+            ),
+        ).rejects.toThrow(
+            /You do not have the right access permissions on the origin space and dashboard/,
+        );
+
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+            dashboardWithoutTiles.uuid,
+        );
+    });
+
+    test('getPromoteDashboardDiff scopes slug resolution when projectUuid is provided', async () => {
+        const dashboardWithoutTiles = {
+            ...promotedDashboard.dashboard,
+            tiles: [],
+        };
+
+        (
+            dashboardModel.getByIdOrSlug as import('vitest').Mock
+        ).mockImplementationOnce(async () => dashboardWithoutTiles);
+        (dashboardModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [existingUpstreamDashboard.dashboard],
+        );
+        (spaceModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [existingUpstreamDashboard.space],
+        );
+
+        await expect(
+            service.getPromoteDashboardDiff(
+                userWithAbilities([{ subject: 'Project', action: ['view'] }]),
+                dashboardWithoutTiles.slug,
+                { projectUuid: promotedDashboard.projectUuid },
+            ),
+        ).rejects.toThrow(
+            /You do not have the right access permissions on the origin space and dashboard/,
+        );
+
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+            dashboardWithoutTiles.slug,
+            { projectUuid: promotedDashboard.projectUuid },
+        );
+    });
+
+    test('getPromoteDashboardDiff error mentions dashboard when project has no upstream', async () => {
+        const dashboardWithoutTiles = {
+            ...promotedDashboard.dashboard,
+            tiles: [],
+        };
+
+        (
+            dashboardModel.getByIdOrSlug as import('vitest').Mock
+        ).mockImplementationOnce(async () => dashboardWithoutTiles);
+        (
+            projectModel.getSummary as import('vitest').Mock
+        ).mockImplementationOnce(async () => ({
+            upstreamProjectUuid: undefined,
+        }));
+
+        await expect(
+            service.getPromoteDashboardDiff(
+                userWithPromotePermissions,
+                dashboardWithoutTiles.uuid,
+                { projectUuid: promotedDashboard.projectUuid },
+            ),
+        ).rejects.toThrow(
+            /This dashboard's project does not have an upstream project/,
         );
     });
 });

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -25,7 +25,10 @@ import {
     UnexpectedServerError,
     UpdateSqlChart,
     type SpaceSummaryBase,
+    type UUID,
+    type UuidOrSlug,
 } from '@lightdash/common';
+import { validate as isValidUuid } from 'uuid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
 import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
@@ -1460,16 +1463,57 @@ export class PromoteService extends BaseService {
         }
     }
 
-    async getPromoteDashboardDiff(user: SessionUser, dashboardUuid: string) {
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+    /**
+     * Resolve a dashboard uuid-or-slug for promotion. Slugs are duplicated
+     * across preview projects by design, so an unscoped slug lookup must not
+     * guess — it only resolves when the slug is unique within the caller's
+     * organization; otherwise callers must pass projectUuid or use the uuid.
+     */
+    private async getDashboardToPromote(
+        user: SessionUser,
+        dashboardUuidOrSlug: UuidOrSlug,
+        projectUuid?: UUID,
+    ): Promise<DashboardDAO> {
+        if (projectUuid) {
+            return this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug, {
+                projectUuid,
+            });
+        }
+        if (isValidUuid(dashboardUuidOrSlug)) {
+            return this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
+        }
+        const matches = await this.dashboardModel.find({
+            slug: dashboardUuidOrSlug,
+            organizationUuid: user.organizationUuid!,
+        });
+        if (matches.length === 0) {
+            throw new NotFoundError('Dashboard not found');
+        }
+        if (matches.length > 1) {
+            throw new ParameterError(
+                `Multiple dashboards match slug '${dashboardUuidOrSlug}'. Use the dashboard uuid or pass projectUuid to disambiguate.`,
+            );
+        }
+        return this.dashboardModel.getByIdOrSlug(matches[0].uuid);
+    }
+
+    async getPromoteDashboardDiff(
+        user: SessionUser,
+        dashboardUuidOrSlug: UuidOrSlug,
+        options?: { projectUuid?: UUID },
+    ) {
+        const dashboard = await this.getDashboardToPromote(
+            user,
+            dashboardUuidOrSlug,
+            options?.projectUuid,
+        );
 
         const { upstreamProjectUuid } = await this.projectModel.getSummary(
             dashboard.projectUuid,
         );
         if (!upstreamProjectUuid)
             throw new NotFoundError(
-                'This chart does not have an upstream project',
+                "This dashboard's project does not have an upstream project",
             );
 
         const { promotedDashboard, upstreamDashboard } =
@@ -2444,16 +2488,23 @@ export class PromoteService extends BaseService {
         return { promotedDashboard, upstreamDashboard };
     }
 
-    async promoteDashboard(user: SessionUser, dashboardUuid: string) {
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+    async promoteDashboard(
+        user: SessionUser,
+        dashboardUuidOrSlug: UuidOrSlug,
+        options?: { projectUuid?: UUID },
+    ) {
+        const dashboard = await this.getDashboardToPromote(
+            user,
+            dashboardUuidOrSlug,
+            options?.projectUuid,
+        );
 
         const { upstreamProjectUuid } = await this.projectModel.getSummary(
             dashboard.projectUuid,
         );
         if (!upstreamProjectUuid)
             throw new NotFoundError(
-                'This chart does not have an upstream project',
+                "This dashboard's project does not have an upstream project",
             );
 
         const { promotedDashboard, upstreamDashboard } =

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -875,7 +875,7 @@ const DashboardHeader = memo(
                                                         }
                                                         onClick={() =>
                                                             getPromoteDashboardDiff(
-                                                                dashboardUuid,
+                                                                dashboard.uuid,
                                                             )
                                                         }
                                                     >
@@ -1011,7 +1011,7 @@ const DashboardHeader = memo(
                                         resetPromoteDashboardDiff();
                                     }}
                                     onConfirm={() => {
-                                        promoteDashboard(dashboardUuid);
+                                        promoteDashboard(dashboard.uuid);
                                     }}
                                 />
                             )}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8767/dashboards-dashboard-promotion-fails-with-misleading-no-upstream-error

### Description:
Dashboard promote endpoints accept a uuid or slug, but slug resolution was global across all projects (newest dashboard version wins). Preview projects duplicate every slug from their upstream, and promotion writes a new version upstream, so after the first promotion a slug-based promote resolved to the upstream copy and failed with a misleading 'This chart does not have an upstream project' error.
