### PR TITLE
refactor(frontend): migrate Center to mantine-8

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
@@ -1,5 +1,6 @@
 import type { EchartsGrid, EchartsLegend } from '@lightdash/common';
-import { Badge, Center, Flex, SimpleGrid } from '@mantine/core';
+import { Center } from '@mantine-8/core';
+import { Badge, Flex, SimpleGrid } from '@mantine/core';
 import { type FC } from 'react';
 import UnitInput from '../../../common/UnitInput';
 

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -3,9 +3,8 @@ import {
     getItemId,
     getItemLabelWithoutTableName,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Center, Stack } from '@mantine-8/core';
 import {
-    Center,
     Checkbox,
     Group,
     NumberInput,

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -10,9 +10,8 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Accordion, Stack } from '@mantine-8/core';
+import { Accordion, Center, Stack } from '@mantine-8/core';
 import {
-    Center,
     Group,
     SegmentedControl,
     Select,

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,9 +14,9 @@ import {
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
+import { Center } from '@mantine-8/core';
 import {
     Button,
-    Center,
     Group,
     Loader,
     Skeleton,

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.module.css
@@ -1,0 +1,3 @@
+.swatch {
+    border-radius: var(--mantine-radius-sm);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.tsx
@@ -1,8 +1,9 @@
-import { Center } from '@mantine/core';
+import { Center } from '@mantine-8/core';
 import { IconCheck } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useCategoryStyles } from '../styles/useCategoryStyles';
+import styles from './CatalogCategorySwatch.module.css';
 
 type Props = {
     color: string;
@@ -15,16 +16,13 @@ export const CatalogCategorySwatch: FC<Props> = ({
     onClick,
     selected,
 }: Props) => {
-    const { classes, theme, cx } = useCategoryStyles(color);
+    const { classes, cx } = useCategoryStyles(color);
     return (
         <Center
             h={18}
             w={18}
-            className={cx(classes.base, classes.withHover)}
+            className={cx(classes.base, classes.withHover, styles.swatch)}
             onClick={onClick}
-            sx={{
-                borderRadius: theme.radius.sm,
-            }}
         >
             {selected && (
                 <MantineIcon

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,10 +5,9 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
+import { Box, Center } from '@mantine-8/core';
 import {
     Anchor,
-    Center,
     Divider,
     Group,
     Paper,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -20,12 +20,11 @@ import {
     type CatalogCategoryFilterMode,
     type CatalogField,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Center, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
     Button,
-    Center,
     Divider,
     Group,
     Popover,

--- a/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
@@ -3,14 +3,8 @@ import {
     DownloadFileType,
     type VizTableConfig,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Center,
-    Popover,
-    SegmentedControl,
-    Text,
-} from '@mantine/core';
+import { Center, Stack } from '@mantine-8/core';
+import { ActionIcon, Popover, SegmentedControl, Text } from '@mantine/core';
 import { IconDownload, IconPhoto, IconTableExport } from '@tabler/icons-react';
 import { memo, useState } from 'react';
 import ChartDownloadOptions from '../../../../components/common/ChartDownload/ChartDownloadOptions';

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -1,4 +1,5 @@
-import { Center, Loader, useMantineTheme } from '@mantine/core';
+import { Center } from '@mantine-8/core';
+import { Loader, useMantineTheme } from '@mantine/core';
 import Editor, {
     useMonaco,
     type BeforeMount,

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -1,7 +1,6 @@
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Center, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
-    Center,
     CopyButton,
     Group,
     Highlight,

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -1,8 +1,7 @@
 import { PartitionType, type PartitionColumn } from '@lightdash/common';
-import { Box, Stack, type BoxProps } from '@mantine-8/core';
+import { Box, Center, Stack, type BoxProps } from '@mantine-8/core';
 import {
     ActionIcon,
-    Center,
     CopyButton,
     Group,
     Highlight,

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -1,14 +1,6 @@
 import { getEmailSchema } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    Button,
-    Center,
-    List,
-    TextInput,
-    Title,
-    Text,
-} from '@mantine/core';
+import { Center, Stack } from '@mantine-8/core';
+import { Anchor, Button, List, TextInput, Title, Text } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -1,9 +1,8 @@
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Center, Stack } from '@mantine-8/core';
 import {
     Anchor,
     Button,
     Card,
-    Center,
     PasswordInput,
     Title,
     Text,


### PR DESCRIPTION
## What & why

Migrates **`Center`** from `@mantine/core` (v6) to `@mantine-8/core` across all 13 remaining files. Revives the scope of #25243, which was closed unmerged when its stack was abandoned.

## Changes

- **12 files**: import splits only — `Center` moves to the `@mantine-8/core` import block; every other specifier stays on v6. Zero prop renames needed (`p`/`px`/`py`/`h`/`w`/`mt` and the custom `one` spacing token are unchanged in v8).
- **`CatalogCategorySwatch.tsx`**: the one `sx` usage (static `borderRadius: theme.radius.sm`) is replaced with a CSS module (`border-radius: var(--mantine-radius-sm)`), since v8 drops `sx` and Mantine 8.0.0 has no `bdrs` style prop. The unused `theme` destructure is removed.

## Scope / regression analysis

- **Only `Center` changes alias** — no other component, page, or shared module is affected.
- The swatch border-radius resolves to the same `sm` radius value, now via the v8 CSS variable instead of the v6 JS theme object. Rendering is identical for all users; no role/permission/edition surface is touched.
- v8 rejects v6-only props at compile time, so typecheck backstops the move.

## Verification

- `pnpm -F frontend typecheck:fast` — 0 errors
- `oxlint -c .oxlintrc.json` on all 13 changed files — 0 warnings / 0 errors
- `oxfmt` — clean
- No vitest file renders any migrated component provider-less (checked; avoids the known v8-context test crash)

Relates: #25243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqLQbfeBy3eENdHPLzTcTa