### PR TITLE
refactor(backend): harden QueryComposer invariants

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -98,6 +98,7 @@ import { SpacePermissionService } from '../../../services/SpaceService/SpacePerm
 import { getFilteredExplore } from '../../../services/UserAttributesService/UserAttributeUtils';
 import { wrapSentryTransaction } from '../../../utils';
 import { EncryptionUtil } from '../../../utils/EncryptionUtil/EncryptionUtil';
+import { QueryComposer } from '../../../utils/QueryBuilder/QueryComposer';
 import { SubtotalsCalculator } from '../../../utils/SubtotalsCalculator';
 import { EmbedDashboardViewed, EmbedQueryViewed } from '../../analytics';
 import { EmbedModel } from '../../models/EmbedModel';
@@ -1049,23 +1050,25 @@ export class EmbedService extends BaseService {
             filteredExplore,
         );
 
-        const compiledQuery = await ProjectService._compileQuery({
-            metricQuery,
-            explore: filteredExplore,
-            warehouseSqlBuilder: warehouseClient,
-            intrinsicUserAttributes,
-            userAttributes,
-            timezone,
-            dateZoom: dateZoomGranularity
-                ? {
-                      granularity: dateZoomGranularity,
-                  }
-                : undefined,
-            parameters: combinedParameters,
-            availableParameterDefinitions,
-            useTimezoneAwareDateTrunc,
-            columnTimezone: getColumnTimezone(warehouseClient.credentials),
-        });
+        const compiledQuery = new QueryComposer(
+            { metricQuery },
+            {
+                explore: filteredExplore,
+                warehouseSqlBuilder: warehouseClient,
+                intrinsicUserAttributes,
+                userAttributes,
+                timezone,
+                dateZoom: dateZoomGranularity
+                    ? {
+                          granularity: dateZoomGranularity,
+                      }
+                    : undefined,
+                parameters: combinedParameters,
+                availableParameterDefinitions,
+                useTimezoneAwareDateTrunc,
+                columnTimezone: getColumnTimezone(warehouseClient.credentials),
+            },
+        ).compile();
 
         const results =
             await this.projectService.getResultsFromCacheOrWarehouse({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -153,7 +153,7 @@ import {
 import { updateExploreWithDateZoom } from '../../utils/QueryBuilder/dateZoom';
 import { safeReplaceParametersWithSqlBuilder } from '../../utils/QueryBuilder/parameters';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
-import type { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
+import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import {
     SQL_QUERY_MOCK_EXPLORER_NAME,
     SqlQueryComposer,
@@ -3503,7 +3503,7 @@ export class AsyncQueryService extends ProjectService {
         /**
          * Opt-in: rewrite WHERE filter LHS to use the zoom-grain dimension
          * for the filter that targets the zoom-rewritten field. Only the
-         * underlying-data path sets this (PROD-880). See `_compileQuery` doc.
+         * underlying-data path sets this (PROD-880).
          */
         applyDateZoomToFilters?: boolean;
         preloadedUserAccessControls?: UserAccessControls;
@@ -3549,25 +3549,25 @@ export class AsyncQueryService extends ProjectService {
             preloadedProjectTimezone,
         });
 
-        return ProjectService._createQueryComposer({
-            metricQuery,
-            explore,
-            warehouseSqlBuilder,
-            intrinsicUserAttributes,
-            userAttributes,
-            timezone: resolvedTimezone,
-            dateZoom,
-            // ! TODO: Should validate the parameters to make sure they are valid from the options
-            parameters,
-            availableParameterDefinitions,
-            pivotConfiguration,
-            totalConfiguration,
-            pivotDimensions: pivotDimensions ?? metricQuery.pivotDimensions,
-            useTimezoneAwareDateTrunc,
-            columnTimezone,
-            applyDateZoomToFilters,
-            displayTimezone,
-        });
+        return new QueryComposer(
+            { metricQuery, pivotConfiguration, totalConfiguration },
+            {
+                explore,
+                warehouseSqlBuilder,
+                intrinsicUserAttributes,
+                userAttributes,
+                timezone: resolvedTimezone,
+                availableParameterDefinitions,
+                // ! TODO: Should validate the parameters to make sure they are valid from the options
+                parameters,
+                dateZoom,
+                pivotDimensions: pivotDimensions ?? metricQuery.pivotDimensions,
+                useTimezoneAwareDateTrunc,
+                columnTimezone,
+                applyDateZoomToFilters,
+                displayTimezone,
+            },
+        );
     }
 
     private async assertOrganizationNotBlocked(
@@ -4215,6 +4215,12 @@ export class AsyncQueryService extends ProjectService {
             materializationRole,
         } = args;
         assertIsAccountWithOrg(account);
+
+        if (args.totalConfiguration && args.dashboardFilters) {
+            throw new UnexpectedServerError(
+                'totalConfiguration and dashboardFilters are mutually exclusive',
+            );
+        }
 
         if (
             materializationRole !== undefined &&

--- a/packages/backend/src/services/AsyncQueryService/CLAUDE.md
+++ b/packages/backend/src/services/AsyncQueryService/CLAUDE.md
@@ -14,6 +14,24 @@ The service follows a two-phase pattern:
 2. **Poll**: Call `getAsyncQueryResults` with the `queryUuid` to fetch paginated results.
 
 The QueryController exposes these operations via REST endpoints at `/api/v2/projects/{projectUuid}/query/`.
+
+**Prepare/execute seam.** Metric execution prepares a `QueryComposer`; SQL
+runner, saved SQL chart, and dashboard SQL-chart execution prepare a
+`SqlQueryComposer`. The prepared args carry that composer plus orchestration
+data such as credentials and routing metadata. They do not duplicate explore,
+query, fields, pivot, timezone, parameter, or access-control state.
+
+`executePreparedAsyncQuery` reads those values through the composer getters,
+and `getSql({ columnLimit })` is the only SQL-generation seam for both metric
+and SQL-chart paths. Keep new query context on the composer and expose a getter
+when execution needs it; do not add parallel loose fields to
+`PreparedAsyncQueryArgs`. Construct composers directly at their preparation
+sites rather than adding a service-level factory.
+
+For metric queries, `totalConfiguration` is reserved for calculate-total
+replays and is mutually exclusive with `dashboardFilters`.
+`executeAsyncMetricQuery` rejects calls that set both before composer
+preparation.
 </howToUse>
 
 <codeExample>
@@ -87,6 +105,12 @@ sequenceDiagram
 **Fire-and-Forget Execution:**
 The `executeAsyncQuery` method starts warehouse queries using `void this.runAsyncWarehouseQuery(...)`. Errors are caught internally and logged, not thrown to the caller.
 
+**Composer ownership:**
+`QueryComposer` owns metric compilation, totals collapse, and optional pivot SQL
+wrapping. `SqlQueryComposer` owns virtual-view/user-SQL wrapping and inherits the
+same pivot seam. Once preparation returns a composer, downstream execution must
+read query context from it rather than recomputing or carrying a second copy.
+
 **Streaming Results to S3:**
 During execution, `runAsyncWarehouseQuery` creates an upload stream via `resultsStorageClient.createUploadStream()`. The warehouse client's `executeAsyncQuery` receives a `write` callback that streams rows as JSONL directly to S3 as they arrive from the warehouse.
 
@@ -122,6 +146,8 @@ Results are paginated (default 500 rows, max 5000). Use `page` and `pageSize` pa
 <links>
 @packages/backend/src/controllers/v2/QueryController.ts - REST API endpoints
 @packages/backend/src/services/AsyncQueryService/types.ts - Type definitions for all execute args
+@packages/backend/src/utils/QueryBuilder/QueryComposer.ts - Metric-query preparation and SQL facade
+@packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts - SQL-chart preparation and SQL facade
 @packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts - Query state persistence
 @packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts - S3 streaming client
 </links>

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -66,6 +66,7 @@ import {
     METRIC_QUERY,
     warehouseClientMock,
 } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
@@ -2798,18 +2799,20 @@ describe('ProjectService', () => {
     });
 });
 
-describe('ProjectService._compileQuery reserved parameters', () => {
+describe('QueryComposer reserved parameters', () => {
     it('resolves date_zoom to the else branch when no date zoom is applied', async () => {
-        const compiled = await ProjectService._compileQuery({
-            metricQuery: metricQueryReservedParameterDimension,
-            explore: exploreWithReservedParameterDimension,
-            warehouseSqlBuilder: warehouseClientMock,
-            intrinsicUserAttributes: {},
-            userAttributes: {},
-            timezone: 'UTC',
-            parameters: {},
-            availableParameterDefinitions: {},
-        });
+        const compiled = new QueryComposer(
+            { metricQuery: metricQueryReservedParameterDimension },
+            {
+                explore: exploreWithReservedParameterDimension,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: {},
+                userAttributes: {},
+                timezone: 'UTC',
+                parameters: {},
+                availableParameterDefinitions: {},
+            },
+        ).compile();
 
         expect(compiled.query).toContain("'other'");
         expect(compiled.query).not.toContain("'weekly'");
@@ -2819,18 +2822,20 @@ describe('ProjectService._compileQuery reserved parameters', () => {
 
     it('lets a user parameter named date_zoom win over the reserved value', async () => {
         // With no date zoom the reserved value is ''; a user date_zoom of 'week' must win.
-        const compiled = await ProjectService._compileQuery({
-            metricQuery: metricQueryReservedParameterDimension,
-            explore: exploreWithReservedParameterDimension,
-            warehouseSqlBuilder: warehouseClientMock,
-            intrinsicUserAttributes: {},
-            userAttributes: {},
-            timezone: 'UTC',
-            parameters: { date_zoom: 'week' },
-            availableParameterDefinitions: {
-                date_zoom: { label: 'My date zoom' },
+        const compiled = new QueryComposer(
+            { metricQuery: metricQueryReservedParameterDimension },
+            {
+                explore: exploreWithReservedParameterDimension,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: {},
+                userAttributes: {},
+                timezone: 'UTC',
+                parameters: { date_zoom: 'week' },
+                availableParameterDefinitions: {
+                    date_zoom: { label: 'My date zoom' },
+                },
             },
-        });
+        ).compile();
 
         expect(compiled.query).toContain("'weekly'");
         expect(compiled.query).not.toContain("'other'");

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -94,7 +94,6 @@ import {
     hasConnectionChanges,
     hasIntersection,
     hasWarehouseCredentials,
-    IntrinsicUserAttributes,
     isCartesianChartConfig,
     isDateItem,
     isExploreError,
@@ -191,7 +190,6 @@ import {
     type ParametersValuesMap,
     type RunQueryTags,
     type Tag,
-    type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import {
     BigqueryWarehouseClient,
@@ -270,12 +268,8 @@ import { runWorkerThread, wrapSentryTransaction } from '../../utils';
 import { buildCacheHash, getCacheUserUuid } from '../../utils/cacheUtils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
-import { CompiledQuery } from '../../utils/QueryBuilder/MetricQueryBuilder';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
-import {
-    QueryComposer,
-    TotalConfiguration,
-} from '../../utils/QueryBuilder/QueryComposer';
+import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
@@ -4061,84 +4055,6 @@ export class ProjectService extends BaseService {
         });
     }
 
-    static _createQueryComposer({
-        metricQuery,
-        explore,
-        warehouseSqlBuilder,
-        intrinsicUserAttributes,
-        userAttributes,
-        timezone,
-        dateZoom,
-        parameters,
-        availableParameterDefinitions,
-        pivotConfiguration,
-        totalConfiguration,
-        pivotDimensions,
-        continueOnError,
-        useTimezoneAwareDateTrunc,
-        columnTimezone,
-        applyDateZoomToFilters,
-        displayTimezone,
-    }: {
-        metricQuery: MetricQuery;
-        explore: Explore;
-        warehouseSqlBuilder: WarehouseSqlBuilder;
-        intrinsicUserAttributes: IntrinsicUserAttributes;
-        userAttributes: UserAttributeValueMap;
-        timezone: string;
-        dateZoom?: DateZoom;
-        parameters?: ParametersValuesMap;
-        availableParameterDefinitions: ParameterDefinitions;
-        pivotConfiguration?: PivotConfiguration;
-        /**
-         * When set, the composer collapses the source query into this totals
-         * grain before compiling (calculate-total path only).
-         */
-        totalConfiguration?: TotalConfiguration;
-        pivotDimensions?: string[];
-        continueOnError?: boolean;
-        useTimezoneAwareDateTrunc?: boolean;
-        columnTimezone?: string;
-        /**
-         * When true, WHERE filter rules targeting the date-zoom dimension are
-         * compiled against the zoom-rewritten SQL (e.g. DATE_TRUNC('MONTH', ...)).
-         * Only safe on the underlying-data path where filters are solely click-filters.
-         */
-        applyDateZoomToFilters?: boolean;
-        /**
-         * Flag-gated timezone echoed to clients and persisted with the query.
-         * Only the async execute path needs it; compile-only callers omit it.
-         */
-        displayTimezone?: string | null;
-    }): QueryComposer {
-        return new QueryComposer(
-            { metricQuery, pivotConfiguration, totalConfiguration },
-            {
-                explore,
-                warehouseSqlBuilder,
-                intrinsicUserAttributes,
-                userAttributes,
-                timezone,
-                availableParameterDefinitions,
-                parameters,
-                dateZoom,
-                pivotDimensions,
-                pivotItemsMap: undefined,
-                continueOnError,
-                useTimezoneAwareDateTrunc,
-                columnTimezone,
-                applyDateZoomToFilters,
-                displayTimezone,
-            },
-        );
-    }
-
-    static async _compileQuery(
-        args: Parameters<typeof ProjectService._createQueryComposer>[0],
-    ): Promise<CompiledQuery> {
-        return ProjectService._createQueryComposer(args).compile();
-    }
-
     /**
      * Get all available parameter definitions for a project and explore
      * @param projectUuid - The UUID of the project
@@ -5289,22 +5205,25 @@ export class ProjectService extends BaseService {
                                 account.organization.organizationUuid,
                         });
 
-                    const fullQuery = await ProjectService._compileQuery({
-                        metricQuery: metricQueryWithLimit,
-                        explore,
-                        warehouseSqlBuilder: warehouseClient,
-                        intrinsicUserAttributes,
-                        userAttributes: mergedUserAttributes,
-                        timezone,
-                        dateZoom,
-                        parameters,
-                        availableParameterDefinitions,
-                        pivotDimensions: metricQueryWithLimit.pivotDimensions,
-                        useTimezoneAwareDateTrunc,
-                        columnTimezone: getColumnTimezone(
-                            warehouseClient.credentials,
-                        ),
-                    });
+                    const fullQuery = new QueryComposer(
+                        { metricQuery: metricQueryWithLimit },
+                        {
+                            explore,
+                            warehouseSqlBuilder: warehouseClient,
+                            intrinsicUserAttributes,
+                            userAttributes: mergedUserAttributes,
+                            timezone,
+                            dateZoom,
+                            parameters,
+                            availableParameterDefinitions,
+                            pivotDimensions:
+                                metricQueryWithLimit.pivotDimensions,
+                            useTimezoneAwareDateTrunc,
+                            columnTimezone: getColumnTimezone(
+                                warehouseClient.credentials,
+                            ),
+                        },
+                    ).compile();
 
                     const { query } = fullQuery;
 
@@ -5905,18 +5824,20 @@ export class ProjectService extends BaseService {
             userTimezone: user.timezone,
         });
 
-        const { query } = await ProjectService._compileQuery({
-            metricQuery,
-            explore,
-            warehouseSqlBuilder: warehouseClient,
-            intrinsicUserAttributes,
-            userAttributes: mergedUserAttributes,
-            timezone,
-            parameters: combinedParameters,
-            availableParameterDefinitions,
-            useTimezoneAwareDateTrunc,
-            columnTimezone: getColumnTimezone(warehouseClient.credentials),
-        });
+        const { query } = new QueryComposer(
+            { metricQuery },
+            {
+                explore,
+                warehouseSqlBuilder: warehouseClient,
+                intrinsicUserAttributes,
+                userAttributes: mergedUserAttributes,
+                timezone,
+                parameters: combinedParameters,
+                availableParameterDefinitions,
+                useTimezoneAwareDateTrunc,
+                columnTimezone: getColumnTimezone(warehouseClient.credentials),
+            },
+        ).compile();
 
         const isUserCacheEnabled =
             this.lightdashConfig.results.autocompleteEnabled && !!user.userUuid;

--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -60,6 +60,12 @@ query's dimensions, which the collapsed totals query typically no longer selects
 This is what the calculate-total path (`executeAsyncCalculateTotalFromQueryHistory`)
 uses instead of hand-collapsing at the call site.
 
+`totalConfiguration` and `dashboardFilters` are mutually exclusive. Totals
+replay a query already persisted in query history; applying the source
+dashboard filters again would change its semantics. `AsyncQueryService` asserts
+this invariant at the `executeAsyncMetricQuery` entry point before preparing a
+composer.
+
 **SqlQueryComposer** — the facade for SQL charts (`extends QueryComposer`). SQL charts run user-written SQL rather than compiling a metric query, so this builds everything from raw inputs — the virtual view (`createVirtualView`) from the discovered columns, the wrapping `SqlQueryBuilder` (reference map + dialect config off the warehouse client), a mock `MetricQuery` metadata carrier, and (on the dashboard path) the applied dashboard filters/sorts — then overrides `computeCompiled()` to shape the wrapped user SQL into a `CompiledQuery`. Because `getSql()` is inherited, a request/config `pivotConfiguration` flows through the same seam as metric queries. Used by `AsyncQueryService.prepareSqlChartAsyncQueryArgs` for all three SQL execute paths (raw SQL runner, saved SQL chart, dashboard SQL chart).
 
 ```typescript
@@ -83,6 +89,17 @@ const metricQuery = composer.getMetricQuery(); // mock metadata carrier (echoed 
 const virtualView = composer.getExplore();
 const appliedDashboardFilters = composer.getAppliedDashboardFilters();
 ```
+
+**dateZoom util.** `updateExploreWithDateZoom` is the single explore-rewrite
+step used by `QueryComposer`. It takes the source explore/query, warehouse SQL
+builder, available parameter names, and optional `DateZoom`; then returns the
+effective explore plus `dateZoomApplied` and `dateZoomTargetFieldId` metadata.
+The rewrite changes the target date dimension's SQL to the selected grain while
+preserving the source explore for field lookup. By default it affects selected
+dimensions only. Set `applyDateZoomToFilters` only for the underlying-data path,
+where the matching click-filter must compile against the rewritten expression.
+Callers should pass `dateZoom` into the composer instead of invoking this util
+or mutating an explore themselves.
 
 **MetricQueryBuilder** — builds the base SQL from an Explore + MetricQuery (dimensions, metrics, filters, joins, table calculations). Handles fan-out protection via CTEs and period-over-period comparisons. Usually driven via `QueryComposer` rather than constructed directly.
 
@@ -192,6 +209,7 @@ graph TD
 
 - @/packages/backend/src/utils/QueryBuilder/QueryComposer.ts — Facade that owns metric SQL generation end-to-end
 - @/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts — SQL-chart subclass of the facade (wraps user SQL)
+- @/packages/backend/src/utils/QueryBuilder/dateZoom.ts — Date-zoom explore rewrite used by QueryComposer
 - @/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts — Query execution and pivot result streaming
 - @/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts — PivotQueryBuilder tests (all CTE paths)
 - @/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts — MetricQueryBuilder tests


### PR DESCRIPTION
Linear: https://linear.app/lightdash/issue/PROD-8779/88-cleanup-invariant-hardening-and-docs

### Description

- remove the transitional ProjectService QueryComposer factory and compile helper
- construct QueryComposer directly at every remaining consumer
- enforce totalConfiguration and dashboardFilters mutual exclusivity at the metric-query entry point
- document QueryComposer, SqlQueryComposer, date zoom, and the async prepare/execute seam

### Validation

- 131 focused backend tests passed
- targeted backend lint passed
- formatting and git diff checks passed

### CI

test-all