### PR TITLE
feat(frontend): support negative values in in-cell table bars

### DIFF
--- a/packages/frontend/src/hooks/TableCellBar.tsx
+++ b/packages/frontend/src/hooks/TableCellBar.tsx
@@ -27,7 +27,9 @@ export const TableCellBar = ({
     max,
     color = DEFAULT_BAR_COLOR,
 }: TableCellBarProps) => {
-    const range = max - min;
+    // Scale always includes zero (Excel-style automatic axis) so all-negative
+    // columns don't clamp distinct values to identical full-width bars.
+    const range = Math.max(max, 0) - min;
 
     // Diverging mode only kicks in when the column contains negative values.
     // Positive-only columns keep the original left-anchored bar unchanged.
@@ -68,7 +70,16 @@ export const TableCellBar = ({
         const showZeroLine = zeroPercent > 0 && zeroPercent < 100;
 
         bar = (
-            <Box h={BAR_HEIGHT} style={{ position: 'relative', width: '100%' }}>
+            <Box
+                h={BAR_HEIGHT}
+                style={{
+                    position: 'relative',
+                    width: '100%',
+                    // Clip min-width bars from spilling past the track edge
+                    // when the baseline sits very close to it.
+                    overflow: 'hidden',
+                }}
+            >
                 {showZeroLine && (
                     <Box
                         aria-hidden

--- a/packages/frontend/src/hooks/TableCellBar.tsx
+++ b/packages/frontend/src/hooks/TableCellBar.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from '@mantine-8/core';
+import { type ReactNode } from 'react';
 
 type TableCellBarProps = {
     value: number;
@@ -11,23 +12,110 @@ type TableCellBarProps = {
     color?: string;
 };
 
+const BAR_HEIGHT = '20px';
+const MIN_BAR_WIDTH = '2px';
+const DEFAULT_BAR_COLOR = '#5470c6';
+
+const clamp = (n: number, lo: number, hi: number) =>
+    Math.max(lo, Math.min(hi, n));
+
 export const TableCellBar = ({
     value,
     formatted,
     maxLabel,
     min,
     max,
-    color = '#5470c6',
+    color = DEFAULT_BAR_COLOR,
 }: TableCellBarProps) => {
-    // Calculate bar width percentage
     const range = max - min;
-    const percentage =
-        range > 0
-            ? Math.max(0, Math.min(100, ((value - min) / range) * 100))
-            : 0;
 
-    // Only show bar for positive numbers
-    const showBar = value > 0;
+    // Diverging mode only kicks in when the column contains negative values.
+    // Positive-only columns keep the original left-anchored bar unchanged.
+    const isDiverging = min < 0 && range > 0;
+
+    let bar: ReactNode;
+
+    if (!isDiverging) {
+        // Positive-only (or zero range): left-anchored fill from the far left.
+        const percentage =
+            range > 0 ? clamp(((value - min) / range) * 100, 0, 100) : 0;
+
+        bar =
+            value > 0 ? (
+                <Box
+                    h={BAR_HEIGHT}
+                    w={`${percentage}%`}
+                    bg={color}
+                    maw="100%"
+                    // Always show a visible bar for positive values
+                    miw={MIN_BAR_WIDTH}
+                    style={{ borderRadius: '2px' }}
+                />
+            ) : (
+                <Box />
+            );
+    } else {
+        // Diverging mode: the zero baseline is placed proportionally along the
+        // track (Excel-style "automatic axis"). Positive bars grow right of
+        // zero, negative bars grow left. When every value is negative
+        // (max <= 0) the zero line clamps to the right edge so all bars grow
+        // leftward from it.
+        const zeroPercent = clamp(((0 - min) / range) * 100, 0, 100);
+        const positiveWidth =
+            value > 0 ? clamp((value / range) * 100, 0, 100 - zeroPercent) : 0;
+        const negativeWidth =
+            value < 0 ? clamp((-value / range) * 100, 0, zeroPercent) : 0;
+        const showZeroLine = zeroPercent > 0 && zeroPercent < 100;
+
+        bar = (
+            <Box h={BAR_HEIGHT} style={{ position: 'relative', width: '100%' }}>
+                {showZeroLine && (
+                    <Box
+                        aria-hidden
+                        style={{
+                            position: 'absolute',
+                            left: `${zeroPercent}%`,
+                            top: 0,
+                            bottom: 0,
+                            width: '1px',
+                            transform: 'translateX(-0.5px)',
+                            backgroundColor: 'var(--mantine-color-ldGray-3)',
+                        }}
+                    />
+                )}
+                {value > 0 && (
+                    <Box
+                        h={BAR_HEIGHT}
+                        bg={color}
+                        miw={MIN_BAR_WIDTH}
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            // Left edge sits on the zero line, grows rightward.
+                            left: `${zeroPercent}%`,
+                            width: `${positiveWidth}%`,
+                            borderRadius: '0 2px 2px 0',
+                        }}
+                    />
+                )}
+                {value < 0 && (
+                    <Box
+                        h={BAR_HEIGHT}
+                        bg={color}
+                        miw={MIN_BAR_WIDTH}
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            // Right edge sits on the zero line, grows leftward.
+                            right: `${100 - zeroPercent}%`,
+                            width: `${negativeWidth}%`,
+                            borderRadius: '2px 0 0 2px',
+                        }}
+                    />
+                )}
+            </Box>
+        );
+    }
 
     return (
         <Box
@@ -39,21 +127,7 @@ export const TableCellBar = ({
                 gap: '4px',
             }}
         >
-            {showBar ? (
-                <Box
-                    h="20px"
-                    w={`${percentage}%`}
-                    bg={color}
-                    maw="100%"
-                    // Always show visible bar for positive values
-                    miw="2px"
-                    style={{
-                        borderRadius: '2px',
-                    }}
-                />
-            ) : (
-                <Box />
-            )}
+            {bar}
             {/* Label gutter: when this row isn't the widest, an invisible
                 sizer holds the column's widest label so the gutter width stays
                 constant across every row. The visible label is right-aligned. */}

--- a/packages/frontend/src/hooks/useColumns.test.tsx
+++ b/packages/frontend/src/hooks/useColumns.test.tsx
@@ -119,7 +119,9 @@ describe('getFormattedValueCell - Bar Chart Display', () => {
         expect(style).toContain('background');
     });
 
-    test('should not render bar for negative number', () => {
+    test('renders a left-growing diverging bar for negative values (PROD-8704)', () => {
+        // min=-100, max=100 => zero baseline at 50%. value=-25 => bar width
+        // 12.5% (25/200), anchored with its right edge on the zero line.
         const context = createMockCellContext({
             columnId: 'revenue',
             value: {
@@ -137,20 +139,139 @@ describe('getFormattedValueCell - Bar Chart Display', () => {
         const result = getFormattedValueCell(context);
         const { container } = renderWithMantine(result as React.ReactElement);
 
-        // Should have the grid container but no colored bar for negative numbers
-        const gridContainer = container.querySelector(
-            'div[style*="grid-template-columns"]',
-        );
-        expect(gridContainer).toBeTruthy();
-
-        // Should not have a bar element with width % for negative numbers
         const barElement = container.querySelector(
-            'div[style*="width:"][style*="%"]',
+            'div[style*="width: 12.5%"]',
         );
-        expect(barElement).toBeFalsy();
+        expect(barElement).toBeTruthy();
+
+        const style = barElement?.getAttribute('style') || '';
+        // Right edge pinned to the zero baseline (at 50%), growing leftward
+        expect(style).toContain('right: 50%');
+        expect(style).toContain('background');
+
+        // Zero baseline divider is rendered at 50%
+        const zeroLine = container.querySelector('div[style*="left: 50%"]');
+        expect(zeroLine).toBeTruthy();
 
         // Should still display the formatted value
         expect(screen.getByText('-$25')).toBeInTheDocument();
+    });
+
+    test('renders a right-growing diverging bar anchored at zero for positive values (PROD-8704)', () => {
+        // min=-100, max=100 => zero baseline at 50%. value=25 => bar width
+        // 12.5% (25/200), anchored with its left edge on the zero line.
+        const context = createMockCellContext({
+            columnId: 'revenue',
+            value: {
+                raw: 25,
+                formatted: '$25',
+            },
+            minMaxMap: {
+                revenue: { min: -100, max: 100 },
+            },
+            columnProperties: {
+                revenue: { displayStyle: 'bar' },
+            },
+        });
+
+        const result = getFormattedValueCell(context);
+        const { container } = renderWithMantine(result as React.ReactElement);
+
+        const barElement = container.querySelector(
+            'div[style*="width: 12.5%"]',
+        );
+        expect(barElement).toBeTruthy();
+
+        const style = barElement?.getAttribute('style') || '';
+        // Left edge pinned to the zero baseline (at 50%), growing rightward
+        expect(style).toContain('left: 50%');
+        expect(style).toContain('background');
+    });
+
+    test('positions the diverging zero baseline proportionally, not centered (PROD-8704)', () => {
+        // min=-20, max=80 => zero baseline at (0 - -20)/100 = 20%, closer to
+        // the left because the positive side dominates.
+        const context = createMockCellContext({
+            columnId: 'revenue',
+            value: {
+                raw: 80,
+                formatted: '$80',
+            },
+            minMaxMap: {
+                revenue: { min: -20, max: 80 },
+            },
+            columnProperties: {
+                revenue: { displayStyle: 'bar' },
+            },
+        });
+
+        const result = getFormattedValueCell(context);
+        const { container } = renderWithMantine(result as React.ReactElement);
+
+        // Zero baseline divider sits at 20%, not 50%
+        const zeroLine = container.querySelector('div[style*="left: 20%"]');
+        expect(zeroLine).toBeTruthy();
+
+        // The max value fills the remaining track to the right edge (80%)
+        const barElement = container.querySelector('div[style*="width: 80%"]');
+        expect(barElement).toBeTruthy();
+        expect(barElement?.getAttribute('style') || '').toContain('left: 20%');
+    });
+
+    test('renders no diverging bar for zero, only the zero baseline (PROD-8704)', () => {
+        const context = createMockCellContext({
+            columnId: 'revenue',
+            value: {
+                raw: 0,
+                formatted: '$0',
+            },
+            minMaxMap: {
+                revenue: { min: -100, max: 100 },
+            },
+            columnProperties: {
+                revenue: { displayStyle: 'bar' },
+            },
+        });
+
+        const result = getFormattedValueCell(context);
+        const { container } = renderWithMantine(result as React.ReactElement);
+
+        // Only the 1px zero baseline divider is present, no colored % bar
+        const percentBar = container.querySelector(
+            'div[style*="background"][style*="%"]',
+        );
+        expect(percentBar).toBeFalsy();
+
+        const zeroLine = container.querySelector('div[style*="left: 50%"]');
+        expect(zeroLine).toBeTruthy();
+
+        expect(screen.getByText('$0')).toBeInTheDocument();
+    });
+
+    test('all-negative column: bars grow left from the right edge (PROD-8704)', () => {
+        // min=-100, max=-20 => zero clamps to the right edge (100%). value=-20
+        // (closest to zero) => 25% width (20/80); most-negative would fill.
+        const context = createMockCellContext({
+            columnId: 'revenue',
+            value: {
+                raw: -20,
+                formatted: '-$20',
+            },
+            minMaxMap: {
+                revenue: { min: -100, max: -20 },
+            },
+            columnProperties: {
+                revenue: { displayStyle: 'bar' },
+            },
+        });
+
+        const result = getFormattedValueCell(context);
+        const { container } = renderWithMantine(result as React.ReactElement);
+
+        const barElement = container.querySelector('div[style*="width: 25%"]');
+        expect(barElement).toBeTruthy();
+        // Anchored at the right edge (right: 0%), growing leftward
+        expect(barElement?.getAttribute('style') || '').toContain('right: 0%');
     });
 
     test('should not render bar for zero', () => {

--- a/packages/frontend/src/hooks/useColumns.test.tsx
+++ b/packages/frontend/src/hooks/useColumns.test.tsx
@@ -236,9 +236,12 @@ describe('getFormattedValueCell - Bar Chart Display', () => {
         const result = getFormattedValueCell(context);
         const { container } = renderWithMantine(result as React.ReactElement);
 
-        // Only the 1px zero baseline divider is present, no colored % bar
+        // Only the 1px zero baseline divider is present, no bar. Bars are the
+        // only elements with a border-radius (the divider's background uses a
+        // CSS var, which jsdom drops from serialized styles — so don't key
+        // this assertion on "background").
         const percentBar = container.querySelector(
-            'div[style*="background"][style*="%"]',
+            'div[style*="border-radius"]',
         );
         expect(percentBar).toBeFalsy();
 
@@ -249,8 +252,9 @@ describe('getFormattedValueCell - Bar Chart Display', () => {
     });
 
     test('all-negative column: bars grow left from the right edge (PROD-8704)', () => {
-        // min=-100, max=-20 => zero clamps to the right edge (100%). value=-20
-        // (closest to zero) => 25% width (20/80); most-negative would fill.
+        // min=-100, max=-20 => scale extends to zero, so range=100 and the
+        // baseline sits exactly at the right edge. value=-20 => 20% width
+        // (|value|/|min|); the most-negative value would fill the track.
         const context = createMockCellContext({
             columnId: 'revenue',
             value: {
@@ -268,10 +272,40 @@ describe('getFormattedValueCell - Bar Chart Display', () => {
         const result = getFormattedValueCell(context);
         const { container } = renderWithMantine(result as React.ReactElement);
 
-        const barElement = container.querySelector('div[style*="width: 25%"]');
+        const barElement = container.querySelector('div[style*="width: 20%"]');
         expect(barElement).toBeTruthy();
         // Anchored at the right edge (right: 0%), growing leftward
         expect(barElement?.getAttribute('style') || '').toContain('right: 0%');
+    });
+
+    test('all-negative column: distinct values render distinct widths (PROD-8704)', () => {
+        // Regression: with range=max-min, any value <= -(max - min) clamped to
+        // a full-width bar (-90 and -100 looked identical). With the scale
+        // extended to zero, -90 => 90% and only min itself fills the track.
+        const context = createMockCellContext({
+            columnId: 'revenue',
+            value: {
+                raw: -90,
+                formatted: '-$90',
+            },
+            minMaxMap: {
+                revenue: { min: -100, max: -20 },
+            },
+            columnProperties: {
+                revenue: { displayStyle: 'bar' },
+            },
+        });
+
+        const result = getFormattedValueCell(context);
+        const { container } = renderWithMantine(result as React.ReactElement);
+
+        const barElement = container.querySelector('div[style*="width: 90%"]');
+        expect(barElement).toBeTruthy();
+        expect(
+            container.querySelector(
+                'div[style*="width: 100%"][style*="right"]',
+            ),
+        ).toBeFalsy();
     });
 
     test('should not render bar for zero', () => {


### PR DESCRIPTION
## What & why

In-cell "tiny bars" ([docs](https://docs.lightdash.com/references/chart-types/table#adding-tiny-bars-to-table-visualization)) previously rendered **only positive values** — negatives got no bar at all, and positive bars were anchored at the column's data-min rather than at zero.

This adds **diverging bars** so a column with negative values renders them extending left from a zero baseline, while positives extend right.

## How it works

All the logic lives in a single presentational component, `packages/frontend/src/hooks/TableCellBar.tsx`:

- **Positive-only columns (`min >= 0`)**: unchanged — early return renders the exact same left-anchored bar as before. Zero regression risk for existing charts.
- **Columns with negative values (`min < 0`)**: switch to a diverging layout using an Excel-style "automatic axis":
  - The zero baseline is placed **proportionally** along the track: `zeroPercent = (0 - min) / (max - min)`. It sits dead-center only when the data is symmetric, and slides toward the lighter side otherwise (e.g. `min=-1000, max=1500` → baseline at 40%).
  - Positive bars grow **right** of the baseline, negatives grow **left**, both scaled by the shared range so magnitudes stay directly comparable.
  - A faint 1px zero divider marks the baseline (matches the table's existing `ldGray-3` border color).
  - **All-negative columns** clamp the baseline to the right edge, so every bar grows leftward.
  - A true zero value renders no bar — just the baseline.

**Fully automatic — no schema, config, backend, or migration changes.** Existing saved charts with negative data light up on their own. The same component drives PDF/image/Slack screenshots, so those are covered too; CSV/Excel exports are data-only and unaffected.

## Testing

- Rewrote the old "no bar for negatives" unit test and added coverage for diverging geometry: left-growing negatives, right-growing positives anchored at zero, proportional (non-centered) baseline position, zero-value shows only the divider, and all-negative right-edge anchoring. **28/28 tests pass** (`useColumns.test.tsx`).
- `typecheck:fast` and lint clean.
- Verified the rendered DOM/CSS reproduces a reference diverging-bar layout's proportions exactly.

## Follow-up ideas (not in this PR)

- Optional `negativeColor` on `ColumnProperties` so positive/negative bars can use different hues (additive, backwards-compatible).

Closes: PROD-8704
Closes: #25204

🤖 Generated with [Claude Code](https://claude.com/claude-code)