### PR TITLE
feat: gate data-app custom dependencies behind admin-only manage:DataAppDependency [GLITCH-558]

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -1,5 +1,6 @@
 import {
     FeatureFlags,
+    ForbiddenError,
     ParameterError,
     TooManyRequestsError,
     type DataAppCode,
@@ -79,6 +80,7 @@ function buildService(
     opts: {
         customDependenciesEnabled?: boolean;
         customDependenciesOrgEnabled?: boolean;
+        canManageDataAppDependencies?: boolean;
     } = {},
 ) {
     const appModel = {
@@ -173,6 +175,22 @@ function buildService(
         client: { send: s3SendSpy },
         bucket: 'test-bucket',
     });
+
+    // The DataAppDependency role gate resolves through createAuditedAbility
+    // (stubbed to allow everything above). Override just that check when a
+    // test needs a non-admin actor.
+    if (opts.canManageDataAppDependencies === false) {
+        vi.spyOn(
+            service as unknown as {
+                assertCanManageDataAppDependencies: () => void;
+            },
+            'assertCanManageDataAppDependencies',
+        ).mockImplementation(() => {
+            throw new ForbiddenError(
+                'You do not have permission to add custom dependencies to data apps. This requires an admin role.',
+            );
+        });
+    }
 
     return { service, appModel, schedulerClient };
 }
@@ -476,6 +494,41 @@ describe('AppGenerateService.importAppCode', () => {
                 },
             } as ImportAppCodeRequestBody),
         ).rejects.toThrow('not enabled for your organization');
+    });
+
+    it('rejects custom deps for a user without manage:DataAppDependency (non-admin)', async () => {
+        const { service, appModel } = buildService({
+            customDependenciesEnabled: true,
+            customDependenciesOrgEnabled: true,
+            canManageDataAppDependencies: false,
+        });
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        await expect(
+            service.importAppCode(makeUser(), PROJECT_UUID, {
+                code: {
+                    ...makeCode(),
+                    dependencies: makeDeps({ 'deck.gl': '9.3.5' }),
+                },
+            } as ImportAppCodeRequestBody),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('allows a template-only upload for a non-admin (no dep permission needed)', async () => {
+        const { service, appModel, schedulerClient } = buildService({
+            canManageDataAppDependencies: false,
+        });
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        // No custom deps → the dependency role gate is never reached.
+        const result = await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: { ...makeCode(), dependencies: makeDeps() },
+        } as ImportAppCodeRequestBody);
+
+        expect(result.action).toBe('create');
+        expect(schedulerClient.appBuildFromSource).toHaveBeenCalledOnce();
     });
 
     it('accepts custom deps when both the instance and org flag allow them', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -391,6 +391,32 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
+     * Adding custom npm dependencies to a data app is a supply-chain
+     * capability gated above ordinary data-app management (admins only by
+     * default), via the dedicated `manage:DataAppDependency` scope.
+     */
+    private assertCanManageDataAppDependencies(
+        user: SessionUser,
+        organizationUuid: string,
+        projectUuid: string,
+    ): void {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('DataAppDependency', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to add custom dependencies to data apps. This requires an admin role.',
+            );
+        }
+    }
+
+    /**
      * Permission check for reading a data app.
      *
      * Apps can live in two modes:
@@ -7306,6 +7332,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             );
         }
 
+        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
+
         // Validate the declared dependency set against the template baseline.
         // An empty custom set is treated as no-dependencies (some CLIs attach
         // the template set redundantly) and nothing is stored.
@@ -7330,6 +7358,16 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 throw new ParameterError(getErrorMessage(err));
             }
             if (Object.keys(customDeps).length > 0) {
+                // Role gate: adding custom npm dependencies is a supply-chain
+                // capability, so it requires manage:DataAppDependency (admins
+                // only by default) — a level above the create/manage:DataApp
+                // needed to upload a template-only app. Checked before the
+                // instance/org gates so an unauthorized user gets a clear 403.
+                this.assertCanManageDataAppDependencies(
+                    user,
+                    organizationUuid,
+                    projectUuid,
+                );
                 if (
                     !this.lightdashConfig.appRuntime.customDependenciesEnabled
                 ) {
@@ -7403,8 +7441,6 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         }
         const action: 'create' | 'append' =
             existingApp !== undefined ? 'append' : 'create';
-
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
 
         const inProgressCount =
             await this.appModel.countInProgressVersionsForProject(projectUuid);

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -413,6 +413,12 @@ export const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
 
+        // Adding custom npm dependencies is a supply-chain capability gated
+        // above ordinary data-app management — admins only by default.
+        can('manage', 'DataAppDependency', {
+            organizationUuid: member.organizationUuid,
+        });
+
         can('manage', 'ExternalConnection', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -341,6 +341,12 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
 
+        // Adding custom npm dependencies is a supply-chain capability gated
+        // above ordinary data-app management — admins only by default.
+        can('manage', 'DataAppDependency', {
+            projectUuid: member.projectUuid,
+        });
+
         can('manage', 'ExternalConnection', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -156,6 +156,7 @@ const BASE_ROLE_SCOPES = {
     [ProjectMemberRole.ADMIN]: [
         // Admin-specific permissions
         'manage:DataApp',
+        'manage:DataAppDependency', // Add custom npm deps (supply-chain capability)
         'manage:ExternalConnection',
         'manage:OrganizationDesign',
         'delete:Project', // Any project

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1276,6 +1276,15 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:DataAppDependency',
+        description:
+            'Add or change custom npm dependencies in data apps (supply-chain capability; admin-only by default)',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [{ name: 'manage:DataApp' }],
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:DataApp@space',
         description:
             'Create, edit, and delete data apps in spaces where you have editor or admin access',

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -330,6 +330,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'DataApp', {
             organizationUuid,
         });
+        can('manage', 'DataAppDependency', {
+            organizationUuid,
+        });
         can('manage', 'ExternalConnection', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -33,6 +33,7 @@ export type CaslSubjectNames =
     | 'CustomSql'
     | 'CustomSqlTableCalculations'
     | 'DataApp'
+    | 'DataAppDependency'
     | 'Dashboard'
     | 'DeployProject'
     | 'DashboardComments'


### PR DESCRIPTION
Adds a role gate: uploading an app with **custom npm dependencies** now requires a dedicated `manage:DataAppDependency` scope — **admins only by default** — a level above the `create`/`manage:DataApp` needed to upload a template-only app. Rationale: adding dependencies is a supply-chain capability, so it shouldn't ride on the basic app-upload permission.

## Enforcement

`importAppCode` checks `manage:DataAppDependency` (403 `ForbiddenError`) **before** the instance/org gates, but only when the upload declares custom deps above the template. Template-only uploads are unaffected — any interactive_viewer+ can still push those.

## New CASL subject, wired across every authorization layer (per the `ld-permissions` checklist)

- `types.ts` — `DataAppDependency` added to `CaslSubjectNames`.
- `scopes.ts` — `manage:DataAppDependency` scope (group AI, depends on `manage:DataApp`), so custom roles can grant it too.
- `projectMemberAbility.ts` / `organizationMemberAbility.ts` — granted in the **admin** roles only.
- `roleToScopeMapping.ts` — added to `ADMIN` (keeps the parity test green).
- `serviceAccountAbility.ts` — granted to `ORG_ADMIN` so CI/CD service accounts that run `lightdash upload` aren't broken.

**Additive scope — no `scoped_roles` migration needed** (existing custom roles simply don't have it; only admins do by default). Because it's a real scope, an org can later grant it to a custom role without a code change.

Tests: non-admin rejected with custom deps; template-only upload still allowed for a non-admin; admin path unaffected. Authorization parity + scope tests green.

Relates: GLITCH-558

🤖 Generated with [Claude Code](https://claude.com/claude-code)