### PR TITLE
fix(ai): open Slack explore links with the generated chart type

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -1,4 +1,9 @@
-import { DimensionType, FilterOperator, FilterType } from '@lightdash/common';
+import {
+    ChartType,
+    DimensionType,
+    FilterOperator,
+    FilterType,
+} from '@lightdash/common';
 import {
     buildFeedbackContextActions,
     buildSlackTaskUpdate,
@@ -8,6 +13,7 @@ import {
     getProjectSelectionBlocks,
     getSlackToolTitle,
 } from './getSlackBlocks';
+import { mockOrdersExplore } from './validationExplore.mock';
 
 describe('Slack AI agent blocks', () => {
     it('maps known tool names to readable task titles', () => {
@@ -778,6 +784,218 @@ describe('Slack AI agent blocks', () => {
             {
                 type: 'carousel',
                 elements: [{ type: 'card' }, { type: 'card' }],
+            },
+        ]);
+    });
+
+    it('opens the Explore link with the generated chart type instead of table', async () => {
+        const capturedShareParams: string[] = [];
+        const createShareUrl = async (path: string, params: string) => {
+            capturedShareParams.push(params);
+            return 'https://lightdash.example.com/share/chart';
+        };
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            createShareUrl,
+            async () => mockOrdersExplore,
+            'agent-1',
+            [
+                {
+                    artifactUuid: 'artifact-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    artifactType: 'chart',
+                    savedQueryUuid: null,
+                    savedDashboardUuid: null,
+                    createdAt: new Date(),
+                    versionNumber: 1,
+                    versionUuid: 'version-1',
+                    title: 'Order count over time',
+                    description: null,
+                    dashboardConfig: null,
+                    versionCreatedAt: new Date(),
+                    verifiedByUserUuid: null,
+                    verifiedAt: null,
+                    chartConfig: {
+                        title: 'Order count over time',
+                        description: 'Order count by order date',
+                        queryConfig: {
+                            exploreName: 'test_explore',
+                            dimensions: ['orders_order_date'],
+                            metrics: ['orders_order_count'],
+                            sorts: [],
+                            limit: 500,
+                            customMetrics: [],
+                            tableCalculations: [],
+                            filters: null,
+                        },
+                        chartConfig: {
+                            groupBy: ['orders_product_category'],
+                            lineType: 'line',
+                            stackBars: null,
+                            xAxisType: 'time',
+                            xAxisLabel: 'Order date',
+                            yAxisLabel: 'Order count',
+                            yAxisMetrics: ['orders_order_count'],
+                            defaultVizType: 'line',
+                            xAxisDimension: 'orders_order_date',
+                            funnelDataInput: null,
+                            secondaryYAxisLabel: null,
+                            secondaryYAxisMetric: null,
+                        },
+                    },
+                },
+            ],
+            [],
+        );
+
+        expect(blocks).toHaveLength(1);
+        expect(capturedShareParams).toHaveLength(1);
+
+        const searchParams = new URLSearchParams(capturedShareParams[0]);
+        const exploreState = JSON.parse(
+            searchParams.get('create_saved_chart_version')!,
+        );
+
+        expect(exploreState.chartConfig.type).toBe(ChartType.CARTESIAN);
+        expect(exploreState.pivotConfig).toEqual({
+            columns: ['orders_product_category'],
+        });
+    });
+
+    it('falls back to a table explore link when the chart config cannot be converted', async () => {
+        const capturedShareParams: string[] = [];
+        const createShareUrl = async (path: string, params: string) => {
+            capturedShareParams.push(params);
+            return 'https://lightdash.example.com/share/chart';
+        };
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            createShareUrl,
+            // Broken explore: chart config conversion throws, table fallback kicks in
+            async () => ({}) as never,
+            'agent-1',
+            [
+                {
+                    artifactUuid: 'artifact-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    artifactType: 'chart',
+                    savedQueryUuid: null,
+                    savedDashboardUuid: null,
+                    createdAt: new Date(),
+                    versionNumber: 1,
+                    versionUuid: 'version-1',
+                    title: 'Order count over time',
+                    description: null,
+                    dashboardConfig: null,
+                    versionCreatedAt: new Date(),
+                    verifiedByUserUuid: null,
+                    verifiedAt: null,
+                    chartConfig: {
+                        title: 'Order count over time',
+                        description: 'Order count by order date',
+                        queryConfig: {
+                            exploreName: 'orders',
+                            dimensions: ['orders_order_date'],
+                            metrics: ['orders_order_count'],
+                            sorts: [],
+                            limit: 500,
+                            customMetrics: [],
+                            tableCalculations: [],
+                            filters: null,
+                        },
+                        chartConfig: null,
+                    },
+                },
+            ],
+            [],
+        );
+
+        expect(blocks).toHaveLength(1);
+        const searchParams = new URLSearchParams(capturedShareParams[0]);
+        const exploreState = JSON.parse(
+            searchParams.get('create_saved_chart_version')!,
+        );
+
+        expect(exploreState.chartConfig.type).toBe(ChartType.TABLE);
+        expect(exploreState.pivotConfig).toBeUndefined();
+    });
+
+    it('links the bare explore when share URL creation fails, keeping the URL short for Slack', async () => {
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async () => {
+                throw new Error('share service unavailable');
+            },
+            async () => mockOrdersExplore,
+            'agent-1',
+            [
+                {
+                    artifactUuid: 'artifact-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    artifactType: 'chart',
+                    savedQueryUuid: null,
+                    savedDashboardUuid: null,
+                    createdAt: new Date(),
+                    versionNumber: 1,
+                    versionUuid: 'version-1',
+                    title: 'Order count over time',
+                    description: null,
+                    dashboardConfig: null,
+                    versionCreatedAt: new Date(),
+                    verifiedByUserUuid: null,
+                    verifiedAt: null,
+                    chartConfig: {
+                        title: 'Order count over time',
+                        description: 'Order count by order date',
+                        queryConfig: {
+                            exploreName: 'test_explore',
+                            dimensions: ['orders_order_date'],
+                            metrics: ['orders_order_count'],
+                            sorts: [],
+                            limit: 500,
+                            customMetrics: [],
+                            tableCalculations: [],
+                            filters: null,
+                        },
+                        chartConfig: null,
+                    },
+                },
+            ],
+            [],
+        );
+
+        expect(blocks).toMatchObject([
+            {
+                type: 'card',
+                actions: [
+                    {
+                        text: { text: 'Explore in Lightdash' },
+                        url: 'https://lightdash.example.com/projects/project-1/tables/test_explore',
+                    },
+                ],
             },
         ]);
     });

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -3,13 +3,18 @@ import {
     AiAgentMessageAssistantArtifact,
     AiAgentToolResult,
     AiArtifact,
+    ChartType,
     FollowUpTools,
     followUpToolsText,
+    getGroupByDimensions,
+    getItemMap,
+    getWebAiChartConfig,
     isToolEditDbtProjectResult,
     isToolProposeChangeResult,
     isToolSetupPreviewDeployResult,
     parseVizConfig,
     SlackPrompt,
+    type ChartConfig,
     type Explore,
 } from '@lightdash/common';
 import { Block, KnownBlock } from '@slack/bolt';
@@ -644,36 +649,69 @@ export async function getModernArtifactCardBlocks(
                     ...tableCalculationNames,
                 ];
 
+                const metricQueryWithSql = {
+                    ...vizConfig.metricQuery,
+                    additionalMetrics: additionalMetricsWithSql,
+                };
+
+                // Match the generated viz type in the explorer; fall back to
+                // table if the conversion fails so the link always works.
+                let chartConfig: ChartConfig = {
+                    type: ChartType.TABLE,
+                    config: {
+                        showColumnCalculation: false,
+                        showRowCalculation: false,
+                        showTableNames: true,
+                        showResultsTotal: false,
+                        showSubtotals: false,
+                        columns: {},
+                        hideRowNumbers: false,
+                        conditionalFormattings: [],
+                        metricsAsRows: false,
+                    },
+                };
+                let pivotConfig: { columns: string[] } | undefined;
+                try {
+                    const webAiChartConfig = getWebAiChartConfig({
+                        vizConfig: artifact.chartConfig,
+                        metricQuery: metricQueryWithSql,
+                        maxQueryLimit,
+                        fieldsMap: getItemMap(
+                            explore,
+                            additionalMetricsWithSql,
+                            vizConfig.metricQuery.tableCalculations,
+                        ),
+                    });
+                    if (webAiChartConfig.echartsConfig) {
+                        chartConfig = webAiChartConfig.echartsConfig;
+                    }
+                    const groupByDimensions =
+                        getGroupByDimensions(webAiChartConfig);
+                    pivotConfig = groupByDimensions?.length
+                        ? { columns: groupByDimensions }
+                        : undefined;
+                } catch {
+                    // keep the table fallback
+                }
+
                 const path = `/projects/${slackPrompt.projectUuid}/tables/${vizConfig.metricQuery.exploreName}`;
                 const params = `?create_saved_chart_version=${encodeURIComponent(
                     JSON.stringify({
                         tableName: vizConfig.metricQuery.exploreName,
-                        metricQuery: {
-                            ...vizConfig.metricQuery,
-                            additionalMetrics: additionalMetricsWithSql,
-                        },
+                        metricQuery: metricQueryWithSql,
                         tableConfig: {
                             columnOrder,
                         },
-                        chartConfig: {
-                            type: 'table',
-                            config: {
-                                showColumnCalculation: false,
-                                showRowCalculation: false,
-                                showTableNames: true,
-                                showResultsTotal: false,
-                                showSubtotals: false,
-                                columns: {},
-                                hideRowNumbers: false,
-                                conditionalFormattings: [],
-                                metricsAsRows: false,
-                            },
-                        },
+                        chartConfig,
+                        ...(pivotConfig ? { pivotConfig } : {}),
                     }),
                 )}`;
 
+                // Always link via a short /share URL — inlining the full chart
+                // state in the button URL exceeds Slack's URL length limits.
+                // If share creation fails, link the bare explore instead.
                 const exploreUrl = await createShareUrl(path, params).catch(
-                    () => `${siteUrl}${path}${params}`,
+                    () => `${siteUrl}${path}`,
                 );
 
                 const metricCount =


### PR DESCRIPTION
## Problem

The Slack AI agent's chart card has an "Explore in Lightdash" button. The `create_saved_chart_version` state embedded in its share link hardcoded `chartConfig: { type: 'table' }`, so the explorer always opened as a table regardless of the visualization the agent actually generated (line, bar, pie, stacked, …).

## Fix

- Build the real chart config with `getWebAiChartConfig` — the same converter the web AI panel uses for its "Explore from here" action — using a fields map from `getItemMap(explore, populatedCustomMetrics, tableCalculations)`.
- Include `pivotConfig` (via `getGroupByDimensions`) so grouped/stacked charts keep their series split in the explorer.
- Fall back to the previous hardcoded table config if conversion throws, so a bad artifact can never break the whole Slack reply.
- The share-link failure fallback now links the bare explore (short URL) instead of inlining the full chart state into the Slack button URL, which could exceed Slack's URL length limits and fail the message.

## Who's affected

- Only the Slack AI agent chart cards' "Explore in Lightdash" button. The web AI panel already used this converter; the MCP explore links have their own builder (`buildMcpExploreConfigState`) and are unchanged.
- Existing behavior is preserved as the fallback: if the chart config can't be converted, the link opens as a table exactly as before.

## Testing

- New unit tests: explore state carries the generated chart type + pivot columns; table fallback when conversion fails; short-URL fallback when share creation fails.
- Verified end-to-end against a local dev server with six live Slack agent runs, decoding the stored share states:
  - line split by status → `cartesian` + `pivotConfig: {columns: [orders_status]}`
  - bar → `cartesian`
  - pie → `pie`
  - stacked bar → `cartesian` with `stack` + pivot
  - dual-axis line → series `yAxisIndex` `[0, 1]`
  - horizontal bar on a custom metric → `flipAxes: true` with `additionalMetrics` populated

Closes: PROD-8783

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEWMxChq5m6DeMrqvjcZJy
