### PR TITLE
fix(cli): stable folder names for unnamed data apps on download

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -870,7 +870,7 @@ Opt-in flags on the existing `lightdash download` / `lightdash upload` commands 
 - **`lightdash download --apps [appUuids...]`** — download data apps into `lightdash/apps/<slug>/`. Bare `--apps` = all apps in the project (listed via the content API); with UUIDs = just those. Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
 - **`lightdash upload --apps [appUuids...]`** — upload each `lightdash/apps/<slug>/` folder; the server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
 
-**Identity:** the manifest's `appUuid` is the source of truth (apps have no persistent slug; the `<slug>` folder name is derived from the app name via `generateSlug`). Uploading to the **same project** appends a new version of that app; uploading to a **different project** creates a new app there.
+**Identity:** the manifest's `appUuid` is the source of truth (apps have no persistent slug; the `<slug>` folder name is derived from the app name via `generateSlug`, with a stable `untitled-app-<uuid8>` fallback for unnamed apps so re-downloads reuse the same folder). Uploading to the **same project** appends a new version of that app; uploading to a **different project** creates a new app there.
 
 ### What the endpoints do
 

--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -279,6 +279,29 @@ describe('appFolderName', () => {
         expect(first).toBe('my-sales-app-aaaa1111');
         expect(second).toBe('my-sales-app-cccc2222');
     });
+
+    // generateSlug returns a RANDOM string for names that sanitize to nothing,
+    // which would give an unnamed app a different folder on every download.
+    it('uses a stable untitled-app-<uuid8> folder for an empty name', () => {
+        const uuid = 'abcd1234-ef56-7890-ab12-cdef01234567';
+        expect(appFolderName('', uuid, new Set())).toBe(
+            'untitled-app-abcd1234',
+        );
+        // Deterministic: a re-download must land in the same folder.
+        expect(appFolderName('', uuid, new Set())).toBe(
+            'untitled-app-abcd1234',
+        );
+    });
+
+    it('uses the stable fallback for a name with no alphanumeric characters', () => {
+        expect(
+            appFolderName(
+                '!!!',
+                'abcd1234-ef56-7890-ab12-cdef01234567',
+                new Set(),
+            ),
+        ).toBe('untitled-app-abcd1234');
+    });
 });
 
 // ─── readDependenciesFromDir ──────────────────────────────────────────────────

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -26,7 +26,14 @@ export const appFolderName = (
     appUuid: string,
     takenFolders: Set<string>,
 ): string => {
-    const slug = generateSlug(name);
+    // generateSlug returns a RANDOM 5-char string for names that sanitize to
+    // nothing (e.g. unnamed apps whose first build never got auto-titled). A
+    // random folder never matches the previous download's, so every run would
+    // duplicate the app on disk — use a stable uuid-based fallback instead,
+    // mirroring the "Untitled app <uuid8>" display convention.
+    const slug = /[a-z0-9]/i.test(name)
+        ? generateSlug(name)
+        : `untitled-app-${appUuid.slice(0, 8)}`;
     if (!takenFolders.has(slug)) {
         return slug;
     }


### PR DESCRIPTION
### Description:

Uses stable names for unnamed apps on download

