### PR TITLE
fix(frontend): invalid DOM nesting and v6 Button props in error fallbacks

### DIFF
--- a/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
+++ b/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
@@ -68,6 +68,7 @@ const SuboptimalState: FC<Props> = ({
             {description && (
                 <Box c="dimmed" fz="xs" maw={400} mt={title ? -10 : 0}>
                     <Text
+                        component="div"
                         size="xs"
                         className={adaptive ? classes.description : undefined}
                         style={

--- a/packages/frontend/src/features/errorBoundary/ErrorFallbacks.module.css
+++ b/packages/frontend/src/features/errorBoundary/ErrorFallbacks.module.css
@@ -1,0 +1,3 @@
+.errorDetails {
+    border-radius: var(--mantine-radius-md);
+}

--- a/packages/frontend/src/features/errorBoundary/ErrorFallbacks.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorFallbacks.tsx
@@ -1,10 +1,10 @@
-import { Box, Stack } from '@mantine-8/core';
-import { Button, Text } from '@mantine/core';
+import { Box, Button, Stack, Text } from '@mantine-8/core';
 import { Prism } from '@mantine/prism';
 import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
 import { type FC } from 'react';
 import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
 import { triggerChunkErrorReload } from '../chunkErrorHandler';
+import classes from './ErrorFallbacks.module.css';
 
 /**
  * Fallback UI shown when a chunk load error occurs after auto-reload has failed.
@@ -53,11 +53,9 @@ export const GeneralErrorFallback: FC<{ eventId: string; error: unknown }> = ({
         description={
             <Stack
                 gap="xs"
-                style={{
-                    borderRadius: 'var(--mantine-radius-md)',
-                    padding: 'var(--mantine-spacing-xs)',
-                    backgroundColor: 'var(--mantine-color-ldGray-1)',
-                }}
+                p="xs"
+                bg="ldGray.1"
+                className={classes.errorDetails}
             >
                 <Text>You can contact support with the following error ID</Text>
                 <Prism


### PR DESCRIPTION
## Summary

Two pre-existing bugs that fire whenever the chunk-error fallback ("Application update required") renders:

1. **Invalid DOM nesting** — `SuboptimalState` wraps its `description` in a Mantine v8 `Text`, which renders a `<p>`. The prop accepts any `ReactNode`, and callers (e.g. `ChunkErrorFallback`) pass block-level content, producing `<div>` inside `<p>` — invalid HTML that React 19 flags as a future hydration error. Fixed at the root with `component="div"` on the description `Text`, so every caller passing block content is covered.

2. **Missing refresh icon** — `ErrorFallbacks.tsx` imported `Button`/`Text` from v6 `@mantine/core` but passed the v8-only `leftSection` prop. v6 leaked it to the DOM (`React does not recognize the leftSection prop`) and the "Refresh page" button rendered without its icon. Migrated the file to `@mantine-8/core` imports.

Also replaced `GeneralErrorFallback`'s inline `style` with component props + a small CSS module, per the frontend style guide.

## Testing

- Reproduced live in dev: blocked the SQL Runner route chunk to force the fallback — it now renders with the refresh icon and neither console error fires (both fired before).
- `vitest` errorBoundary + chunkErrorHandler suites pass (8 tests).
- `pnpm -F frontend typecheck:fast` and oxlint clean.

No Linear ticket — drive-by fix found while testing route chunk load errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QVh7yFyd4kAcQH39WQ2qh