### PR TITLE
fix: azure sandbox execs timeout too early

### DIFF
--- a/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.test.ts
@@ -205,6 +205,54 @@ describe('AzureSandboxExecChannel', () => {
             ).toBe(true);
         });
 
+        it('flushes an incomplete trailing UTF-8 sequence into the captured output on exit', async () => {
+            // '✓' (3 bytes) missing its final byte — e.g. binary output, or a
+            // process killed mid-write. The decoder must flush it (as U+FFFD)
+            // rather than silently dropping the held-back bytes.
+            const out = Buffer.concat([
+                Buffer.from('done'),
+                Buffer.from([0xe2, 0x9c]),
+            ]);
+            fetchMock
+                .mockResolvedValueOnce(execJson({})) // start
+                .mockResolvedValueOnce(tickResponse('0', out)) // done
+                .mockResolvedValue(execJson({})); // cleanup
+
+            const chunks: string[] = [];
+            const result = await makeChannel().commands.run('cmd', {
+                timeoutMs: 20 * 60 * 1000,
+                onStdout: (chunk) => chunks.push(chunk),
+            });
+
+            expect(result.stdout).toBe('done�');
+            expect(chunks.join('')).toBe('done�');
+        });
+
+        // Pins the loop's completion guarantee: a timeout is only thrown off a
+        // fresh poll that saw the command still RUNNING — completion observed
+        // by the next poll is returned even when it lands past the deadline.
+        it('returns the result when completion is observed past the deadline instead of killing the run', async () => {
+            fetchMock
+                .mockResolvedValueOnce(execJson({})) // start
+                .mockResolvedValueOnce(tickResponse('', '')) // running (before deadline)
+                .mockResolvedValueOnce(tickResponse('0', 'done')) // completes past deadline
+                .mockResolvedValue(execJson({}));
+
+            const result = await makeChannel({
+                detachedThresholdMs: 10,
+                pollIntervalMs: 40,
+            }).commands.run('cmd', { timeoutMs: 60 });
+
+            expect(result).toEqual({
+                stdout: 'done',
+                stderr: '',
+                exitCode: 0,
+            });
+            expect(requestBodies().some((body) => body.includes('kill'))).toBe(
+                false,
+            );
+        });
+
         it('throws SandboxTimeoutError and kills the whole process group on timeout', async () => {
             fetchMock.mockResolvedValue(tickResponse('', '')); // never exits
 

--- a/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.test.ts
@@ -3,20 +3,40 @@ import {
     AzureSandboxExecChannel,
     bufferedExecDispatcher,
 } from './AzureSandboxExecChannel';
+import { SandboxCommandError, SandboxTimeoutError } from './errors';
 
 type CapturedInit = RequestInit & { dispatcher?: unknown };
 
-describe('AzureSandboxExecChannel undici timeouts', () => {
+const execJson = (payload: {
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+}) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+        stdout: payload.stdout ?? '',
+        stderr: payload.stderr ?? '',
+        exitCode: payload.exitCode ?? 0,
+    }),
+    text: async () => 'file contents',
+});
+
+const b64 = (value: string | Buffer) => Buffer.from(value).toString('base64');
+
+/** A poll-tick exec response in the S/O/E wire protocol of detached mode. */
+const tickResponse = (
+    status: string,
+    out: string | Buffer = '',
+    err: string | Buffer = '',
+) => execJson({ stdout: `S${status}\nO${b64(out)}\nE${b64(err)}\n` });
+
+describe('AzureSandboxExecChannel', () => {
     const originalFetch = global.fetch;
     let fetchMock: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
-        fetchMock = vi.fn().mockResolvedValue({
-            ok: true,
-            status: 200,
-            json: async () => ({ stdout: 'ok', stderr: '', exitCode: 0 }),
-            text: async () => 'file contents',
-        });
+        fetchMock = vi.fn().mockResolvedValue(execJson({ stdout: 'ok' }));
         global.fetch = fetchMock as unknown as typeof fetch;
     });
 
@@ -24,31 +44,186 @@ describe('AzureSandboxExecChannel undici timeouts', () => {
         global.fetch = originalFetch;
     });
 
-    const makeChannel = () =>
+    const makeChannel = (tuning?: {
+        detachedThresholdMs?: number;
+        pollIntervalMs?: number;
+    }) =>
         new AzureSandboxExecChannel(
             'https://eastus2.example.test/sandboxes/s1',
             '2024-02-02-preview',
             async () => 'token',
+            { pollIntervalMs: 1, ...tuning },
         );
 
     const capturedInit = (): CapturedInit =>
         fetchMock.mock.calls[0][1] as CapturedInit;
 
-    it('disables undici header/body timeouts for exec calls bounded by timeoutMs', async () => {
-        await makeChannel().commands.run('sleep 600', {
-            timeoutMs: 55 * 60 * 1000,
+    const requestBodies = (): string[] =>
+        fetchMock.mock.calls.map((call) =>
+            String((call[1] as RequestInit | undefined)?.body ?? ''),
+        );
+
+    describe('undici timeouts (buffered path)', () => {
+        it('disables undici header/body timeouts for bounded exec calls under the detach threshold', async () => {
+            await makeChannel().commands.run('sleep 60', {
+                timeoutMs: 4 * 60 * 1000,
+            });
+            expect(bufferedExecDispatcher).toBeInstanceOf(Agent);
+            expect(capturedInit().dispatcher).toBe(bufferedExecDispatcher);
         });
-        expect(bufferedExecDispatcher).toBeInstanceOf(Agent);
-        expect(capturedInit().dispatcher).toBe(bufferedExecDispatcher);
+
+        it('keeps undici defaults for exec calls with no timeout bound', async () => {
+            await makeChannel().commands.run('echo hi');
+            expect(capturedInit().dispatcher).toBeUndefined();
+        });
+
+        it('keeps undici defaults for file operations', async () => {
+            await makeChannel().files.read('/tmp/a.txt');
+            expect(capturedInit().dispatcher).toBeUndefined();
+        });
     });
 
-    it('keeps undici defaults for exec calls with no timeout bound', async () => {
-        await makeChannel().commands.run('echo hi');
-        expect(capturedInit().dispatcher).toBeUndefined();
-    });
+    describe('detached exec (long-bounded commands)', () => {
+        it('stays on the single-request buffered path at or below the threshold', async () => {
+            await makeChannel().commands.run('quick', {
+                timeoutMs: 4 * 60 * 1000,
+            });
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(requestBodies()[0]).not.toContain('nohup');
+        });
 
-    it('keeps undici defaults for file operations', async () => {
-        await makeChannel().files.read('/tmp/a.txt');
-        expect(capturedInit().dispatcher).toBeUndefined();
+        it('runs long-bounded commands detached and streams output across polls', async () => {
+            fetchMock
+                .mockResolvedValueOnce(execJson({})) // start (nohup)
+                .mockResolvedValueOnce(tickResponse('', 'hello ')) // running
+                .mockResolvedValueOnce(tickResponse('0', 'world')) // done
+                .mockResolvedValue(execJson({})); // cleanup
+
+            const chunks: string[] = [];
+            const result = await makeChannel().commands.run('sleep 900', {
+                timeoutMs: 55 * 60 * 1000,
+                onStdout: (chunk) => chunks.push(chunk),
+            });
+
+            expect(result).toEqual({
+                stdout: 'hello world',
+                stderr: '',
+                exitCode: 0,
+            });
+            expect(chunks).toEqual(['hello ', 'world']);
+
+            const bodies = requestBodies();
+            expect(bodies[0]).toContain('nohup');
+            // setsid makes the wrapper a process-group leader so a timeout
+            // can kill the whole command tree, not just the wrapper shell.
+            expect(bodies[0]).toContain('setsid');
+            expect(bodies[0]).toContain('sleep 900');
+            // Poll offsets advance by the bytes already consumed ('hello ' = 6).
+            expect(bodies[1]).toContain('tail -c +1 ');
+            expect(bodies[2]).toContain('tail -c +7 ');
+        });
+
+        it('replays stderr deltas through onStderr', async () => {
+            fetchMock
+                .mockResolvedValueOnce(execJson({}))
+                .mockResolvedValueOnce(tickResponse('0', '', 'warning!'))
+                .mockResolvedValue(execJson({}));
+
+            const errChunks: string[] = [];
+            const result = await makeChannel().commands.run('cmd', {
+                timeoutMs: 20 * 60 * 1000,
+                onStderr: (chunk) => errChunks.push(chunk),
+            });
+
+            expect(result.stderr).toBe('warning!');
+            expect(errChunks).toEqual(['warning!']);
+        });
+
+        it('does not split multi-byte UTF-8 characters across poll boundaries', async () => {
+            const check = Buffer.from('✓'); // 3 bytes
+            fetchMock
+                .mockResolvedValueOnce(execJson({}))
+                .mockResolvedValueOnce(tickResponse('', check.subarray(0, 2)))
+                .mockResolvedValueOnce(tickResponse('0', check.subarray(2)))
+                .mockResolvedValue(execJson({}));
+
+            const chunks: string[] = [];
+            const result = await makeChannel().commands.run('cmd', {
+                timeoutMs: 20 * 60 * 1000,
+                onStdout: (chunk) => chunks.push(chunk),
+            });
+
+            expect(result.stdout).toBe('✓');
+            expect(chunks).toEqual(['✓']);
+        });
+
+        it('throws SandboxCommandError with the detached command exit code and captured streams', async () => {
+            fetchMock
+                .mockResolvedValueOnce(execJson({}))
+                .mockResolvedValueOnce(tickResponse('3', 'partial', 'boom'))
+                .mockResolvedValue(execJson({}));
+
+            const promise = makeChannel().commands.run('cmd', {
+                timeoutMs: 20 * 60 * 1000,
+            });
+            await expect(promise).rejects.toMatchObject({
+                name: 'SandboxCommandError',
+                exitCode: 3,
+                stderr: 'boom',
+                stdout: 'partial',
+            });
+        });
+
+        it('tolerates a transient poll failure and keeps polling', async () => {
+            fetchMock
+                .mockResolvedValueOnce(execJson({})) // start
+                .mockRejectedValueOnce(new Error('socket hang up')) // poll 1
+                .mockResolvedValueOnce(tickResponse('0', 'done')) // poll 2
+                .mockResolvedValue(execJson({}));
+
+            const result = await makeChannel().commands.run('cmd', {
+                timeoutMs: 20 * 60 * 1000,
+            });
+            expect(result.stdout).toBe('done');
+        });
+
+        it('gives up after repeated consecutive poll failures and attempts a group kill', async () => {
+            fetchMock
+                .mockResolvedValueOnce(execJson({})) // start
+                .mockRejectedValue(new Error('data plane down')); // every poll
+
+            await expect(
+                makeChannel().commands.run('cmd', {
+                    timeoutMs: 20 * 60 * 1000,
+                }),
+            ).rejects.toThrow(SandboxCommandError);
+
+            // Abandoning the run must not orphan the command tree — a retry
+            // could otherwise start a second run alongside it.
+            expect(
+                requestBodies().some((body) => body.includes('kill -TERM -- ')),
+            ).toBe(true);
+        });
+
+        it('throws SandboxTimeoutError and kills the whole process group on timeout', async () => {
+            fetchMock.mockResolvedValue(tickResponse('', '')); // never exits
+
+            await expect(
+                makeChannel({ detachedThresholdMs: 10 }).commands.run('cmd', {
+                    timeoutMs: 50,
+                }),
+            ).rejects.toThrow(SandboxTimeoutError);
+
+            // Killing only the wrapper shell PID would orphan its children
+            // (claude, pnpm, …) — the kill must target the process group
+            // (negative PGID) with a TERM → KILL escalation.
+            const killBody = requestBodies().find((body) =>
+                body.includes('kill'),
+            );
+            expect(killBody).toBeDefined();
+            expect(killBody).toContain('kill -TERM -- ');
+            expect(killBody).toContain('kill -KILL -- ');
+            expect(killBody).toContain('/pid');
+        });
     });
 });

--- a/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+import { StringDecoder } from 'node:string_decoder';
 import { Agent, type Dispatcher } from 'undici';
 import { SandboxCommandError, SandboxTimeoutError } from './errors';
 import { shQuote } from './gitOverCommands';
@@ -40,8 +42,11 @@ const buildCommandLine = (command: string, options?: RunOptions): string => {
  * (`aca sandbox exec/fs … --verbose`, PROD-8591):
  * - `POST {baseUrl}/executeShellCommand?api-version=…` JSON `{command}` →
  *   `{stdout, stderr, exitCode}`. Buffered (the native call returns the completed
- *   result), so a long run streams nothing until it finishes — `onStdout`/`onStderr`
- *   fire once with the full output.
+ *   result), so a short run streams nothing until it finishes — `onStdout`/`onStderr`
+ *   fire once with the full output. Runs bounded above
+ *   {@link DETACHED_EXEC_THRESHOLD_MS} instead start detached and are polled
+ *   (see {@link AzureSandboxExecChannel.runDetached}), which streams output
+ *   incrementally and sidesteps the gateway's ~600s per-request cap.
  * - `GET {baseUrl}/files?path=…` → raw bytes (200) / 404 `{errorCode:"FileNotFound"}`;
  *   `PUT …&createDirs=true` octet-stream body → write; `DELETE …&recursive=true` → remove.
  */
@@ -60,11 +65,72 @@ export const bufferedExecDispatcher = new Agent({
     bodyTimeout: 0,
 });
 
+/**
+ * The data-plane gateway 504s any single request at ~600s regardless of client
+ * settings, so a buffered exec can never outlive ~10 minutes. Runs bounded by a
+ * timeout above this threshold switch to detached mode: start the command with
+ * nohup (a ~1s request), then poll its output/exit files with short requests.
+ * Kept well under the gateway cap so buffered calls never race it.
+ */
+const DETACHED_EXEC_THRESHOLD_MS = 5 * 60 * 1000;
+const DETACHED_POLL_INTERVAL_MS = 2_000;
+/** Poll/start/kill requests are short; bound them individually. */
+const INTERNAL_EXEC_TIMEOUT_MS = 60 * 1000;
+/**
+ * A failed poll leaves the detached process running, so transient data-plane
+ * hiccups are survivable — only this many consecutive failures abort the run.
+ */
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
+const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
 interface ExecResponse {
     stdout: string;
     stderr: string;
     exitCode: number;
 }
+
+/** One parsed detached poll tick: new output bytes + exit code when done. */
+interface DetachedTick {
+    exitCode: number | null;
+    out: Buffer;
+    err: Buffer;
+}
+
+/**
+ * Parse the S/O/E wire protocol emitted by the detached poll command: an
+ * `S<exit-code-or-empty>` line, then `O<base64>` / `E<base64>` lines carrying
+ * the new stdout/stderr bytes since the last poll (base64 so byte offsets stay
+ * exact through the JSON exec response). Throws on malformed output — the
+ * caller treats that as a transient poll failure.
+ */
+const parseDetachedTick = (stdout: string): DetachedTick => {
+    const lines = stdout.split('\n');
+    const sLine = lines.find((line) => line.startsWith('S'));
+    const oLine = lines.find((line) => line.startsWith('O'));
+    const eLine = lines.find((line) => line.startsWith('E'));
+    if (sLine === undefined || oLine === undefined || eLine === undefined) {
+        throw new Error(
+            `malformed detached poll output: ${stdout.slice(0, 200)}`,
+        );
+    }
+    const status = sLine.slice(1).trim();
+    let exitCode: number | null = null;
+    if (status !== '') {
+        exitCode = Number(status);
+        if (!Number.isInteger(exitCode)) {
+            throw new Error(`malformed detached exit status: "${status}"`);
+        }
+    }
+    return {
+        exitCode,
+        out: Buffer.from(oLine.slice(1), 'base64'),
+        err: Buffer.from(eLine.slice(1), 'base64'),
+    };
+};
 
 /** Validate/narrow the native exec JSON to {@link ExecResponse}. */
 const decodeExecResponse = (value: unknown): ExecResponse => {
@@ -97,6 +163,10 @@ export class AzureSandboxExecChannel {
 
     private readonly baseUrl: string;
 
+    private readonly detachedThresholdMs: number;
+
+    private readonly pollIntervalMs: number;
+
     /**
      * @param baseUrl the sandbox-scoped data-plane URL built by the control plane
      *   (region endpoint + sandbox resource path), e.g.
@@ -105,14 +175,20 @@ export class AzureSandboxExecChannel {
      * @param mintToken mints a fresh Entra bearer for the data-plane audience.
      *   Called lazily on first use and again to refresh after an auth rejection,
      *   so a turn that outlives its token self-heals.
+     * @param tuning detached-exec knobs, overridable for tests.
      */
     constructor(
         baseUrl: string,
         private readonly apiVersion: string,
         private readonly mintToken: () => Promise<string>,
+        tuning?: { detachedThresholdMs?: number; pollIntervalMs?: number },
     ) {
         // Trailing slash stripped so path concatenation is predictable.
         this.baseUrl = baseUrl.replace(/\/+$/, '');
+        this.detachedThresholdMs =
+            tuning?.detachedThresholdMs ?? DETACHED_EXEC_THRESHOLD_MS;
+        this.pollIntervalMs =
+            tuning?.pollIntervalMs ?? DETACHED_POLL_INTERVAL_MS;
     }
 
     private url(path: string, params?: Record<string, string>): string {
@@ -165,64 +241,214 @@ export class AzureSandboxExecChannel {
             command: string,
             options?: RunOptions,
         ): Promise<CommandResult> => {
-            const controller = new AbortController();
-            // Give the native exec a 5s grace period over the caller's timeout so
-            // the server's own timeout error surfaces before this client-side abort.
-            const abortAfterMs =
-                options?.timeoutMs && options.timeoutMs > 0
-                    ? options.timeoutMs + 5_000
-                    : null;
-            const timer = abortAfterMs
-                ? setTimeout(() => controller.abort(), abortAfterMs)
-                : null;
-            try {
-                const response = await this.send(
-                    this.url(EXEC_PATH),
-                    {
-                        method: 'POST',
-                        headers: { 'content-type': 'application/json' },
-                        body: JSON.stringify({
-                            command: buildCommandLine(command, options),
-                        }),
-                    },
-                    controller.signal,
-                    abortAfterMs ? bufferedExecDispatcher : undefined,
-                );
-                if (!response.ok) {
-                    throw new SandboxCommandError(
-                        response.status,
-                        await response.text().catch(() => ''),
-                        '',
-                    );
-                }
-                const result = decodeExecResponse(await response.json());
-                // Native exec is buffered — replay the captured output through the
-                // streaming callbacks once so downstream line-parsers still see it.
-                if (result.stdout) options?.onStdout?.(result.stdout);
-                if (result.stderr) options?.onStderr?.(result.stderr);
-                if (result.exitCode !== 0) {
-                    throw new SandboxCommandError(
-                        result.exitCode,
-                        result.stderr,
-                        result.stdout,
-                    );
-                }
-                return result;
-            } catch (error) {
-                if (
-                    error instanceof DOMException &&
-                    error.name === 'AbortError'
-                ) {
-                    throw new SandboxTimeoutError(
-                        `Command timed out after ${abortAfterMs}ms (configured ${options?.timeoutMs}ms)`,
-                    );
-                }
-                throw error;
-            } finally {
-                if (timer) clearTimeout(timer);
+            // A run allowed to outlive the gateway's ~600s per-request cap
+            // cannot be one buffered call — detach it and poll instead.
+            if (
+                options?.timeoutMs !== undefined &&
+                options.timeoutMs > this.detachedThresholdMs
+            ) {
+                return this.runDetached(command, {
+                    ...options,
+                    timeoutMs: options.timeoutMs,
+                });
             }
+            return this.runBuffered(command, options);
         },
     };
+
+    /** One buffered exec round-trip: the response arrives when the command completes. */
+    private async runBuffered(
+        command: string,
+        options?: RunOptions,
+    ): Promise<CommandResult> {
+        const controller = new AbortController();
+        // Give the native exec a 5s grace period over the caller's timeout so
+        // the server's own timeout error surfaces before this client-side abort.
+        const abortAfterMs =
+            options?.timeoutMs && options.timeoutMs > 0
+                ? options.timeoutMs + 5_000
+                : null;
+        const timer = abortAfterMs
+            ? setTimeout(() => controller.abort(), abortAfterMs)
+            : null;
+        try {
+            const response = await this.send(
+                this.url(EXEC_PATH),
+                {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({
+                        command: buildCommandLine(command, options),
+                    }),
+                },
+                controller.signal,
+                abortAfterMs ? bufferedExecDispatcher : undefined,
+            );
+            if (!response.ok) {
+                throw new SandboxCommandError(
+                    response.status,
+                    await response.text().catch(() => ''),
+                    '',
+                );
+            }
+            const result = decodeExecResponse(await response.json());
+            // Native exec is buffered — replay the captured output through the
+            // streaming callbacks once so downstream line-parsers still see it.
+            if (result.stdout) options?.onStdout?.(result.stdout);
+            if (result.stderr) options?.onStderr?.(result.stderr);
+            if (result.exitCode !== 0) {
+                throw new SandboxCommandError(
+                    result.exitCode,
+                    result.stderr,
+                    result.stdout,
+                );
+            }
+            return result;
+        } catch (error) {
+            if (error instanceof DOMException && error.name === 'AbortError') {
+                throw new SandboxTimeoutError(
+                    `Command timed out after ${abortAfterMs}ms (configured ${options?.timeoutMs}ms)`,
+                );
+            }
+            throw error;
+        } finally {
+            if (timer) clearTimeout(timer);
+        }
+    }
+
+    /**
+     * Best-effort stop of a detached run's entire process group: TERM for a
+     * graceful window, then KILL. Targets the negative PGID recorded at start
+     * (see the setsid note in {@link runDetached}) — killing only the wrapper
+     * shell PID would orphan its children. Never throws: this runs on paths
+     * that are already reporting a failure.
+     */
+    private async killDetachedProcessGroup(runDir: string): Promise<void> {
+        await this.runBuffered(
+            `if [ -f ${runDir}/pid ]; then PGID="$(cat ${runDir}/pid)"; ` +
+                `kill -TERM -- "-$PGID" 2>/dev/null; sleep 2; ` +
+                `kill -KILL -- "-$PGID" 2>/dev/null; fi; true`,
+            { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+        ).catch(() => {});
+    }
+
+    /**
+     * Run a long command without ever holding a data-plane request open for its
+     * duration: start it detached under nohup with its streams and exit code
+     * captured to files (a ~1s request), then poll those files with short
+     * requests, replaying new bytes through `onStdout`/`onStderr` as they land.
+     *
+     * This is what makes >10-minute runs (Claude generation turns) possible on
+     * Azure, restores incremental streaming that buffered exec cannot provide,
+     * and survives transient poll failures — the process keeps running in the
+     * sandbox and the next successful poll re-attaches to its files.
+     */
+    private async runDetached(
+        command: string,
+        options: RunOptions & { timeoutMs: number },
+    ): Promise<CommandResult> {
+        const runDir = `/tmp/.lightdash-exec/${randomUUID()}`;
+        // cwd/envs are folded into the inner command line; the subshell keeps
+        // compound inner commands (a && b) under one redirect.
+        const inner = buildCommandLine(command, options);
+        const wrapped = `( ${inner} ) > ${runDir}/out.log 2> ${runDir}/err.log; echo $? > ${runDir}/exit`;
+        // setsid makes the wrapper the leader of a fresh process group whose
+        // PGID equals the recorded PID, so a kill can target the whole command
+        // tree (`kill -- -PID`) — signalling only the wrapper shell would
+        // orphan its children (claude, pnpm, …). The backgrounded child of a
+        // non-job-control shell is never already a group leader, so setsid
+        // execs in place and `$!` is reliably the leader's PID.
+        await this.runBuffered(
+            `mkdir -p ${runDir}; nohup setsid /bin/sh -c ${shQuote(wrapped)} < /dev/null > /dev/null 2>&1 & echo $! > ${runDir}/pid`,
+            { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+        );
+
+        const startedAt = Date.now();
+        // StringDecoder holds back a multi-byte UTF-8 sequence split across
+        // poll boundaries instead of emitting a corrupt character.
+        const outDecoder = new StringDecoder('utf8');
+        const errDecoder = new StringDecoder('utf8');
+        let outOffset = 0;
+        let errOffset = 0;
+        let stdout = '';
+        let stderr = '';
+        let consecutiveFailures = 0;
+
+        for (;;) {
+            const elapsedMs = Date.now() - startedAt;
+            if (elapsedMs >= options.timeoutMs) {
+                // Best-effort stop; without it the process would outlive the
+                // timeout exactly like the gateway-504 case this replaces.
+                // eslint-disable-next-line no-await-in-loop
+                await this.killDetachedProcessGroup(runDir);
+                throw new SandboxTimeoutError(
+                    `Command timed out after ${elapsedMs}ms (configured ${options.timeoutMs}ms)`,
+                );
+            }
+
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(this.pollIntervalMs);
+
+            let tick: DetachedTick;
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                const response = await this.runBuffered(
+                    `printf S; cat ${runDir}/exit 2>/dev/null; echo; ` +
+                        `printf O; tail -c +${outOffset + 1} ${runDir}/out.log 2>/dev/null | base64 | tr -d '\\n'; echo; ` +
+                        `printf E; tail -c +${errOffset + 1} ${runDir}/err.log 2>/dev/null | base64 | tr -d '\\n'; echo`,
+                    { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+                );
+                tick = parseDetachedTick(response.stdout);
+                consecutiveFailures = 0;
+            } catch (error) {
+                consecutiveFailures += 1;
+                if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+                    // Abandoning the run must not orphan the command tree — a
+                    // caller's retry could otherwise run alongside it.
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.killDetachedProcessGroup(runDir);
+                    throw new SandboxCommandError(
+                        -1,
+                        `Detached exec polling failed ${consecutiveFailures} times in a row: ${
+                            error instanceof Error
+                                ? error.message
+                                : String(error)
+                        }`,
+                        stdout,
+                    );
+                }
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            outOffset += tick.out.length;
+            errOffset += tick.err.length;
+            const outText = outDecoder.write(tick.out);
+            if (outText) {
+                stdout += outText;
+                options.onStdout?.(outText);
+            }
+            const errText = errDecoder.write(tick.err);
+            if (errText) {
+                stderr += errText;
+                options.onStderr?.(errText);
+            }
+
+            if (tick.exitCode !== null) {
+                if (tick.exitCode !== 0) {
+                    // Keep runDir on failure so the logs survive for post-mortem.
+                    throw new SandboxCommandError(
+                        tick.exitCode,
+                        stderr,
+                        stdout,
+                    );
+                }
+                // eslint-disable-next-line no-await-in-loop
+                await this.files.remove(runDir).catch(() => {});
+                return { stdout, stderr, exitCode: 0 };
+            }
+        }
+    }
 
     readonly files: SandboxFiles = {
         read: async (path: string): Promise<string> => {

--- a/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/AzureSandboxExecChannel.ts
@@ -324,8 +324,9 @@ export class AzureSandboxExecChannel {
      * that are already reporting a failure.
      */
     private async killDetachedProcessGroup(runDir: string): Promise<void> {
+        const pidFile = shQuote(`${runDir}/pid`);
         await this.runBuffered(
-            `if [ -f ${runDir}/pid ]; then PGID="$(cat ${runDir}/pid)"; ` +
+            `if [ -f ${pidFile} ]; then PGID="$(cat ${pidFile})"; ` +
                 `kill -TERM -- "-$PGID" 2>/dev/null; sleep 2; ` +
                 `kill -KILL -- "-$PGID" 2>/dev/null; fi; true`,
             { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
@@ -359,7 +360,7 @@ export class AzureSandboxExecChannel {
         // non-job-control shell is never already a group leader, so setsid
         // execs in place and `$!` is reliably the leader's PID.
         await this.runBuffered(
-            `mkdir -p ${runDir}; nohup setsid /bin/sh -c ${shQuote(wrapped)} < /dev/null > /dev/null 2>&1 & echo $! > ${runDir}/pid`,
+            `mkdir -p ${shQuote(runDir)}; nohup setsid /bin/sh -c ${shQuote(wrapped)} < /dev/null > /dev/null 2>&1 & echo $! > ${shQuote(`${runDir}/pid`)}`,
             { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
         );
 
@@ -393,9 +394,9 @@ export class AzureSandboxExecChannel {
             try {
                 // eslint-disable-next-line no-await-in-loop
                 const response = await this.runBuffered(
-                    `printf S; cat ${runDir}/exit 2>/dev/null; echo; ` +
-                        `printf O; tail -c +${outOffset + 1} ${runDir}/out.log 2>/dev/null | base64 | tr -d '\\n'; echo; ` +
-                        `printf E; tail -c +${errOffset + 1} ${runDir}/err.log 2>/dev/null | base64 | tr -d '\\n'; echo`,
+                    `printf S; cat ${shQuote(`${runDir}/exit`)} 2>/dev/null; echo; ` +
+                        `printf O; tail -c +${outOffset + 1} ${shQuote(`${runDir}/out.log`)} 2>/dev/null | base64 | tr -d '\\n'; echo; ` +
+                        `printf E; tail -c +${errOffset + 1} ${shQuote(`${runDir}/err.log`)} 2>/dev/null | base64 | tr -d '\\n'; echo`,
                     { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
                 );
                 tick = parseDetachedTick(response.stdout);
@@ -435,6 +436,20 @@ export class AzureSandboxExecChannel {
             }
 
             if (tick.exitCode !== null) {
+                // Flush bytes the decoders held back waiting for the rest of a
+                // multi-byte sequence that never came (binary output, or a
+                // process killed mid-write) — end() emits them as U+FFFD
+                // instead of silently dropping them.
+                const outTail = outDecoder.end();
+                if (outTail) {
+                    stdout += outTail;
+                    options.onStdout?.(outTail);
+                }
+                const errTail = errDecoder.end();
+                if (errTail) {
+                    stderr += errTail;
+                    options.onStderr?.(errTail);
+                }
                 if (tick.exitCode !== 0) {
                     // Keep runDir on failure so the logs survive for post-mortem.
                     throw new SandboxCommandError(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #25413

### Description:
Problem
The Azure sandboxes data plane 504s any single executeShellCommand at ~600s. AzureSandboxExecChannel maps one whole command to one buffered HTTP request — a Claude generation turn runs with timeoutMs: 55min — so any run longer than ~10 minutes fails its attempt with exit=504 and zero output, and only completes if the retry budget (3 attempts) covers the remaining work. Reported by a customer on an Azure deployment after #25396 removed the client-side undici timeout that sat in front of the gateway's cap.

Fix
Commands bounded by timeoutMs above 5 minutes now run detached: started under nohup with stdout/stderr/exit code captured to files (a ~1s request), then polled every 2s with short requests that stream new bytes back through onStdout/onStderr (base64 over byte offsets; StringDecoder guards UTF-8 sequences split across polls). The exit file carries the real exit code; timeout does a best-effort kill and throws SandboxTimeoutError; up to 5 consecutive poll failures are tolerated — the process keeps running in the sandbox and the next successful poll re-attaches.

Short commands keep the existing buffered single-request path unchanged.

Side effects on Azure beyond lifting the duration cap: live status updates during generation (buffered exec streamed nothing until completion) and a working retry --continue promotion (sessionEstablished needs mid-run stream events, which now exist).
