### PR TITLE
feat(backend): make screenshot readiness timeout configurable

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -291,6 +291,7 @@ export const lightdashConfigMock: LightdashConfig = {
         browserEndpoint: 'ws://headless-browser:3000',
         maxScreenshotRetries: 5,
         retryBaseDelayMs: 3000,
+        screenshotTimeoutMs: 180000,
     },
     contentAsCode: {
         maxDownloads: 100,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -648,6 +648,17 @@ describe('process.env.LIGHTDASH_IFRAME_EMBEDDING_DOMAINS', () => {
                 config.headlessBrowser.internalLightdashHostIgnoreHttpsErrors,
             ).toBe(false);
         });
+
+        test('screenshotTimeoutMs defaults to 180000', () => {
+            const config = parseConfig();
+            expect(config.headlessBrowser.screenshotTimeoutMs).toBe(180000);
+        });
+
+        test('screenshotTimeoutMs is overridden by HEADLESS_BROWSER_SCREENSHOT_TIMEOUT_MS', () => {
+            process.env.HEADLESS_BROWSER_SCREENSHOT_TIMEOUT_MS = '360000';
+            const config = parseConfig();
+            expect(config.headlessBrowser.screenshotTimeoutMs).toBe(360000);
+        });
     });
 
     describe('environment variables for API tokens', () => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1584,6 +1584,10 @@ export type HeadlessBrowserConfig = {
     browserEndpoint: string;
     maxScreenshotRetries: number;
     retryBaseDelayMs: number;
+    // How long to wait for page content (tiles/charts) to be ready before
+    // screenshotting. The browser container's own session timeout (browserless
+    // TIMEOUT env) must be >= this value or it becomes the binding limit.
+    screenshotTimeoutMs: number;
 };
 export type S3Config = {
     region: string;
@@ -2619,6 +2623,10 @@ export const parseConfig = (): LightdashConfig => {
             browserEndpoint,
             maxScreenshotRetries: parseInt(
                 process.env.HEADLESS_BROWSER_MAX_SCREENSHOT_RETRIES || '5',
+                10,
+            ),
+            screenshotTimeoutMs: parseInt(
+                process.env.HEADLESS_BROWSER_SCREENSHOT_TIMEOUT_MS || '180000',
                 10,
             ),
             retryBaseDelayMs: parseInt(

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -69,7 +69,6 @@ import { traceSpan } from '../../tracing/tracing';
 import { BaseService } from '../BaseService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 
-const RESPONSE_TIMEOUT_MS = 180000;
 const uuid = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
 const uuidRegex = new RegExp(uuid, 'g');
 const nanoid = '[\\w-]{21}';
@@ -328,6 +327,8 @@ export class UnfurlService extends BaseService {
 
     spacePermissionService: SpacePermissionService;
 
+    private readonly screenshotTimeoutMs: number;
+
     constructor({
         lightdashConfig,
         dashboardModel,
@@ -359,6 +360,8 @@ export class UnfurlService extends BaseService {
         this.analytics = analytics;
         this.slackAuthenticationModel = slackAuthenticationModel;
         this.spacePermissionService = spacePermissionService;
+        this.screenshotTimeoutMs =
+            lightdashConfig.headlessBrowser.screenshotTimeoutMs;
     }
 
     async getPreviewSignedUrl(previewId: string): Promise<string> {
@@ -1431,7 +1434,8 @@ export class UnfurlService extends BaseService {
                                             `#loom-loaded-${id}`,
                                             {
                                                 state: 'attached',
-                                                timeout: RESPONSE_TIMEOUT_MS,
+                                                timeout:
+                                                    this.screenshotTimeoutMs,
                                             },
                                         ),
                                 );
@@ -1578,7 +1582,7 @@ export class UnfurlService extends BaseService {
                                 SCREENSHOT_SELECTORS.READY_INDICATOR,
                                 {
                                     state: 'attached',
-                                    timeout: RESPONSE_TIMEOUT_MS,
+                                    timeout: this.screenshotTimeoutMs,
                                 },
                             );
                             this.logger.info(
@@ -1753,7 +1757,7 @@ export class UnfurlService extends BaseService {
 
                     const fullPage = await page.locator(finalSelector);
                     const fullPageSize = await fullPage?.boundingBox({
-                        timeout: RESPONSE_TIMEOUT_MS,
+                        timeout: this.screenshotTimeoutMs,
                     });
 
                     if (
@@ -1836,7 +1840,7 @@ export class UnfurlService extends BaseService {
                         ) {
                             await page.locator(finalSelector).screenshot({
                                 animations: 'disabled',
-                                timeout: RESPONSE_TIMEOUT_MS,
+                                timeout: this.screenshotTimeoutMs,
                             });
                         } else {
                             await page.screenshot({
@@ -1859,7 +1863,7 @@ export class UnfurlService extends BaseService {
                             .screenshot({
                                 path,
                                 animations: 'disabled',
-                                timeout: RESPONSE_TIMEOUT_MS,
+                                timeout: this.screenshotTimeoutMs,
                             });
                     } else if (lightdashPage === LightdashPage.APP) {
                         // Leave the iframe at the initial tall viewport and
@@ -1869,7 +1873,7 @@ export class UnfurlService extends BaseService {
                         const iframeBox = await page
                             .locator('iframe')
                             .first()
-                            .boundingBox({ timeout: RESPONSE_TIMEOUT_MS });
+                            .boundingBox({ timeout: this.screenshotTimeoutMs });
 
                         if (iframeBox) {
                             const clipWidth = Math.max(
@@ -2038,7 +2042,7 @@ export class UnfurlService extends BaseService {
                             imageBuffer = await page.screenshot({
                                 path,
                                 animations: 'disabled',
-                                timeout: RESPONSE_TIMEOUT_MS,
+                                timeout: this.screenshotTimeoutMs,
                                 clip: {
                                     x: iframeBox.x,
                                     y: iframeBox.y,
@@ -2053,7 +2057,7 @@ export class UnfurlService extends BaseService {
                                 .screenshot({
                                     path,
                                     animations: 'disabled',
-                                    timeout: RESPONSE_TIMEOUT_MS,
+                                    timeout: this.screenshotTimeoutMs,
                                 });
                         }
                     } else {


### PR DESCRIPTION
## Problem

The screenshot readiness timeout in `UnfurlService` (how long we wait for dashboard tiles/charts to report ready before screenshotting) was a hardcoded constant: `RESPONSE_TIMEOUT_MS = 180000`. Self-hosted deployments whose dashboards legitimately take longer than 3 minutes to render (slow warehouse queries, many tabs) had no way to raise it — every image export, preview, and scheduled delivery on such dashboards times out, and each timeout triggers up to 5 full retries that re-fire every tile query against the warehouse.

## Solution

- New `headlessBrowser.screenshotTimeoutMs` config, set via `HEADLESS_BROWSER_SCREENSHOT_TIMEOUT_MS` (default unchanged: `180000`), alongside the existing `HEADLESS_BROWSER_MAX_SCREENSHOT_RETRIES` / `HEADLESS_BROWSER_RETRY_BASE_DELAY_MS`.
- `UnfurlService` reads it from injected config; all former `RESPONSE_TIMEOUT_MS` usages (ready-indicator wait, loom tile waits, element boundingBox/screenshot/PDF operations) now use the configured value.

Note for operators (also in the config comment): the headless-browser container's own session timeout (browserless v2 `TIMEOUT` env, default 30s) must be ≥ this value, otherwise it becomes the binding limit — the session is killed before our wait expires. Docs update for docs.lightdash.com env-var reference to follow.

## Verification

- Unit tests for the config default and env override (`parseConfig.test.ts`).
- End-to-end against a local dashboard whose queries were artificially slowed to 210s (pg_sleep view): with default config the ready-timeout fired at exactly ~180s (previously it fired at whatever the browserless session cap was); with a raised timeout the same export completed successfully with a valid image on a single attempt.

The retry-on-ready-timeout behavior itself (re-firing all tile queries per attempt) is intentionally unchanged here and tracked in the related issue.

Closes: PROD-7153
Relates: PROD-8788
Relates: #25397
