### PR TITLE
feat(backend): minimum release-age guard for data-app custom dependencies [GLITCH-558]

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -418,6 +418,7 @@ export const lightdashConfigMock: LightdashConfig = {
         e2bCodingAgentTemplateTag: '',
         dependencyRegistryHosts: ['registry.npmjs.org'],
         dependencyInstallTimeoutMs: 120_000,
+        dependencyMinReleaseAgeDays: 0,
     },
     enabledFeatureFlags: new Set<string>(),
     disabledFeatureFlags: new Set<string>(),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1773,6 +1773,19 @@ export type AppRuntimeConfig = {
      * Vite build when a version has custom dependencies. Defaults to 2 minutes.
      */
     dependencyInstallTimeoutMs: number;
+    /**
+     * Minimum age (in days) a declared custom dependency's resolved version
+     * must have since publication, checked against npm registry metadata at
+     * upload time. Guards against freshly-published (potentially compromised)
+     * versions. Env var `LIGHTDASH_APP_DEPENDENCY_MIN_RELEASE_AGE_DAYS`.
+     *
+     * `0` (default) disables the check — deliberately off, matching the rest
+     * of the custom-dependencies feature, since enabling it adds registry
+     * round-trips and can block legitimate recent releases. When you do turn
+     * it on, `3` is a sensible starting point: it mirrors this repo's own
+     * `minimum-release-age=3d` npm policy.
+     */
+    dependencyMinReleaseAgeDays: number;
 };
 
 export type IntercomConfig = {
@@ -2119,6 +2132,10 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             getIntegerFromEnvironmentVariable(
                 'LIGHTDASH_APP_DEPENDENCY_INSTALL_TIMEOUT_MS',
             ) ?? 120_000,
+        dependencyMinReleaseAgeDays:
+            getIntegerFromEnvironmentVariable(
+                'LIGHTDASH_APP_DEPENDENCY_MIN_RELEASE_AGE_DAYS',
+            ) ?? 0,
     };
 };
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -125,6 +125,8 @@ function buildService(
     const lightdashConfig = {
         appRuntime: {
             customDependenciesEnabled: opts.customDependenciesEnabled ?? true,
+            dependencyRegistryHosts: ['registry.npmjs.org'],
+            dependencyMinReleaseAgeDays: 0,
         },
     };
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -19,6 +19,7 @@ import {
     dataAppVizJsonSchema,
     dataAppVizSchema,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
+    extractLockfilePackages,
     FeatureFlags,
     ForbiddenError,
     formatPromptWithClarifications,
@@ -152,6 +153,7 @@ import {
     ZERO_CLAUDE_USAGE,
     type ClaudeGenerationUsage,
 } from './ClaudeStreamProcessor';
+import { assertDependenciesMeetMinReleaseAge } from './dependencyGuards';
 import {
     copyDesignIntoSandbox,
     type DesignSandboxCopyResult,
@@ -7348,6 +7350,22 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                         'Custom app dependencies are not enabled for your organization. Contact your Lightdash admin to request access.',
                     );
                 }
+                // Minimum-release-age guard (no-op unless the instance opts in
+                // via LIGHTDASH_APP_DEPENDENCY_MIN_RELEASE_AGE_DAYS): reject
+                // custom packages whose resolved version is too freshly
+                // published to trust.
+                await assertDependenciesMeetMinReleaseAge({
+                    packages: extractLockfilePackages(
+                        code.dependencies.lockfile,
+                    ).filter((p) => customDeps[p.name] !== undefined),
+                    minReleaseAgeDays:
+                        this.lightdashConfig.appRuntime
+                            .dependencyMinReleaseAgeDays,
+                    registryHost:
+                        this.lightdashConfig.appRuntime
+                            .dependencyRegistryHosts[0] ?? 'registry.npmjs.org',
+                    now: Date.now(),
+                });
                 dependencySummary = {
                     custom: Object.entries(customDeps).map(
                         ([name, version]) => ({ name, version }),

--- a/packages/backend/src/ee/services/AppGenerateService/dependencyGuards.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dependencyGuards.test.ts
@@ -1,0 +1,161 @@
+import { ParameterError } from '@lightdash/common';
+import {
+    assertDependenciesMeetMinReleaseAge,
+    registryPackumentUrl,
+    type RegistryFetch,
+} from './dependencyGuards';
+
+const NOW = new Date('2026-07-10T00:00:00.000Z').getTime();
+const DAY = 24 * 60 * 60 * 1000;
+
+const packumentFetch =
+    (times: Record<string, Record<string, string>>): RegistryFetch =>
+    async (url) => {
+        // last path segment, decoding the %2F used for scoped names
+        const name = decodeURIComponent(url.split('/').pop() ?? '').replace(
+            '%2F',
+            '/',
+        );
+        const time = times[name];
+        if (!time)
+            return { status: 404, bodyText: 'not found', truncated: false };
+        return {
+            status: 200,
+            bodyText: JSON.stringify({ time }),
+            truncated: false,
+        };
+    };
+
+describe('registryPackumentUrl', () => {
+    it('builds a plain package url', () => {
+        expect(registryPackumentUrl('registry.npmjs.org', 'deck.gl')).toBe(
+            'https://registry.npmjs.org/deck.gl',
+        );
+    });
+    it('percent-encodes the slash in a scoped name', () => {
+        expect(registryPackumentUrl('registry.npmjs.org', '@scope/pkg')).toBe(
+            'https://registry.npmjs.org/@scope%2Fpkg',
+        );
+    });
+});
+
+describe('assertDependenciesMeetMinReleaseAge', () => {
+    const base = {
+        registryHost: 'registry.npmjs.org',
+        now: NOW,
+    };
+
+    it('is a no-op when the minimum age is 0 (disabled)', async () => {
+        const fetchImpl = vi.fn();
+        await assertDependenciesMeetMinReleaseAge({
+            ...base,
+            minReleaseAgeDays: 0,
+            packages: [{ name: 'deck.gl', version: '9.3.5' }],
+            fetchImpl: fetchImpl as unknown as RegistryFetch,
+        });
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when there are no packages', async () => {
+        const fetchImpl = vi.fn();
+        await assertDependenciesMeetMinReleaseAge({
+            ...base,
+            minReleaseAgeDays: 7,
+            packages: [],
+            fetchImpl: fetchImpl as unknown as RegistryFetch,
+        });
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('accepts a version older than the minimum', async () => {
+        await assertDependenciesMeetMinReleaseAge({
+            ...base,
+            minReleaseAgeDays: 7,
+            packages: [{ name: 'deck.gl', version: '9.3.5' }],
+            fetchImpl: packumentFetch({
+                'deck.gl': {
+                    '9.3.5': new Date(NOW - 30 * DAY).toISOString(),
+                },
+            }),
+        });
+    });
+
+    it('rejects a version published more recently than the minimum', async () => {
+        await expect(
+            assertDependenciesMeetMinReleaseAge({
+                ...base,
+                minReleaseAgeDays: 7,
+                packages: [{ name: 'deck.gl', version: '9.3.5' }],
+                fetchImpl: packumentFetch({
+                    'deck.gl': {
+                        '9.3.5': new Date(NOW - 2 * DAY).toISOString(),
+                    },
+                }),
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('fails closed when the registry has no publish date for the version', async () => {
+        await expect(
+            assertDependenciesMeetMinReleaseAge({
+                ...base,
+                minReleaseAgeDays: 7,
+                packages: [{ name: 'deck.gl', version: '9.3.5' }],
+                fetchImpl: packumentFetch({
+                    'deck.gl': {
+                        '9.0.0': new Date(NOW - 90 * DAY).toISOString(),
+                    },
+                }),
+            }),
+        ).rejects.toThrow(/publish date/i);
+    });
+
+    it('fails closed when the registry call errors', async () => {
+        await expect(
+            assertDependenciesMeetMinReleaseAge({
+                ...base,
+                minReleaseAgeDays: 7,
+                packages: [{ name: 'deck.gl', version: '9.3.5' }],
+                fetchImpl: async () => {
+                    throw new Error('network down');
+                },
+            }),
+        ).rejects.toThrow(/Could not verify the release age/i);
+    });
+
+    it('fails closed on a truncated registry response', async () => {
+        await expect(
+            assertDependenciesMeetMinReleaseAge({
+                ...base,
+                minReleaseAgeDays: 7,
+                packages: [{ name: 'deck.gl', version: '9.3.5' }],
+                fetchImpl: async () => ({
+                    status: 200,
+                    bodyText: '{"time":{}',
+                    truncated: true,
+                }),
+            }),
+        ).rejects.toThrow(/Could not verify the release age/i);
+    });
+
+    it('fetches each package name only once even with multiple versions', async () => {
+        const fetchImpl = vi.fn(
+            packumentFetch({
+                'deck.gl': {
+                    '9.3.5': new Date(NOW - 30 * DAY).toISOString(),
+                    '9.3.4': new Date(NOW - 40 * DAY).toISOString(),
+                },
+            }),
+        );
+        await assertDependenciesMeetMinReleaseAge({
+            ...base,
+            minReleaseAgeDays: 7,
+            packages: [
+                { name: 'deck.gl', version: '9.3.5' },
+                { name: 'deck.gl', version: '9.3.4' },
+            ],
+            fetchImpl: fetchImpl as unknown as RegistryFetch,
+        });
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/dependencyGuards.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dependencyGuards.ts
@@ -1,0 +1,106 @@
+import { ParameterError, type LockfilePackage } from '@lightdash/common';
+import { secureFetch } from '../../../utils/secureFetch/secureFetch';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const REGISTRY_TIMEOUT_MS = 15_000;
+// npm packuments carry the full `time` map (publish dates per version) — there
+// is no lighter endpoint for it, so allow a few MB. A truncated response is
+// treated as unverifiable (fail closed), not silently accepted.
+const REGISTRY_MAX_BYTES = 8 * 1024 * 1024;
+
+export type RegistryFetchResult = {
+    status: number;
+    bodyText: string;
+    truncated: boolean;
+};
+
+export type RegistryFetch = (url: string) => Promise<RegistryFetchResult>;
+
+const defaultRegistryFetch: RegistryFetch = (url) =>
+    secureFetch(url, {
+        method: 'GET',
+        timeoutMs: REGISTRY_TIMEOUT_MS,
+        maxResponseBytes: REGISTRY_MAX_BYTES,
+        allowedContentTypes: ['application/json'],
+    });
+
+/**
+ * npm registry packument URL for a package. Scoped names keep the `@` but the
+ * `/` must be percent-encoded (`@scope%2Fname`).
+ */
+export const registryPackumentUrl = (host: string, name: string): string => {
+    const encoded = name.startsWith('@') ? name.replace('/', '%2F') : name;
+    return `https://${host}/${encoded}`;
+};
+
+/**
+ * Rejects the upload if any declared custom dependency's resolved version was
+ * published more recently than `minReleaseAgeDays`, per npm registry metadata.
+ * Guards against installing freshly-published (potentially compromised)
+ * versions before advisory feeds catch up.
+ *
+ * Opt-in: a non-positive `minReleaseAgeDays` (the default) makes this a no-op,
+ * so instances that don't enable it pay no registry round-trips. When enabled
+ * it fails CLOSED — if a version's publish date can't be verified (registry
+ * error, truncation, unknown version) the upload is rejected.
+ */
+export async function assertDependenciesMeetMinReleaseAge(args: {
+    packages: LockfilePackage[];
+    minReleaseAgeDays: number;
+    registryHost: string;
+    now: number;
+    fetchImpl?: RegistryFetch;
+}): Promise<void> {
+    const { packages, minReleaseAgeDays, registryHost, now } = args;
+    if (minReleaseAgeDays <= 0 || packages.length === 0) return;
+
+    const fetchImpl = args.fetchImpl ?? defaultRegistryFetch;
+    const minAgeMs = minReleaseAgeDays * DAY_MS;
+
+    // De-dupe by package name — one packument fetch covers all its versions.
+    const byName = new Map<string, Set<string>>();
+    for (const { name, version } of packages) {
+        const versions = byName.get(name) ?? new Set<string>();
+        versions.add(version);
+        byName.set(name, versions);
+    }
+
+    for (const [name, versions] of byName) {
+        let timeMap: Record<string, string>;
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            const res = await fetchImpl(
+                registryPackumentUrl(registryHost, name),
+            );
+            if (res.status !== 200 || res.truncated) {
+                throw new Error(`registry status ${res.status}`);
+            }
+            const doc = JSON.parse(res.bodyText) as {
+                time?: Record<string, string>;
+            };
+            timeMap = doc.time ?? {};
+        } catch {
+            throw new ParameterError(
+                `Could not verify the release age of "${name}" against the registry. This instance enforces a minimum dependency age (LIGHTDASH_APP_DEPENDENCY_MIN_RELEASE_AGE_DAYS); try again shortly.`,
+            );
+        }
+
+        for (const version of versions) {
+            const published = timeMap[version];
+            if (!published) {
+                throw new ParameterError(
+                    `Could not find a publish date for "${name}@${version}" in the registry, so its release age cannot be verified.`,
+                );
+            }
+            const ageMs = now - new Date(published).getTime();
+            if (Number.isNaN(ageMs) || ageMs < minAgeMs) {
+                const ageDays = Number.isNaN(ageMs)
+                    ? 'an unknown number of'
+                    : Math.floor(ageMs / DAY_MS);
+                throw new ParameterError(
+                    `"${name}@${version}" was published ${ageDays} day(s) ago, under the ${minReleaseAgeDays}-day minimum required by this instance. Pin an older version or wait before uploading.`,
+                );
+            }
+        }
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -16880,6 +16880,10 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['timeout'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -16889,10 +16893,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['timeout'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -17558,10 +17558,10 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "timeout",
                                                             "error",
                                                             "rejected",
-                                                            "success",
-                                                            "timeout"
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -44586,7 +44586,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3354.1",
+        "version": "0.3355.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/apps/code.test.ts
+++ b/packages/common/src/ee/apps/code.test.ts
@@ -1,7 +1,9 @@
 import {
     currentDataAppCodeVersion,
+    extractLockfilePackages,
     MAX_DECLARED_DEPENDENCIES,
     MAX_LOCKFILE_BYTES,
+    parseLockfilePackageKey,
     sanitizeAppPackageJsonScripts,
     validateDataAppCode,
     validateDataAppDependencies,
@@ -475,6 +477,61 @@ describe('sanitizeAppPackageJsonScripts', () => {
         expect(sanitizeAppPackageJsonScripts('not-json', templateScripts)).toBe(
             'not-json',
         );
+    });
+});
+
+describe('parseLockfilePackageKey', () => {
+    it.each([
+        [
+            'canvas-confetti@1.9.4',
+            { name: 'canvas-confetti', version: '1.9.4' },
+        ],
+        ['@scope/pkg@1.2.3', { name: '@scope/pkg', version: '1.2.3' }],
+        [
+            'react-dom@19.0.0(react@19.0.0)',
+            { name: 'react-dom', version: '19.0.0' },
+        ],
+        [
+            '@scope/pkg@1.2.3(peer@2.0.0)',
+            { name: '@scope/pkg', version: '1.2.3' },
+        ],
+    ])('parses %s', (key, expected) => {
+        expect(parseLockfilePackageKey(key)).toEqual(expected);
+    });
+
+    it.each(['@scope-only', 'no-version', 'foo@link:../foo'])(
+        'returns null for non-registry key %s',
+        (key) => {
+            expect(parseLockfilePackageKey(key)).toBeNull();
+        },
+    );
+});
+
+describe('extractLockfilePackages', () => {
+    it('returns every resolved package from the packages section, de-duped', () => {
+        const lockfile = [
+            "lockfileVersion: '9.0'",
+            'packages:',
+            '  canvas-confetti@1.9.4:',
+            '    resolution: {integrity: sha512-aaa}',
+            '  react@19.0.0:',
+            '    resolution: {integrity: sha512-bbb}',
+            '  react@19.0.0(react-dom@19.0.0):',
+            '    resolution: {integrity: sha512-bbb}',
+            "  '@scope/pkg@2.1.0':",
+            '    resolution: {integrity: sha512-ccc}',
+            '',
+        ].join('\n');
+        expect(extractLockfilePackages(lockfile)).toEqual([
+            { name: 'canvas-confetti', version: '1.9.4' },
+            { name: 'react', version: '19.0.0' },
+            { name: '@scope/pkg', version: '2.1.0' },
+        ]);
+    });
+
+    it('returns [] for unparseable or package-less lockfiles', () => {
+        expect(extractLockfilePackages('{{ not yaml')).toEqual([]);
+        expect(extractLockfilePackages("lockfileVersion: '9.0'\n")).toEqual([]);
     });
 });
 

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -166,6 +166,57 @@ function validateLockfileTarballHosts(
     }
 }
 
+export type LockfilePackage = { name: string; version: string };
+
+/**
+ * Splits a pnpm lockfile package key (`name@version`, optionally scoped and/or
+ * with a `(peer@x)` suffix) into name + version. Returns null for anything
+ * that doesn't parse — e.g. link:/file: entries that carry no registry version.
+ */
+export function parseLockfilePackageKey(key: string): LockfilePackage | null {
+    // Drop the peer-dependency suffix pnpm appends, e.g. `(react@19.0.0)`.
+    const base = key.replace(/\(.*\)$/, '');
+    const at = base.lastIndexOf('@');
+    // `@` at position 0 = a scope-only string with no version.
+    if (at <= 0) return null;
+    const name = base.slice(0, at);
+    const version = base.slice(at + 1);
+    if (!name || !version || version.includes('/')) return null;
+    return { name, version };
+}
+
+/**
+ * Extracts every resolved package (direct AND transitive) from a pnpm
+ * lockfile's `packages:` section as { name, version } pairs. Pure/structural —
+ * used by backend guards that check declared deps against registry metadata or
+ * advisory feeds. Returns [] when the lockfile can't be parsed.
+ */
+export function extractLockfilePackages(lockfile: string): LockfilePackage[] {
+    let parsed: unknown;
+    try {
+        parsed = parseYaml(lockfile);
+    } catch {
+        return [];
+    }
+    if (!parsed || typeof parsed !== 'object') return [];
+    const { packages } = parsed as Record<string, unknown>;
+    if (!packages || typeof packages !== 'object') return [];
+
+    const seen = new Set<string>();
+    const out: LockfilePackage[] = [];
+    for (const key of Object.keys(packages)) {
+        const pkg = parseLockfilePackageKey(key);
+        if (pkg) {
+            const dedupeKey = `${pkg.name}@${pkg.version}`;
+            if (!seen.has(dedupeKey)) {
+                seen.add(dedupeKey);
+                out.push(pkg);
+            }
+        }
+    }
+    return out;
+}
+
 /**
  * Returns `packageJson` with its `scripts` replaced by the trusted template
  * scripts. The build sandbox runs `pnpm build` against this file, and download


### PR DESCRIPTION
Guarded-rollout guard 2/3 for data-app custom dependencies.

Optional upload-time check (`LIGHTDASH_APP_DEPENDENCY_MIN_RELEASE_AGE_DAYS`, `0` = off, the default): rejects declared custom packages whose resolved version was published more recently than the configured age, per npm registry `time` metadata. Guards against freshly-published, potentially-compromised versions before advisory feeds catch up (mirrors pnpm's `minimumReleaseAge`).

- **Fails closed**: if a publish date can't be verified (registry error, truncation, unknown version) the upload is rejected — the operator opted into the check.
- **No-op when disabled**: zero registry round-trips.
- Adds a pure `extractLockfilePackages` helper in common (parses the pnpm lockfile `packages:` section); the guard lives in a new backend `dependencyGuards.ts` with an injectable fetch for unit tests.
- Checks the **direct** custom deps' resolved versions (you don't pin transitive deps, so age-gating them would be noise).

**On the default (`0` = off):** deliberate, and consistent with the rest of the feature — custom deps are already opt-in, so defaulting this on would silently add registry round-trips and could block legitimate recent releases the moment an operator enables custom deps. A non-zero default is also a policy judgment (3 vs 7 vs 14 days). The malware screen (#25387) is the guard that defaults on instead — it's precise (`MAL-` only, near-zero false positives), whereas min-age is blunt (blocks legitimate recent releases), so min-age stays opt-in. Recommended value when enabling: `3` days, mirroring this repo's own `minimum-release-age=3d` npm policy (now documented in the config).

Relates: GLITCH-558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

