### PR TITLE
feat: download all apps, add a limit option

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -1,13 +1,20 @@
-import { type DataAppCodeDownload } from '@lightdash/common';
+import {
+    LightdashError,
+    ParameterError,
+    type DataAppCodeDownload,
+} from '@lightdash/common';
 import {
     appsDownloadSummary,
     capListedApps,
+    classifyAppDownloadError,
     classifyAppUpload,
     computeUpsertedTotal,
+    DEFAULT_APPS_LIMIT,
     ensureDownloadedAppContext,
     manifestRetargetHint,
-    MAX_INCLUDE_APPS,
+    resolveAppsLimit,
     selectAppsToDownload,
+    shouldFallBackToSpaceScopedListing,
     shouldWarnAllSkipped,
 } from './appsDownload';
 
@@ -66,19 +73,87 @@ describe('selectAppsToDownload', () => {
 });
 
 describe('capListedApps', () => {
-    it('keeps all listed apps when under the cap', () => {
-        expect(capListedApps(['a', 'b', 'c'])).toEqual({
+    it('keeps all listed apps when under the limit', () => {
+        expect(capListedApps(['a', 'b', 'c'], 5)).toEqual({
             appUuids: ['a', 'b', 'c'],
             truncatedCount: 0,
         });
     });
 
-    it(`caps listed apps at ${MAX_INCLUDE_APPS} and reports the truncated count`, () => {
+    it('caps listed apps at the given limit and reports the truncated count', () => {
         const listed = Array.from({ length: 12 }, (_, i) => `uuid-${i}`);
-        const result = capListedApps(listed);
-        expect(result.appUuids).toHaveLength(MAX_INCLUDE_APPS);
-        expect(result.appUuids).toEqual(listed.slice(0, MAX_INCLUDE_APPS));
+        const result = capListedApps(listed, 10);
+        expect(result.appUuids).toHaveLength(10);
+        expect(result.appUuids).toEqual(listed.slice(0, 10));
         expect(result.truncatedCount).toBe(2);
+    });
+
+    it('reports no truncation when exactly at the limit', () => {
+        expect(capListedApps(['a', 'b'], 2)).toEqual({
+            appUuids: ['a', 'b'],
+            truncatedCount: 0,
+        });
+    });
+});
+
+describe('resolveAppsLimit', () => {
+    it('defaults to DEFAULT_APPS_LIMIT when the flag is not passed', () => {
+        expect(DEFAULT_APPS_LIMIT).toBe(50);
+        expect(resolveAppsLimit(undefined, true)).toEqual({
+            limit: DEFAULT_APPS_LIMIT,
+            noEffectWarning: null,
+        });
+    });
+
+    it('does not warn when the flag is not passed, even without --include-apps', () => {
+        expect(resolveAppsLimit(undefined, false)).toEqual({
+            limit: DEFAULT_APPS_LIMIT,
+            noEffectWarning: null,
+        });
+    });
+
+    it('parses an explicit limit', () => {
+        expect(resolveAppsLimit('200', true)).toEqual({
+            limit: 200,
+            noEffectWarning: null,
+        });
+    });
+
+    it('warns (but succeeds) when passed without --include-apps', () => {
+        const result = resolveAppsLimit('5', false);
+        expect(result.limit).toBe(5);
+        expect(result.noEffectWarning).toContain('--include-apps');
+    });
+
+    it.each(['0', '-5', 'abc', '1.5', ''])(
+        'rejects %p as a ParameterError',
+        (raw) => {
+            expect(() => resolveAppsLimit(raw, true)).toThrow(ParameterError);
+        },
+    );
+});
+
+describe('shouldFallBackToSpaceScopedListing', () => {
+    const makeError = (statusCode: number) =>
+        new LightdashError({
+            message: 'x',
+            name: 'TestError',
+            statusCode,
+            data: {},
+        });
+
+    it('falls back when the listing endpoint 404s (older server)', () => {
+        expect(shouldFallBackToSpaceScopedListing(makeError(404))).toBe(true);
+    });
+
+    it('propagates 403 (data apps disabled) instead of falling back', () => {
+        expect(shouldFallBackToSpaceScopedListing(makeError(403))).toBe(false);
+    });
+
+    it('propagates non-Lightdash errors', () => {
+        expect(shouldFallBackToSpaceScopedListing(new Error('boom'))).toBe(
+            false,
+        );
     });
 });
 
@@ -181,12 +256,66 @@ describe('manifestRetargetHint', () => {
     });
 });
 
+describe('classifyAppDownloadError', () => {
+    const make404 = (message: string) =>
+        new LightdashError({
+            message,
+            name: 'NotFoundError',
+            statusCode: 404,
+            data: {},
+        });
+
+    it('skips apps that have no built version yet', () => {
+        expect(
+            classifyAppDownloadError(
+                make404('Data app has no ready version yet: uuid-a'),
+            ),
+        ).toEqual({ kind: 'skip-not-built' });
+    });
+
+    it('passes the server message through for other 404s', () => {
+        expect(classifyAppDownloadError(make404('App not found'))).toEqual({
+            kind: 'fail',
+            message: 'App not found',
+        });
+    });
+
+    it('falls back to a canned explanation only when a 404 has no server message', () => {
+        const outcome = classifyAppDownloadError(make404(''));
+        expect(outcome.kind).toBe('fail');
+        if (outcome.kind === 'fail') {
+            expect(outcome.message).toContain('data apps');
+        }
+    });
+
+    it('passes the server message through for non-404 Lightdash errors', () => {
+        const err = new LightdashError({
+            message: 'Data apps are not enabled',
+            name: 'ForbiddenError',
+            statusCode: 403,
+            data: {},
+        });
+        expect(classifyAppDownloadError(err)).toEqual({
+            kind: 'fail',
+            message: 'Data apps are not enabled',
+        });
+    });
+
+    it('fails with the error message for plain errors', () => {
+        expect(classifyAppDownloadError(new Error('boom'))).toEqual({
+            kind: 'fail',
+            message: 'boom',
+        });
+    });
+});
+
 describe('appsDownloadSummary', () => {
     it('reports success when all apps downloaded', () => {
-        const summary = appsDownloadSummary(2, 2, [], '/tmp/x/apps');
+        const summary = appsDownloadSummary(2, 2, [], '/tmp/x/apps', 0);
         expect(summary.ok).toBe(true);
         expect(summary.message).toContain('Downloaded 2 of 2 data app(s)');
         expect(summary.message).toContain('/tmp/x/apps');
+        expect(summary.message).not.toContain('skipped');
         expect(summary.failureLines).toEqual([]);
     });
 
@@ -196,6 +325,7 @@ describe('appsDownloadSummary', () => {
             1,
             [{ appUuid: 'uuid-a', message: 'server exploded' }],
             '/tmp/x/apps',
+            0,
         );
         expect(summary.ok).toBe(false);
         expect(summary.message).toContain('Downloaded 0 of 1 data app(s)');
@@ -203,5 +333,27 @@ describe('appsDownloadSummary', () => {
         expect(summary.failureLines).toHaveLength(1);
         expect(summary.failureLines[0]).toContain('uuid-a');
         expect(summary.failureLines[0]).toContain('server exploded');
+    });
+
+    it('excludes skipped apps from the attempted count and stays ok', () => {
+        const summary = appsDownloadSummary(41, 50, [], '/tmp/x/apps', 9);
+        expect(summary.ok).toBe(true);
+        expect(summary.message).toContain('Downloaded 41 of 41 data app(s)');
+        expect(summary.message).toContain('9 skipped: no built version');
+        expect(summary.failureLines).toEqual([]);
+    });
+
+    it('reports skips and failures together', () => {
+        const summary = appsDownloadSummary(
+            1,
+            3,
+            [{ appUuid: 'uuid-a', message: 'server exploded' }],
+            '/tmp/x/apps',
+            1,
+        );
+        expect(summary.ok).toBe(false);
+        expect(summary.message).toContain('Downloaded 1 of 2 data app(s)');
+        expect(summary.message).toContain('1 skipped: no built version');
+        expect(summary.message).toContain('1 failed');
     });
 });

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -1,6 +1,46 @@
-import { type DataAppCodeDownload } from '@lightdash/common';
+import {
+    getErrorMessage,
+    LightdashError,
+    ParameterError,
+    type DataAppCodeDownload,
+} from '@lightdash/common';
 
-export const MAX_INCLUDE_APPS = 10;
+export const DEFAULT_APPS_LIMIT = 50;
+
+/**
+ * Resolves the --apps-limit flag. Commander passes the raw string (or
+ * undefined when the flag was not given, so an explicit flag is
+ * distinguishable from the default). Throws ParameterError on anything
+ * that is not a positive integer.
+ */
+export const resolveAppsLimit = (
+    rawLimit: string | undefined,
+    includeApps: boolean,
+): { limit: number; noEffectWarning: string | null } => {
+    if (rawLimit === undefined) {
+        return { limit: DEFAULT_APPS_LIMIT, noEffectWarning: null };
+    }
+    if (!/^\d+$/.test(rawLimit) || parseInt(rawLimit, 10) < 1) {
+        throw new ParameterError(
+            `--apps-limit must be a positive integer, got "${rawLimit}".`,
+        );
+    }
+    return {
+        limit: parseInt(rawLimit, 10),
+        noEffectWarning: includeApps
+            ? null
+            : '--apps-limit only applies to --include-apps; explicit --apps UUIDs are never capped.',
+    };
+};
+
+/**
+ * The project-wide apps listing endpoint 404s on servers that predate it
+ * (or builds without EE routes) — fall back to the space-scoped content
+ * API listing there. Other errors (401/403/5xx) are real and propagate;
+ * in particular 403 means data apps are disabled on the instance.
+ */
+export const shouldFallBackToSpaceScopedListing = (err: unknown): boolean =>
+    err instanceof LightdashError && err.statusCode === 404;
 
 export type AppsDownloadSelection =
     | { mode: 'none' }
@@ -8,9 +48,9 @@ export type AppsDownloadSelection =
     | { mode: 'list-all'; extraAppUuids: string[] };
 
 /**
- * Explicit UUIDs (--apps) are fetched directly (works for apps not in any
- * space); only --include-apps lists apps via the space-scoped content API,
- * which omits apps that were never added to a space.
+ * Explicit UUIDs (--apps) are fetched directly; --include-apps lists every
+ * app in the project via the project-wide apps endpoint, falling back to
+ * the space-scoped content API on servers that predate it.
  */
 export const selectAppsToDownload = (request: {
     apps?: string[];
@@ -28,9 +68,10 @@ export const selectAppsToDownload = (request: {
 
 export const capListedApps = (
     listedUuids: string[],
+    limit: number,
 ): { appUuids: string[]; truncatedCount: number } => ({
-    appUuids: listedUuids.slice(0, MAX_INCLUDE_APPS),
-    truncatedCount: Math.max(0, listedUuids.length - MAX_INCLUDE_APPS),
+    appUuids: listedUuids.slice(0, limit),
+    truncatedCount: Math.max(0, listedUuids.length - limit),
 });
 
 /**
@@ -49,6 +90,40 @@ export const ensureDownloadedAppContext = (
 };
 
 export type AppDownloadFailure = { appUuid: string; message: string };
+
+export type AppDownloadErrorOutcome =
+    | { kind: 'skip-not-built' }
+    | { kind: 'fail'; message: string };
+
+/**
+ * A 404 saying the app has no ready version means it exists but never
+ * finished a successful build — nothing to download, so it's a skip, not a
+ * failure. Everything else fails the app, preferring the server's own
+ * message over a canned guess.
+ */
+export const classifyAppDownloadError = (
+    err: unknown,
+): AppDownloadErrorOutcome => {
+    if (err instanceof LightdashError) {
+        if (
+            err.statusCode === 404 &&
+            err.message.includes('no ready version')
+        ) {
+            return { kind: 'skip-not-built' };
+        }
+        if (err.message) {
+            return { kind: 'fail', message: err.message };
+        }
+        if (err.statusCode === 404) {
+            return {
+                kind: 'fail',
+                message:
+                    'App not found. It may not exist on this server, or data apps may not be enabled.',
+            };
+        }
+    }
+    return { kind: 'fail', message: getErrorMessage(err) };
+};
 
 /**
  * Shown when a newly created app's folder manifest was NOT retargeted —
@@ -108,8 +183,14 @@ export const appsDownloadSummary = (
     total: number,
     failures: AppDownloadFailure[],
     appsDir: string,
+    skippedNotBuiltCount: number,
 ): { ok: boolean; message: string; failureLines: string[] } => {
-    const base = `Downloaded ${successCount} of ${total} data app(s) to ${appsDir}`;
+    const attempted = total - skippedNotBuiltCount;
+    const skippedSuffix =
+        skippedNotBuiltCount > 0
+            ? ` (${skippedNotBuiltCount} skipped: no built version)`
+            : '';
+    const base = `Downloaded ${successCount} of ${attempted} data app(s) to ${appsDir}${skippedSuffix}`;
     if (failures.length === 0) {
         return { ok: true, message: base, failureLines: [] };
     }

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -7,6 +7,7 @@ import {
     ApiContentResponse,
     ApiDashboardAsCodeListResponse,
     ApiDashboardValidationResponse,
+    ApiEmbedProjectAppsResponse,
     ApiImportAppCodeResponse,
     ApiSqlChartAsCodeListResponse,
     assertUnreachable,
@@ -55,11 +56,13 @@ import {
 import {
     appsDownloadSummary,
     capListedApps,
+    classifyAppDownloadError,
     classifyAppUpload,
     ensureDownloadedAppContext,
     manifestRetargetHint,
-    MAX_INCLUDE_APPS,
+    resolveAppsLimit,
     selectAppsToDownload,
+    shouldFallBackToSpaceScopedListing,
     shouldWarnAllSkipped,
     type AppDownloadFailure,
 } from './apps/appsDownload';
@@ -85,7 +88,8 @@ export type DownloadHandlerOptions = {
     charts: string[]; // These can be slugs, uuids or urls
     dashboards: string[]; // These can be slugs, uuids or urls
     apps: string[] | boolean | null; // download: string[] = specific UUIDs; upload: true = all app folders on disk; null/false/absent = skip
-    includeApps?: boolean; // download only: include the project's apps (space-scoped listing, capped)
+    includeApps?: boolean; // download only: include all of the project's apps, capped at --apps-limit
+    appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
     createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
     force: boolean;
     path?: string; // New optional path parameter
@@ -847,10 +851,43 @@ export const downloadContent = async (
     return [total, [...new Set(chartSlugs)], allMetadataEntries, allSpaces];
 };
 
+// Space-scoped fallback listing for servers without the project-wide apps
+// endpoint; omits apps that were never added to a space.
+const listAppUuidsViaContentApi = async (
+    projectId: string,
+): Promise<string[]> => {
+    const listedAppUuids: string[] = [];
+    let page = 1;
+    let totalPageCount = 1;
+    do {
+        const contentResult = await lightdashApi<ApiContentResponse['results']>(
+            {
+                method: 'GET',
+                url: `/api/v2/content?projectUuids=${projectId}&contentTypes=data_app&page=${page}&pageSize=100`,
+                body: undefined,
+            },
+        );
+        listedAppUuids.push(
+            ...contentResult.data
+                .filter((item) => item.contentType === 'data_app')
+                .map((item) => item.uuid),
+        );
+        totalPageCount = contentResult.pagination?.totalPageCount ?? 1;
+        page += 1;
+    } while (page <= totalPageCount);
+    return listedAppUuids;
+};
+
 export const downloadHandler = async (
     options: DownloadHandlerOptions,
 ): Promise<void> => {
     GlobalState.setVerbose(options.verbose);
+
+    const { limit: appsLimit, noEffectWarning: appsLimitWarning } =
+        resolveAppsLimit(options.appsLimit, options.includeApps === true);
+    if (appsLimitWarning) {
+        GlobalState.log(styles.warning(appsLimitWarning));
+    }
 
     if (options.appsOnly) {
         const appsOnlySelection = selectAppsToDownload({
@@ -1073,39 +1110,36 @@ export const downloadHandler = async (
             if (appsSelection.mode === 'explicit') {
                 appUuidsToDownload = appsSelection.appUuids;
             } else {
-                // List all apps via content API (paginated)
+                // List every app in the project (includes apps not in any space)
                 spinner.start(`Listing data apps in project`);
-                const listedAppUuids: string[] = [];
-                let page = 1;
-                let totalPageCount = 1;
-
-                do {
-                    // eslint-disable-next-line no-await-in-loop
-                    const contentResult = await lightdashApi<
-                        ApiContentResponse['results']
+                let listedAppUuids: string[];
+                try {
+                    const projectApps = await lightdashApi<
+                        ApiEmbedProjectAppsResponse['results']
                     >({
                         method: 'GET',
-                        url: `/api/v2/content?projectUuids=${projectId}&contentTypes=data_app&page=${page}&pageSize=100`,
+                        url: `/api/v1/ee/projects/${projectId}/apps`,
                         body: undefined,
                     });
-
-                    listedAppUuids.push(
-                        ...contentResult.data
-                            .filter((item) => item.contentType === 'data_app')
-                            .map((item) => item.uuid),
+                    listedAppUuids = projectApps.map((app) => app.appUuid);
+                } catch (listErr) {
+                    if (!shouldFallBackToSpaceScopedListing(listErr)) {
+                        throw listErr;
+                    }
+                    GlobalState.log(
+                        styles.warning(
+                            'This server does not support project-wide app listing; only apps that are in a space will be included.',
+                        ),
                     );
-
-                    totalPageCount =
-                        contentResult.pagination?.totalPageCount ?? 1;
-                    page += 1;
-                } while (page <= totalPageCount);
+                    listedAppUuids = await listAppUuidsViaContentApi(projectId);
+                }
 
                 const { appUuids: cappedAppUuids, truncatedCount } =
-                    capListedApps(listedAppUuids);
+                    capListedApps(listedAppUuids, appsLimit);
                 if (truncatedCount > 0) {
                     GlobalState.log(
                         styles.warning(
-                            `--include-apps is capped at ${MAX_INCLUDE_APPS} apps (${listedAppUuids.length} found, ${truncatedCount} skipped). Pass --apps <uuids> to download specific apps.`,
+                            `Found ${listedAppUuids.length} data apps, downloading the first ${appsLimit}. Pass --apps-limit <n> to raise the cap.`,
                         ),
                     );
                 }
@@ -1127,6 +1161,7 @@ export const downloadHandler = async (
                 const appsDir = path.join(baseDir, 'apps');
                 const takenFolders = new Set<string>();
                 let appSuccessCount = 0;
+                let appSkippedNotBuiltCount = 0;
                 const appFailures: AppDownloadFailure[] = [];
 
                 for (const appUuid of appUuidsToDownload) {
@@ -1176,17 +1211,23 @@ export const downloadHandler = async (
                         await writeContextToDir(appDir, code.context);
                         appSuccessCount += 1;
                     } catch (appErr) {
-                        const message =
-                            appErr instanceof LightdashError &&
-                            appErr.statusCode === 404
-                                ? `Data apps are not enabled on this instance, or app ${appUuid} was not found.`
-                                : getErrorMessage(appErr);
-                        appFailures.push({ appUuid, message });
-                        GlobalState.log(
-                            styles.error(
-                                `Failed to download app ${appUuid}: ${message}`,
-                            ),
-                        );
+                        const outcome = classifyAppDownloadError(appErr);
+                        if (outcome.kind === 'skip-not-built') {
+                            appSkippedNotBuiltCount += 1;
+                            GlobalState.debug(
+                                `> Skipped app ${appUuid}: no built version to download`,
+                            );
+                        } else {
+                            appFailures.push({
+                                appUuid,
+                                message: outcome.message,
+                            });
+                            GlobalState.log(
+                                styles.error(
+                                    `Failed to download app ${appUuid}: ${outcome.message}`,
+                                ),
+                            );
+                        }
                     }
                 }
 
@@ -1195,6 +1236,7 @@ export const downloadHandler = async (
                     appUuidsToDownload.length,
                     appFailures,
                     appsDir,
+                    appSkippedNotBuiltCount,
                 );
                 if (summary.ok) {
                     spinner.succeed(summary.message);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -767,8 +767,13 @@ program
     )
     .option(
         '--include-apps',
-        'Include the project\'s data apps (enterprise), capped at the first 10. Only lists apps that are in a space; use "--apps <uuids>" for the rest.',
+        "Include all of the project's data apps (enterprise), capped at --apps-limit (default: 50)",
         false,
+    )
+    .option(
+        '--apps-limit <number>',
+        'Maximum number of data apps downloaded by --include-apps (default: 50)',
+        undefined,
     )
     .option(
         '--apps-only',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #25348 

### Description:


`lightdash download --include-apps` previously listed apps via the space-scoped
content API, silently omitting any app never added to a space. The only workaround
was passing each missing app's UUID via `--apps`.

- `--include-apps` now lists every app in the project via
  `GET /api/v1/ee/projects/{projectUuid}/apps`. On older servers where that
  endpoint 404s, it falls back to the space-scoped listing with a warning.
- New `--apps-limit <number>` (default 50) replaces the hardcoded cap of 10.
  Explicit `--apps` UUIDs are never capped.
- Apps with no built version are now skipped with a summary count
  (`9 skipped: no built version`) instead of failing the run, and per-app
  download errors surface the server's actual message instead of a canned guess.
