### PR TITLE
fix: rename MCP connection action

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1222,9 +1222,7 @@ export const AiAgentMcpServersInput = ({
                                     isPersistingSelection
                                 }
                             >
-                                {isRetesting
-                                    ? 'Re-testing...'
-                                    : 'Re-test connection'}
+                                {isRetesting ? 'Testing...' : 'Test connection'}
                             </Menu.Item>
                         )}
                         {mcpServer.hasCredentials &&
@@ -1504,7 +1502,7 @@ export const AiAgentMcpServersInput = ({
                                                         connectionStatus,
                                                     ) && (
                                                         <Tooltip
-                                                            label="Re-test connection"
+                                                            label="Test connection"
                                                             withArrow
                                                             withinPortal
                                                         >


### PR DESCRIPTION
### Summary

- Rename "Re-test connection" actions to "Test connection"

### Validation

- Frontend lint
- Frontend format check
- Pre-commit hooks