### PR TITLE
fix(backend): seed spotlight categories for the demo project

### DIFF
--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -289,6 +289,30 @@ export async function seed(knex: Knex): Promise<void> {
             lightdashConfig,
         });
         const tagsModel = new TagsModel({ database: knex });
+
+        const lightdashProjectConfig = await adapter.getLightdashProjectConfig({
+            projectUuid,
+            organizationUuid,
+            userUuid: user.user_uuid,
+        });
+
+        // Persist spotlight categories as yaml tags before indexing so the
+        // catalog index attaches them (mirrors ProjectService compile). Without
+        // this the seed project has no categories and category filtering
+        // returns nothing.
+        await tagsModel.replaceYamlTags(
+            projectUuid,
+            Object.entries(
+                lightdashProjectConfig.spotlight?.categories ?? {},
+            ).map(([yamlReference, category]) => ({
+                project_uuid: projectUuid,
+                name: category.label,
+                color: category.color ?? 'gray',
+                created_by_user_uuid: user.user_uuid,
+                yaml_reference: yamlReference,
+            })),
+        );
+
         const projectYamlTags = await tagsModel.getYamlTags(projectUuid);
         const cachedExploresMap = await projectModel.findExploresFromCache(
             projectUuid,
@@ -303,11 +327,6 @@ export async function seed(knex: Knex): Promise<void> {
         );
 
         // Seed parameters
-        const lightdashProjectConfig = await adapter.getLightdashProjectConfig({
-            projectUuid,
-            organizationUuid,
-            userUuid: user.user_uuid,
-        });
         await new ProjectParametersModel({
             database: knex,
         }).replace(projectUuid, lightdashProjectConfig.parameters ?? {});


### PR DESCRIPTION
### Description:
The dev seed compiled explores and indexed the catalog directly but never persisted the project config's spotlight categories, so a freshly-seeded demo project had no categories. Category filtering (e.g. the metricsWithTimeDimensions API tests) then returned 0 results until an unrelated ProjectService compile happened to run and create them — a race that made those tests flaky.

Persist the categories via replaceYamlTags from the project config before indexing, mirroring the ProjectService compile path, so getYamlTags is non-empty and indexCatalog attaches them. Reuse the single getLightdashProjectConfig fetch for both categories and parameters.

test-all
