### PR TITLE
feat(backend): per-org gate for data-app custom dependencies [GLITCH-558]

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     ParameterError,
     TooManyRequestsError,
     type DataAppCode,
@@ -74,7 +75,12 @@ const makeDeps = (
 
 const s3SendSpy = vi.fn().mockResolvedValue({});
 
-function buildService(opts: { customDependenciesEnabled?: boolean } = {}) {
+function buildService(
+    opts: {
+        customDependenciesEnabled?: boolean;
+        customDependenciesOrgEnabled?: boolean;
+    } = {},
+) {
     const appModel = {
         findApp: vi.fn(),
         getApp: vi.fn(),
@@ -93,7 +99,16 @@ function buildService(opts: { customDependenciesEnabled?: boolean } = {}) {
     };
 
     const featureFlagModel = {
-        get: vi.fn().mockResolvedValue({ enabled: true }),
+        get: vi.fn(async ({ featureFlagId }: { featureFlagId: string }) => {
+            if (
+                featureFlagId === FeatureFlags.EnableDataAppCustomDependencies
+            ) {
+                return {
+                    enabled: opts.customDependenciesOrgEnabled ?? true,
+                };
+            }
+            return { enabled: true };
+        }),
     };
 
     const projectModel = {
@@ -434,6 +449,43 @@ describe('AppGenerateService.importAppCode', () => {
         // Template-only = no custom deps above the baseline
         const result = await service.importAppCode(makeUser(), PROJECT_UUID, {
             code: { ...makeCode(), dependencies: makeDeps() },
+        } as ImportAppCodeRequestBody);
+
+        expect(result.action).toBe('create');
+        expect(schedulerClient.appBuildFromSource).toHaveBeenCalledOnce();
+    });
+
+    it('rejects custom deps when the instance allows them but the org flag is off', async () => {
+        const { service, appModel } = buildService({
+            customDependenciesEnabled: true,
+            customDependenciesOrgEnabled: false,
+        });
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        await expect(
+            service.importAppCode(makeUser(), PROJECT_UUID, {
+                code: {
+                    ...makeCode(),
+                    dependencies: makeDeps({ 'deck.gl': '9.3.5' }),
+                },
+            } as ImportAppCodeRequestBody),
+        ).rejects.toThrow('not enabled for your organization');
+    });
+
+    it('accepts custom deps when both the instance and org flag allow them', async () => {
+        const { service, appModel, schedulerClient } = buildService({
+            customDependenciesEnabled: true,
+            customDependenciesOrgEnabled: true,
+        });
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        const result = await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: {
+                ...makeCode(),
+                dependencies: makeDeps({ 'deck.gl': '9.3.5' }),
+            },
         } as ImportAppCodeRequestBody);
 
         expect(result.action).toBe('create');

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7332,6 +7332,22 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                         'Custom app dependencies are disabled on this instance (LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED). Remove the added packages or ask an admin to enable them.',
                     );
                 }
+                // Per-org rollout gate, layered on the instance env gate: even
+                // when the instance allows custom deps, the org must be
+                // explicitly enabled. Only applies to uploading NEW custom-dep
+                // content — builds/downloads of already-approved sets stay
+                // gated by the env kill-switch alone.
+                const { enabled: orgAllowsCustomDeps } =
+                    await this.featureFlagModel.get({
+                        user,
+                        featureFlagId:
+                            FeatureFlags.EnableDataAppCustomDependencies,
+                    });
+                if (!orgAllowsCustomDeps) {
+                    throw new ParameterError(
+                        'Custom app dependencies are not enabled for your organization. Contact your Lightdash admin to request access.',
+                    );
+                }
                 dependencySummary = {
                     custom: Object.entries(customDeps).map(
                         ([name, version]) => ({ name, version }),

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -98,6 +98,17 @@ export enum FeatureFlags {
     EnableDataApps = 'enable-data-apps',
 
     /**
+     * Per-organization gate for declaring custom npm dependencies in data
+     * apps. Layered ON TOP of the instance-level
+     * LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED env var: both must be true to
+     * upload an app with a custom dependency set. Lets cloud enable the
+     * feature for specific orgs without instance-wide exposure. Disabled by
+     * default (self-hosted single-org can enable instance-wide via
+     * LIGHTDASH_ENABLE_FEATURE_FLAGS).
+     */
+    EnableDataAppCustomDependencies = 'enable-data-app-custom-dependencies',
+
+    /**
      * Enable AI Dashboard Summary feature (generates summaries of dashboard
      * contents using the AI Copilot).
      */


### PR DESCRIPTION
Guarded-rollout guard 1/3 for data-app custom dependencies (all three stack off main, merge independently). Ships behind config — no behavior change unless enabled.

Adds a per-organization feature flag (`EnableDataAppCustomDependencies`) layered on top of the instance-level `LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED` env gate. Both must be true to upload an app declaring custom npm dependencies, so cloud can enable specific design-partner orgs without instance-wide exposure. Self-hosted single-org can enable instance-wide via `LIGHTDASH_ENABLE_FEATURE_FLAGS`.

Applies at **upload only** — builds/downloads of already-approved dep sets stay gated by the env kill-switch (consistent with the existing model). Rejection is a clear 400.

Relates: GLITCH-558

🤖 Generated with [Claude Code](https://claude.com/claude-code)