### PR TITLE
feat: update preview expiration when start-preview runs on an existing preview

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -13,6 +13,7 @@ import {
     ApiGetProjectGroupAccesses,
     ApiGetProjectMemberResponse,
     ApiPreviewExpirationProjectSettingsResponse,
+    ApiPreviewExpiresAtResponse,
     ApiProjectAccessListResponse,
     ApiProjectColorPaletteResponse,
     ApiProjectResponse,
@@ -60,6 +61,7 @@ import {
     type Tag,
     type UpdateMultipleDashboards,
     type UpdatePreviewExpirationProjectSettings,
+    type UpdatePreviewExpiresAt,
     type UpdateQueryTimezoneSettings,
     type UpdateSchedulerSettings,
 } from '@lightdash/common';
@@ -1153,6 +1155,39 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         return {
             status: 'ok',
             results: settings,
+        };
+    }
+
+    /**
+     * Update the expiration date of a preview project. The expiration is
+     * recomputed from now, clamped to the upstream project's maximum preview
+     * expiration. Omit expiresInHours to reset to the upstream default.
+     * @summary Update preview expiration
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Updated')
+    @Patch('{projectUuid}/preview-expiration')
+    @OperationId('updatePreviewExpiresAt')
+    async updatePreviewExpiresAt(
+        @Path() projectUuid: string,
+        @Body() body: UpdatePreviewExpiresAt,
+        @Request() req: express.Request,
+    ): Promise<ApiPreviewExpiresAtResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getProjectService()
+            .updatePreviewExpiresAt(
+                toSessionUser(req.account),
+                projectUuid,
+                body.expiresInHours,
+            );
+        return {
+            status: 'ok',
+            results,
         };
     }
 

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -80,6 +80,7 @@ type UpdateDbProject = Partial<
         | 'project_defaults'
         | 'color_palette_uuid'
         | 'table_groups'
+        | 'expires_at'
         | 'default_preview_expiration_hours'
         | 'max_preview_expiration_hours'
     >

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -33278,6 +33278,44 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PreviewExpiresAt: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                expiresAt: { dataType: 'datetime', required: true },
+                projectUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_PreviewExpiresAt_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'PreviewExpiresAt', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPreviewExpiresAtResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_PreviewExpiresAt_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdatePreviewExpiresAt: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { expiresInHours: { dataType: 'double' } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdateSchedulerSettings: {
         dataType: 'refAlias',
         type: {
@@ -71199,6 +71237,71 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateProjectPreviewExpirationSettings',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_updatePreviewExpiresAt: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdatePreviewExpiresAt',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/preview-expiration',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.updatePreviewExpiresAt,
+        ),
+
+        async function ProjectController_updatePreviewExpiresAt(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_updatePreviewExpiresAt,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updatePreviewExpiresAt',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -33721,6 +33721,45 @@
                 ],
                 "type": "object"
             },
+            "PreviewExpiresAt": {
+                "properties": {
+                    "expiresAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["expiresAt", "projectUuid"],
+                "type": "object"
+            },
+            "ApiSuccess_PreviewExpiresAt_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/PreviewExpiresAt"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiPreviewExpiresAtResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_PreviewExpiresAt_"
+            },
+            "UpdatePreviewExpiresAt": {
+                "properties": {
+                    "expiresInHours": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "type": "object"
+            },
             "UpdateSchedulerSettings": {
                 "properties": {
                     "schedulerFailureContactOverride": {
@@ -61104,6 +61143,57 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/UpdatePreviewExpirationProjectSettings"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/preview-expiration": {
+            "patch": {
+                "operationId": "updatePreviewExpiresAt",
+                "responses": {
+                    "200": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiPreviewExpiresAtResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update the expiration date of a preview project. The expiration is\nrecomputed from now, clamped to the upstream project's maximum preview\nexpiration. Omit expiresInHours to reset to the upstream default.",
+                "summary": "Update preview expiration",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdatePreviewExpiresAt"
                             }
                         }
                     }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -722,6 +722,12 @@ export class ProjectModel {
             });
     }
 
+    async updateExpiresAt(projectUuid: string, expiresAt: Date): Promise<void> {
+        await this.database(ProjectTableName)
+            .where('project_uuid', projectUuid)
+            .update({ expires_at: expiresAt });
+    }
+
     async update(projectUuid: string, data: UpdateProject): Promise<void> {
         // Invalidate warehouse credentials cache
         warehouseCredentialsCache?.del(projectUuid);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -132,6 +132,7 @@ import {
     PreAggregateMatchMiss,
     PreAggregateMissReason,
     preAggregateUtils,
+    PreviewExpiresAt,
     Project,
     ProjectCatalog,
     ProjectContextEntry,
@@ -7418,6 +7419,51 @@ export class ProjectService extends BaseService {
         const persisted =
             await this.projectModel.getPreviewExpirationSettings(projectUuid);
         return { projectUuid, ...persisted };
+    }
+
+    async updatePreviewExpiresAt(
+        user: SessionUser,
+        projectUuid: string,
+        expiresInHours?: number,
+    ): Promise<PreviewExpiresAt> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('Project', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        if (project.type !== ProjectType.PREVIEW) {
+            throw new ParameterError(
+                'Expiration can only be updated on preview projects',
+            );
+        }
+        if (
+            expiresInHours !== undefined &&
+            (!Number.isInteger(expiresInHours) || expiresInHours < 1)
+        ) {
+            throw new ParameterError(
+                'expiresInHours must be a whole number of at least 1',
+            );
+        }
+        const expiresAt = await this.getPreviewExpiresAt(
+            ProjectType.PREVIEW,
+            project.upstreamProjectUuid,
+            expiresInHours,
+        );
+        if (expiresAt === null) {
+            throw new UnexpectedServerError(
+                'Failed to compute preview expiration',
+            );
+        }
+        await this.projectModel.updateExpiresAt(projectUuid, expiresAt);
+        return { projectUuid, expiresAt };
     }
 
     async getAvailableFiltersForSavedQuery(

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import {
     CreateProjectTableConfiguration,
     getErrorMessage,
+    PreviewExpiresAt,
     Project,
     ProjectType,
 } from '@lightdash/common';
@@ -115,6 +116,36 @@ const projectUrl = async (project: Project): Promise<URL> => {
     throw new Error(
         'Missing server url. Make sure you login before running other commands.',
     );
+};
+
+const updatePreviewExpiration = async (
+    projectUuid: string,
+    expiresIn: string | undefined,
+): Promise<void> => {
+    try {
+        const { expiresAt } = await lightdashApi<PreviewExpiresAt>({
+            method: 'PATCH',
+            url: `/api/v1/projects/${projectUuid}/preview-expiration`,
+            body: JSON.stringify({
+                expiresInHours: expiresIn ? parseInt(expiresIn, 10) : undefined,
+            }),
+        });
+        console.error(
+            `${styles.success(
+                '✔',
+            )}   Preview expiration extended until ${new Date(
+                expiresAt,
+            ).toLocaleString()}`,
+        );
+    } catch (e) {
+        // Non-critical: keep the preview update working against older servers
+        const message = `Could not update preview expiration: ${getErrorMessage(e)}`;
+        if (expiresIn) {
+            console.error(styles.warning(message));
+        } else {
+            GlobalState.debug(`> ${message}`);
+        }
+    }
 };
 
 const getPreviewProject = async (name: string) => {
@@ -471,6 +502,14 @@ export const startPreviewHandler = async (
                 name: options.name,
             },
         });
+
+        // Re-running start-preview confirms the preview is still in use,
+        // so refresh its expiration (uses the upstream default when
+        // --expires-in is not set)
+        await updatePreviewExpiration(
+            previewProject.projectUuid,
+            options.expiresIn,
+        );
 
         // Update
         options.disableTimestampConversion =

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -214,7 +214,10 @@ import type {
     ApiPreAggregateCheckResponse,
     PreAggregateMatchMiss,
 } from './preAggregate';
-import { type ApiPreviewExpirationProjectSettingsResponse } from './previewExpirationProjectSettings';
+import {
+    type ApiPreviewExpirationProjectSettingsResponse,
+    type ApiPreviewExpiresAtResponse,
+} from './previewExpirationProjectSettings';
 import { type ProjectCiStatus } from './projectCiStatus';
 import {
     type ApiProjectCompileLogResponse,
@@ -1190,6 +1193,7 @@ type ApiResults =
     | ApiPreAggregateCheckResponse['results']
     | ApiImpersonationOrganizationSettingsResponse['results']
     | ApiPreviewExpirationProjectSettingsResponse['results']
+    | ApiPreviewExpiresAtResponse['results']
     | ApiContentVerificationResponse['results']
     | ApiContentVerificationDeleteResponse['results']
     | ApiVerifiedContentListResponse['results']

--- a/packages/common/src/types/previewExpirationProjectSettings.ts
+++ b/packages/common/src/types/previewExpirationProjectSettings.ts
@@ -13,3 +13,15 @@ export type UpdatePreviewExpirationProjectSettings = {
 
 export type ApiPreviewExpirationProjectSettingsResponse =
     ApiSuccess<PreviewExpirationProjectSettings>;
+
+export type UpdatePreviewExpiresAt = {
+    // When omitted, the expiration resets to the upstream project's default
+    expiresInHours?: number;
+};
+
+export type PreviewExpiresAt = {
+    projectUuid: string;
+    expiresAt: Date;
+};
+
+export type ApiPreviewExpiresAtResponse = ApiSuccess<PreviewExpiresAt>;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7928/cli-start-preview-expires-in-should-update-expiration-on-existing

### Description:

Re-running 'lightdash start-preview' on an existing preview previously ignored --expires-in entirely; the only way to change a preview's expiration was to delete and recreate it, losing content developed inside the preview.

Adds PATCH /api/v1/projects/{projectUuid}/preview-expiration which recomputes expires_at from now via the existing getPreviewExpiresAt logic (honouring the upstream project's default and max), and calls it from the CLI's existing-preview update path. Re-running without --expires-in resets the expiration to the upstream default, since a re-run confirms the preview is still in use.

<img width="876" height="483" alt="image" src="https://github.com/user-attachments/assets/7ce231f6-0536-42ce-b8e2-a4592516ee1b" />