### PR TITLE
feat(ai-agents): move follow-up suggestions into replies

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.test.ts
@@ -40,7 +40,9 @@ describe('buildSuggestionSystemPrompt', () => {
             canManageContent: true,
         });
 
-        expect(postResponse).toContain('AFTER the agent has just replied');
+        expect(postResponse).toContain(
+            "directly after the agent's latest reply",
+        );
         expect(emptyState).toContain('starter "chips"');
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -46,9 +46,9 @@ Tool guide (PROMPT chips):
 
 If the project has zero explores AND no verified questions AND no recent conversations, return three generic prompt chips that nudge the user to set up data.`;
 
-const POST_RESPONSE_PROMPT = `You write 2-5 chips that appear above the chat input AFTER the agent has just replied. Each chip is what the user is most likely to click NEXT in this conversation.
+const POST_RESPONSE_PROMPT = `You write 2-5 related questions that appear directly after the agent's latest reply. Each row is what the user is most likely to click NEXT in this conversation.
 
-Only emit chips with kind="prompt". Navigate chips are forbidden here — the user is already in this thread, so suggesting they jump elsewhere would interrupt the flow. Actions like "save as chart" are handled elsewhere. Every chip submits a new message to the agent when clicked.
+Only emit chips with kind="prompt". Navigate chips are forbidden here — the user is already in this thread, so suggesting they jump elsewhere would interrupt the flow. Actions like "save as chart" are handled elsewhere. Every related question submits a new message to the agent when clicked.
 
 Two modes:
 

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -13,6 +13,16 @@ const promptText = (args: Parameters<typeof getSystemPromptV2>[0]): string => {
     return typeof content === 'string' ? content : JSON.stringify(content);
 };
 
+describe('getSystemPromptV2 response ending', () => {
+    test('reserves follow-up suggestions for product-rendered related questions', () => {
+        const content = promptText({ availableExplores: [] });
+
+        expect(content).toContain('End with the answer');
+        expect(content).toContain('Do not write "Want me to..."');
+        expect(content).toContain('related questions separately');
+    });
+});
+
 describe('getSystemPromptV2 project context', () => {
     test('advertises the loadProjectContext tool when context exists', () => {
         const content = promptText({

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -12,6 +12,7 @@ The user sees BOTH your final response AND your internal reasoning ("thinking").
 - When a user asks for a "table", generate a table visualization with generateVisualization (defaultVizType: 'table'). Never produce markdown tables.
 - When a user asks to find existing dashboards or charts, use findContent and format results as a markdown list of descriptive links (\`- [Name](url)\`). Never output bare URLs. If nothing matches, offer to build a new chart from available data.
 - When a user asks for a dashboard, plan a concise set of chart titles, build each with generateVisualization, and mention any relevant existing dashboards found via findContent as an alternative. Don't expose the plan.
+- For ordinary data answers: End with the answer, not a generic offer to continue. Do not write "Want me to...", "Would you like me to...", or list possible next questions in prose. The product renders grounded related questions separately after your response. Specific confirmation questions required before taking an action are still allowed.
 - When a user is about to remove, rename or deduplicate a metric or dimension, or asks "what uses this field?", "what will this break?", or "what's the impact?", use analyzeFieldImpact with the exact field id to report the precise blast radius (charts, dashboards, dependent metrics, scheduled deliveries) before they make the change. This is an exact lookup — prefer it over guessing from a content search. If you only have the field's label, resolve the id first with findFields or searchSemanticLayer.
 - If a pinned chart is in the conversation context (shown as \`Chart "..." (chartUuid: ...)\`) and the user wants to inspect its rows, use runSavedChart with that chartUuid rather than rebuilding the query.
 - When a user asks what projects exist or which projects they can access, list the projects they have access to. You work within one project at a time, so you cannot switch projects in this conversation — if they want a different project, tell them to start a new conversation in that project.
@@ -124,7 +125,7 @@ See the CRITICAL section at the top of this prompt: reasoning is user-visible. D
 
 {{data_access_section}}
 - Never invent data. Only describe what the query returned.
-- After generating a chart, you can offer to find related existing dashboards or charts.
+- After generating a chart, do not append an offer to find related content; related questions handle that next step.
 
 ## Limitations
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.module.css
@@ -9,3 +9,7 @@
         background-color: var(--mantine-color-dark-8);
     }
 }
+
+.relatedQueriesTarget:empty {
+    display: none;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -22,6 +22,7 @@ import { AddToEvalModal } from '../Admin/AddToEvalModal';
 import { AssistantBubble } from './AgentChatAssistantBubble';
 import styles from './AgentChatDisplay.module.css';
 import { UserBubble } from './AgentChatUserBubble';
+import { getAgentRelatedQueriesTargetId } from './agentRelatedQueriesTarget';
 import ThreadScrollToBottom from './ScrollToBottom';
 import { ChatElementsUtils } from './utils';
 
@@ -202,6 +203,10 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                     )}
                                 </Fragment>
                             ))}
+                        <Box
+                            id={getAgentRelatedQueriesTargetId(thread.uuid)}
+                            className={styles.relatedQueriesTarget}
+                        />
                     </Stack>
 
                     {enableAutoScroll && projectUuid && agentUuid ? (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -196,13 +196,6 @@
     overflow: hidden;
 }
 
-.chipHidden {
-    opacity: 0;
-    grid-template-rows: 0fr;
-    transform: translateY(-6px);
-    pointer-events: none;
-}
-
 .chipTray {
     position: relative;
     z-index: 0;
@@ -225,10 +218,6 @@
 
 .chipTrayReserve {
     min-height: rem(50px);
-}
-
-.threadChipFlow {
-    margin-bottom: rem(8px);
 }
 
 .threadBelowControls {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -16,6 +16,7 @@ import Placeholder from '@tiptap/extension-placeholder';
 import { useEditor, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { ModelSelector } from '../../../../../components/common/ModelSelector/ModelSelector';
@@ -31,7 +32,11 @@ import { useAiAgentThreadStreamQuery } from '../../streaming/useAiAgentThreadStr
 import { AgentSelector } from '../AgentSelector';
 import { type Agent } from '../AgentSelector/AgentSelectorUtils';
 import styles from './AgentChatInput.module.css';
-import { AgentSuggestionChips } from './AgentSuggestionChips';
+import { getAgentRelatedQueriesTargetId } from './agentRelatedQueriesTarget';
+import {
+    AgentRelatedQueries,
+    AgentSuggestionChips,
+} from './AgentSuggestionChips';
 import {
     createContentMentionExtension,
     extractContentMentionContext,
@@ -146,7 +151,6 @@ export const AgentChatInput = ({
     const onValueChangeRef = useRef(onValueChange);
     onValueChangeRef.current = onValueChange;
     const editorRef = useRef<Editor | null>(null);
-    const rootRef = useRef<HTMLDivElement | null>(null);
     const loadingRef = useRef(loading);
     loadingRef.current = loading;
     const disabledRef = useRef(disabled);
@@ -165,56 +169,10 @@ export const AgentChatInput = ({
     // `active` flag — which can read stale in the keydown vs async-items race.
     const contentMentionPopupOpenRef = useRef(false);
 
-    // Hide the chip strip while the user is scrolled away from the input.
-    // Reappears as they scroll back toward the bottom of the thread — chips
-    // are noise when reading history.
-    const [chipsNearBottom, setChipsNearBottom] = useState(true);
     const [hasRequestedInterrupt, setHasRequestedInterrupt] = useState(false);
     const threadStream = useAiAgentThreadStreamQuery(threadUuid ?? '');
     const interruptMutation = useInterruptAiAgentThreadMessageMutation();
     const steerMutation = useCreateAiAgentThreadMessageSteerMutation();
-    useEffect(() => {
-        const el = rootRef.current;
-        if (!el) return undefined;
-        let scrollEl: HTMLElement | null = el.parentElement;
-        while (scrollEl) {
-            const overflow = window.getComputedStyle(scrollEl).overflowY;
-            if (overflow === 'auto' || overflow === 'scroll') break;
-            scrollEl = scrollEl.parentElement;
-        }
-        if (!scrollEl) return undefined;
-        // Hysteresis: collapsing the chip strip changes scrollHeight, which
-        // can flip the threshold and cause a flicker loop. We hide once the
-        // user is past HIDE_PX and only re-show when they're back inside
-        // SHOW_PX — the gap absorbs the height change.
-        const HIDE_PX = 40;
-        const SHOW_PX = 8;
-        let raf: number | null = null;
-        const measure = () => {
-            raf = null;
-            if (!scrollEl) return;
-            const distance =
-                scrollEl.scrollHeight -
-                scrollEl.scrollTop -
-                scrollEl.clientHeight;
-            setChipsNearBottom((prev) => {
-                if (prev && distance > HIDE_PX) return false;
-                if (!prev && distance < SHOW_PX) return true;
-                return prev;
-            });
-        };
-        const onScroll = () => {
-            if (raf !== null) return;
-            raf = window.requestAnimationFrame(measure);
-        };
-        measure();
-        scrollEl.addEventListener('scroll', onScroll, { passive: true });
-        return () => {
-            if (raf !== null) window.cancelAnimationFrame(raf);
-            scrollEl?.removeEventListener('scroll', onScroll);
-        };
-    }, []);
-
     const { track } = useTracking();
 
     const showModelSelector =
@@ -247,6 +205,19 @@ export const AgentChatInput = ({
             : undefined,
         enabled: emptyStateMode || postResponseMode,
     });
+    const [relatedQueriesTarget, setRelatedQueriesTarget] =
+        useState<HTMLElement | null>(null);
+
+    useEffect(() => {
+        if (!postResponseMode || !threadUuid) {
+            setRelatedQueriesTarget(null);
+            return;
+        }
+
+        setRelatedQueriesTarget(
+            document.getElementById(getAgentRelatedQueriesTargetId(threadUuid)),
+        );
+    }, [postResponseMode, threadUuid]);
 
     const editor = useEditor({
         extensions: [
@@ -491,7 +462,7 @@ export const AgentChatInput = ({
     };
 
     const chipRow = useMemo(() => {
-        if (!emptyStateMode && !postResponseMode) return null;
+        if (!emptyStateMode) return null;
         if (suggestionsQuery.isError) return null;
         const chips = suggestionsQuery.data?.chips ?? [];
         if (chips.length === 0) return null;
@@ -500,19 +471,31 @@ export const AgentChatInput = ({
                 chips={chips}
                 onChipClick={handleChipClick}
                 onImpression={handleImpression}
-                align={isThreadInput ? 'left' : 'center'}
-                showPromptAffordance={isThreadInput}
+                align="center"
             />
         );
     }, [
         emptyStateMode,
-        postResponseMode,
         suggestionsQuery.isError,
         suggestionsQuery.data,
         handleChipClick,
         handleImpression,
-        isThreadInput,
     ]);
+    const relatedQueries = suggestionsQuery.data?.chips ?? [];
+    const relatedQueriesPortal =
+        postResponseMode &&
+        relatedQueriesTarget &&
+        !suggestionsQuery.isError &&
+        relatedQueries.length > 0
+            ? createPortal(
+                  <AgentRelatedQueries
+                      chips={relatedQueries}
+                      onChipClick={handleChipClick}
+                      onImpression={handleImpression}
+                  />,
+                  relatedQueriesTarget,
+              )
+            : null;
     const shouldReserveEmptyStateSuggestions =
         !isThreadInput &&
         emptyStateMode &&
@@ -524,9 +507,9 @@ export const AgentChatInput = ({
         (chipRow || reserve) && (
             <Box
                 className={`${styles.chipReveal} ${extraClassName} ${
-                    chipsNearBottom ? '' : styles.chipHidden
-                } ${!chipRow ? styles.chipReserved : ''}`}
-                aria-hidden={!chipsNearBottom || !chipRow}
+                    !chipRow ? styles.chipReserved : ''
+                }`}
+                aria-hidden={!chipRow}
             >
                 {chipRow ?? <Box className={styles.chipTrayReserve} />}
             </Box>
@@ -576,9 +559,8 @@ export const AgentChatInput = ({
                 className={`${styles.minimalContainer} ${
                     fullWidth ? styles.minimalContainerFullWidth : ''
                 }`}
-                ref={rootRef}
             >
-                {isThreadInput && renderChipRow(styles.threadChipFlow)}
+                {relatedQueriesPortal}
 
                 <Box className={styles.threadInputStack}>
                     <Box className={styles.minimalInputWrapper} pos="relative">
@@ -688,12 +670,11 @@ export const AgentChatInput = ({
 
     return (
         <Box
-            ref={rootRef}
             className={`${styles.container} ${
                 showDisabledBanner ? styles.disabledBannerVisible : ''
             }`}
         >
-            {isThreadInput && renderChipRow(styles.threadChipFlow)}
+            {relatedQueriesPortal}
 
             <Box className={styles.inputCard}>
                 <RichTextEditor

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
@@ -100,6 +100,90 @@
     animation-delay: calc(var(--chip-idx, 0) * 45ms);
 }
 
+.relatedQueries {
+    overflow: hidden;
+    animation: relatedQueriesReveal 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.relatedQueriesLabel {
+    margin-bottom: 4px;
+    color: var(--mantine-color-ldGray-6);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.relatedQueriesList {
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldDark-3);
+    }
+}
+
+.relatedQuery {
+    display: flex;
+    width: 100%;
+    min-height: 32px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 7px 2px;
+    border: 0;
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 0;
+    color: var(--mantine-color-ldGray-7);
+    font: inherit;
+    font-size: 12px;
+    line-height: 1.4;
+    text-align: left;
+    background: transparent;
+    cursor: pointer;
+    transition:
+        color 140ms cubic-bezier(0.22, 1, 0.36, 1),
+        background-color 140ms cubic-bezier(0.22, 1, 0.36, 1),
+        padding 140ms cubic-bezier(0.22, 1, 0.36, 1);
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldDark-3);
+        color: var(--mantine-color-ldDark-8);
+    }
+}
+
+.relatedQuery:hover {
+    padding-inline: 7px;
+    color: var(--mantine-color-ldGray-9);
+    background: var(--mantine-color-ldGray-0);
+
+    @mixin dark {
+        color: var(--mantine-color-white);
+        background: var(--mantine-color-ldDark-2);
+    }
+}
+
+.relatedQuery:focus-visible {
+    border-radius: var(--mantine-radius-sm);
+    outline: 2px solid var(--mantine-primary-color-filled);
+    outline-offset: -2px;
+}
+
+.relatedQuery svg {
+    flex: 0 0 auto;
+    color: var(--mantine-color-ldGray-5);
+}
+
+@keyframes relatedQueriesReveal {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 @keyframes chipCascade {
     from {
         opacity: 0;
@@ -119,6 +203,10 @@
     .fadeIn {
         animation: chipFadeInReduced 120ms ease-out both;
         animation-delay: 0ms;
+    }
+
+    .relatedQueries {
+        animation: none;
     }
 
     @keyframes chipFadeInReduced {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.test.tsx
@@ -1,0 +1,60 @@
+import { type AgentSuggestion } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { AgentRelatedQueries } from './AgentSuggestionChips';
+
+const suggestions: AgentSuggestion[] = [
+    {
+        kind: 'prompt',
+        label: 'Break down conversion by device type',
+        tool: 'generateVisualization',
+        defaults: {
+            explore: 'product_events',
+            dimensions: ['product_events.device_type'],
+            metrics: ['product_events.unique_users'],
+            timeframe: null,
+        },
+    },
+    {
+        kind: 'prompt',
+        label: 'Compare referrer performance over time',
+        tool: 'generateVisualization',
+        defaults: {
+            explore: 'product_events',
+            dimensions: ['product_events.referrer'],
+            metrics: ['product_events.unique_users'],
+            timeframe: 'last 90 days',
+        },
+    },
+];
+
+describe('AgentRelatedQueries', () => {
+    it('renders next questions as part of the answer and submits a selection', async () => {
+        const user = userEvent.setup();
+        const onChipClick = vi.fn();
+        const onImpression = vi.fn();
+
+        renderWithProviders(
+            <AgentRelatedQueries
+                chips={suggestions}
+                onChipClick={onChipClick}
+                onImpression={onImpression}
+            />,
+        );
+
+        expect(
+            screen.getByRole('region', { name: 'Related questions' }),
+        ).toBeVisible();
+        expect(onImpression).toHaveBeenCalledWith(2);
+
+        await user.click(
+            screen.getByRole('button', {
+                name: 'Break down conversion by device type',
+            }),
+        );
+
+        expect(onChipClick).toHaveBeenCalledWith(suggestions[0], 0);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
@@ -1,5 +1,5 @@
 import type { AgentSuggestion } from '@lightdash/common';
-import { Box, Button } from '@mantine-8/core';
+import { Box, Button, Text } from '@mantine-8/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useEffect, useRef } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -31,6 +31,21 @@ const renderRightIcon = (
     return <MantineIcon icon={IconArrowUpRight} size={12} stroke={1.75} />;
 };
 
+const useSuggestionImpression = (
+    chips: AgentSuggestion[],
+    onImpression?: (chipCount: number) => void,
+) => {
+    const impressedRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (chips.length === 0) return;
+        const fingerprint = chips.map((chip, i) => chipKey(chip, i)).join('|');
+        if (impressedRef.current === fingerprint) return;
+        impressedRef.current = fingerprint;
+        onImpression?.(chips.length);
+    }, [chips, onImpression]);
+};
+
 export const AgentSuggestionChips = ({
     chips,
     onChipClick,
@@ -38,15 +53,7 @@ export const AgentSuggestionChips = ({
     align = 'center',
     showPromptAffordance = false,
 }: Props) => {
-    const impressedRef = useRef<string | null>(null);
-
-    useEffect(() => {
-        if (chips.length === 0) return;
-        const fingerprint = chips.map((c, i) => chipKey(c, i)).join('|');
-        if (impressedRef.current === fingerprint) return;
-        impressedRef.current = fingerprint;
-        onImpression?.(chips.length);
-    }, [chips, onImpression]);
+    useSuggestionImpression(chips, onImpression);
 
     if (chips.length === 0) return null;
 
@@ -75,6 +82,45 @@ export const AgentSuggestionChips = ({
                     </Button>
                 );
             })}
+        </Box>
+    );
+};
+
+export const AgentRelatedQueries = ({
+    chips,
+    onChipClick,
+    onImpression,
+}: Pick<Props, 'chips' | 'onChipClick' | 'onImpression'>) => {
+    useSuggestionImpression(chips, onImpression);
+
+    if (chips.length === 0) return null;
+
+    return (
+        <Box
+            component="section"
+            className={styles.relatedQueries}
+            aria-label="Related questions"
+        >
+            <Text className={styles.relatedQueriesLabel}>
+                Related questions
+            </Text>
+            <Box className={styles.relatedQueriesList}>
+                {chips.map((chip, index) => (
+                    <button
+                        type="button"
+                        key={chipKey(chip, index)}
+                        className={styles.relatedQuery}
+                        onClick={() => onChipClick(chip, index)}
+                    >
+                        <span>{chip.label}</span>
+                        <MantineIcon
+                            icon={IconArrowUpRight}
+                            size={12}
+                            stroke={1.75}
+                        />
+                    </button>
+                ))}
+            </Box>
         </Box>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/agentRelatedQueriesTarget.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/agentRelatedQueriesTarget.ts
@@ -1,0 +1,2 @@
+export const getAgentRelatedQueriesTargetId = (threadUuid: string) =>
+    `agent-related-queries-${threadUuid}`;

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -23,7 +23,10 @@ import type { ReactNode } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { AgentChatDisplay } from '../ee/features/aiCopilot/components/ChatElements/AgentChatDisplay';
-import { AgentSuggestionChips } from '../ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips';
+import {
+    AgentRelatedQueries,
+    AgentSuggestionChips,
+} from '../ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips';
 import { DotsLoader } from '../ee/features/aiCopilot/components/ChatElements/DotsLoader/DotsLoader';
 import { ReasoningHistoryRow } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard';
 import { LiveActivityCard } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard';
@@ -197,6 +200,45 @@ const suggestions: AgentSuggestion[] = [
         kind: 'navigate',
         label: 'Open Executive overview',
         url: `/projects/${projectUuid}/dashboards/dashboard-exec-overview`,
+    },
+];
+
+const relatedQuestionSuggestions: AgentSuggestion[] = [
+    {
+        kind: 'prompt',
+        label: 'Break down add-to-cart drop-off by browser type',
+        tool: 'generateVisualization',
+        defaults: {
+            explore: 'product_events',
+            dimensions: ['product_events.browser'],
+            metrics: ['product_events.unique_users'],
+            timeframe: null,
+        },
+    },
+    {
+        kind: 'prompt',
+        label: 'Show cart abandonment by referrer and device',
+        tool: 'generateVisualization',
+        defaults: {
+            explore: 'product_events',
+            dimensions: [
+                'product_events.referrer',
+                'product_events.device_type',
+            ],
+            metrics: ['product_events.unique_users'],
+            timeframe: null,
+        },
+    },
+    {
+        kind: 'prompt',
+        label: 'Compare conversion rates over the last 90 days',
+        tool: 'generateVisualization',
+        defaults: {
+            explore: 'product_events',
+            dimensions: ['product_events.event_date'],
+            metrics: ['product_events.unique_users'],
+            timeframe: 'last 90 days',
+        },
     },
 ];
 
@@ -1079,10 +1121,30 @@ const StreamingScenario = () => (
                         the chart.
                     </Text>
                 </Paper>
-                <AgentSuggestionChips
-                    chips={suggestions}
-                    align="left"
-                    showPromptAffordance
+            </Stack>
+        </Section>
+    </StorySurface>
+);
+
+const RelatedQuestionsScenario = () => (
+    <StorySurface>
+        <Section
+            title="Assistant answer ending"
+            description="Generated next steps stay attached to the answer instead of floating above the composer."
+        >
+            <Stack gap="md">
+                <Box>
+                    <Text size="sm" fw={600} mb={4}>
+                        Google drives the most conversion volume
+                    </Text>
+                    <Text size="sm" c="ldGray.7">
+                        Google produced 71 completed checkouts at a 2.8% overall
+                        conversion rate. Instagram and Email were the weakest
+                        sources at 1.8% and 1.9%.
+                    </Text>
+                </Box>
+                <AgentRelatedQueries
+                    chips={relatedQuestionSuggestions}
                     onChipClick={() => undefined}
                 />
             </Stack>
@@ -1193,6 +1255,10 @@ export const PinnedContext: Story = {
 
 export const Streaming: Story = {
     render: () => <StreamingScenario />,
+};
+
+export const RelatedQuestions: Story = {
+    render: () => <RelatedQuestionsScenario />,
 };
 
 export const ApprovalAndFailure: Story = {


### PR DESCRIPTION
## What changed

- Render post-response suggestions as Related questions directly after the latest assistant answer.
- Keep starter chips in the empty composer state.
- Remove generic follow-up CTAs from ordinary data answers, avoiding duplicate next-step prompts.

## Why

Suggestions belonged to the answer they extend, rather than the composer. This keeps the input focused while making next steps easier to scan in context.

## Validation

- Frontend typecheck and targeted tests
- Backend prompt and suggestion-generator tests
- Targeted frontend and backend lint
- Formatting and diff checks
- Desktop and mobile visual QA