### PR TITLE
feat(backend): OSV malware screen for data-app custom dependencies [GLITCH-558]

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -419,6 +419,9 @@ export const lightdashConfigMock: LightdashConfig = {
         dependencyRegistryHosts: ['registry.npmjs.org'],
         dependencyInstallTimeoutMs: 120_000,
         dependencyMinReleaseAgeDays: 0,
+        // Off in the test fixture (real default is `true`) so tests never make
+        // a live OSV call.
+        dependencyMalwareCheckEnabled: false,
     },
     enabledFeatureFlags: new Set<string>(),
     disabledFeatureFlags: new Set<string>(),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1786,6 +1786,22 @@ export type AppRuntimeConfig = {
      * `minimum-release-age=3d` npm policy.
      */
     dependencyMinReleaseAgeDays: number;
+    /**
+     * When true, every resolved package in a custom-dependency upload's
+     * lockfile (direct + transitive) is checked against the OSV
+     * malicious-packages feed at upload time; known-malicious versions are
+     * rejected. Only runs for uploads that already passed the custom-deps
+     * gates, so orgs not using custom deps are unaffected.
+     *
+     * Env var `LIGHTDASH_APP_DEPENDENCY_MALWARE_CHECK_ENABLED`; defaults to
+     * `true`. It is precise (matches only OSV `MAL-` advisories, so
+     * near-zero false positives), which is why it is the one dependency guard
+     * that defaults on. The check FAILS CLOSED — if OSV can't be reached the
+     * upload is rejected — so an instance whose backend has no egress to
+     * `api.osv.dev` (air-gapped, or during an OSV outage) must set this to
+     * `false` to keep uploading custom-dependency apps.
+     */
+    dependencyMalwareCheckEnabled: boolean;
 };
 
 export type IntercomConfig = {
@@ -2136,6 +2152,9 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             getIntegerFromEnvironmentVariable(
                 'LIGHTDASH_APP_DEPENDENCY_MIN_RELEASE_AGE_DAYS',
             ) ?? 0,
+        dependencyMalwareCheckEnabled:
+            process.env.LIGHTDASH_APP_DEPENDENCY_MALWARE_CHECK_ENABLED !==
+            'false',
     };
 };
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -127,6 +127,9 @@ function buildService(
             customDependenciesEnabled: opts.customDependenciesEnabled ?? true,
             dependencyRegistryHosts: ['registry.npmjs.org'],
             dependencyMinReleaseAgeDays: 0,
+            // Off in these gate-focused tests so no upload attempts a real
+            // OSV call; the malware guard has its own unit tests.
+            dependencyMalwareCheckEnabled: false,
         },
     };
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -153,7 +153,10 @@ import {
     ZERO_CLAUDE_USAGE,
     type ClaudeGenerationUsage,
 } from './ClaudeStreamProcessor';
-import { assertDependenciesMeetMinReleaseAge } from './dependencyGuards';
+import {
+    assertDependenciesHaveNoKnownMalware,
+    assertDependenciesMeetMinReleaseAge,
+} from './dependencyGuards';
 import {
     copyDesignIntoSandbox,
     type DesignSandboxCopyResult,
@@ -7354,10 +7357,13 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 // via LIGHTDASH_APP_DEPENDENCY_MIN_RELEASE_AGE_DAYS): reject
                 // custom packages whose resolved version is too freshly
                 // published to trust.
+                const lockfilePackages = extractLockfilePackages(
+                    code.dependencies.lockfile,
+                );
                 await assertDependenciesMeetMinReleaseAge({
-                    packages: extractLockfilePackages(
-                        code.dependencies.lockfile,
-                    ).filter((p) => customDeps[p.name] !== undefined),
+                    packages: lockfilePackages.filter(
+                        (p) => customDeps[p.name] !== undefined,
+                    ),
                     minReleaseAgeDays:
                         this.lightdashConfig.appRuntime
                             .dependencyMinReleaseAgeDays,
@@ -7365,6 +7371,15 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                         this.lightdashConfig.appRuntime
                             .dependencyRegistryHosts[0] ?? 'registry.npmjs.org',
                     now: Date.now(),
+                });
+                // Malware screen over the WHOLE resolved tree (transitive
+                // included) — supply-chain attacks usually arrive through a
+                // transitive dep, not the package the author added directly.
+                await assertDependenciesHaveNoKnownMalware({
+                    packages: lockfilePackages,
+                    enabled:
+                        this.lightdashConfig.appRuntime
+                            .dependencyMalwareCheckEnabled,
                 });
                 dependencySummary = {
                     custom: Object.entries(customDeps).map(

--- a/packages/backend/src/ee/services/AppGenerateService/dependencyGuards.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dependencyGuards.test.ts
@@ -1,7 +1,9 @@
 import { ParameterError } from '@lightdash/common';
 import {
+    assertDependenciesHaveNoKnownMalware,
     assertDependenciesMeetMinReleaseAge,
     registryPackumentUrl,
+    type OsvBatchFetch,
     type RegistryFetch,
 } from './dependencyGuards';
 
@@ -157,5 +159,126 @@ describe('assertDependenciesMeetMinReleaseAge', () => {
             fetchImpl: fetchImpl as unknown as RegistryFetch,
         });
         expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('assertDependenciesHaveNoKnownMalware', () => {
+    const okResponse =
+        (count: number): OsvBatchFetch =>
+        async () => ({
+            status: 200,
+            bodyText: JSON.stringify({
+                results: Array.from({ length: count }, () => ({})),
+            }),
+            truncated: false,
+        });
+
+    it('is a no-op when disabled', async () => {
+        const fetchImpl = vi.fn();
+        await assertDependenciesHaveNoKnownMalware({
+            enabled: false,
+            packages: [{ name: 'deck.gl', version: '9.3.5' }],
+            fetchImpl: fetchImpl as unknown as OsvBatchFetch,
+        });
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when there are no packages', async () => {
+        const fetchImpl = vi.fn();
+        await assertDependenciesHaveNoKnownMalware({
+            enabled: true,
+            packages: [],
+            fetchImpl: fetchImpl as unknown as OsvBatchFetch,
+        });
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('accepts packages with no malicious advisories', async () => {
+        await assertDependenciesHaveNoKnownMalware({
+            enabled: true,
+            packages: [
+                { name: 'deck.gl', version: '9.3.5' },
+                { name: 'react', version: '19.0.0' },
+            ],
+            fetchImpl: okResponse(2),
+        });
+    });
+
+    it('ignores non-malware advisories (e.g. a plain CVE)', async () => {
+        await assertDependenciesHaveNoKnownMalware({
+            enabled: true,
+            packages: [{ name: 'lodash', version: '4.17.20' }],
+            fetchImpl: async () => ({
+                status: 200,
+                bodyText: JSON.stringify({
+                    results: [{ vulns: [{ id: 'GHSA-xxxx-yyyy-zzzz' }] }],
+                }),
+                truncated: false,
+            }),
+        });
+    });
+
+    it('rejects a package flagged MAL- by OSV, naming it', async () => {
+        await expect(
+            assertDependenciesHaveNoKnownMalware({
+                enabled: true,
+                packages: [
+                    { name: 'good-pkg', version: '1.0.0' },
+                    { name: 'evil-pkg', version: '6.6.6' },
+                ],
+                fetchImpl: async () => ({
+                    status: 200,
+                    bodyText: JSON.stringify({
+                        results: [{}, { vulns: [{ id: 'MAL-2026-0001' }] }],
+                    }),
+                    truncated: false,
+                }),
+            }),
+        ).rejects.toThrow(/evil-pkg@6\.6\.6/);
+    });
+
+    it('fails closed when OSV is unreachable', async () => {
+        await expect(
+            assertDependenciesHaveNoKnownMalware({
+                enabled: true,
+                packages: [{ name: 'deck.gl', version: '9.3.5' }],
+                fetchImpl: async () => {
+                    throw new Error('network down');
+                },
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('fails closed on a truncated OSV response', async () => {
+        await expect(
+            assertDependenciesHaveNoKnownMalware({
+                enabled: true,
+                packages: [{ name: 'deck.gl', version: '9.3.5' }],
+                fetchImpl: async () => ({
+                    status: 200,
+                    bodyText: '{"results":[',
+                    truncated: true,
+                }),
+            }),
+        ).rejects.toThrow(/malware feed/i);
+    });
+
+    it('fails closed when OSV returns fewer results than queries', async () => {
+        await expect(
+            assertDependenciesHaveNoKnownMalware({
+                enabled: true,
+                packages: [
+                    { name: 'a', version: '1.0.0' },
+                    { name: 'b', version: '2.0.0' },
+                ],
+                // One result for two queries — the tail package would go
+                // unscreened if the length weren't guarded.
+                fetchImpl: async () => ({
+                    status: 200,
+                    bodyText: JSON.stringify({ results: [{}] }),
+                    truncated: false,
+                }),
+            }),
+        ).rejects.toThrow(/malware feed/i);
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/dependencyGuards.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dependencyGuards.ts
@@ -104,3 +104,91 @@ export async function assertDependenciesMeetMinReleaseAge(args: {
         }
     }
 }
+
+const OSV_BATCH_URL = 'https://api.osv.dev/v1/querybatch';
+const OSV_TIMEOUT_MS = 15_000;
+const OSV_MAX_BYTES = 4 * 1024 * 1024;
+// OSV IDs from the malicious-packages database are prefixed `MAL-`. Matching on
+// this prefix targets known-malicious packages specifically, rather than every
+// package that merely has a CVE (which would reject most of the ecosystem).
+const OSV_MALWARE_ID_PREFIX = 'MAL-';
+
+export type OsvBatchFetch = (body: string) => Promise<RegistryFetchResult>;
+
+const defaultOsvFetch: OsvBatchFetch = (body) =>
+    secureFetch(OSV_BATCH_URL, {
+        method: 'POST',
+        body,
+        headers: { 'Content-Type': 'application/json' },
+        timeoutMs: OSV_TIMEOUT_MS,
+        maxResponseBytes: OSV_MAX_BYTES,
+        allowedContentTypes: ['application/json'],
+    });
+
+type OsvBatchResponse = {
+    results?: Array<{ vulns?: Array<{ id?: string }> }>;
+};
+
+/**
+ * Rejects the upload if any resolved package (direct or transitive) matches a
+ * known-malicious advisory in the OSV malicious-packages feed. Supply-chain
+ * attacks usually arrive through a transitive dependency, so this checks the
+ * whole lockfile, not just the packages the author added directly.
+ *
+ * Opt-in via `enabled` (default off → no OSV round-trip). Fails CLOSED: if OSV
+ * can't be reached or returns an unexpected shape, the upload is rejected so a
+ * malicious package can't slip through on an API hiccup.
+ */
+export async function assertDependenciesHaveNoKnownMalware(args: {
+    packages: LockfilePackage[];
+    enabled: boolean;
+    fetchImpl?: OsvBatchFetch;
+}): Promise<void> {
+    const { packages, enabled } = args;
+    if (!enabled || packages.length === 0) return;
+
+    const fetchImpl = args.fetchImpl ?? defaultOsvFetch;
+    const queries = packages.map((p) => ({
+        package: { ecosystem: 'npm', name: p.name },
+        version: p.version,
+    }));
+
+    let results: NonNullable<OsvBatchResponse['results']>;
+    try {
+        const res = await fetchImpl(JSON.stringify({ queries }));
+        if (res.status !== 200 || res.truncated) {
+            throw new Error(`OSV status ${res.status}`);
+        }
+        const parsed = JSON.parse(res.bodyText) as OsvBatchResponse;
+        results = parsed.results ?? [];
+        // OSV returns results 1:1 with queries. A short/misaligned array would
+        // leave tail packages unscreened — fail closed rather than skip them.
+        if (results.length !== packages.length) {
+            throw new Error(
+                `OSV returned ${results.length} results for ${packages.length} queries`,
+            );
+        }
+    } catch {
+        throw new ParameterError(
+            'Could not screen the declared dependencies against the malware feed (OSV returned an unexpected response). This instance requires that check (LIGHTDASH_APP_DEPENDENCY_MALWARE_CHECK_ENABLED); try again shortly.',
+        );
+    }
+
+    const flagged: string[] = [];
+    results.forEach((result, index) => {
+        const isMalicious = (result?.vulns ?? []).some((v) =>
+            v.id?.startsWith(OSV_MALWARE_ID_PREFIX),
+        );
+        if (isMalicious && packages[index]) {
+            flagged.push(`${packages[index].name}@${packages[index].version}`);
+        }
+    });
+
+    if (flagged.length > 0) {
+        throw new ParameterError(
+            `Upload blocked: ${flagged.length} package(s) flagged as malicious by the OSV feed — ${flagged.join(
+                ', ',
+            )}. Remove or replace them and re-upload.`,
+        );
+    }
+}


### PR DESCRIPTION
Guarded-rollout guard 3/3 for data-app custom dependencies.

Optional upload-time check (`LIGHTDASH_APP_DEPENDENCY_MALWARE_CHECK_ENABLED`, default **ON**): screens every resolved package in the upload's lockfile against the [OSV](https://osv.dev) malicious-packages feed via one batch query, and rejects the upload if any version carries a `MAL-` advisory.

- **Whole tree, not just direct deps**: supply-chain malware usually arrives through a transitive dependency, so the check covers the full resolved lockfile.
- **`MAL-` prefix only**: matches OSV's malicious-packages database specifically — blocks *known-malicious* packages, not every package that has a CVE (which would reject most of the ecosystem).
- **Free, no API key** (OSV public API); via the hardened `secureFetch` wrapper.
- **Defaults on** — it's the one dependency guard that does, because `MAL-`-only matching gives near-zero false positives and it's the highest-value guard. Only runs for uploads that already cleared the custom-deps gates.
- **Fails closed** when OSV is unreachable. So a backend with no egress to `api.osv.dev` (air-gapped, or during an OSV outage) must set the env var to `false` to keep uploading custom-dependency apps — that's the documented escape hatch.

This is the enforceable, server-side equivalent of `sfw` — it protects an author's teammates before `download` puts a package on their machines, and can't be bypassed by an old CLI or curl.

Relates: GLITCH-558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
