### PR TITLE
fix: saved dashboard owns filter requirement flags in overrides

### DIFF
--- a/packages/common/src/types/applyDimensionOverrides.test.ts
+++ b/packages/common/src/types/applyDimensionOverrides.test.ts
@@ -327,6 +327,8 @@ describe('applyDimensionOverrides', () => {
             expect(result[0]).toEqual({
                 ...overrides[0],
                 tileTargets: baseDashboardFilters.dimensions[0].tileTargets,
+                // Requirement flags are owned by the saved dashboard
+                required: undefined,
             });
         });
 
@@ -687,6 +689,126 @@ describe('applyDimensionOverrides', () => {
             expect(result).toHaveLength(1);
             expect(result[0].disabled).toBe(true);
             expect(result[0].values).toEqual(['new']);
+        });
+    });
+
+    // required / requiredGroupId are set by the dashboard editor; an override
+    // (shared link, embed JWT, scheduler) must not be able to strip or inject
+    // them.
+    describe('requirement flags are saved-dashboard-owned', () => {
+        it('keeps the saved requirement flags when an override omits them', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    {
+                        ...createBaseDashboardFilter(
+                            'filter-1',
+                            'customers_customer_id',
+                            'customers',
+                        ),
+                        required: true,
+                    },
+                    {
+                        ...createBaseDashboardFilter(
+                            'filter-2',
+                            'orders_status',
+                            'orders',
+                        ),
+                        requiredGroupId: 'group-1',
+                    },
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                createOverrideFilter(
+                    'filter-1',
+                    'customers_customer_id',
+                    'customers',
+                    ['789'],
+                ),
+                // Field-matched override with a stale id
+                createOverrideFilter('stale', 'orders_status', 'orders', [
+                    'completed',
+                ]),
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].required).toBe(true);
+            expect(result[0].values).toEqual(['789']);
+            expect(result[1].requiredGroupId).toBe('group-1');
+            expect(result[1].values).toEqual(['completed']);
+        });
+
+        it('ignores requirement flags supplied by the override', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    createBaseDashboardFilter(
+                        'filter-1',
+                        'customers_customer_id',
+                        'customers',
+                    ),
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                {
+                    ...createOverrideFilter(
+                        'filter-1',
+                        'customers_customer_id',
+                        'customers',
+                    ),
+                    required: true,
+                    requiredGroupId: 'injected-group',
+                },
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].required).toBeUndefined();
+            expect(result[0].requiredGroupId).toBeUndefined();
+        });
+
+        it('strips requirement flags from appended overrides', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    {
+                        ...createBaseDashboardFilter(
+                            'filter-1',
+                            'orders_status',
+                            'orders',
+                        ),
+                        requiredGroupId: 'group-1',
+                        disabled: true,
+                    },
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            // Matches no saved filter by id or field, so it gets appended
+            const overrides: DashboardFilterRule[] = [
+                {
+                    ...createOverrideFilter(
+                        'new-filter',
+                        'customers_customer_id',
+                        'customers',
+                        ['789'],
+                    ),
+                    required: true,
+                    requiredGroupId: 'group-1',
+                },
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(2);
+            expect(result[1].id).toBe('new-filter');
+            expect(result[1].values).toEqual(['789']);
+            expect(result[1].required).toBeUndefined();
+            expect(result[1].requiredGroupId).toBeUndefined();
         });
     });
 });

--- a/packages/common/src/types/applyMetricOverrides.test.ts
+++ b/packages/common/src/types/applyMetricOverrides.test.ts
@@ -1,0 +1,101 @@
+import {
+    applyMetricOverrides,
+    FilterOperator,
+    type DashboardFilterRule,
+    type DashboardFilters,
+} from './filter';
+
+describe('applyMetricOverrides', () => {
+    const createMetricFilter = (
+        id: string,
+        fieldId: string,
+        values: string[] = ['value1'],
+    ): DashboardFilterRule => ({
+        id,
+        label: `Label for ${fieldId}`,
+        operator: FilterOperator.EQUALS,
+        target: {
+            fieldId,
+            tableName: 'orders',
+        },
+        tileTargets: {},
+        disabled: false,
+        values,
+    });
+
+    const createDashboardFilters = (
+        metrics: DashboardFilterRule[],
+    ): DashboardFilters => ({
+        dimensions: [],
+        metrics,
+        tableCalculations: [],
+    });
+
+    it('applies override values while keeping saved-dashboard-owned fields', () => {
+        const savedTileTargets = {
+            'tile-1': { fieldId: 'orders_total', tableName: 'orders' },
+        };
+        const savedFilters = createDashboardFilters([
+            {
+                ...createMetricFilter('metric-1', 'orders_total'),
+                tileTargets: savedTileTargets,
+                required: true,
+                lockedTabUuids: ['tab-1'],
+            },
+            {
+                ...createMetricFilter('metric-2', 'orders_count'),
+                requiredGroupId: 'group-1',
+            },
+        ]);
+        const overrides = [
+            createMetricFilter('metric-1', 'orders_total', ['999']),
+        ];
+
+        const result = applyMetricOverrides(savedFilters, overrides);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].values).toEqual(['999']);
+        expect(result[0].tileTargets).toEqual(savedTileTargets);
+        expect(result[0].required).toBe(true);
+        expect(result[0].lockedTabUuids).toEqual(['tab-1']);
+        expect(result[1]).toEqual(savedFilters.metrics[1]);
+    });
+
+    it('ignores requirement flags supplied by the override', () => {
+        const savedFilters = createDashboardFilters([
+            createMetricFilter('metric-1', 'orders_total'),
+        ]);
+        const overrides = [
+            {
+                ...createMetricFilter('metric-1', 'orders_total', ['999']),
+                required: true,
+                requiredGroupId: 'injected-group',
+            },
+        ];
+
+        const result = applyMetricOverrides(savedFilters, overrides);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].required).toBeUndefined();
+        expect(result[0].requiredGroupId).toBeUndefined();
+    });
+
+    it('accepts DashboardFilters as overrides and never appends unmatched rules', () => {
+        const savedFilters = createDashboardFilters([
+            {
+                ...createMetricFilter('metric-1', 'orders_total'),
+                requiredGroupId: 'group-1',
+            },
+        ]);
+        const overrides = createDashboardFilters([
+            createMetricFilter('metric-1', 'orders_total', ['999']),
+            createMetricFilter('unmatched', 'orders_count'),
+        ]);
+
+        const result = applyMetricOverrides(savedFilters, overrides);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].values).toEqual(['999']);
+        expect(result[0].requiredGroupId).toBe('group-1');
+    });
+});

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -212,7 +212,7 @@ export type FilterDashboardToRule = DashboardFilterRule & {
 
 export type DashboardFilterRuleOverride = Omit<
     DashboardFilterRule,
-    'tileTargets' | 'lockedTabUuids'
+    'tileTargets' | 'lockedTabUuids' | 'required' | 'requiredGroupId'
 >;
 
 export type DateFilterSettings = {
@@ -444,25 +444,61 @@ export const applyDimensionOverrides = (
                 appliedOverrideIds.add(override.id);
                 return {
                     ...override,
-                    // The saved dashboard owns identity, tile targeting and lock
-                    // state; the override only carries value/operator. Forcing the
-                    // id re-homes a field-matched override onto the saved filter.
+                    // The saved dashboard owns identity, tile targeting, lock
+                    // state and requirement flags; the override only carries
+                    // value/operator. Forcing the id re-homes a field-matched
+                    // override onto the saved filter.
                     id: dimension.id,
                     tileTargets: dimension.tileTargets,
                     lockedTabUuids: dimension.lockedTabUuids,
+                    required: dimension.required,
+                    requiredGroupId: dimension.requiredGroupId,
                 };
             }
             return dimension;
         },
     );
 
-    // Append overrides that matched no saved filter by id or field.
-    const newDimensions = overrideArray.filter(
-        (o) => !savedIds.has(o.id) && !appliedOverrideIds.has(o.id),
-    );
+    // Append overrides that matched no saved filter by id or field. Strip
+    // requirement flags: like the matched branch above, overrides cannot
+    // assert requirement metadata, so a stale or crafted rule can't inject
+    // a required filter or satisfy a group.
+    const newDimensions = overrideArray
+        .filter((o) => !savedIds.has(o.id) && !appliedOverrideIds.has(o.id))
+        .map((o) => ({
+            ...o,
+            required: undefined,
+            requiredGroupId: undefined,
+        }));
     overriddenDimensions.push(...newDimensions);
 
     return overriddenDimensions;
+};
+
+export const applyMetricOverrides = (
+    dashboardFilters: DashboardFilters,
+    overrides: DashboardFilters | DashboardFilterRule[],
+) => {
+    const overrideArray =
+        overrides instanceof Array ? overrides : overrides.metrics;
+
+    // Match by id only; unmatched metric overrides are never appended.
+    return dashboardFilters.metrics.map((metric) => {
+        const override = overrideArray.find((o) => o.id === metric.id);
+        if (override) {
+            return {
+                ...override,
+                // Same ownership contract as applyDimensionOverrides: the
+                // saved dashboard owns tile targeting, lock state and
+                // requirement flags; the override only carries value/operator.
+                tileTargets: metric.tileTargets,
+                lockedTabUuids: metric.lockedTabUuids,
+                required: metric.required,
+                requiredGroupId: metric.requiredGroupId,
+            };
+        }
+        return metric;
+    });
 };
 
 export const isDashboardFilterRule = (

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.test.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.test.tsx
@@ -1,0 +1,73 @@
+import { FilterOperator, type DashboardFilterRule } from '@lightdash/common';
+import { act, renderHook } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { useSavedDashboardFiltersOverrides } from './useSavedDashboardFiltersOverrides';
+
+vi.mock('./toaster/useToaster', () => ({
+    default: () => ({
+        showToastWarning: vi.fn(),
+    }),
+}));
+
+const sanitizedRule = {
+    id: 'filter-1',
+    label: 'Status',
+    operator: FilterOperator.EQUALS,
+    target: { fieldId: 'orders_status', tableName: 'orders' },
+    values: ['completed'],
+    disabled: false,
+};
+
+// Carries every saved-dashboard-owned field the hook must strip
+const urlOverrideRule = {
+    ...sanitizedRule,
+    lockedTabUuids: ['tab-1'],
+    required: true,
+    requiredGroupId: 'group-1',
+};
+
+const createWrapper = (search: string) =>
+    function Wrapper({ children }: PropsWithChildren) {
+        return (
+            <MemoryRouter initialEntries={[`/dashboard${search}`]}>
+                {children}
+            </MemoryRouter>
+        );
+    };
+
+describe('useSavedDashboardFiltersOverrides', () => {
+    it('strips saved-dashboard-owned fields from URL override rules', () => {
+        const param = encodeURIComponent(
+            JSON.stringify({ dimensions: [urlOverrideRule] }),
+        );
+        const { result } = renderHook(
+            () => useSavedDashboardFiltersOverrides(),
+            { wrapper: createWrapper(`?filters=${param}`) },
+        );
+
+        expect(
+            result.current.overridesForSavedDashboardFilters.dimensions,
+        ).toStrictEqual([sanitizedRule]);
+    });
+
+    it('strips saved-dashboard-owned fields when adding an override', () => {
+        const { result } = renderHook(
+            () => useSavedDashboardFiltersOverrides(),
+            { wrapper: createWrapper('') },
+        );
+
+        const savedRule: DashboardFilterRule = {
+            ...urlOverrideRule,
+            tileTargets: {},
+        };
+        act(() => {
+            result.current.addSavedFilterOverride(savedRule);
+        });
+
+        expect(
+            result.current.overridesForSavedDashboardFilters.dimensions,
+        ).toStrictEqual([sanitizedRule]);
+    });
+});

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.ts
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.ts
@@ -7,27 +7,28 @@ import { useEffect, useReducer, useRef } from 'react';
 import { useLocation } from 'react-router';
 import useToaster from './toaster/useToaster';
 
-// Lock state is metadata of the saved dashboard, not something the URL
-// should be able to assert. Strip `lockedTabUuids` from URL-provided
-// override rules so a stale shared link can't keep a filter "locked"
-// after an editor has removed the lock from the saved dashboard.
+// Lock state and requirement flags are metadata of the saved dashboard, not
+// something the URL should be able to assert. Strip them from URL-provided
+// override rules so a stale shared link can't keep a filter "locked",
+// required, or in a requirement group after an editor has changed the saved
+// dashboard.
+type UrlOverrideRule = DashboardFilterRuleOverride & {
+    lockedTabUuids?: string[];
+    required?: boolean;
+    requiredGroupId?: string;
+};
+
 const sanitizeOverrideRule = (
-    rule: DashboardFilterRuleOverride & { lockedTabUuids?: string[] },
+    rule: UrlOverrideRule,
 ): DashboardFilterRuleOverride => {
-    const { lockedTabUuids: _, ...rest } = rule;
+    const { lockedTabUuids, required, requiredGroupId, ...rest } = rule;
     return rest;
 };
 
 const sanitizeOverrideState = (state: {
-    dimensions?: (DashboardFilterRuleOverride & {
-        lockedTabUuids?: string[];
-    })[];
-    metrics?: (DashboardFilterRuleOverride & {
-        lockedTabUuids?: string[];
-    })[];
-    tableCalculations?: (DashboardFilterRuleOverride & {
-        lockedTabUuids?: string[];
-    })[];
+    dimensions?: UrlOverrideRule[];
+    metrics?: UrlOverrideRule[];
+    tableCalculations?: UrlOverrideRule[];
 }): Record<keyof DashboardFilters, DashboardFilterRuleOverride[]> => ({
     dimensions: (state.dimensions ?? []).map(sanitizeOverrideRule),
     metrics: (state.metrics ?? []).map(sanitizeOverrideRule),
@@ -143,7 +144,13 @@ export const useSavedDashboardFiltersOverrides = () => {
     }, [showToastWarning]);
 
     const addSavedFilterOverride = (
-        { tileTargets, lockedTabUuids, ...item }: DashboardFilterRule,
+        {
+            tileTargets,
+            lockedTabUuids,
+            required,
+            requiredGroupId,
+            ...item
+        }: DashboardFilterRule,
         category: FilterCategory = 'dimensions',
     ) => {
         dispatch({
@@ -154,7 +161,13 @@ export const useSavedDashboardFiltersOverrides = () => {
     };
 
     const removeSavedFilterOverride = (
-        { tileTargets, lockedTabUuids, ...item }: DashboardFilterRule,
+        {
+            tileTargets,
+            lockedTabUuids,
+            required,
+            requiredGroupId,
+            ...item
+        }: DashboardFilterRule,
         category: FilterCategory = 'dimensions',
     ) => {
         dispatch({

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -1,5 +1,6 @@
 import {
     applyDimensionOverrides,
+    applyMetricOverrides,
     compressDashboardFiltersToParam,
     convertDashboardFiltersParamToDashboardFilters,
     DashboardTileTypes,
@@ -1155,14 +1156,10 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 };
 
                 if (safeOverrides.metrics?.length > 0) {
-                    updated.metrics = prevFilters.metrics.map((metric) => {
-                        const override = safeOverrides.metrics.find(
-                            (m) => m.id === metric.id,
-                        );
-                        return override
-                            ? { ...override, tileTargets: metric.tileTargets }
-                            : metric;
-                    });
+                    updated.metrics = applyMetricOverrides(
+                        prevFilters,
+                        safeOverrides,
+                    );
                 }
 
                 return updated;


### PR DESCRIPTION
Makes the saved dashboard the sole owner of filter requirement flags when merging URL/embed/scheduler filter overrides onto saved filters. This is the **only un-flag-gated behavior change in the stack**, isolated here so it gets its own review and its own revert handle.

### What changes

- `applyDimensionOverrides` now keeps the saved filter's `required`/`requiredGroupId` when applying a matched override (same treatment as the existing `tileTargets`/`lockedTabUuids` ownership), and strips both flags from unmatched overrides before appending them — a stale or crafted `?filters=` rule can no longer inject a required filter or satisfy a group.
- The inline metric-override merge in `DashboardProvider` is extracted into a new `applyMetricOverrides` helper in common with the same ownership contract: `tileTargets`, `lockedTabUuids`, `required` and `requiredGroupId` are pinned from the saved filter (previously only `tileTargets` was, so a metric override could strip requirement flags or lock state). Merge semantics are otherwise unchanged: id-match only, unmatched metric overrides are never appended.
- Type-level companion, matching the `lockedTabUuids` precedent: `required`/`requiredGroupId` removed from `DashboardFilterRuleOverride` and stripped in `sanitizeOverrideRule` (`useSavedDashboardFiltersOverrides`).

### Risk class: live behavior change (deliberate tightening)

Applies to the existing required-filter feature as soon as this merges, flag or no flag. In practice: a shared link carrying a still-unset override for a required filter now locks the dashboard the same way a fresh load does, instead of running unfiltered; links that carry a value behave exactly as before.

- Verification: unit tests for all three layers (`applyDimensionOverrides.test.ts`, `applyMetricOverrides.test.ts`, `useSavedDashboardFiltersOverrides.test.tsx`); browser-verified that a URL override attempting to strip `required` stays locked with zero tile queries (dimension and metric paths). Note: an override carrying `disabled:false` + empty values still unlocks on this branch, as on main. The operator-aware valueless check that closes that hole ships flag-gated later in the stack (#25306).
- Backend consumers confirmed safe: scheduler/AI call sites feed the result into query compilation where the requirement flags are inert metadata; `disabled` (which drives filter skipping) is untouched. Table-calculation filters are not requirement-eligible (parity with the existing required scan) and their overrides are never merged.
- Rollback: revert this PR alone; it has no dependents besides the type import.

### Stack

PR 2/5 of the dashboard filter requirement groups stack (types → **overrides hardening** → module → switch → e2e).

Relates: PROD-8661
Relates: #25095

