### PR TITLE
feat(frontend): generate dashboard export/preview images via async job

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -2133,6 +2133,7 @@ export class UnfurlService extends BaseService {
                             context,
                             contextId,
                             selectedTabs,
+                            sendNowSchedulerDashboardFilters,
                             sendNowSchedulerFilters,
                             sendNowSchedulerParameters,
                             outputFormat,

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -23,14 +23,13 @@ import {
     IconScreenshot,
 } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
-import { useLocation } from 'react-router';
 import { PreviewAndCustomizeScreenshot } from '../../../features/preview';
 import { CsvFormattingOptions } from '../../../features/scheduler/components/CsvFormattingOptions';
 import { Limit, Values } from '../../../features/scheduler/components/types';
 import { CUSTOM_WIDTH_OPTIONS } from '../../../features/scheduler/constants';
 import {
     useExportDashboardContent,
-    useExportDashboard,
+    useExportDashboardContentPreview,
 } from '../../../hooks/dashboard/useDashboard';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import Callout from '../Callout';
@@ -54,7 +53,6 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     const [exportType, setExportType] = useState<
         SchedulerFormat.IMAGE | SchedulerFormat.CSV | SchedulerFormat.XLSX
     >(SchedulerFormat.IMAGE);
-    const location = useLocation();
     const exportDashboardContentMutation = useExportDashboardContent();
     const dashboardFilters = useDashboardContext((c) => c.allFilters);
     const dateZoomGranularity = useDashboardContext(
@@ -65,7 +63,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     const [previewChoice, setPreviewChoice] = useState<
         (typeof CUSTOM_WIDTH_OPTIONS)[number]['value'] | undefined
     >(CUSTOM_WIDTH_OPTIONS[1].value);
-    const exportDashboardMutation = useExportDashboard();
+    const exportPreviewMutation = useExportDashboardContentPreview();
 
     const [formatted, setFormatted] = useState<Values>(Values.FORMATTED);
     const [limit, setLimit] = useState<Limit>(Limit.TABLE);
@@ -132,14 +130,8 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
             format: exportType,
             options:
                 exportType === SchedulerFormat.IMAGE ? {} : getCsvOptions(),
-            dashboardFilters:
-                exportType === SchedulerFormat.IMAGE
-                    ? undefined
-                    : dashboardFilters,
-            dateZoomGranularity:
-                exportType === SchedulerFormat.IMAGE
-                    ? undefined
-                    : dateZoomGranularity,
+            dashboardFilters,
+            dateZoomGranularity,
             customViewportWidth:
                 exportType === SchedulerFormat.IMAGE && previewChoice
                     ? parseInt(previewChoice)
@@ -165,32 +157,17 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
             return;
         }
 
-        const queryParams = new URLSearchParams(location.search);
-
-        exportDashboardMutation.mutate({
-            dashboard,
-            gridWidth: undefined,
-            queryFilters: `?${queryParams.toString()}`,
-            selectedTabs: exportSelectedTabs,
-        });
-    }, [
-        dashboard,
-        exportDashboardMutation,
-        exportSelectedTabs,
-        getPreviewKey,
-        location.search,
-        previewChoice,
-        previews,
-    ]);
+        handleAsyncExport();
+    }, [getPreviewKey, handleAsyncExport, previewChoice, previews]);
 
     const handlePreviewClick = useCallback(async () => {
-        const queryParams = new URLSearchParams(location.search);
-
-        const url = await exportDashboardMutation.mutateAsync({
+        const url = await exportPreviewMutation.mutateAsync({
             dashboard,
-            gridWidth: previewChoice ? parseInt(previewChoice) : undefined,
-            queryFilters: `?${queryParams.toString()}`,
-            isPreview: true,
+            customViewportWidth: previewChoice
+                ? parseInt(previewChoice)
+                : undefined,
+            dashboardFilters,
+            dateZoomGranularity,
             selectedTabs: exportSelectedTabs,
         });
 
@@ -203,10 +180,11 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
         }
     }, [
         dashboard,
-        exportDashboardMutation,
+        dashboardFilters,
+        dateZoomGranularity,
+        exportPreviewMutation,
         exportSelectedTabs,
         getPreviewKey,
-        location.search,
         previewChoice,
     ]);
 
@@ -239,7 +217,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
 
         return (
             <Button
-                loading={exportDashboardMutation.isLoading}
+                loading={exportDashboardContentMutation.isLoading}
                 onClick={handleImageExport}
                 disabled={!hasTilesInSelectedTabs()}
                 leftSection={
@@ -399,7 +377,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                     <Stack gap="xs">
                         <PreviewAndCustomizeScreenshot
                             containerWidth={gridWidth}
-                            exportMutation={exportDashboardMutation}
+                            isLoading={exportPreviewMutation.isLoading}
                             previewChoice={previewChoice}
                             setPreviewChoice={setPreviewChoice}
                             onPreviewClick={handlePreviewClick}

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -1,4 +1,3 @@
-import { type ApiError, type Dashboard } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -17,24 +16,13 @@ import {
     IconEye,
     IconEyeClosed,
 } from '@tabler/icons-react';
-import { type UseMutationResult } from '@tanstack/react-query';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { CUSTOM_WIDTH_OPTIONS } from '../../scheduler/constants';
 
 type PreviewAndCustomizeScreenshotProps = {
     containerWidth?: number | undefined;
-    exportMutation: UseMutationResult<
-        string,
-        ApiError,
-        {
-            dashboard: Dashboard;
-            gridWidth: number | undefined;
-            queryFilters: string;
-            isPreview?: boolean | undefined;
-            selectedTabs: string[] | null;
-        }
-    >;
+    isLoading: boolean;
     previewChoice: (typeof CUSTOM_WIDTH_OPTIONS)[number]['value'] | undefined;
     setPreviewChoice: (
         prev: (typeof CUSTOM_WIDTH_OPTIONS)[number]['value'] | undefined,
@@ -48,7 +36,7 @@ export const PreviewAndCustomizeScreenshot: FC<
     PreviewAndCustomizeScreenshotProps
 > = ({
     containerWidth,
-    exportMutation,
+    isLoading,
     previewChoice,
     setPreviewChoice,
     onPreviewClick,
@@ -59,7 +47,7 @@ export const PreviewAndCustomizeScreenshot: FC<
 
     return (
         <Box>
-            <LoadingOverlay visible={exportMutation.isLoading} />
+            <LoadingOverlay visible={isLoading} />
 
             <Stack>
                 <Flex align="flex-start" justify="space-between">

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerPreviewPanel.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerPreviewPanel.tsx
@@ -32,7 +32,7 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useState, type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { useExportDashboard } from '../../../../../hooks/dashboard/useDashboard';
+import { useExportDashboardContentPreview } from '../../../../../hooks/dashboard/useDashboard';
 import { CUSTOM_WIDTH_OPTIONS } from '../../../constants';
 import { useSchedulerFormContext } from '../schedulerFormContext';
 import classes from './SchedulerDeliveryModal.module.css';
@@ -199,7 +199,7 @@ export const SchedulerPreviewPanel: FC<Props> = ({
               ? IconChartBar
               : IconTable;
 
-    const exportDashboardMutation = useExportDashboard();
+    const exportPreviewMutation = useExportDashboardContentPreview();
     const [previewUrl, setPreviewUrl] = useState<string>();
     const [isEnlarged, setIsEnlarged] = useState(false);
 
@@ -208,31 +208,26 @@ export const SchedulerPreviewPanel: FC<Props> = ({
 
     const handleGenerate = useCallback(async () => {
         if (!dashboard) return;
-        let queryFilters = '';
-        if (form.values.dashboardFilters) {
-            const overriddenDimensions = applyDimensionOverrides(
-                dashboard.filters,
-                form.values.dashboardFilters,
-            );
-            queryFilters = `?filters=${encodeURIComponent(
-                JSON.stringify({
-                    dimensions: overriddenDimensions,
-                    metrics: [],
-                    tableCalculations: [],
-                }),
-            )}`;
-        }
-        const url = await exportDashboardMutation.mutateAsync({
+        const dashboardFilters = form.values.dashboardFilters
+            ? {
+                  dimensions: applyDimensionOverrides(
+                      dashboard.filters,
+                      form.values.dashboardFilters,
+                  ),
+                  metrics: [],
+                  tableCalculations: [],
+              }
+            : undefined;
+        const url = await exportPreviewMutation.mutateAsync({
             dashboard,
-            gridWidth: parseInt(widthChoice),
-            queryFilters,
-            isPreview: true,
+            customViewportWidth: parseInt(widthChoice),
+            dashboardFilters,
             selectedTabs: form.values.selectedTabs ?? null,
         });
         if (url) setPreviewUrl(url);
     }, [
         dashboard,
-        exportDashboardMutation,
+        exportPreviewMutation,
         widthChoice,
         form.values.dashboardFilters,
         form.values.selectedTabs,
@@ -249,7 +244,7 @@ export const SchedulerPreviewPanel: FC<Props> = ({
                         leftSection={
                             <MantineIcon icon={IconRefresh} size="sm" />
                         }
-                        loading={exportDashboardMutation.isLoading}
+                        loading={exportPreviewMutation.isLoading}
                         onClick={handleGenerate}
                     >
                         Regenerate
@@ -293,7 +288,7 @@ export const SchedulerPreviewPanel: FC<Props> = ({
                                                             variant="default"
                                                             size="xs"
                                                             loading={
-                                                                exportDashboardMutation.isLoading
+                                                                exportPreviewMutation.isLoading
                                                             }
                                                             onClick={
                                                                 handleGenerate

--- a/packages/frontend/src/hooks/dashboard/useDashboard.test.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.test.tsx
@@ -1,0 +1,125 @@
+import { SchedulerFormat, type Dashboard } from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { vi, type Mock } from 'vitest';
+
+vi.mock('../../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+vi.mock('../../features/scheduler/hooks/useScheduler', () => ({
+    pollJobStatus: vi.fn(),
+}));
+
+vi.mock('../toaster/useToaster', () => ({
+    default: () => ({
+        showToastInfo: vi.fn(),
+        showToastSuccess: vi.fn(),
+        showToastError: vi.fn(),
+        showToastWarning: vi.fn(),
+        showToastApiError: vi.fn(),
+    }),
+}));
+
+vi.mock('../../providers/App/useApp', () => ({
+    default: () => ({ user: { data: undefined } }),
+}));
+
+vi.mock('../useQueryError', () => ({
+    default: () => vi.fn(),
+}));
+
+vi.mock('./useDashboardStorage', () => ({
+    default: () => ({ clearDashboardStorage: vi.fn() }),
+}));
+
+vi.mock('react-router', () => ({
+    useNavigate: () => vi.fn(),
+    useParams: () => ({}),
+}));
+
+import { lightdashApi } from '../../api';
+import { pollJobStatus } from '../../features/scheduler/hooks/useScheduler';
+import { useExportDashboardContentPreview } from './useDashboard';
+
+const mockApi = lightdashApi as unknown as Mock;
+const mockPollJobStatus = pollJobStatus as unknown as Mock;
+
+const dashboard = {
+    uuid: 'dashboard-uuid',
+    name: 'My dashboard',
+} as Dashboard;
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+}
+
+describe('useExportDashboardContentPreview', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('schedules an async image export and resolves with the preview url', async () => {
+        mockApi.mockResolvedValue({ jobId: 'job-1' });
+        mockPollJobStatus.mockResolvedValue({
+            url: 'https://example.com/preview.png',
+            fileType: 'image',
+        });
+
+        const { result } = renderHook(
+            () => useExportDashboardContentPreview(),
+            { wrapper: createWrapper() },
+        );
+
+        const url = await result.current.mutateAsync({
+            dashboard,
+            customViewportWidth: 1400,
+            selectedTabs: ['tab-1'],
+        });
+
+        expect(url).toBe('https://example.com/preview.png');
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: `/dashboards/${dashboard.uuid}/exports`,
+                version: 'v2',
+                method: 'POST',
+            }),
+        );
+        const body = JSON.parse(mockApi.mock.calls[0][0].body);
+        expect(body).toEqual(
+            expect.objectContaining({
+                format: SchedulerFormat.IMAGE,
+                customViewportWidth: 1400,
+                selectedTabs: ['tab-1'],
+            }),
+        );
+        expect(mockPollJobStatus).toHaveBeenCalledWith('job-1');
+    });
+
+    it('rejects when the job completes without a url', async () => {
+        mockApi.mockResolvedValue({ jobId: 'job-2' });
+        mockPollJobStatus.mockResolvedValue(null);
+
+        const { result } = renderHook(
+            () => useExportDashboardContentPreview(),
+            { wrapper: createWrapper() },
+        );
+
+        await expect(
+            result.current.mutateAsync({ dashboard }),
+        ).rejects.toThrow();
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+});

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -1,5 +1,6 @@
 import {
     formatDate,
+    SchedulerFormat,
     type ApiError,
     type ApiJobScheduledResponse,
     type CreateDashboard,
@@ -110,18 +111,6 @@ const postEmbedDashboardsAvailableFilters = async (
         body: JSON.stringify(savedChartUuidsAndTileUuids),
     });
 
-const exportDashboard = async (
-    id: string,
-    gridWidth: number | undefined,
-    queryFilters: string,
-    selectedTabs: string[] | null,
-) =>
-    lightdashApi<string>({
-        url: `/dashboards/${id}/export`,
-        method: 'POST',
-        body: JSON.stringify({ queryFilters, gridWidth, selectedTabs }),
-    });
-
 export const useDashboardsAvailableFilters = (
     savedChartUuidsAndTileUuids: SavedChartsInfoForDashboardAvailableFilters,
     projectUuid?: string,
@@ -218,62 +207,6 @@ export const useDashboardVersionRefresh = (
             }
         },
     });
-};
-
-export const useExportDashboard = () => {
-    const { showToastSuccess, showToastApiError, showToastInfo } = useToaster();
-    return useMutation<
-        string,
-        ApiError,
-        {
-            dashboard: Dashboard;
-            gridWidth: number | undefined;
-            queryFilters: string;
-            isPreview?: boolean;
-            selectedTabs: string[] | null;
-        }
-    >(
-        (data) =>
-            exportDashboard(
-                data.dashboard.uuid,
-                data.gridWidth,
-                data.queryFilters,
-                data.selectedTabs,
-            ),
-        {
-            mutationKey: ['export_dashboard'],
-            onMutate: (data) => {
-                showToastInfo({
-                    key: 'dashboard_export_toast',
-                    title: data.isPreview
-                        ? `Generating preview for ${data.dashboard.name}`
-                        : `${data.dashboard.name} is being exported. This might take a few seconds.`,
-                    autoClose: false,
-                    loading: true,
-                });
-            },
-            onSuccess: async (url, data) => {
-                if (url) {
-                    if (!data.isPreview) window.open(url, '_blank');
-                    showToastSuccess({
-                        key: 'dashboard_export_toast',
-                        title: data.isPreview
-                            ? 'Success!'
-                            : `Success! ${data.dashboard.name} was exported.`,
-                    });
-                }
-            },
-            onError: ({ error }, data) => {
-                showToastApiError({
-                    key: 'dashboard_export_toast',
-                    title: data.isPreview
-                        ? `Failed to generate preview for ${data.dashboard.name}`
-                        : `Failed to export ${data.dashboard.name}`,
-                    apiError: error,
-                });
-            },
-        },
-    );
 };
 
 const exportDashboardContent = async (
@@ -398,6 +331,81 @@ export const useExportDashboardContent = () => {
                     title: `Failed to export ${data.dashboard.name}`,
                     apiError: error,
                 });
+            },
+        },
+    );
+};
+
+// Preview generation goes through the async EXPORT_CONTENT job instead of the
+// synchronous export endpoint, so heavy dashboards don't hold an HTTP request
+// open until the gateway times out.
+export const useExportDashboardContentPreview = () => {
+    const {
+        showToastInfo,
+        showToastSuccess,
+        showToastError,
+        showToastApiError,
+    } = useToaster();
+
+    return useMutation<
+        string,
+        ApiError | Error,
+        {
+            dashboard: Dashboard;
+            dashboardFilters?: DashboardFilters;
+            dateZoomGranularity?: DateGranularity | string;
+            customViewportWidth?: number;
+            selectedTabs?: string[] | null;
+        }
+    >(
+        async (data) => {
+            const job = await exportDashboardContent(data.dashboard.uuid, {
+                format: SchedulerFormat.IMAGE,
+                options: {},
+                dashboardFilters: data.dashboardFilters,
+                dateZoomGranularity: data.dateZoomGranularity,
+                customViewportWidth: data.customViewportWidth,
+                selectedTabs: data.selectedTabs,
+            });
+            const details = (await pollJobStatus(
+                job.jobId,
+            )) as DashboardContentExportDetails | null;
+            if (!details?.url) {
+                throw new Error('Preview generation returned no image');
+            }
+            return details.url;
+        },
+        {
+            mutationKey: ['export_dashboard_preview'],
+            onMutate: (data) => {
+                showToastInfo({
+                    key: 'dashboard_export_toast',
+                    title: `Generating preview for ${data.dashboard.name}`,
+                    autoClose: false,
+                    loading: true,
+                });
+            },
+            onSuccess: () => {
+                showToastSuccess({
+                    key: 'dashboard_export_toast',
+                    title: 'Success!',
+                });
+            },
+            onError: (error, data) => {
+                const title = `Failed to generate preview for ${data.dashboard.name}`;
+                if ('error' in error) {
+                    showToastApiError({
+                        key: 'dashboard_export_toast',
+                        title,
+                        apiError: error.error,
+                    });
+                } else {
+                    showToastError({
+                        key: 'dashboard_export_toast',
+                        title,
+                        subtitle: error.message,
+                    });
+                }
             },
         },
     );


### PR DESCRIPTION
## Problem

Dashboard image exports and previews (the "Export dashboard" modal and the scheduled-deliveries preview panel) called the synchronous `POST /api/v1/dashboards/:uuid/export`, holding the HTTP request open while a headless browser rendered every tile across all selected tabs and took a screenshot. On dashboards with slow warehouse queries this takes minutes, so the request dies at the gateway (504) even when the screenshot would eventually succeed.

## Solution

Route image exports and previews through the existing async `EXPORT_CONTENT` worker job (`POST /api/v2/dashboards/:uuid/exports` + job polling), which the modal already used for CSV/XLSX. Frontend-only — the backend path already supported `format: IMAGE` with `selectedTabs`, `customViewportWidth`, and `dashboardFilters`.

- New `useExportDashboardContentPreview` hook: schedules the job, polls via `pollJobStatus`, and resolves with the image URL (no auto-download, preview-worded toasts). Covers `isLoading` for the whole job so existing loading states keep working.
- `SchedulerPreviewPanel` and the export modal's preview swap the sync mutation for it. The scheduler panel's filter override handling gets simpler: it passes the `DashboardFilters` object directly instead of serializing it into a URL query string.
- The modal's real image export now goes through the same `handleAsyncExport` as CSV/XLSX, and image exports/previews now pass `dashboardFilters` + `dateZoomGranularity` (previously carried via `location.search` on the sync path; the async IMAGE branch dropped them).
- `PreviewAndCustomizeScreenshot` takes a plain `isLoading` prop instead of a whole mutation object.
- Removes the now-unused sync `useExportDashboard` hook. The backend endpoint stays; deprecating it is a follow-up.

## Verification

- Unit tests for the new hook (schedules v2 export, polls the job, resolves the URL; rejects when the job returns no URL).
- Verified live in the dev app: both the export-modal preview and the scheduled-delivery preview now issue `POST /api/v2/dashboards/:uuid/exports` followed by `GET /api/v1/schedulers/job/:id/status` polling, and render the resulting image in place.

Note: the worker reuses the same screenshot timeout and retry logic, so this alone doesn't reduce warehouse load for slow dashboards — that's addressed by #25397 / PR #25399 (configurable screenshot timeout).

Closes: PROD-8789
Closes: #25398
