### PR TITLE
fix: render sql chart time axis in utc to match label formatter

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.test.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.test.ts
@@ -1,5 +1,11 @@
-import { Format } from '../types/field';
+import { DimensionType, Format } from '../types/field';
 import { CartesianChartDataModel } from './CartesianChartDataModel';
+import {
+    VizAggregationOptions,
+    VizIndexType,
+    type PivotChartData,
+} from './types';
+import { type IResultsRunner } from './types/IResultsRunner';
 
 describe('CartesianChartDataModel formatters', () => {
     test('formats SI tooltip values dynamically', () => {
@@ -22,5 +28,72 @@ describe('CartesianChartDataModel formatters', () => {
                 value: { category: 'Jan', value: 1200000 },
             }),
         ).toEqual('1.2M');
+    });
+});
+
+describe('CartesianChartDataModel getSpec', () => {
+    const pivotChartData: PivotChartData = {
+        queryUuid: undefined,
+        fileUrl: undefined,
+        results: [
+            { month: '2026-04-01T00:00:00.000Z', month_count: '1' },
+            { month: '2026-05-01T00:00:00.000Z', month_count: '2' },
+        ],
+        indexColumn: { reference: 'month', type: VizIndexType.TIME },
+        valuesColumns: [
+            {
+                referenceField: 'month_count',
+                pivotColumnName: 'month_count',
+                aggregation: VizAggregationOptions.COUNT,
+                pivotValues: [],
+            },
+        ],
+        columns: [
+            { reference: 'month', type: DimensionType.TIMESTAMP },
+            { reference: 'month_count', type: DimensionType.NUMBER },
+        ],
+        columnCount: 2,
+    };
+
+    const resultsRunner: IResultsRunner = {
+        getPivotedVisualizationData: async () => pivotChartData,
+        getColumnNames: () => ['month', 'month_count'],
+        getRows: () => [],
+        getPivotQueryDimensions: () => [
+            {
+                reference: 'month',
+                axisType: VizIndexType.TIME,
+                dimensionType: DimensionType.TIMESTAMP,
+            },
+        ],
+        getPivotQueryMetrics: () => [],
+        getPivotQueryCustomMetrics: () => [],
+    };
+
+    test('renders time axis in UTC so tick placement matches the UTC label formatter', async () => {
+        const model = new CartesianChartDataModel({
+            resultsRunner,
+            fieldConfig: {
+                x: { reference: 'month', type: VizIndexType.TIME },
+                y: [
+                    {
+                        reference: 'month_count',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupBy: undefined,
+            },
+        });
+
+        await model.getPivotedChartData({
+            sql: 'SELECT 1',
+            limit: 500,
+            sortBy: [],
+            filters: [],
+        });
+        const spec = model.getSpec();
+
+        expect(spec.useUTC).toBe(true);
+        expect(spec.xAxis.type).toBe(VizIndexType.TIME);
     });
 });

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -901,6 +901,9 @@ export class CartesianChartDataModel {
         const showLegend = transformedData.valuesColumns.length > 1;
 
         const spec = {
+            // Snap time-axis ticks in UTC to match the UTC label formatter;
+            // local snapping shifts labels back a day for UTC-positive viewers
+            useUTC: true,
             tooltip: {
                 ...getTooltipStyle(),
                 trigger: 'axis',


### PR DESCRIPTION
## Problem

On SQL charts (SQL runner, saved SQL charts, dashboard SQL tiles) with a time x-axis, viewers in timezones ahead of UTC saw axis labels one day early. For monthly data this read as "last day of the previous month": bars were labeled "Mar 31, 2026", "Apr 30, 2026", "May 31, 2026", while the results table correctly showed first-of-month timestamps like `2026-04-01T00:00:00.000Z`.

The shift depended only on the viewer's browser timezone:

- UK viewers saw it on months after the spring clock change, which made it look like a DST bug.
- Viewers in zones ahead of UTC all year round (Central/Eastern Europe, APAC) saw it on every label.
- Viewers in UTC or the Americas saw correct labels, which is why it went unnoticed for so long.

Viewed from Europe/London, the same saved chart:

| | Axis labels |
|---|---|
| **Before** | Jan 1, Feb 1, Mar 1, **Mar 31, Apr 30, May 31** |
| **After** | Jan 1, Feb 1, Mar 1, **Apr 1, May 1, Jun 1** |

### Before
<img width="1406" height="723" alt="prod-8762-before" src="https://github.com/user-attachments/assets/332c05bc-5272-4737-bbc0-87fc194d97b1" />

### After
<img width="1406" height="723" alt="prod-8762-after" src="https://github.com/user-attachments/assets/96f6e3bc-7b72-4650-b3f4-cc6b76d58d94" />

## Why it happened

ECharts decides where to place time-axis ticks using the viewer's local clock, but our axis label formatter (`formatDateWithPattern`) renders those tick instants in UTC. In London during summer time, "start of April" on the local clock is `2026-03-31T23:00:00Z`, so the label formatter printed "Mar 31, 2026" for the April tick. One side used local time, the other used UTC.

Explore charts were never affected because that pipeline already sets `useUTC: true` on the ECharts spec. The SQL chart pipeline was missing the same flag.

## Fix

Set `useUTC: true` on the spec in `CartesianChartDataModel.getSpec`, so tick placement uses the same clock (UTC) as the label formatter. This matches the explore chart pipeline. Plus a regression test pinning the spec contract.

## Testing

- Unit test exercises the real `getPivotedChartData` to `getSpec` path with a time x-axis and asserts `useUTC: true`.
- Verified in a Europe/London browser context on a monthly bar chart: labels now read Jan 1 through Jun 1.
- No change for UTC and UTC-negative viewers, tooltips (they format the raw value, not the tick), or scheduled-delivery screenshots (the headless browser runs in UTC, where the flag is a no-op).

Closes: PROD-8762
Closes: https://github.com/lightdash/lightdash/issues/25346
