### PR TITLE
refactor(backend): slim PreparedAsyncQueryArgs, read query context off composer

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -22,6 +22,11 @@ import {
     VizIndexType,
     WarehouseClient,
     WarehouseTypes,
+    type Explore,
+    type ItemsMap,
+    type MetricQuery,
+    type ParameterDefinitions,
+    type UserAccessControls,
 } from '@lightdash/common';
 import type { SshTunnel } from '@lightdash/warehouses';
 import ExecutionContext from 'node-execution-context';
@@ -147,6 +152,49 @@ const warehouseCredentialsMock = {
     ...warehouseClientMock.credentials,
     userWarehouseCredentialsUuid: undefined,
 };
+
+// Execute reads query/context data off the composer — mock the getter surface
+const createQueryComposerMock = ({
+    sql = 'SELECT * FROM test',
+    explore = validExplore,
+    metricQuery = metricQueryMock,
+    fields = {},
+    missingParameterReferences = [],
+    timezone = undefined,
+    displayTimezone = null,
+    useTimezoneAwareDateTrunc = false,
+    userAccessControls = undefined,
+    availableParameterDefinitions = undefined,
+}: {
+    sql?: string;
+    explore?: Explore;
+    metricQuery?: MetricQuery;
+    fields?: ItemsMap;
+    missingParameterReferences?: string[];
+    timezone?: string;
+    displayTimezone?: string | null;
+    useTimezoneAwareDateTrunc?: boolean;
+    userAccessControls?: UserAccessControls;
+    availableParameterDefinitions?: ParameterDefinitions;
+} = {}) =>
+    ({
+        getSql: () => sql,
+        getExplore: () => explore,
+        getMetricQuery: () => metricQuery,
+        getPivotConfiguration: () => undefined,
+        getFields: () => fields,
+        getMissingParameterReferences: () => missingParameterReferences,
+        getParameterReferences: () => [],
+        getWarnings: () => [],
+        getUsedParameters: () => ({}),
+        getParameters: () => undefined,
+        getDateZoom: () => undefined,
+        getTimezone: () => timezone,
+        getDisplayTimezone: () => displayTimezone,
+        getUseTimezoneAwareDateTrunc: () => useTimezoneAwareDateTrunc,
+        getUserAccessControls: () => userAccessControls,
+        getAvailableParameterDefinitions: () => availableParameterDefinitions,
+    }) as unknown as QueryComposer;
 
 const projectModel = {
     getWithSensitiveFields: vi.fn(async () => projectWithSensitiveFields),
@@ -548,21 +596,12 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
+                    queryComposer: createQueryComposerMock(),
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -645,21 +684,12 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
+                    queryComposer: createQueryComposerMock(),
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -749,26 +779,20 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
                     // Resolved tz is set (project has query_timezone) but
                     // the gating flag is off — SQL was built without a
                     // timezone-aware DATE_TRUNC, so the persisted snapshot
                     // must not carry the resolved value either.
-                    timezone: 'Asia/Tokyo',
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
+                    queryComposer: createQueryComposerMock({
+                        timezone: 'Asia/Tokyo',
+                        displayTimezone: null,
+                        useTimezoneAwareDateTrunc: false,
+                    }),
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -809,22 +833,16 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
-                    timezone: 'Asia/Tokyo',
-                    displayTimezone: 'Asia/Tokyo',
-                    useTimezoneAwareDateTrunc: true,
+                    queryComposer: createQueryComposerMock({
+                        timezone: 'Asia/Tokyo',
+                        displayTimezone: 'Asia/Tokyo',
+                        useTimezoneAwareDateTrunc: true,
+                    }),
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -871,21 +889,12 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: true,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
+                    queryComposer: createQueryComposerMock(),
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -963,21 +972,12 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
+                    queryComposer: createQueryComposerMock(),
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock, invalidateCache: true },
@@ -1029,21 +1029,12 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
+                    queryComposer: createQueryComposerMock(),
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -1124,25 +1115,18 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () =>
-                            'SELECT * FROM test WHERE param = {{ missing_param }}',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [
-                        'missing_param',
-                        'another_missing_param',
-                    ],
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
+                    queryComposer: createQueryComposerMock({
+                        sql: 'SELECT * FROM test WHERE param = {{ missing_param }}',
+                        missingParameterReferences: [
+                            'missing_param',
+                            'another_missing_param',
+                        ],
+                    }),
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -1200,31 +1184,23 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
+                    queryComposer: createQueryComposerMock({
+                        userAccessControls: {
+                            userAttributes: {},
+                            intrinsicUserAttributes: {},
+                        },
+                        availableParameterDefinitions: {},
+                    }),
                     preAggregationRoute: {
                         sourceExploreName: metricQueryMock.exploreName,
                         preAggregateName: 'orders_daily',
                         mode: 'opportunistic',
                     },
-                    userAccessControls: {
-                        userAttributes: {},
-                        intrinsicUserAttributes: {},
-                    },
-                    availableParameterDefinitions: {},
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -1274,33 +1250,27 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: {
-                        ...metricQueryMock,
-                        exploreName: preAggregateExplore.name,
-                    },
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: preAggregateExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
+                    queryComposer: createQueryComposerMock({
+                        explore: preAggregateExplore,
+                        metricQuery: {
+                            ...metricQueryMock,
+                            exploreName: preAggregateExplore.name,
+                        },
+                        userAccessControls: {
+                            userAttributes: {},
+                            intrinsicUserAttributes: {},
+                        },
+                        availableParameterDefinitions: {},
+                    }),
                     preAggregationRoute: {
                         ...preAggregateExplore.preAggregateSource!,
                         mode: 'required',
                     },
-                    userAccessControls: {
-                        userAttributes: {},
-                        intrinsicUserAttributes: {},
-                    },
-                    availableParameterDefinitions: {},
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 {
@@ -1360,33 +1330,28 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: {
-                        ...metricQueryMock,
-                        exploreName: preAggregateExplore.name,
-                    },
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: preAggregateExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM warehouse',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
+                    queryComposer: createQueryComposerMock({
+                        sql: 'SELECT * FROM warehouse',
+                        explore: preAggregateExplore,
+                        metricQuery: {
+                            ...metricQueryMock,
+                            exploreName: preAggregateExplore.name,
+                        },
+                        userAccessControls: {
+                            userAttributes: {},
+                            intrinsicUserAttributes: {},
+                        },
+                        availableParameterDefinitions: {},
+                    }),
                     preAggregationRoute: {
                         ...preAggregateExplore.preAggregateSource!,
                         mode: 'required',
                     },
-                    userAccessControls: {
-                        userAttributes: {},
-                        intrinsicUserAttributes: {},
-                    },
-                    availableParameterDefinitions: {},
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 {
@@ -1452,31 +1417,24 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM warehouse',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    missingParameterReferences: [],
+                    queryComposer: createQueryComposerMock({
+                        sql: 'SELECT * FROM warehouse',
+                        userAccessControls: {
+                            userAttributes: {},
+                            intrinsicUserAttributes: {},
+                        },
+                        availableParameterDefinitions: {},
+                    }),
                     preAggregationRoute: {
                         sourceExploreName: metricQueryMock.exploreName,
                         preAggregateName: 'orders_daily',
                         mode: 'opportunistic',
                     },
-                    userAccessControls: {
-                        userAttributes: {},
-                        intrinsicUserAttributes: {},
-                    },
-                    availableParameterDefinitions: {},
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -1512,22 +1470,15 @@ describe('AsyncQueryService', () => {
             service.combineParameters = vi.fn().mockResolvedValue(undefined);
             (service as AnyType).prepareMetricQueryAsyncQueryArgs = vi
                 .fn()
-                .mockResolvedValue({
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    warnings: [],
-                    parameterReferences: [],
-                    missingParameterReferences: [],
-                    usedParameters: {},
-                    responseMetricQuery: metricQueryMock,
-                    userAccessControls: {
-                        userAttributes: {},
-                        intrinsicUserAttributes: {},
-                    },
-                    availableParameterDefinitions: {},
-                });
+                .mockResolvedValue(
+                    createQueryComposerMock({
+                        userAccessControls: {
+                            userAttributes: {},
+                            intrinsicUserAttributes: {},
+                        },
+                        availableParameterDefinitions: {},
+                    }),
+                );
             service['executeAsyncQuery'] = vi.fn().mockResolvedValue({
                 queryUuid: 'queryUuid',
                 cacheMetadata: {
@@ -1617,25 +1568,21 @@ describe('AsyncQueryService', () => {
             service.combineParameters = vi.fn().mockResolvedValue(undefined);
             (service as AnyType).prepareMetricQueryAsyncQueryArgs = vi
                 .fn()
-                .mockResolvedValue({
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM duckdb_preagg',
-                    } as unknown as QueryComposer,
-                    fields: {},
-                    warnings: [],
-                    parameterReferences: [],
-                    missingParameterReferences: [],
-                    usedParameters: {},
-                    responseMetricQuery: {
-                        ...metricQueryMock,
-                        exploreName: preAggregateExplore.name,
-                    },
-                    userAccessControls: {
-                        userAttributes: {},
-                        intrinsicUserAttributes: {},
-                    },
-                    availableParameterDefinitions: {},
-                });
+                .mockResolvedValue(
+                    createQueryComposerMock({
+                        sql: 'SELECT * FROM duckdb_preagg',
+                        explore: preAggregateExplore,
+                        metricQuery: {
+                            ...metricQueryMock,
+                            exploreName: preAggregateExplore.name,
+                        },
+                        userAccessControls: {
+                            userAttributes: {},
+                            intrinsicUserAttributes: {},
+                        },
+                        availableParameterDefinitions: {},
+                    }),
+                );
             service['executeAsyncQuery'] = vi.fn().mockResolvedValue({
                 queryUuid: 'queryUuid',
                 cacheMetadata: {
@@ -2792,22 +2739,13 @@ describe('AsyncQueryService', () => {
                 {
                     account: sessionAccount,
                     projectUuid,
-                    metricQuery: metricQueryMock,
                     context: QueryExecutionContext.SQL_RUNNER,
-                    dateZoom: undefined,
                     queryTags: {
                         query_context: QueryExecutionContext.SQL_RUNNER,
                     },
-                    explore: validExplore,
                     invalidateCache: false,
-                    queryComposer: {
-                        getSql: () => 'SELECT * FROM test',
-                    } as unknown as QueryComposer,
-                    fields: {},
+                    queryComposer: createQueryComposerMock(),
                     originalColumns: mockOriginalColumns,
-                    missingParameterReferences: [],
-                    displayTimezone: null,
-                    useTimezoneAwareDateTrunc: false,
                     warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
@@ -3769,22 +3707,16 @@ describe('AsyncQueryService', () => {
                 .fn()
                 .mockResolvedValue({ fields: {} });
 
-            const prepareSpy = vi.fn().mockResolvedValue({
-                queryComposer: {
-                    getSql: () => 'SELECT 1',
-                } as unknown as QueryComposer,
-                fields: {},
-                warnings: [],
-                parameterReferences: [],
-                missingParameterReferences: [],
-                usedParameters: {},
-                responseMetricQuery: metricQueryMock,
-                userAccessControls: {
-                    userAttributes: {},
-                    intrinsicUserAttributes: {},
-                },
-                availableParameterDefinitions: {},
-            });
+            const prepareSpy = vi.fn().mockResolvedValue(
+                createQueryComposerMock({
+                    sql: 'SELECT 1',
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                    availableParameterDefinitions: {},
+                }),
+            );
             (service as AnyType).prepareMetricQueryAsyncQueryArgs = prepareSpy;
 
             service['executeAsyncQuery'] = vi.fn().mockResolvedValue({
@@ -3881,22 +3813,16 @@ describe('AsyncQueryService', () => {
             (service as AnyType).getMetricQueryFields = vi
                 .fn()
                 .mockResolvedValue({ fields: {} });
-            const prepareSpy = vi.fn().mockResolvedValue({
-                queryComposer: {
-                    getSql: () => 'SELECT 1',
-                } as unknown as QueryComposer,
-                fields: {},
-                warnings: [],
-                parameterReferences: [],
-                missingParameterReferences: [],
-                usedParameters: {},
-                responseMetricQuery: metricQueryMock,
-                userAccessControls: {
-                    userAttributes: {},
-                    intrinsicUserAttributes: {},
-                },
-                availableParameterDefinitions: {},
-            });
+            const prepareSpy = vi.fn().mockResolvedValue(
+                createQueryComposerMock({
+                    sql: 'SELECT 1',
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                    availableParameterDefinitions: {},
+                }),
+            );
             (service as AnyType).prepareMetricQueryAsyncQueryArgs = prepareSpy;
             service['executeAsyncQuery'] = vi.fn().mockResolvedValue({
                 queryUuid: 'queryUuid',
@@ -3964,22 +3890,16 @@ describe('AsyncQueryService', () => {
             (service as AnyType).getMetricQueryFields = vi
                 .fn()
                 .mockResolvedValue({ fields: {} });
-            const prepareSpy = vi.fn().mockResolvedValue({
-                queryComposer: {
-                    getSql: () => 'SELECT 1',
-                } as unknown as QueryComposer,
-                fields: {},
-                warnings: [],
-                parameterReferences: [],
-                missingParameterReferences: [],
-                usedParameters: {},
-                responseMetricQuery: metricQueryMock,
-                userAccessControls: {
-                    userAttributes: {},
-                    intrinsicUserAttributes: {},
-                },
-                availableParameterDefinitions: {},
-            });
+            const prepareSpy = vi.fn().mockResolvedValue(
+                createQueryComposerMock({
+                    sql: 'SELECT 1',
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                    availableParameterDefinitions: {},
+                }),
+            );
             (service as AnyType).prepareMetricQueryAsyncQueryArgs = prepareSpy;
             service['executeAsyncQuery'] = vi.fn().mockResolvedValue({
                 queryUuid: 'queryUuid',

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -200,6 +200,7 @@ import {
     ExecuteAsyncSqlQueryArgs,
     isExecuteAsyncDashboardSqlChartByUuid,
     isExecuteAsyncSqlChartByUuid,
+    type CommonAsyncQueryArgs,
     type DownloadAsyncQueryResultsArgs,
     type ExecuteAsyncDashboardChartQueryArgs,
     type ExecuteAsyncDashboardSqlChartArgs,
@@ -279,6 +280,36 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
 
 type ResolvedWarehouseCredentials = CreateWarehouseCredentials & {
     userWarehouseCredentialsUuid: string | undefined;
+};
+
+/**
+ * Args for the async execute seam. Query/context data (explore, metric query,
+ * fields, pivot, timezones, parameters, access controls) is read off the
+ * composer — only orchestration inputs travel as args.
+ */
+type ExecuteAsyncQueryArgs = Pick<
+    CommonAsyncQueryArgs,
+    'account' | 'projectUuid' | 'invalidateCache' | 'context'
+> & {
+    queryTags: RunQueryTags;
+    // Saved chart (metric or SQL) the query was executed from, for analytics attribution
+    chart?: { uuid: string };
+    // Single SQL seam: metric paths pass a QueryComposer, SQL-chart
+    // paths a SqlQueryComposer — getSql() owns pivot wrapping for both.
+    queryComposer: QueryComposer;
+    originalColumns?: ResultColumns;
+    routingTarget?: PreAggregationRoutingDecision['target'];
+    preAggregationRoute?: PreAggregationRoute;
+    warehouseCredentials: ResolvedWarehouseCredentials;
+    // Preloaded org from the caller (e.g. saved chart) to skip a redundant getSummary
+    organizationUuid?: string;
+};
+
+type PreparedAsyncQueryArgs = Omit<
+    ExecuteAsyncQueryArgs,
+    'organizationUuid'
+> & {
+    isPreviewProject: boolean;
 };
 
 export class AsyncQueryService extends ProjectService {
@@ -3285,8 +3316,11 @@ export class AsyncQueryService extends ProjectService {
 
     private static addUserAttributeQueryTags(
         queryTags: RunQueryTags,
-        userAccessControls: UserAccessControls,
+        userAccessControls: UserAccessControls | undefined,
     ): RunQueryTags {
+        if (!userAccessControls) {
+            return queryTags;
+        }
         return {
             ...queryTags,
             ...getUserAttributeQueryTags(userAccessControls.userAttributes),
@@ -3475,7 +3509,7 @@ export class AsyncQueryService extends ProjectService {
         preloadedUserAccessControls?: UserAccessControls;
         preloadedProjectParameters?: DbProjectParameter[];
         preloadedProjectTimezone?: string;
-    }) {
+    }): Promise<QueryComposer> {
         assertIsAccountWithOrg(account);
 
         const resolvedUserAccessControls =
@@ -3515,7 +3549,7 @@ export class AsyncQueryService extends ProjectService {
             preloadedProjectTimezone,
         });
 
-        const queryComposer = ProjectService._createQueryComposer({
+        return ProjectService._createQueryComposer({
             metricQuery,
             explore,
             warehouseSqlBuilder,
@@ -3532,59 +3566,8 @@ export class AsyncQueryService extends ProjectService {
             useTimezoneAwareDateTrunc,
             columnTimezone,
             applyDateZoomToFilters,
-        });
-
-        const fullQuery = queryComposer.compile();
-        const effectiveMetricQuery = queryComposer.getMetricQuery();
-        const effectivePivotConfiguration =
-            queryComposer.getPivotConfiguration();
-
-        const resolvedMetricOverrides =
-            getMetricOverridesWithPopInheritance(metricQuery);
-
-        const fieldsWithOverrides: ItemsMap = Object.fromEntries(
-            Object.entries(fullQuery.fields).map(([key, value]) => {
-                // Check for metric or dimension overrides. PoP metric overrides
-                // are inherited from their base metric by the shared util above.
-                const override =
-                    resolvedMetricOverrides[key] ||
-                    metricQuery.dimensionOverrides?.[key];
-                if (override) {
-                    const { formatOptions } = override;
-
-                    if (formatOptions) {
-                        return [
-                            key,
-                            {
-                                ...value,
-                                ...getFieldFormatOverrideProps(formatOptions),
-                            },
-                        ];
-                    }
-                }
-                return [key, value];
-            }),
-        );
-
-        const responseMetricQuery = effectiveMetricQuery;
-
-        return {
-            queryComposer,
-            fields: fieldsWithOverrides,
-            warnings: fullQuery.warnings,
-            parameterReferences: Array.from(fullQuery.parameterReferences),
-            missingParameterReferences: Array.from(
-                fullQuery.missingParameterReferences,
-            ),
-            usedParameters: fullQuery.usedParameters,
-            responseMetricQuery,
-            effectivePivotConfiguration,
-            userAccessControls: { userAttributes, intrinsicUserAttributes },
-            availableParameterDefinitions,
-            resolvedTimezone,
             displayTimezone,
-            useTimezoneAwareDateTrunc,
-        };
+        });
     }
 
     private async assertOrganizationNotBlocked(
@@ -3598,28 +3581,7 @@ export class AsyncQueryService extends ProjectService {
     }
 
     private async executePreparedAsyncQuery(
-        // TODO: remove metric query, fields, etc from args once they are no longer needed in the database
-        args: ExecuteAsyncMetricQueryArgs & {
-            queryTags: RunQueryTags;
-            explore: Explore;
-            isPreviewProject: boolean;
-            // Saved chart (metric or SQL) the query was executed from, for analytics attribution
-            chart?: { uuid: string };
-            fields: ItemsMap;
-            // Single SQL seam: metric paths pass a QueryComposer, SQL-chart
-            // paths a SqlQueryComposer — getSql() owns pivot wrapping for both.
-            queryComposer: QueryComposer;
-            originalColumns?: ResultColumns;
-            missingParameterReferences: string[];
-            timezone?: string;
-            displayTimezone: string | null;
-            useTimezoneAwareDateTrunc: boolean;
-            routingTarget?: PreAggregationRoutingDecision['target'];
-            preAggregationRoute?: PreAggregationRoute;
-            userAccessControls?: UserAccessControls;
-            availableParameterDefinitions?: ParameterDefinitions;
-            warehouseCredentials: ResolvedWarehouseCredentials;
-        },
+        args: PreparedAsyncQueryArgs,
         requestParameters: ExecuteAsyncQueryRequestParams,
         organizationUuid: string,
     ): Promise<ExecuteAsyncQueryReturn> {
@@ -3632,30 +3594,29 @@ export class AsyncQueryService extends ProjectService {
                     account,
                     projectUuid,
                     context,
-                    dateZoom,
                     queryTags,
-                    explore,
                     chart,
                     isPreviewProject,
                     queryComposer,
-                    metricQuery,
-                    fields: fieldsMap,
                     originalColumns,
-                    missingParameterReferences,
-                    pivotConfiguration,
-                    parameters,
-                    timezone,
-                    displayTimezone,
-                    useTimezoneAwareDateTrunc,
                     routingTarget,
                     preAggregationRoute,
-                    userAccessControls,
-                    availableParameterDefinitions,
                     warehouseCredentials,
                 } = args;
 
                 try {
                     assertIsAccountWithOrg(account);
+
+                    const explore = queryComposer.getExplore();
+                    const metricQuery = queryComposer.getMetricQuery();
+                    const fieldsMap = queryComposer.getFields();
+                    const pivotConfiguration =
+                        queryComposer.getPivotConfiguration();
+                    const missingParameterReferences =
+                        queryComposer.getMissingParameterReferences();
+                    const dateZoom = queryComposer.getDateZoom();
+                    const timezone = queryComposer.getTimezone();
+                    const displayTimezone = queryComposer.getDisplayTimezone();
 
                     const warehouseCredentialsType = warehouseCredentials.type;
                     const warehouseCredentialsOverrides: RunAsyncWarehouseQueryArgs['warehouseCredentialsOverrides'] =
@@ -3938,16 +3899,19 @@ export class AsyncQueryService extends ProjectService {
                             metricQuery,
                             timezone: timezone ?? 'UTC',
                             dateZoom,
-                            parameters,
+                            parameters: queryComposer.getParameters(),
                             routingTarget: routingTarget ?? 'warehouse',
                             preAggregationRoute,
                             fieldsMap,
                             pivotConfiguration,
                             startOfWeek: warehouseCredentials.startOfWeek,
-                            userAccessControls,
-                            availableParameterDefinitions,
+                            userAccessControls:
+                                queryComposer.getUserAccessControls(),
+                            availableParameterDefinitions:
+                                queryComposer.getAvailableParameterDefinitions(),
                             queryUuid: queryHistoryUuid,
-                            useTimezoneAwareDateTrunc,
+                            useTimezoneAwareDateTrunc:
+                                queryComposer.getUseTimezoneAwareDateTrunc(),
                         });
                     const resolveMs = Date.now() - resolveStart;
 
@@ -4194,27 +4158,7 @@ export class AsyncQueryService extends ProjectService {
     }
 
     private async executeAsyncQuery(
-        // TODO: remove metric query, fields, etc from args once they are no longer needed in the database
-        args: ExecuteAsyncMetricQueryArgs & {
-            queryTags: RunQueryTags;
-            explore: Explore;
-            // Saved chart (metric or SQL) the query was executed from, for analytics attribution
-            chart?: { uuid: string };
-            fields: ItemsMap;
-            queryComposer: QueryComposer;
-            originalColumns?: ResultColumns;
-            missingParameterReferences: string[];
-            timezone?: string;
-            displayTimezone: string | null;
-            useTimezoneAwareDateTrunc: boolean;
-            routingTarget?: PreAggregationRoutingDecision['target'];
-            preAggregationRoute?: PreAggregationRoute;
-            userAccessControls?: UserAccessControls;
-            availableParameterDefinitions?: ParameterDefinitions;
-            warehouseCredentials: ResolvedWarehouseCredentials;
-            // Preloaded org from the caller (e.g. saved chart) to skip a redundant getSummary
-            organizationUuid?: string;
-        },
+        args: ExecuteAsyncQueryArgs,
         requestParameters: ExecuteAsyncQueryRequestParams,
     ): Promise<ExecuteAsyncQueryReturn> {
         assertIsAccountWithOrg(args.account);
@@ -4226,6 +4170,7 @@ export class AsyncQueryService extends ProjectService {
             args.organizationUuid ?? projectSummary.organizationUuid;
         // Preview project queries are excluded from the usage event stream
         const isPreviewProject = projectSummary.type === ProjectType.PREVIEW;
+        const exploreName = args.queryComposer.getExplore().name;
         const auditedAbility = this.createAuditedAbility(args.account);
         const isForbidden =
             auditedAbility.cannot(
@@ -4240,9 +4185,9 @@ export class AsyncQueryService extends ProjectService {
                 subject('Explore', {
                     organizationUuid,
                     projectUuid: args.projectUuid,
-                    exploreNames: [args.explore.name],
+                    exploreNames: [exploreName],
                     metadata: {
-                        exploreName: args.explore.name,
+                        exploreName,
                     },
                 }),
             );
@@ -4417,21 +4362,7 @@ export class AsyncQueryService extends ProjectService {
         );
 
         const prepareStart = Date.now();
-        const {
-            queryComposer,
-            fields,
-            warnings,
-            parameterReferences,
-            missingParameterReferences,
-            usedParameters,
-            responseMetricQuery,
-            effectivePivotConfiguration,
-            userAccessControls,
-            availableParameterDefinitions,
-            resolvedTimezone,
-            displayTimezone,
-            useTimezoneAwareDateTrunc,
-        } = await this.prepareMetricQueryAsyncQueryArgs({
+        const queryComposer = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery,
             dateZoom,
@@ -4448,14 +4379,15 @@ export class AsyncQueryService extends ProjectService {
             preloadedProjectParameters: projectParameters,
             preloadedProjectTimezone: projectTimezone,
         });
+        const fields = queryComposer.getFields();
         const prepareMs = Date.now() - prepareStart;
 
-        const effectiveMetricQuery = responseMetricQuery;
+        const effectiveMetricQuery = queryComposer.getMetricQuery();
 
         const queryTagsWithUserAttributes =
             AsyncQueryService.addUserAttributeQueryTags(
                 queryTags,
-                userAccessControls,
+                queryComposer.getUserAccessControls(),
             );
 
         const requestParameters: ExecuteAsyncMetricQueryRequestParams = {
@@ -4486,29 +4418,17 @@ export class AsyncQueryService extends ProjectService {
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 account,
-                metricQuery: effectiveMetricQuery,
                 projectUuid,
                 organizationUuid,
-                explore,
                 context,
                 queryTags: queryTagsWithUserAttributes,
-                dateZoom,
                 invalidateCache,
-                parameters: combinedParameters,
-                fields,
                 queryComposer,
                 originalColumns: undefined,
-                missingParameterReferences,
-                timezone: resolvedTimezone,
-                displayTimezone,
-                useTimezoneAwareDateTrunc,
-                pivotConfiguration: effectivePivotConfiguration,
                 warehouseCredentials,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
-                    userAccessControls,
-                    availableParameterDefinitions,
                 }),
             },
             requestParameters,
@@ -4520,12 +4440,12 @@ export class AsyncQueryService extends ProjectService {
                 ...cacheMetadata,
                 preAggregate: routingDecision.preAggregateMetadata,
             },
-            metricQuery: responseMetricQuery,
+            metricQuery: effectiveMetricQuery,
             fields,
-            warnings,
-            parameterReferences,
-            usedParametersValues: usedParameters,
-            resolvedTimezone: displayTimezone,
+            warnings: queryComposer.getWarnings(),
+            parameterReferences: queryComposer.getParameterReferences(),
+            usedParametersValues: queryComposer.getUsedParameters(),
+            resolvedTimezone: queryComposer.getDisplayTimezone(),
         };
     }
 
@@ -4668,15 +4588,7 @@ export class AsyncQueryService extends ProjectService {
             parameters,
         );
 
-        const {
-            queryComposer,
-            fields,
-            missingParameterReferences,
-            userAccessControls,
-            resolvedTimezone,
-            displayTimezone,
-            useTimezoneAwareDateTrunc,
-        } = await this.prepareMetricQueryAsyncQueryArgs({
+        const queryComposer = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery,
             explore,
@@ -4690,7 +4602,7 @@ export class AsyncQueryService extends ProjectService {
         const queryTagsWithUserAttributes =
             AsyncQueryService.addUserAttributeQueryTags(
                 baseQueryTags,
-                userAccessControls,
+                queryComposer.getUserAccessControls(),
             );
 
         const requestParameters: ExecuteAsyncFieldValueSearchRequestParams = {
@@ -4707,21 +4619,13 @@ export class AsyncQueryService extends ProjectService {
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 account,
-                metricQuery,
                 projectUuid,
                 organizationUuid,
-                explore,
                 context,
                 queryTags: queryTagsWithUserAttributes,
                 invalidateCache: invalidateCache || forceRefresh,
-                parameters: combinedParameters,
-                fields,
                 queryComposer,
                 originalColumns: undefined,
-                missingParameterReferences,
-                timezone: resolvedTimezone,
-                displayTimezone,
-                useTimezoneAwareDateTrunc,
                 warehouseCredentials,
                 routingTarget: 'warehouse',
             },
@@ -4966,20 +4870,7 @@ export class AsyncQueryService extends ProjectService {
               )
             : undefined;
 
-        const {
-            queryComposer,
-            fields: fieldsWithOverrides,
-            warnings,
-            parameterReferences,
-            missingParameterReferences,
-            usedParameters,
-            responseMetricQuery,
-            userAccessControls,
-            availableParameterDefinitions,
-            resolvedTimezone,
-            displayTimezone,
-            useTimezoneAwareDateTrunc,
-        } = await this.prepareMetricQueryAsyncQueryArgs({
+        const queryComposer = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery: metricQueryWithLimit,
             explore,
@@ -4991,6 +4882,7 @@ export class AsyncQueryService extends ProjectService {
             columnTimezone: getColumnTimezone(warehouseCredentials),
             preloadedUserAccessControls,
         });
+        const fieldsWithOverrides = queryComposer.getFields();
 
         const routingDecision = this.getPreAggregationRoutingDecision({
             metricQuery: metricQueryWithLimit,
@@ -5032,7 +4924,7 @@ export class AsyncQueryService extends ProjectService {
         const queryTagsWithUserAttributes =
             AsyncQueryService.addUserAttributeQueryTags(
                 queryTags,
-                userAccessControls,
+                queryComposer.getUserAccessControls(),
             );
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
@@ -5040,27 +4932,16 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 projectUuid,
                 organizationUuid: savedChartOrganizationUuid,
-                explore,
                 chart: { uuid: savedChart.uuid },
                 context,
                 queryTags: queryTagsWithUserAttributes,
                 invalidateCache,
-                metricQuery: metricQueryWithLimit,
-                parameters: combinedParameters,
-                fields: fieldsWithOverrides,
                 queryComposer,
                 originalColumns: undefined,
-                missingParameterReferences,
-                timezone: resolvedTimezone,
-                displayTimezone,
-                useTimezoneAwareDateTrunc,
-                pivotConfiguration,
                 warehouseCredentials,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
-                    userAccessControls,
-                    availableParameterDefinitions,
                 }),
             },
             requestParameters,
@@ -5072,12 +4953,12 @@ export class AsyncQueryService extends ProjectService {
                 ...cacheMetadata,
                 preAggregate: routingDecision.preAggregateMetadata,
             },
-            metricQuery: responseMetricQuery,
+            metricQuery: queryComposer.getMetricQuery(),
             fields: fieldsWithOverrides,
-            warnings,
-            parameterReferences,
-            usedParametersValues: usedParameters,
-            resolvedTimezone: displayTimezone,
+            warnings: queryComposer.getWarnings(),
+            parameterReferences: queryComposer.getParameterReferences(),
+            usedParametersValues: queryComposer.getUsedParameters(),
+            resolvedTimezone: queryComposer.getDisplayTimezone(),
         };
     }
 
@@ -5434,19 +5315,7 @@ export class AsyncQueryService extends ProjectService {
               )
             : undefined;
 
-        const {
-            queryComposer,
-            fields: fieldsWithOverrides,
-            parameterReferences,
-            missingParameterReferences,
-            usedParameters,
-            responseMetricQuery,
-            userAccessControls: queryUserAccessControls,
-            availableParameterDefinitions,
-            resolvedTimezone,
-            displayTimezone,
-            useTimezoneAwareDateTrunc,
-        } = await this.prepareMetricQueryAsyncQueryArgs({
+        const queryComposer = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery: metricQueryWithLimit,
             explore,
@@ -5462,6 +5331,8 @@ export class AsyncQueryService extends ProjectService {
             preloadedProjectParameters: projectParameters,
             preloadedProjectTimezone: projectTimezone,
         });
+        const fieldsWithOverrides = queryComposer.getFields();
+        const parameterReferences = queryComposer.getParameterReferences();
 
         const routingDecision = this.getPreAggregationRoutingDecision({
             metricQuery: metricQueryWithLimit,
@@ -5504,7 +5375,7 @@ export class AsyncQueryService extends ProjectService {
         const queryTagsWithUserAttributes =
             AsyncQueryService.addUserAttributeQueryTags(
                 baseQueryTags,
-                queryUserAccessControls,
+                queryComposer.getUserAccessControls(),
             );
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
@@ -5512,28 +5383,16 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 projectUuid,
                 organizationUuid,
-                explore,
                 chart: { uuid: savedChart.uuid },
-                metricQuery: metricQueryWithLimit,
                 context,
                 queryTags: queryTagsWithUserAttributes,
                 invalidateCache,
-                dateZoom,
-                parameters: combinedParameters,
-                fields: fieldsWithOverrides,
                 queryComposer,
                 originalColumns: undefined,
-                missingParameterReferences,
-                timezone: resolvedTimezone,
-                displayTimezone,
-                useTimezoneAwareDateTrunc,
-                pivotConfiguration,
                 warehouseCredentials,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
-                    userAccessControls: queryUserAccessControls,
-                    availableParameterDefinitions,
                 }),
             },
             requestParameters,
@@ -5546,17 +5405,17 @@ export class AsyncQueryService extends ProjectService {
                 preAggregate: routingDecision.preAggregateMetadata,
             },
             appliedDashboardFilters,
-            metricQuery: responseMetricQuery,
+            metricQuery: queryComposer.getMetricQuery(),
             fields: fieldsWithOverrides,
             parameterReferences,
-            usedParametersValues: usedParameters,
+            usedParametersValues: queryComposer.getUsedParameters(),
             // In effect when a date dimension was overridden, or a grain is selected and
             // the chart references a reserved date-zoom parameter.
             dateZoomApplied:
                 dateZoomApplied ||
                 (!!dateZoom?.granularity &&
                     hasReservedParameterReference(parameterReferences)),
-            resolvedTimezone: displayTimezone,
+            resolvedTimezone: queryComposer.getDisplayTimezone(),
         };
     }
 
@@ -5807,19 +5666,7 @@ export class AsyncQueryService extends ProjectService {
             maxLimit,
         );
 
-        const {
-            queryComposer,
-            fields,
-            warnings,
-            parameterReferences,
-            missingParameterReferences,
-            usedParameters,
-            responseMetricQuery,
-            userAccessControls,
-            resolvedTimezone,
-            displayTimezone,
-            useTimezoneAwareDateTrunc,
-        } = await this.prepareMetricQueryAsyncQueryArgs({
+        const queryComposer = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery: underlyingDataMetricQueryWithLimit,
             explore,
@@ -5836,28 +5683,20 @@ export class AsyncQueryService extends ProjectService {
         const queryTagsWithUserAttributes =
             AsyncQueryService.addUserAttributeQueryTags(
                 baseQueryTags,
-                userAccessControls,
+                queryComposer.getUserAccessControls(),
             );
 
         const { queryUuid: underlyingDataQueryUuid, cacheMetadata } =
             await this.executeAsyncQuery(
                 {
                     account,
-                    metricQuery: underlyingDataMetricQueryWithLimit,
                     projectUuid,
                     organizationUuid,
-                    explore,
                     context,
                     queryTags: queryTagsWithUserAttributes,
                     invalidateCache,
-                    dateZoom,
-                    fields,
                     queryComposer,
                     originalColumns: undefined,
-                    missingParameterReferences,
-                    timezone: resolvedTimezone,
-                    displayTimezone,
-                    useTimezoneAwareDateTrunc,
                     warehouseCredentials,
                 },
                 requestParameters,
@@ -5866,12 +5705,12 @@ export class AsyncQueryService extends ProjectService {
         return {
             queryUuid: underlyingDataQueryUuid,
             cacheMetadata,
-            metricQuery: responseMetricQuery,
-            fields,
-            warnings,
-            parameterReferences,
-            usedParametersValues: usedParameters,
-            resolvedTimezone: displayTimezone,
+            metricQuery: queryComposer.getMetricQuery(),
+            fields: queryComposer.getFields(),
+            warnings: queryComposer.getWarnings(),
+            parameterReferences: queryComposer.getParameterReferences(),
+            usedParametersValues: queryComposer.getUsedParameters(),
+            resolvedTimezone: queryComposer.getDisplayTimezone(),
         };
     }
 
@@ -5911,12 +5750,9 @@ export class AsyncQueryService extends ProjectService {
             warehouseConnection,
             warehouseCredentials,
             queryTags,
-            metricQuery,
-            virtualView,
             queryComposer,
             originalColumns,
             parameterReferences,
-            missingParameterReferences,
             usedParameters,
         } = await this.prepareSqlChartAsyncQueryArgs({
             account,
@@ -5937,17 +5773,10 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 projectUuid,
                 organizationUuid,
-                explore: virtualView,
                 queryTags,
-                metricQuery,
                 context,
-                fields: getItemMap(virtualView),
                 queryComposer,
                 originalColumns,
-                missingParameterReferences,
-                pivotConfiguration,
-                displayTimezone: null,
-                useTimezoneAwareDateTrunc: false,
                 warehouseCredentials,
             },
             {
@@ -6232,12 +6061,9 @@ export class AsyncQueryService extends ProjectService {
             warehouseCredentials,
             queryTags,
             metricQuery,
-            virtualView,
-            pivotConfiguration,
             queryComposer,
             originalColumns,
             parameterReferences,
-            missingParameterReferences,
             usedParameters,
         } = await this.prepareSqlChartAsyncQueryArgs({
             account,
@@ -6259,18 +6085,11 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 projectUuid,
                 organizationUuid: sqlChart.organization.organizationUuid,
-                explore: virtualView,
                 chart: { uuid: sqlChart.savedSqlUuid },
                 queryTags,
-                metricQuery,
                 context,
-                fields: getItemMap(virtualView),
                 queryComposer,
                 originalColumns,
-                missingParameterReferences,
-                pivotConfiguration,
-                displayTimezone: null,
-                useTimezoneAwareDateTrunc: false,
                 warehouseCredentials,
             },
             {
@@ -6384,13 +6203,10 @@ export class AsyncQueryService extends ProjectService {
             warehouseCredentials,
             queryTags,
             metricQuery,
-            virtualView,
-            pivotConfiguration,
             queryComposer,
             appliedDashboardFilters,
             originalColumns,
             parameterReferences,
-            missingParameterReferences,
             usedParameters,
         } = await this.prepareSqlChartAsyncQueryArgs({
             account,
@@ -6416,18 +6232,11 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 projectUuid,
                 organizationUuid: savedChart.organization.organizationUuid,
-                explore: virtualView,
                 chart: { uuid: savedChart.savedSqlUuid },
                 queryTags,
-                metricQuery,
                 context,
-                fields: getItemMap(virtualView),
                 queryComposer,
                 originalColumns,
-                missingParameterReferences,
-                pivotConfiguration,
-                displayTimezone: null,
-                useTimezoneAwareDateTrunc: false,
                 warehouseCredentials,
             },
             {
@@ -6768,16 +6577,7 @@ export class AsyncQueryService extends ProjectService {
             warehouseCredentials.startOfWeek,
         );
 
-        const {
-            queryComposer,
-            fields,
-            missingParameterReferences,
-            userAccessControls: resolvedUserAccessControls,
-            availableParameterDefinitions,
-            resolvedTimezone,
-            displayTimezone,
-            useTimezoneAwareDateTrunc,
-        } = await this.prepareMetricQueryAsyncQueryArgs({
+        const queryComposer = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery,
             dateZoom,
@@ -6788,6 +6588,7 @@ export class AsyncQueryService extends ProjectService {
             materializationRole: userAccessControls,
             columnTimezone: getColumnTimezone(warehouseCredentials),
         });
+        const fields = queryComposer.getFields();
 
         const routingDecision = this.getPreAggregationRoutingDecision({
             metricQuery,
@@ -6806,7 +6607,7 @@ export class AsyncQueryService extends ProjectService {
         const queryTagsWithUserAttributes =
             AsyncQueryService.addUserAttributeQueryTags(
                 queryTags,
-                resolvedUserAccessControls,
+                queryComposer.getUserAccessControls(),
             );
 
         const { queryUuid, cacheMetadata } =
@@ -6815,26 +6616,15 @@ export class AsyncQueryService extends ProjectService {
                     account,
                     projectUuid,
                     isPreviewProject: await this.isProjectPreview(projectUuid),
-                    explore,
-                    metricQuery,
                     context,
                     queryTags: queryTagsWithUserAttributes,
                     invalidateCache,
-                    dateZoom,
-                    parameters,
-                    fields,
                     queryComposer,
                     originalColumns: undefined,
-                    missingParameterReferences,
-                    timezone: resolvedTimezone,
-                    displayTimezone,
-                    useTimezoneAwareDateTrunc,
                     warehouseCredentials,
                     routingTarget: routingDecision.target,
                     ...(routingDecision.target === 'pre_aggregate' && {
                         preAggregationRoute: routingDecision.route,
-                        userAccessControls: resolvedUserAccessControls,
-                        availableParameterDefinitions,
                     }),
                 },
                 {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4077,6 +4077,7 @@ export class ProjectService extends BaseService {
         useTimezoneAwareDateTrunc,
         columnTimezone,
         applyDateZoomToFilters,
+        displayTimezone,
     }: {
         metricQuery: MetricQuery;
         explore: Explore;
@@ -4103,6 +4104,11 @@ export class ProjectService extends BaseService {
          * Only safe on the underlying-data path where filters are solely click-filters.
          */
         applyDateZoomToFilters?: boolean;
+        /**
+         * Flag-gated timezone echoed to clients and persisted with the query.
+         * Only the async execute path needs it; compile-only callers omit it.
+         */
+        displayTimezone?: string | null;
     }): QueryComposer {
         return new QueryComposer(
             { metricQuery, pivotConfiguration, totalConfiguration },
@@ -4121,6 +4127,7 @@ export class ProjectService extends BaseService {
                 useTimezoneAwareDateTrunc,
                 columnTimezone,
                 applyDateZoomToFilters,
+                displayTimezone,
             },
         );
     }

--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -47,6 +47,8 @@ const sql = composer.getSql({ columnLimit }); // PivotQueryBuilder-wrapped when 
 
 `compile()` delegates to a protected `computeCompiled()` template-method seam (memoized). Subclasses override `computeCompiled()` to build the base `CompiledQuery` from different inputs; the pivot pipeline (`getSql`) is inherited unchanged.
 
+**Getter surface.** The composer is the single carrier of query/context data through the async execute seam — `AsyncQueryService.executePreparedAsyncQuery` reads everything (explore, metric query, fields, pivot, timezones, parameters, access controls) off `get*()` getters instead of loose args. Non-obvious ones: `getFields()` applies metric/dimension format overrides from the **source** query, `getParameters()` returns the raw combined values (not the reserved-merged compile variant), and `getDisplayTimezone()` is a context carry (not a compile input) that SQL charts pin to `null`.
+
 **Totals mode.** Set `totalConfiguration: { kind, subtotalDimensions }` on the
 definition to build a totals query. The composer collapses the source
 `metricQuery` + `pivotConfiguration` into the requested grain

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
@@ -1,4 +1,5 @@
 import {
+    CustomFormatType,
     MetricQuery,
     PivotConfiguration,
     SortByDirection,
@@ -103,6 +104,58 @@ describe('QueryComposer', () => {
         // The pivot SQL wraps (and therefore differs from) the base query.
         expect(sql).not.toBe(composer.compile().query);
         expect(sql).toMatchSnapshot();
+    });
+
+    describe('getters', () => {
+        it('combines user access controls only when both attribute maps are in context', () => {
+            const withAttributes = new QueryComposer(
+                { metricQuery: METRIC_QUERY },
+                CONTEXT,
+            );
+            expect(withAttributes.getUserAccessControls()).toEqual({
+                userAttributes: {},
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            });
+
+            const withoutAttributes = new QueryComposer(
+                { metricQuery: METRIC_QUERY },
+                {
+                    explore: EXPLORE,
+                    warehouseSqlBuilder: warehouseClientMock,
+                },
+            );
+            expect(withoutAttributes.getUserAccessControls()).toBeUndefined();
+        });
+
+        it('applies metric format overrides from the source query in getFields', () => {
+            const composer = new QueryComposer(
+                {
+                    metricQuery: {
+                        ...METRIC_QUERY,
+                        metricOverrides: {
+                            table1_metric1: {
+                                formatOptions: {
+                                    type: CustomFormatType.PERCENT,
+                                    round: 1,
+                                },
+                            },
+                        },
+                    },
+                },
+                CONTEXT,
+            );
+
+            const fields = composer.getFields();
+            const baseFields = composer.compile().fields;
+
+            expect(fields.table1_metric1).toEqual({
+                ...baseFields.table1_metric1,
+                format: '#,##0.0%',
+                separator: undefined,
+            });
+            // Fields without an override pass through untouched.
+            expect(fields.table1_dim1).toEqual(baseFields.table1_dim1);
+        });
     });
 
     describe('totalConfiguration', () => {

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -1,4 +1,6 @@
 import {
+    getFieldFormatOverrideProps,
+    getMetricOverridesWithPopInheritance,
     mergeReservedDefinitions,
     mergeReservedValues,
     resolveReservedParameterValues,
@@ -10,6 +12,8 @@ import {
     type ParameterDefinitions,
     type ParametersValuesMap,
     type PivotConfiguration,
+    type QueryWarning,
+    type UserAccessControls,
     type UserAttributeValueMap,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
@@ -67,6 +71,11 @@ export type QueryComposerContext = {
     useTimezoneAwareDateTrunc?: boolean;
     columnTimezone?: string;
     applyDateZoomToFilters?: boolean;
+    /**
+     * Flag-gated timezone echoed to clients and persisted with the query.
+     * Not a compile input — `timezone` drives SQL. SQL charts set it to null.
+     */
+    displayTimezone?: string | null;
 };
 
 /**
@@ -139,6 +148,91 @@ export class QueryComposer {
     /** The effective (totals-collapsed) pivot configuration, if any. */
     getPivotConfiguration(): PivotConfiguration | undefined {
         return this.getEffectiveDefinition().pivotConfiguration;
+    }
+
+    /**
+     * Compiled fields with metric/dimension format overrides applied.
+     * Overrides live on the source query; PoP metric overrides inherit from
+     * their base metric.
+     */
+    getFields(): ItemsMap {
+        const { fields } = this.compile();
+        const sourceMetricQuery = this.definition.metricQuery;
+        const resolvedMetricOverrides =
+            getMetricOverridesWithPopInheritance(sourceMetricQuery);
+
+        return Object.fromEntries(
+            Object.entries(fields).map(([key, value]) => {
+                const override =
+                    resolvedMetricOverrides[key] ||
+                    sourceMetricQuery.dimensionOverrides?.[key];
+                const formatOptions = override?.formatOptions;
+                if (formatOptions) {
+                    return [
+                        key,
+                        {
+                            ...value,
+                            ...getFieldFormatOverrideProps(formatOptions),
+                        },
+                    ];
+                }
+                return [key, value];
+            }),
+        );
+    }
+
+    /** Resolved timezone the SQL was compiled with. */
+    getTimezone(): string | undefined {
+        return this.context.timezone;
+    }
+
+    /** Flag-gated timezone echoed to clients and persisted with the query. */
+    getDisplayTimezone(): string | null {
+        return this.context.displayTimezone ?? null;
+    }
+
+    getDateZoom(): DateZoom | undefined {
+        return this.context.dateZoom;
+    }
+
+    /** Raw combined parameter values (not the reserved-merged compile variant). */
+    getParameters(): ParametersValuesMap | undefined {
+        return this.context.parameters;
+    }
+
+    getUserAccessControls(): UserAccessControls | undefined {
+        const { userAttributes, intrinsicUserAttributes } = this.context;
+        if (
+            userAttributes === undefined ||
+            intrinsicUserAttributes === undefined
+        ) {
+            return undefined;
+        }
+        return { userAttributes, intrinsicUserAttributes };
+    }
+
+    getAvailableParameterDefinitions(): ParameterDefinitions | undefined {
+        return this.context.availableParameterDefinitions;
+    }
+
+    getUseTimezoneAwareDateTrunc(): boolean {
+        return this.context.useTimezoneAwareDateTrunc ?? false;
+    }
+
+    getWarnings(): QueryWarning[] {
+        return this.compile().warnings;
+    }
+
+    getUsedParameters(): ParametersValuesMap {
+        return this.compile().usedParameters;
+    }
+
+    getParameterReferences(): string[] {
+        return Array.from(this.compile().parameterReferences);
+    }
+
+    getMissingParameterReferences(): string[] {
+        return Array.from(this.compile().missingParameterReferences);
     }
 
     /** Compile to base SQL, memoized. Delegates to the overridable seam. */

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
@@ -54,7 +54,7 @@ export class SqlQueryComposer extends QueryComposer {
         const built = SqlQueryComposer.build(args);
         // SQL charts override computeCompiled, so only the explore and warehouse
         // builder (used by the inherited getSql) are needed — the metric-compile
-        // context fields are omitted.
+        // context fields are omitted. SQL charts have no display timezone.
         super(
             {
                 metricQuery: built.metricQuery,
@@ -63,6 +63,8 @@ export class SqlQueryComposer extends QueryComposer {
             {
                 explore: built.virtualView,
                 warehouseSqlBuilder: args.warehouseClient,
+                parameters: args.parameters,
+                displayTimezone: null,
             },
         );
         this.sqlQueryBuilder = built.sqlQueryBuilder;


### PR DESCRIPTION
test-all

Closes: PROD-8778

### Description:

Part of the QueryComposer facade rebuild ([5/8]). Adds getters on `QueryComposer` for every value the async execute seam needs (fields with format overrides, effective metric query/pivot, explore, timezones, date zoom, parameters, access controls, parameter references/warnings), with `displayTimezone` carried on the composer context (the SQL subclass pins it to `null`). `executePreparedAsyncQuery`/`executeAsyncQuery` now take a slim `PreparedAsyncQueryArgs` of orchestration-only inputs and derive the rest from the composer, `prepareMetricQueryAsyncQueryArgs` returns the composer directly instead of a bag, and all execute call sites (including the pre-aggregate conditional spread) are updated.

Correctness notes:
- The pre-agg-only args (`userAccessControls`, `availableParameterDefinitions`, `dateZoom`, `parameters`) are consumed only after the `if (!preAggregationRoute) return warehouse` early-return in `resolveAsyncQueryExecutionPlan`, so deriving them (always defined) vs. the old undefined-for-warehouse-routing is inert.
- `getParameters()` returns the raw combined parameters, not the reserved-merged variant used internally for compilation.
- Persisted `metricQuery.timezone` still follows the flag-gated `displayTimezone` (regression tests kept, now driven through the composer).

Tests: existing `AsyncQueryService.test.ts` green (52), getter unit tests added for the getters with logic (`getFields` overrides, `getUserAccessControls`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
