### PR TITLE
fix: track AI context tokens for compaction

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -994,9 +994,7 @@ export const generateAgentResponse = async ({
             promptUuid: args.promptUuid,
             response: result.text,
             tokenUsage: {
-                // All-steps total (matches the ai.usage stream). `usage` is
-                // last-step only and undercounts multi-step tool-calling runs.
-                totalTokens: result.totalUsage.totalTokens ?? 0,
+                totalTokens: result.usage.totalTokens ?? 0,
             },
         });
 
@@ -1344,10 +1342,6 @@ export const streamAgentResponse = async ({
 
                 const stepCapReached = steps.length >= STEP_CAP;
 
-                // All-steps total (matches the ai.usage stream). `usage` is
-                // last-step only and undercounts multi-step tool-calling runs.
-                const promptTotalTokens = totalUsage.totalTokens ?? 0;
-
                 if (stepCapReached && !completeResponse) {
                     void dependencies.updatePrompt({
                         promptUuid: args.promptUuid,
@@ -1355,7 +1349,7 @@ export const streamAgentResponse = async ({
                             new AiAgentStepCapReachedError(steps.length),
                         ),
                         tokenUsage: {
-                            totalTokens: promptTotalTokens,
+                            totalTokens: usage.totalTokens ?? 0,
                         },
                     });
                 } else {
@@ -1363,7 +1357,7 @@ export const streamAgentResponse = async ({
                         response: completeResponse,
                         promptUuid: args.promptUuid,
                         tokenUsage: {
-                            totalTokens: promptTotalTokens,
+                            totalTokens: usage.totalTokens ?? 0,
                         },
                     });
                 }
@@ -1380,7 +1374,7 @@ export const streamAgentResponse = async ({
                         projectId: args.agentSettings.projectUuid,
                         aiAgentId: args.agentSettings.uuid,
                         agentName: args.agentSettings.name,
-                        usageTokensCount: promptTotalTokens,
+                        usageTokensCount: totalUsage.totalTokens ?? 0,
                         stepsCount: steps.length,
                         model:
                             typeof args.model === 'string'


### PR DESCRIPTION
## Summary

- Persist last-step usage for compaction context tracking.
- Keep aggregate `totalUsage` for analytics reporting.

## Testing

- Targeted `agentV2` test
- Backend `typecheck:fast`

Closes: PROD-8790
Closes: #25401