### PR TITLE
feat: embed dashboard scheduled delivery

### DIFF
--- a/packages/backend/src/ee/controllers/embedController.test.ts
+++ b/packages/backend/src/ee/controllers/embedController.test.ts
@@ -1,0 +1,106 @@
+import {
+    ForbiddenError,
+    SchedulerFormat,
+    type Account,
+    type SessionUser,
+} from '@lightdash/common';
+import express from 'express';
+import { EmbedController } from './embedController';
+
+const embedWriteUser = {
+    userUuid: 'embed-write-user-uuid',
+} as SessionUser;
+
+const buildRequest = (
+    recipients: string[],
+    writeUser: SessionUser = embedWriteUser,
+) =>
+    ({
+        account: {
+            isJwtUser: () => true,
+            authentication: {
+                type: 'jwt',
+                data: {
+                    content: {
+                        type: 'dashboard',
+                        projectUuid: 'project-uuid',
+                        dashboardUuid: 'dashboard-uuid',
+                        scheduledDeliveryRecipients: recipients,
+                    },
+                    writeActions: {
+                        userUuid: writeUser.userUuid,
+                        spaceUuid: 'space-uuid',
+                    },
+                },
+            },
+            access: {
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-uuid',
+                    chartUuids: [],
+                    explores: [],
+                },
+            },
+            embedWriteUser: writeUser,
+        } as unknown as Account,
+    }) as express.Request;
+
+describe('EmbedController scheduled deliveries', () => {
+    const sendScheduler = vi.fn().mockResolvedValue({ jobId: 'job-uuid' });
+    const controller = new EmbedController({
+        getSchedulerService: () => ({ sendScheduler }),
+    } as unknown as ConstructorParameters<typeof EmbedController>[0]);
+    controller.setStatus = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('queues an image delivery to a recipient allowed by the embed token', async () => {
+        const result = await controller.sendEmbedDashboardDelivery(
+            buildRequest(['viewer@example.com']),
+            'project-uuid',
+            { recipient: 'viewer@example.com' },
+        );
+
+        expect(sendScheduler).toHaveBeenCalledWith(
+            embedWriteUser,
+            expect.objectContaining({
+                dashboardUuid: 'dashboard-uuid',
+                enabled: true,
+                format: SchedulerFormat.IMAGE,
+                includeLinks: false,
+                targets: [{ recipient: 'viewer@example.com' }],
+            }),
+        );
+        expect(result.results.jobId).toBe('job-uuid');
+    });
+
+    it('rejects recipients that are not in the embed token', async () => {
+        await expect(
+            controller.sendEmbedDashboardDelivery(
+                buildRequest(['viewer@example.com']),
+                'project-uuid',
+                { recipient: 'other@example.com' },
+            ),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(sendScheduler).not.toHaveBeenCalled();
+    });
+
+    it('rejects service account actors that cannot render through browser sessions', async () => {
+        await expect(
+            controller.sendEmbedDashboardDelivery(
+                buildRequest(['viewer@example.com'], {
+                    ...embedWriteUser,
+                    serviceAccount: {
+                        uuid: 'service-account-uuid',
+                        description: 'Embed actions',
+                    },
+                }),
+                'project-uuid',
+                { recipient: 'viewer@example.com' },
+            ),
+        ).rejects.toThrow('Dashboard deliveries require writeActions.userUuid');
+        expect(sendScheduler).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -17,6 +17,7 @@ import {
     CommonEmbedJwtContent,
     CreateEmbedJwt,
     CreateEmbedRequestBody,
+    CreateSchedulerAndTargets,
     Dashboard,
     DashboardAvailableFilters,
     DashboardFilters,
@@ -30,12 +31,14 @@ import {
     FieldValueSearchResult,
     ForbiddenError,
     GetEmbedDashboardRequest,
+    isDashboardContent,
     Item,
     MetricQueryResponse,
     OrganizationColorPalette,
     ParametersValuesMap,
     SavedChart,
     SavedChartsInfoForDashboardAvailableFilters,
+    SchedulerFormat,
     SortField,
     UpdateEmbed,
 } from '@lightdash/common';
@@ -55,6 +58,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { getAccountWriteContext } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     getDeprecatedRouteMiddleware,
@@ -261,6 +265,68 @@ export class EmbedController extends BaseController {
                 req.account,
                 { paletteUuid: body?.paletteUuid },
             ),
+        };
+    }
+
+    @SuccessResponse('200', 'Success')
+    @Post('/dashboard/send')
+    @OperationId('sendEmbedDashboardDelivery')
+    async sendEmbedDashboardDelivery(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: { recipient: string },
+    ): Promise<{
+        status: 'ok';
+        results: { jobId: string };
+    }> {
+        this.setStatus(200);
+        assertEmbeddedAuth(req.account);
+
+        const tokenContent = req.account.authentication.data.content;
+        if (!isDashboardContent(tokenContent)) {
+            throw new ForbiddenError('Not authorized for dashboard content');
+        }
+
+        const recipients = tokenContent.scheduledDeliveryRecipients ?? [];
+        if (!recipients.includes(body.recipient)) {
+            throw new ForbiddenError('Delivery destination is not allowed');
+        }
+
+        const { dashboardUuid } = req.account.access.content;
+        if (!dashboardUuid) {
+            throw new ForbiddenError('Dashboard is not available');
+        }
+
+        const { user } = getAccountWriteContext(req.account);
+        if (user.serviceAccount) {
+            throw new ForbiddenError(
+                'Dashboard deliveries require writeActions.userUuid',
+            );
+        }
+
+        const scheduler = {
+            name: 'Embedded dashboard delivery',
+            format: SchedulerFormat.IMAGE,
+            cron: '0 0 1 1 *',
+            timezone: 'UTC',
+            savedChartUuid: null,
+            dashboardUuid,
+            savedSqlUuid: null,
+            appUuid: null,
+            appName: null,
+            projectUuid,
+            options: { withPdf: false },
+            enabled: true,
+            includeLinks: false,
+            targets: [{ recipient: body.recipient }],
+            createdBy: user.userUuid,
+        } satisfies CreateSchedulerAndTargets;
+
+        return {
+            status: 'ok',
+            results: await this.services
+                .getSchedulerService()
+                .sendScheduler(user, scheduler),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2564,6 +2564,10 @@ const models: TsoaRoute.Models = {
                         },
                     },
                 },
+                scheduledDeliveryRecipients: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
                 isPreview: { dataType: 'boolean' },
                 projectUuid: { dataType: 'string' },
                 type: {
@@ -48384,6 +48388,74 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getEmbedDashboard',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsEmbedController_sendEmbedDashboardDelivery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                recipient: { dataType: 'string', required: true },
+            },
+        },
+    };
+    app.post(
+        '/api/v1/embed/:projectUuid/dashboard/send',
+        ...fetchMiddlewares<RequestHandler>(EmbedController),
+        ...fetchMiddlewares<RequestHandler>(
+            EmbedController.prototype.sendEmbedDashboardDelivery,
+        ),
+
+        async function EmbedController_sendEmbedDashboardDelivery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsEmbedController_sendEmbedDashboardDelivery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<EmbedController>(EmbedController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'sendEmbedDashboardDelivery',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2564,6 +2564,12 @@
                         "required": ["enabled"],
                         "type": "object"
                     },
+                    "scheduledDeliveryRecipients": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "isPreview": {
                         "type": "boolean"
                     },

--- a/packages/common/src/ee/embed/index.test.ts
+++ b/packages/common/src/ee/embed/index.test.ts
@@ -52,6 +52,36 @@ describe('EmbedJwtSchema canAddFilters', () => {
     });
 });
 
+describe('EmbedJwtSchema scheduled delivery recipients', () => {
+    it('accepts email destinations on dashboard tokens', () => {
+        expect(
+            EmbedJwtSchema.parse({
+                ...baseJwt,
+                content: {
+                    ...baseJwt.content,
+                    scheduledDeliveryRecipients: ['viewer@example.com'],
+                },
+            }).content,
+        ).toEqual(
+            expect.objectContaining({
+                scheduledDeliveryRecipients: ['viewer@example.com'],
+            }),
+        );
+    });
+
+    it('rejects invalid email destinations', () => {
+        expect(() =>
+            EmbedJwtSchema.parse({
+                ...baseJwt,
+                content: {
+                    ...baseJwt.content,
+                    scheduledDeliveryRecipients: ['not-an-email'],
+                },
+            }),
+        ).toThrow();
+    });
+});
+
 describe('canAddDashboardFiltersInEmbed', () => {
     const cases: Array<{
         name: string;

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -150,6 +150,9 @@ export const EmbedJwtSchema = z
                     projectUuid: z.string().optional(),
                     dashboardUuid: z.string(),
                     isPreview: z.boolean().optional(),
+                    scheduledDeliveryRecipients: z
+                        .array(z.string().email())
+                        .optional(),
                 })
                 .merge(InteractivityOptionsSchema),
             z
@@ -158,6 +161,9 @@ export const EmbedJwtSchema = z
                     projectUuid: z.string().optional(),
                     dashboardSlug: z.string(),
                     isPreview: z.boolean().optional(),
+                    scheduledDeliveryRecipients: z
+                        .array(z.string().email())
+                        .optional(),
                 })
                 .merge(InteractivityOptionsSchema),
             z
@@ -206,6 +212,7 @@ export type CommonEmbedJwtContent = {
     type: 'dashboard';
     projectUuid?: string;
     isPreview?: boolean;
+    scheduledDeliveryRecipients?: string[];
     dashboardFiltersInteractivity?: {
         enabled: FilterInteractivityValues | boolean;
         allowedFilters?: string[] | null;

--- a/packages/frontend/sdk/index.test.tsx
+++ b/packages/frontend/sdk/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -139,6 +139,7 @@ import { FilterOperator } from '@lightdash/common';
 import {
     AiAgent,
     Dashboard,
+    DashboardDelivery,
     MetricsCatalog,
     createLightdashApiClient,
 } from './index';
@@ -442,6 +443,65 @@ describe('SDK metrics catalog', () => {
         });
 
         expect(mockNavigate).not.toHaveBeenCalled();
+    });
+});
+
+describe('SDK dashboard delivery', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('queues a report for a recipient preset in the embed token', async () => {
+        const token = [
+            btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })),
+            btoa(
+                JSON.stringify({
+                    content: {
+                        type: 'dashboard',
+                        projectUuid: 'test-project-uuid',
+                        dashboardUuid: 'test-dashboard-uuid',
+                        scheduledDeliveryRecipients: ['viewer@example.com'],
+                    },
+                }),
+            ),
+            'signature',
+        ].join('.');
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    status: 'ok',
+                    results: { jobId: 'job-uuid' },
+                }),
+                { status: 200 },
+            ),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(
+            <DashboardDelivery
+                token={token}
+                instanceUrl="https://example.lightdash.cloud"
+            />,
+        );
+
+        fireEvent.click(
+            await screen.findByRole('button', { name: 'Send report' }),
+        );
+
+        await screen.findByText('Report queued for viewer@example.com');
+        expect(fetchMock).toHaveBeenCalledWith(
+            new URL(
+                'https://example.lightdash.cloud/api/v1/embed/test-project-uuid/dashboard/send',
+            ),
+            expect.objectContaining({
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'lightdash-embed-token': token,
+                },
+                body: JSON.stringify({ recipient: 'viewer@example.com' }),
+            }),
+        );
     });
 });
 

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -2,10 +2,12 @@ import '@mantine-8/core/styles.css';
 import {
     FilterOperator,
     getErrorMessage,
+    JWT_HEADER_NAME,
     type EmbedDashboard as EmbedDashboardType,
     type LanguageMap,
     type SavedChart,
 } from '@lightdash/common';
+import { Button, Select, Stack, Text } from '@mantine-8/core';
 import { ModalsProvider } from '@mantine/modals';
 import {
     useEffect,
@@ -133,6 +135,7 @@ const useEmbedTokenContext = (
     const [tokenContext, setTokenContext] = useState<{
         token: string;
         projectUuid: string;
+        scheduledDeliveryRecipients: string[];
     } | null>(null);
 
     useEffect(() => {
@@ -158,6 +161,16 @@ const useEmbedTokenContext = (
                         setTokenContext({
                             token: tokenToDecode,
                             projectUuid: payload.content.projectUuid,
+                            scheduledDeliveryRecipients: Array.isArray(
+                                payload.content.scheduledDeliveryRecipients,
+                            )
+                                ? payload.content.scheduledDeliveryRecipients.filter(
+                                      (
+                                          recipient: unknown,
+                                      ): recipient is string =>
+                                          typeof recipient === 'string',
+                                  )
+                                : [],
                         });
                     }
                 } else {
@@ -366,6 +379,121 @@ const Dashboard: FC<DashboardProps> = ({
                 />
             </EmbedProvider>
         </SdkProviders>
+    );
+};
+
+type DashboardDeliveryProps = Pick<
+    BaseProps,
+    'instanceUrl' | 'theme' | 'token'
+>;
+
+const DashboardDeliveryContent: FC<{
+    instanceUrl: string;
+    projectUuid: string;
+    recipients: string[];
+    token: string;
+}> = ({ instanceUrl, projectUuid, recipients, token }) => {
+    const [recipient, setRecipient] = useState<string | null>(
+        recipients[0] ?? null,
+    );
+    const [isSending, setIsSending] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const sendReport = async () => {
+        if (!recipient) return;
+
+        setIsSending(true);
+        setMessage(null);
+        setError(null);
+
+        try {
+            const baseUrl = instanceUrl.endsWith('/')
+                ? instanceUrl
+                : `${instanceUrl}/`;
+            const response = await fetch(
+                new URL(`api/v1/embed/${projectUuid}/dashboard/send`, baseUrl),
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        [JWT_HEADER_NAME]: token,
+                    },
+                    body: JSON.stringify({ recipient }),
+                },
+            );
+
+            if (!response.ok) {
+                throw new Error(getErrorMessage(await response.json()));
+            }
+
+            setMessage(`Report queued for ${recipient}`);
+        } catch (sendError) {
+            setError(getErrorMessage(sendError));
+        } finally {
+            setIsSending(false);
+        }
+    };
+
+    if (!recipient) {
+        return <Text size="sm">No delivery destinations configured.</Text>;
+    }
+
+    return (
+        <Stack gap="xs">
+            {recipients.length > 1 ? (
+                <Select
+                    label="Destination"
+                    data={recipients}
+                    value={recipient}
+                    onChange={setRecipient}
+                />
+            ) : (
+                <Text size="sm">Send to {recipient}</Text>
+            )}
+            <Button loading={isSending} onClick={() => void sendReport()}>
+                Send report
+            </Button>
+            {message ? (
+                <Text c="green" size="sm">
+                    {message}
+                </Text>
+            ) : null}
+            {error ? (
+                <Text c="red" size="sm">
+                    {error}
+                </Text>
+            ) : null}
+        </Stack>
+    );
+};
+
+const DashboardDelivery: FC<DashboardDeliveryProps> = ({
+    instanceUrl,
+    theme,
+    token,
+}) => {
+    const tokenContext = useEmbedTokenContext(instanceUrl, token);
+
+    if (!tokenContext) return null;
+
+    return (
+        <MantineProvider
+            withGlobalStyles
+            withNormalizeCSS
+            withCSSVariables
+            notificationsLimit={0}
+            forceColorScheme={theme}
+        >
+            <Mantine8Provider forceColorScheme={theme}>
+                <DashboardDeliveryContent
+                    instanceUrl={instanceUrl}
+                    projectUuid={tokenContext.projectUuid}
+                    recipients={tokenContext.scheduledDeliveryRecipients}
+                    token={tokenContext.token}
+                />
+            </Mantine8Provider>
+        </MantineProvider>
     );
 };
 
@@ -788,6 +916,7 @@ const MetricsCatalog: FC<MetricsCatalogProps> = ({
 const Lightdash = {
     AiAgent,
     Dashboard,
+    DashboardDelivery,
     DashboardBuilder,
     MetricsCatalog,
     Explore,
@@ -803,6 +932,7 @@ export {
     AiAgent,
     Chart,
     Dashboard,
+    DashboardDelivery,
     DashboardBuilder,
     Explore,
     MetricsCatalog,
@@ -820,6 +950,7 @@ export type {
     LightdashSdkApiAuth,
     ListAiAgentThreadsOptions,
     ListContentOptions,
+    DashboardDeliveryProps,
 };
 // ts-unused-exports:disable-next-line
 export default Lightdash;

--- a/packages/sdk-test-app/generate-embed-token.ts
+++ b/packages/sdk-test-app/generate-embed-token.ts
@@ -212,9 +212,12 @@ async function main() {
                 isPreview: false,
                 canDateZoom: false,
                 canExportPagePdf: false,
+                scheduledDeliveryRecipients: [
+                    process.env.DELIVERY_EMAIL || 'demo@lightdash.com',
+                ],
             },
             writeActions: {
-                ...writeActor,
+                userUuid: user.user_uuid,
                 spaceUuid,
             },
             user: {

--- a/packages/sdk-test-app/src/examples/DashboardDeliveryExamplePage.tsx
+++ b/packages/sdk-test-app/src/examples/DashboardDeliveryExamplePage.tsx
@@ -1,0 +1,40 @@
+import Lightdash from '@lightdash/sdk';
+import { ExampleLayout } from '../components/ExampleLayout';
+import type { EmbedConfigState } from '../hooks/useEmbedConfig';
+import { getRepoSourceUrl } from '../lib/repo';
+import { emptyStateBoxStyle, emptyStateStyle } from '../styles';
+
+const sourceUrl = getRepoSourceUrl(
+    'packages/sdk-test-app/src/examples/DashboardDeliveryExamplePage.tsx',
+);
+
+export function DashboardDeliveryExamplePage({
+    embedConfig,
+}: {
+    embedConfig: EmbedConfigState;
+}) {
+    return (
+        <ExampleLayout
+            embedConfig={embedConfig}
+            sourceUrl={sourceUrl}
+            title="Dashboard delivery demo"
+            description="Send the embedded dashboard as an image report to an email destination preset in the signed embed token."
+        >
+            {embedConfig.instanceUrl && embedConfig.token ? (
+                <div style={{ maxWidth: '360px' }}>
+                    <Lightdash.DashboardDelivery
+                        key={embedConfig.remountKey}
+                        instanceUrl={embedConfig.instanceUrl}
+                        token={embedConfig.token}
+                    />
+                </div>
+            ) : (
+                <div style={emptyStateStyle}>
+                    <div style={emptyStateBoxStyle}>
+                        Click <strong>Config</strong> to add your embed URL
+                    </div>
+                </div>
+            )}
+        </ExampleLayout>
+    );
+}

--- a/packages/sdk-test-app/src/examples/examples.tsx
+++ b/packages/sdk-test-app/src/examples/examples.tsx
@@ -3,6 +3,7 @@ import type { EmbedConfigState } from '../hooks/useEmbedConfig';
 import { AiAgentExamplePage } from './AiAgentExamplePage';
 import { ContentCatalogExamplePage } from './ContentCatalogExamplePage';
 import { DashboardBuilderExamplePage } from './DashboardBuilderExamplePage';
+import { DashboardDeliveryExamplePage } from './DashboardDeliveryExamplePage';
 import { FiltersExamplePage } from './FiltersExamplePage';
 import { I18nExamplePage } from './I18nExamplePage';
 import { MetricsCatalogExamplePage } from './MetricsCatalogExamplePage';
@@ -19,6 +20,16 @@ export type ExampleDefinition = {
 };
 
 export const examples: ExampleDefinition[] = [
+    {
+        slug: 'dashboard-delivery',
+        path: '/examples/dashboard-delivery',
+        title: 'Dashboard delivery demo',
+        description:
+            'Send a dashboard report to an email destination preset in the embed token.',
+        sourcePath:
+            'packages/sdk-test-app/src/examples/DashboardDeliveryExamplePage.tsx',
+        component: DashboardDeliveryExamplePage,
+    },
     {
         slug: 'ai-agent',
         path: '/examples/ai-agent',


### PR DESCRIPTION
Closes:

### Description:

Adds a `DashboardDelivery` SDK component that allows embedded dashboard viewers to send a one-time image report to an email address pre-approved in the signed embed JWT.

**Embed token changes:**
- `scheduledDeliveryRecipients` can now be included in dashboard embed JWTs as an array of validated email addresses. The backend and schema validation enforce that only recipients explicitly listed in the token can be targeted.

**New API endpoint:**
- `POST /api/v1/embed/:projectUuid/dashboard/send` accepts a `recipient` email and queues an image delivery via the scheduler. The endpoint enforces that the recipient is in the token's allowlist, that the token is scoped to a dashboard, and that the write actor is a real user (not a service account, since browser-rendered deliveries require a user session).

**New SDK component:**
- `DashboardDelivery` reads the allowed recipients from the decoded embed token and renders a simple UI with a "Send report" button. When there are multiple recipients, a dropdown lets the user select one. Success and error states are shown inline.

**SDK test app:**
- A new `DashboardDeliveryExamplePage` demonstrates the component. The token generator now uses `writeActions.userUuid` directly and supports a `DELIVERY_EMAIL` environment variable to configure the demo recipient.