### PR TITLE
feat(data-apps): move `create:DataApp` to Editor role

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -206,12 +206,6 @@ export const applyOrganizationMemberStaticAbilities: Record<
                 $elemMatch: { userUuid: member.userUuid },
             },
         });
-        // Create personal data apps; once created, the user can also view
-        // and manage their own. Moving an app into a space is gated
-        // separately by the target space's manage rule.
-        can('create', 'DataApp', {
-            organizationUuid: member.organizationUuid,
-        });
         can('view', 'DataApp', {
             organizationUuid: member.organizationUuid,
             createdByUserUuid: member.userUuid,
@@ -255,6 +249,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
     editor(member, { can }) {
         applyOrganizationMemberStaticAbilities.interactive_viewer(member, {
             can,
+        });
+        can('create', 'DataApp', {
+            organizationUuid: member.organizationUuid,
         });
         can('manage', 'Space', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -167,12 +167,6 @@ export const projectMemberAbilities: Record<
                 $elemMatch: { userUuid: member.userUuid },
             },
         });
-        // Create personal data apps; once created, the user can also view
-        // and manage their own. Moving an app into a space is gated
-        // separately by the target space's manage rule.
-        can('create', 'DataApp', {
-            projectUuid: member.projectUuid,
-        });
         can('view', 'DataApp', {
             projectUuid: member.projectUuid,
             createdByUserUuid: member.userUuid,
@@ -212,6 +206,9 @@ export const projectMemberAbilities: Record<
     },
     editor(member, { can }) {
         projectMemberAbilities.interactive_viewer(member, { can });
+        can('create', 'DataApp', {
+            projectUuid: member.projectUuid,
+        });
         can('create', 'Space', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -68,10 +68,9 @@ const BASE_ROLE_SCOPES = {
         'view:AiAgentDocument',
         'create:AiAgentThread',
         'view:DataApp', // Project-wide + space-access view (parity with manage:Explore)
-        'create:DataApp', // Personal apps (not yet in a space)
-        'view:DataApp@self', // Own personal apps
-        'manage:DataApp@self', // Own personal apps
-        'view:ExternalConnection', // Select/link connections in the app builder (manage stays admin-only)
+        'view:DataApp@self', // Own personal apps (created before demotion / under older rules)
+        'manage:DataApp@self', // Own personal apps (created before demotion / under older rules)
+        'view:ExternalConnection', // Select/link connections when editing space apps (manage stays admin-only)
         'view:ContentVerification', // Read-only discovery of verified content (manage stays developer-level)
     ],
 
@@ -98,6 +97,7 @@ const BASE_ROLE_SCOPES = {
         'manage:MetricsTree',
         'manage:AiAgentThread@self', // User's own threads
         'view:ContentAsCode', // Download (but not upload) content as code
+        'create:DataApp',
     ],
 
     [ProjectMemberRole.DEVELOPER]: [


### PR DESCRIPTION
Ref: https://lightdash.slack.com/archives/C0AMFDF6VBR/p1783415214664499

### Description:
To be more in line with the rest of the permissions, Data Apps should only be available for creation for Editors+.
