### PR TITLE
fix: add --include-apps to cli upload

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -867,8 +867,8 @@ Data apps can be **downloaded as source, versioned in git, edited, and re-upload
 
 Opt-in flags on the existing `lightdash download` / `lightdash upload` commands (off by default — core users never touch app code paths unless they ask):
 
-- **`lightdash download --apps [appUuids...]`** — download data apps into `lightdash/apps/<slug>/`. Bare `--apps` = all apps in the project (listed via the content API); with UUIDs = just those. Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
-- **`lightdash upload --apps [appUuids...]`** — upload each `lightdash/apps/<slug>/` folder; the server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
+- **`lightdash download --apps <appUuids...>`** — download specific data apps into `lightdash/apps/<slug>/`; **`--include-apps`** downloads all of the project's apps (capped at `--apps-limit`, default 50). Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
+- **`lightdash upload --apps <appUuids...>`** — upload specific apps (matched by manifest `appUuid`); **`--include-apps`** uploads every `lightdash/apps/<slug>/` folder on disk. The server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
 
 **Identity:** the manifest's `appUuid` is the source of truth (apps have no persistent slug; the `<slug>` folder name is derived from the app name via `generateSlug`). Uploading to the **same project** appends a new version of that app; uploading to a **different project** creates a new app there.
 
@@ -879,8 +879,8 @@ Opt-in flags on the existing `lightdash download` / `lightdash upload` commands 
 
 ### Moving an app between projects or instances
 
-- **Different project (same instance):** `lightdash upload --apps --project <target-project>` — creates and builds the app in the target project.
-- **Different instance:** point the CLI at the destination first — `lightdash login <destination-url>` (or set `LIGHTDASH_URL` / `LIGHTDASH_API_KEY`) — then `lightdash upload --apps --project <target>`. The **destination builds the source in its own sandbox** (so it must have data apps / the build sandbox enabled); it never receives code built elsewhere.
+- **Different project (same instance):** `lightdash upload --apps <appUuid> --project <target-project>` — creates and builds the app in the target project.
+- **Different instance:** point the CLI at the destination first — `lightdash login <destination-url>` (or set `LIGHTDASH_URL` / `LIGHTDASH_API_KEY`) — then `lightdash upload --apps <appUuid> --project <target>`. The **destination builds the source in its own sandbox** (so it must have data apps / the build sandbox enabled); it never receives code built elsewhere.
 
 ### Constraints & notes
 
@@ -893,7 +893,7 @@ Opt-in flags on the existing `lightdash download` / `lightdash upload` commands 
 
 Phase 1 makes apps [downloadable and uploadable from source](#cli); Phase 2 makes the downloaded tree **locally buildable**, so you can verify changes compile before uploading.
 
-#### What `lightdash download --apps` now includes
+#### What downloading an app now includes
 
 The download folder adds to the Phase 1 output (`src/` + `lightdash-app.yml`):
 
@@ -907,12 +907,12 @@ All scaffolding and context files are read-only reference — see [Upload is sou
 #### The local loop
 
 ```sh
-edit src/  →  pnpm install && pnpm build  →  lightdash upload --apps  →  server rebuilds
+edit src/  →  pnpm install && pnpm build  →  lightdash upload --apps <appUuid>  →  server rebuilds
 ```
 
 1. Edit files under `src/`.
 2. Run `pnpm install && pnpm build` as a pre-flight compile check against the downloaded scaffolding.
-3. Upload with `lightdash upload --apps` (fire-and-forget, as in Phase 1). The server rebuilds in its trusted sandbox.
+3. Upload with `lightdash upload --apps <appUuid>` — or `--include-apps` for every downloaded app folder (fire-and-forget, as in Phase 1). The server rebuilds in its trusted sandbox.
 
 **The server's build is authoritative.** Your local build is a compile check only; the deployed app is always the server's output.
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -34,7 +34,9 @@ import {
     type AiRouterDecisionConfidence,
     type AiRouterRouteNextAction,
     type AiWritebackFailureStage,
+    type AppVersionDependencyEntry,
     type DataAppClaudeModel,
+    type DataAppTemplate,
     type PullRequestProvider,
 } from '@lightdash/common';
 import Analytics, {
@@ -1433,6 +1435,64 @@ export type DataAppPromotedEvent = BaseTrack & {
     };
 };
 
+export type DataAppDownloadedEvent = BaseTrack & {
+    event: 'data_app.downloaded';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        // true when the caller pinned an explicit version rather than
+        // resolving to the latest ready one.
+        versionPinned: boolean;
+        fileCount: number;
+        sourceBytes: number;
+        hasCustomDependencies: boolean;
+    };
+};
+
+export type DataAppUploadedEvent = BaseTrack & {
+    event: 'data_app.uploaded';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        action: 'create' | 'append';
+        template: Exclude<DataAppTemplate, 'custom'> | null;
+        sourceFileCount: number;
+        sourceBytes: number;
+        hasCustomDependencies: boolean;
+        // The version's full custom set (delta vs the template baseline),
+        // not just packages new since the previous version.
+        customDependencyCount: number;
+        customDependencies: AppVersionDependencyEntry[];
+        lockfileHash?: string;
+    };
+};
+
+export type DataAppUploadRejectedEvent = BaseTrack & {
+    event: 'data_app.upload_rejected';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        targetAppUuid?: string;
+        reason:
+            | 'dependency_validation'
+            | 'insufficient_permissions'
+            | 'custom_dependencies_disabled_instance'
+            | 'custom_dependencies_disabled_org'
+            | 'min_release_age'
+            | 'malware';
+        customDependencyCount?: number;
+        customDependencies?: AppVersionDependencyEntry[];
+        error?: string;
+    };
+};
+
 export type DataAppEvent =
     | DataAppCreatedEvent
     | DataAppIteratedEvent
@@ -1443,7 +1503,10 @@ export type DataAppEvent =
     | DataAppViewedEvent
     | DataAppVersionRestoredEvent
     | DataAppDuplicatedEvent
-    | DataAppPromotedEvent;
+    | DataAppPromotedEvent
+    | DataAppDownloadedEvent
+    | DataAppUploadedEvent
+    | DataAppUploadRejectedEvent;
 
 export type AiWritebackStartedEvent = BaseTrack & {
     event: 'ai_writeback.started';

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -135,9 +135,11 @@ function buildService(
         },
     };
 
+    const analytics = { track: vi.fn() };
+
     const service = new AppGenerateService({
         lightdashConfig: lightdashConfig as never,
-        analytics: {} as never,
+        analytics: analytics as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
         appModel: appModel as never,
@@ -192,7 +194,7 @@ function buildService(
         });
     }
 
-    return { service, appModel, schedulerClient };
+    return { service, appModel, schedulerClient, analytics };
 }
 
 describe('AppGenerateService.importAppCode', () => {
@@ -202,7 +204,8 @@ describe('AppGenerateService.importAppCode', () => {
     });
 
     it('create mode: creates a new app with version 1 and enqueues build', async () => {
-        const { service, appModel, schedulerClient } = buildService();
+        const { service, appModel, schedulerClient, analytics } =
+            buildService();
 
         appModel.findApp.mockResolvedValue(undefined); // no existing app
 
@@ -242,6 +245,22 @@ describe('AppGenerateService.importAppCode', () => {
         expect(schedulerClient.appBuildFromSource).not.toHaveBeenCalledWith(
             expect.objectContaining({ organizationUuid: USER_ORG_UUID }),
         );
+
+        expect(analytics.track).toHaveBeenCalledWith({
+            event: 'data_app.uploaded',
+            userId: USER_UUID,
+            properties: expect.objectContaining({
+                organizationId: PROJECT_ORG_UUID,
+                projectId: PROJECT_UUID,
+                appUuid: NEW_APP_UUID,
+                version: 1,
+                action: 'create',
+                sourceFileCount: 2,
+                hasCustomDependencies: false,
+                customDependencyCount: 0,
+                customDependencies: [],
+            }),
+        });
     });
 
     it('append mode: appends version 5 when latest is 4 and enqueues build', async () => {
@@ -438,7 +457,7 @@ describe('AppGenerateService.importAppCode', () => {
     });
 
     it('throws ParameterError when custom deps are present but customDependenciesEnabled is false', async () => {
-        const { service, appModel } = buildService({
+        const { service, appModel, analytics } = buildService({
             customDependenciesEnabled: false,
         });
 
@@ -460,6 +479,21 @@ describe('AppGenerateService.importAppCode', () => {
                 code: codeWithCustomDep,
             } as ImportAppCodeRequestBody),
         ).rejects.toThrow('LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED');
+
+        expect(analytics.track).toHaveBeenCalledWith({
+            event: 'data_app.upload_rejected',
+            userId: USER_UUID,
+            properties: expect.objectContaining({
+                organizationId: PROJECT_ORG_UUID,
+                projectId: PROJECT_UUID,
+                reason: 'custom_dependencies_disabled_instance',
+                customDependencyCount: 1,
+                customDependencies: [{ name: 'deck.gl', version: '9.3.5' }],
+            }),
+        });
+        expect(analytics.track).not.toHaveBeenCalledWith(
+            expect.objectContaining({ event: 'data_app.uploaded' }),
+        );
     });
 
     it('accepts template-only upload when customDependenciesEnabled is false', async () => {
@@ -479,7 +513,7 @@ describe('AppGenerateService.importAppCode', () => {
     });
 
     it('rejects custom deps when the instance allows them but the org flag is off', async () => {
-        const { service, appModel } = buildService({
+        const { service, appModel, analytics } = buildService({
             customDependenciesEnabled: true,
             customDependenciesOrgEnabled: false,
         });
@@ -494,10 +528,19 @@ describe('AppGenerateService.importAppCode', () => {
                 },
             } as ImportAppCodeRequestBody),
         ).rejects.toThrow('not enabled for your organization');
+
+        expect(analytics.track).toHaveBeenCalledWith({
+            event: 'data_app.upload_rejected',
+            userId: USER_UUID,
+            properties: expect.objectContaining({
+                reason: 'custom_dependencies_disabled_org',
+                customDependencies: [{ name: 'deck.gl', version: '9.3.5' }],
+            }),
+        });
     });
 
     it('rejects custom deps for a user without manage:DataAppDependency (non-admin)', async () => {
-        const { service, appModel } = buildService({
+        const { service, appModel, analytics } = buildService({
             customDependenciesEnabled: true,
             customDependenciesOrgEnabled: true,
             canManageDataAppDependencies: false,
@@ -513,6 +556,15 @@ describe('AppGenerateService.importAppCode', () => {
                 },
             } as ImportAppCodeRequestBody),
         ).rejects.toThrow(ForbiddenError);
+
+        expect(analytics.track).toHaveBeenCalledWith({
+            event: 'data_app.upload_rejected',
+            userId: USER_UUID,
+            properties: expect.objectContaining({
+                reason: 'insufficient_permissions',
+                customDependencies: [{ name: 'deck.gl', version: '9.3.5' }],
+            }),
+        });
     });
 
     it('allows a template-only upload for a non-admin (no dep permission needed)', async () => {
@@ -532,7 +584,7 @@ describe('AppGenerateService.importAppCode', () => {
     });
 
     it('accepts custom deps when both the instance and org flag allow them', async () => {
-        const { service, appModel, schedulerClient } = buildService({
+        const { service, appModel, schedulerClient, analytics } = buildService({
             customDependenciesEnabled: true,
             customDependenciesOrgEnabled: true,
         });
@@ -548,6 +600,17 @@ describe('AppGenerateService.importAppCode', () => {
 
         expect(result.action).toBe('create');
         expect(schedulerClient.appBuildFromSource).toHaveBeenCalledOnce();
+
+        expect(analytics.track).toHaveBeenCalledWith({
+            event: 'data_app.uploaded',
+            userId: USER_UUID,
+            properties: expect.objectContaining({
+                hasCustomDependencies: true,
+                customDependencyCount: 1,
+                customDependencies: [{ name: 'deck.gl', version: '9.3.5' }],
+                lockfileHash: expect.any(String),
+            }),
+        });
     });
 
     it('create mode: source.tar contains only src/ entries when bundle has mixed files', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -147,6 +147,8 @@ function makeFakeS3(tarBuffer: Buffer, expectedVersion: number = VERSION) {
 
 // ── service factory ───────────────────────────────────────────────────────────
 
+const analyticsTrackSpy = vi.fn();
+
 function buildService(overrides: {
     appModel?: Record<string, unknown>;
     s3ClientOverride?: { client: never; bucket: string };
@@ -198,7 +200,7 @@ function buildService(overrides: {
         lightdashConfig: {
             appRuntime: { customDependenciesEnabled },
         } as never,
-        analytics: {} as never,
+        analytics: { track: analyticsTrackSpy } as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
         appModel: fullAppModel as never,
@@ -240,6 +242,7 @@ describe('AppGenerateService.getAppCode', () => {
 
     beforeEach(() => {
         vi.mocked(assertCanViewApp).mockResolvedValue(undefined);
+        analyticsTrackSpy.mockClear();
     });
 
     it('returns a DataAppCode with manifest and extracted source files for the latest ready version', async () => {
@@ -279,6 +282,21 @@ describe('AppGenerateService.getAppCode', () => {
         expect(Buffer.from(themeFile!.contentBase64, 'base64').toString()).toBe(
             'export const theme = {};',
         );
+
+        expect(analyticsTrackSpy).toHaveBeenCalledWith({
+            event: 'data_app.downloaded',
+            userId: fakeUser.userUuid,
+            properties: expect.objectContaining({
+                organizationId: ORG_UUID,
+                projectId: PROJECT_UUID,
+                appUuid: APP_UUID,
+                version: VERSION,
+                versionPinned: false,
+                fileCount: 2,
+                sourceBytes: expect.any(Number),
+                hasCustomDependencies: false,
+            }),
+        });
     });
 
     it('uses the provided version number instead of latest ready', async () => {
@@ -306,6 +324,16 @@ describe('AppGenerateService.getAppCode', () => {
         expect(result.manifest.version).toBe(EXPLICIT_VERSION);
         expect(appModel.getLatestReadyVersion).not.toHaveBeenCalled();
         expect(result.files).toHaveLength(2);
+
+        expect(analyticsTrackSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'data_app.downloaded',
+                properties: expect.objectContaining({
+                    version: EXPLICIT_VERSION,
+                    versionPinned: true,
+                }),
+            }),
+        );
     });
 
     it('refuses to download an app with custom deps when the kill-switch is off', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -43,6 +43,7 @@ import {
     type AppGeneratePipelineJobPayload,
     type AppVersionChartResource,
     type AppVersionDependencies,
+    type AppVersionDependencyEntry,
     type AppVersionExternalConnectionResource,
     type AppVersionResources,
     type ChartReference,
@@ -83,7 +84,10 @@ import {
     emitAiUsage,
     languageModelUsageToTokens,
 } from '../../../analytics/aiUsage';
-import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import {
+    LightdashAnalytics,
+    type DataAppUploadRejectedEvent,
+} from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
 import { resolveS3Credentials } from '../../../clients/Aws/S3BaseClient';
 import { LightdashConfig } from '../../../config/parseConfig';
@@ -7200,6 +7204,21 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             };
         }
 
+        this.analytics.track({
+            event: 'data_app.downloaded',
+            userId: user.userUuid,
+            properties: {
+                organizationId: app.organization_uuid,
+                projectId: projectUuid,
+                appUuid,
+                version: resolvedVersion,
+                versionPinned: version !== undefined,
+                fileCount: files.length,
+                sourceBytes: tarBuffer.length,
+                hasCustomDependencies: dependencies !== undefined,
+            },
+        });
+
         return {
             manifest,
             files,
@@ -7334,6 +7353,40 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
 
         const organizationUuid = await this.getProjectOrgUuid(projectUuid);
 
+        const trackUploadRejected = (
+            reason: DataAppUploadRejectedEvent['properties']['reason'],
+            details: {
+                customDependencies?: AppVersionDependencyEntry[];
+                error?: unknown;
+            } = {},
+        ): void => {
+            this.analytics.track({
+                event: 'data_app.upload_rejected',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    targetAppUuid: body.targetAppUuid,
+                    reason,
+                    ...(details.customDependencies !== undefined
+                        ? {
+                              customDependencyCount:
+                                  details.customDependencies.length,
+                              customDependencies: details.customDependencies,
+                          }
+                        : {}),
+                    ...(details.error !== undefined
+                        ? {
+                              error: AppGenerateService.truncateEnd(
+                                  getErrorMessage(details.error),
+                                  500,
+                              ),
+                          }
+                        : {}),
+                },
+            });
+        };
+
         // Validate the declared dependency set against the template baseline.
         // An empty custom set is treated as no-dependencies (some CLIs attach
         // the template set redundantly) and nothing is stored.
@@ -7355,22 +7408,40 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                     },
                 ));
             } catch (err) {
+                trackUploadRejected('dependency_validation', { error: err });
                 throw new ParameterError(getErrorMessage(err));
             }
             if (Object.keys(customDeps).length > 0) {
+                const customDependencies: AppVersionDependencyEntry[] =
+                    Object.entries(customDeps).map(([name, version]) => ({
+                        name,
+                        version,
+                    }));
                 // Role gate: adding custom npm dependencies is a supply-chain
                 // capability, so it requires manage:DataAppDependency (admins
                 // only by default) — a level above the create/manage:DataApp
                 // needed to upload a template-only app. Checked before the
                 // instance/org gates so an unauthorized user gets a clear 403.
-                this.assertCanManageDataAppDependencies(
-                    user,
-                    organizationUuid,
-                    projectUuid,
-                );
+                try {
+                    this.assertCanManageDataAppDependencies(
+                        user,
+                        organizationUuid,
+                        projectUuid,
+                    );
+                } catch (err) {
+                    trackUploadRejected('insufficient_permissions', {
+                        customDependencies,
+                        error: err,
+                    });
+                    throw err;
+                }
                 if (
                     !this.lightdashConfig.appRuntime.customDependenciesEnabled
                 ) {
+                    trackUploadRejected(
+                        'custom_dependencies_disabled_instance',
+                        { customDependencies },
+                    );
                     throw new ParameterError(
                         'Custom app dependencies are disabled on this instance (LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED). Remove the added packages or ask an admin to enable them.',
                     );
@@ -7387,6 +7458,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                             FeatureFlags.EnableDataAppCustomDependencies,
                     });
                 if (!orgAllowsCustomDeps) {
+                    trackUploadRejected('custom_dependencies_disabled_org', {
+                        customDependencies,
+                    });
                     throw new ParameterError(
                         'Custom app dependencies are not enabled for your organization. Contact your Lightdash admin to request access.',
                     );
@@ -7398,31 +7472,46 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 const lockfilePackages = extractLockfilePackages(
                     code.dependencies.lockfile,
                 );
-                await assertDependenciesMeetMinReleaseAge({
-                    packages: lockfilePackages.filter(
-                        (p) => customDeps[p.name] !== undefined,
-                    ),
-                    minReleaseAgeDays:
-                        this.lightdashConfig.appRuntime
-                            .dependencyMinReleaseAgeDays,
-                    registryHost:
-                        this.lightdashConfig.appRuntime
-                            .dependencyRegistryHosts[0] ?? 'registry.npmjs.org',
-                    now: Date.now(),
-                });
+                try {
+                    await assertDependenciesMeetMinReleaseAge({
+                        packages: lockfilePackages.filter(
+                            (p) => customDeps[p.name] !== undefined,
+                        ),
+                        minReleaseAgeDays:
+                            this.lightdashConfig.appRuntime
+                                .dependencyMinReleaseAgeDays,
+                        registryHost:
+                            this.lightdashConfig.appRuntime
+                                .dependencyRegistryHosts[0] ??
+                            'registry.npmjs.org',
+                        now: Date.now(),
+                    });
+                } catch (err) {
+                    trackUploadRejected('min_release_age', {
+                        customDependencies,
+                        error: err,
+                    });
+                    throw err;
+                }
                 // Malware screen over the WHOLE resolved tree (transitive
                 // included) — supply-chain attacks usually arrive through a
                 // transitive dep, not the package the author added directly.
-                await assertDependenciesHaveNoKnownMalware({
-                    packages: lockfilePackages,
-                    enabled:
-                        this.lightdashConfig.appRuntime
-                            .dependencyMalwareCheckEnabled,
-                });
+                try {
+                    await assertDependenciesHaveNoKnownMalware({
+                        packages: lockfilePackages,
+                        enabled:
+                            this.lightdashConfig.appRuntime
+                                .dependencyMalwareCheckEnabled,
+                    });
+                } catch (err) {
+                    trackUploadRejected('malware', {
+                        customDependencies,
+                        error: err,
+                    });
+                    throw err;
+                }
                 dependencySummary = {
-                    custom: Object.entries(customDeps).map(
-                        ([name, version]) => ({ name, version }),
-                    ),
+                    custom: customDependencies,
                     lockfileHash: createHash('sha256')
                         .update(code.dependencies.lockfile)
                         .digest('hex'),
@@ -7601,6 +7690,27 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             projectUuid,
             organizationUuid,
             userUuid: user.userUuid,
+        });
+
+        this.analytics.track({
+            event: 'data_app.uploaded',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                appUuid: newAppUuid,
+                version: newVersion,
+                action,
+                template: code.manifest.template,
+                sourceFileCount: sourceFiles.length,
+                sourceBytes: sourceTar.length,
+                hasCustomDependencies: dependencySummary !== undefined,
+                customDependencyCount: dependencySummary?.custom.length ?? 0,
+                customDependencies: dependencySummary?.custom ?? [],
+                ...(dependencySummary !== undefined
+                    ? { lockfileHash: dependencySummary.lockfileHash }
+                    : {}),
+            },
         });
 
         return { appUuid: newAppUuid, version: newVersion, action };

--- a/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
@@ -2,7 +2,7 @@
 
 Two skills in `.claude/skills/` describe how to edit this app:
 - `lightdash-data-app` — the Lightdash SDK surface (querying data, filters, downloads).
-- `developing-data-apps-locally` — the local workflow: edit `src/`, `pnpm build`, `lightdash upload --apps`; the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
+- `developing-data-apps-locally` — the local workflow: edit `src/`, `pnpm build`, `lightdash upload --apps <appUuid>` (uuid in `lightdash-app.yml`); the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
 
 Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
 

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -1,11 +1,11 @@
 # {{APP_NAME}} — Lightdash data app (local copy)
 
-Downloaded with `lightdash download --apps`.
+Downloaded with the Lightdash CLI (`lightdash download`).
 
 ## Edit → build → upload
 1. Edit files under `src/`.
 2. Optionally, `pnpm install && pnpm build` to check it compiles locally. If install fails in your environment, skip it — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
-3. `lightdash upload --apps` — Lightdash rebuilds and serves the app.
+3. `lightdash upload --apps <appUuid>` (the `appUuid` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
 
 ## What's read-only
 Most root config is read-only: `vite.config.js`, `tailwind.config.js`, `tsconfig.json`, etc. The server rebuilds against a trusted template, so local edits to those files don't change the deployed app.

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -5,7 +5,7 @@ description: Use when editing a downloaded Lightdash data app on your machine �
 
 # Developing Lightdash Data Apps Locally
 
-You are editing a Lightdash **data app** that was downloaded with `lightdash download --apps`.
+You are editing a Lightdash **data app** that was downloaded with the Lightdash CLI (`lightdash download`).
 
 ## The only way to reach data is the SDK
 
@@ -22,7 +22,7 @@ You are editing a Lightdash **data app** that was downloaded with `lightdash dow
 
 1. Edit files under `src/` only.
 2. Optionally, `pnpm install` then `pnpm build` to check it compiles. This is an **optional local pre-check** — see below.
-3. `lightdash upload --apps` — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
+3. `lightdash upload --apps <appUuid>` (the `appUuid` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
 
 ## The local build is optional — never fight a failing install
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -87,8 +87,8 @@ export type DownloadHandlerOptions = {
     verbose: boolean;
     charts: string[]; // These can be slugs, uuids or urls
     dashboards: string[]; // These can be slugs, uuids or urls
-    apps: string[] | boolean | null; // download: string[] = specific UUIDs; upload: true = all app folders on disk; null/false/absent = skip
-    includeApps?: boolean; // download only: include all of the project's apps, capped at --apps-limit
+    apps?: string[]; // specific app UUIDs (enterprise); absent = no explicit selection
+    includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
     appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
     createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
     force: boolean;
@@ -1886,12 +1886,13 @@ export const uploadHandler = async (
             dashboardTotal = total;
         }
 
-        // Upload data apps (enterprise, opt-in via --apps, fire-and-forget)
-        const appsOption = options.apps;
+        // Upload data apps (enterprise, opt-in via --apps <uuids...> or
+        // --include-apps, fire-and-forget)
+        const explicitAppUuids = Array.isArray(options.apps)
+            ? options.apps
+            : [];
         const shouldUploadApps =
-            appsOption !== null &&
-            appsOption !== false &&
-            appsOption !== undefined;
+            options.includeApps === true || explicitAppUuids.length > 0;
 
         let appsCreated = 0;
         let appsUpdated = 0;
@@ -1899,10 +1900,10 @@ export const uploadHandler = async (
         let appsSkipped = 0;
 
         if (shouldUploadApps) {
+            // --include-apps uploads every folder on disk; explicit UUIDs
+            // filter folders by their manifest appUuid
             const filterUuids: Set<string> | null =
-                Array.isArray(appsOption) && appsOption.length > 0
-                    ? new Set(appsOption)
-                    : null;
+                options.includeApps === true ? null : new Set(explicitAppUuids);
 
             const baseDir = getDownloadFolder(options.path);
             const appsDir = path.join(baseDir, 'apps');
@@ -1916,7 +1917,7 @@ export const uploadHandler = async (
                 if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
                     GlobalState.log(
                         styles.warning(
-                            `No apps directory found at ${appsDir}. Run 'lightdash download --apps' first.`,
+                            `No apps directory found at ${appsDir}. Run 'lightdash download --include-apps' first.`,
                         ),
                     );
                     appFolderEntries = [];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -831,8 +831,13 @@ program
     .option('--validate', 'Validate charts and dashboards after upload', false)
     .option('--gzip', 'Enable gzip compression for request bodies', false)
     .option(
-        '--apps [appUuids...]',
-        'Include data apps (enterprise). Optionally limit to specific app UUIDs; default: all app folders on disk.',
+        '--apps <appUuids...>',
+        'Upload specific data apps by UUID (enterprise).',
+    )
+    .option(
+        '--include-apps',
+        'Upload all app folders on disk (enterprise).',
+        false,
     )
     .option(
         '--create-new',


### PR DESCRIPTION


### Description:
Mirrors the download flag grammar (GLITCH-579) on `lightdash upload` — bare `--apps` no longer means "upload everything".

  - `--apps <appUuids...>` now requires UUIDs and filters app folders by manifest `appUuid`
  - New `--include-apps` uploads every app folder under `<path>/apps/`
  - No flag → apps skipped (unchanged)
  - **Breaking:** bare `upload --apps` now fails with `argument missing` instead of uploading all folders on disk
  - Docs + vendored authoring templates (SKILL.md / README / AGENTS) now teach `upload --apps <appUuid>` (uuid from `lightdash-app.yml`) so agents editing one app don't re-upload siblings
