### PR TITLE
fix(frontend): metrics catalog column menu renders blank labels

### DIFF
--- a/packages/frontend/src/components/common/ContentTable/ContentTable.tsx
+++ b/packages/frontend/src/components/common/ContentTable/ContentTable.tsx
@@ -19,7 +19,6 @@ import {
 } from '@tabler/icons-react';
 import {
     flexRender,
-    type Column,
     type Header,
     type Row,
     type RowData,
@@ -36,11 +35,11 @@ import {
 import MantineIcon from '../MantineIcon';
 import classes from './ContentTable.module.css';
 import {
-    type ContentTableColumnDef,
     type ContentTableInstance,
     type ContentTableMantineProps,
     type ContentTablePropFactory,
 } from './types';
+import { getLightdashColumnDef } from './utils';
 
 const cx = (...classNames: Array<false | null | string | undefined>) =>
     classNames.filter(Boolean).join(' ');
@@ -117,15 +116,6 @@ const resolveProps = <TElement extends HTMLElement, TArgs>(
     args: TArgs,
 ) =>
     typeof propFactory === 'function' ? propFactory(args) : (propFactory ?? {});
-
-const getLightdashColumnDef = <TData extends RowData>(
-    column: Column<TData, unknown>,
-) =>
-    (
-        column.columnDef.meta as
-            | { lightdashColumnDef?: ContentTableColumnDef<TData> }
-            | undefined
-    )?.lightdashColumnDef;
 
 type ColumnSizeVars = CSSProperties & Record<`--${string}`, number>;
 

--- a/packages/frontend/src/components/common/ContentTable/index.ts
+++ b/packages/frontend/src/components/common/ContentTable/index.ts
@@ -1,6 +1,7 @@
 export { ContentTable } from './ContentTable';
 export { ContentTableSearchInput } from './ContentTableSearchInput';
 export { useContentTable } from './useContentTable';
+export { getColumnHeaderLabel } from './utils';
 export type { ContentTableSearchInputProps } from './ContentTableSearchInput';
 export type {
     ContentTableColumnDef,

--- a/packages/frontend/src/components/common/ContentTable/useContentTable.test.tsx
+++ b/packages/frontend/src/components/common/ContentTable/useContentTable.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import { type ContentTableColumnDef } from './types';
 import { useContentTable } from './useContentTable';
+import { getColumnHeaderLabel } from './utils';
 
 type Row = { name: string; createdAt: string };
 
@@ -51,5 +52,44 @@ describe('useContentTable', () => {
         const sortedRows = result.current.getSortedRowModel().rows;
 
         expect(sortedRows.map((r) => r.original.name)).toEqual(['a', 'b']);
+    });
+
+    describe('getColumnHeaderLabel', () => {
+        test('returns the original string header even though the runtime header is a render callback', () => {
+            const columns: ContentTableColumnDef<Row>[] = [
+                {
+                    accessorKey: 'name',
+                    header: 'Metric',
+                    Header: ({ column }) => column.columnDef.header,
+                },
+            ];
+
+            const { result } = renderHook(() =>
+                useContentTable<Row>({ columns, data }),
+            );
+
+            const [column] = result.current.getAllLeafColumns();
+
+            expect(typeof column.columnDef.header).toBe('function');
+            expect(getColumnHeaderLabel(column)).toBe('Metric');
+        });
+
+        test('falls back to the column id when the original header is not a string', () => {
+            const columns: ContentTableColumnDef<Row>[] = [
+                {
+                    accessorKey: 'name',
+                    id: 'name',
+                    header: () => 'rendered',
+                },
+            ];
+
+            const { result } = renderHook(() =>
+                useContentTable<Row>({ columns, data }),
+            );
+
+            const [column] = result.current.getAllLeafColumns();
+
+            expect(getColumnHeaderLabel(column)).toBe('name');
+        });
     });
 });

--- a/packages/frontend/src/components/common/ContentTable/utils.ts
+++ b/packages/frontend/src/components/common/ContentTable/utils.ts
@@ -1,0 +1,20 @@
+import { type Column, type RowData } from '@tanstack/react-table';
+import { type ContentTableColumnDef } from './types';
+
+export const getLightdashColumnDef = <TData extends RowData>(
+    column: Column<TData, unknown>,
+) =>
+    (
+        column.columnDef.meta as
+            | { lightdashColumnDef?: ContentTableColumnDef<TData> }
+            | undefined
+    )?.lightdashColumnDef;
+
+// The runtime `columnDef.header` is always a render callback (see
+// `toTanStackColumn`), so string labels must come from the preserved def.
+export const getColumnHeaderLabel = <TData extends RowData>(
+    column: Column<TData, unknown>,
+): string => {
+    const header = getLightdashColumnDef(column)?.header;
+    return typeof header === 'string' ? header : column.id;
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -47,7 +47,10 @@ import isEqual from 'lodash/isEqual';
 import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useDebounce } from 'react-use';
-import { type ContentTableInstance } from '../../../../components/common/ContentTable';
+import {
+    getColumnHeaderLabel,
+    type ContentTableInstance,
+} from '../../../../components/common/ContentTable';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useEmbed from '../../../../ee/providers/Embed/useEmbed';
 import useTracking from '../../../../providers/Tracking/useTracking';
@@ -474,9 +477,9 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                                     <SortableColumn
                                                         key={column.id}
                                                         column={{
-                                                            name: column
-                                                                .columnDef
-                                                                .header as string,
+                                                            name: getColumnHeaderLabel(
+                                                                column,
+                                                            ),
                                                             uuid: column.id,
                                                             visible:
                                                                 column.getIsVisible(),


### PR DESCRIPTION
Closes PROD-8814

### Description:

The Metrics Catalog "Manage column visibility" popover rendered blank column labels, and hovering the pinned Metric column's drag handle showed the serialized source of a header-rendering function in the tooltip.

`MetricsTableTopToolbar` read `column.columnDef.header as string`, but `useContentTable` replaces the runtime `header` with a render callback (the original definition is preserved at `columnDef.meta.lightdashColumnDef`). React rendered the function as nothing, and the tooltip template string serialized it.

This adds a `getColumnHeaderLabel` helper to `ContentTable` that resolves the original string header from the preserved Lightdash column definition (falling back to the column id), moves the existing `getLightdashColumnDef` into a shared `utils.ts`, and uses the helper in the toolbar.

Verified locally: labels (Metric, Table, Description, Category, Popularity, Owner) render and the pinned-column tooltip reads "The Metric column is pinned for usability". Unit tests added in `useContentTable.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)