### PR TITLE
refactor(managed-agent): make session runner reusable

### DIFF
--- a/packages/backend/src/ee/clients/ManagedAgentClient.test.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.test.ts
@@ -1,0 +1,413 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { AgentCreateParams } from '@anthropic-ai/sdk/resources/beta/agents';
+import type { LightdashConfig } from '../../config/parseConfig';
+import {
+    ManagedAgentClient,
+    type ManagedAgentRunConfig,
+    type ManagedAgentSessionConfig,
+} from './ManagedAgentClient';
+
+vi.mock('../../tracing/tracing', () => ({
+    traceSpan: vi.fn(
+        async (
+            _config: unknown,
+            callback: (span: {
+                setAttributes: ReturnType<typeof vi.fn>;
+            }) => Promise<unknown> | unknown,
+        ) => callback({ setAttributes: vi.fn() }),
+    ),
+}));
+
+const agentConfig: AgentCreateParams = {
+    name: 'Test agent',
+    model: 'claude-sonnet-4-5',
+    system: 'Test system prompt',
+};
+
+const lightdashConfig = {
+    siteUrl: 'https://lightdash.example.com',
+    managedAgent: {
+        anthropicApiKey: 'anthropic-key',
+        sessionTimeoutMs: 10_000,
+    },
+} as unknown as LightdashConfig;
+
+const createStream = (events: unknown[]) => {
+    const controller = new AbortController();
+    vi.spyOn(controller, 'abort');
+    const stream = {
+        controller,
+        async *[Symbol.asyncIterator]() {
+            for (const event of events) {
+                yield event;
+            }
+        },
+    };
+
+    return { controller, stream };
+};
+
+const createPendingStream = () => {
+    const controller = new AbortController();
+    vi.spyOn(controller, 'abort');
+    const stream = {
+        controller,
+        async *[Symbol.asyncIterator]() {
+            yield await new Promise<never>(() => {});
+        },
+    };
+
+    return { controller, stream };
+};
+
+const createAnthropicClient = (stream: unknown) => {
+    const mocks = {
+        agentCreate: vi.fn().mockResolvedValue({
+            id: 'agent-1',
+            version: 1,
+        }),
+        environmentList: vi.fn().mockResolvedValue({ data: [] }),
+        environmentCreate: vi.fn().mockResolvedValue({ id: 'environment-1' }),
+        vaultCreate: vi.fn().mockResolvedValue({ id: 'vault-1' }),
+        credentialCreate: vi.fn().mockResolvedValue({}),
+        sessionCreate: vi.fn().mockResolvedValue({ id: 'session-1' }),
+        eventStream: vi.fn().mockResolvedValue(stream),
+        eventSend: vi.fn().mockResolvedValue({}),
+    };
+    const client = {
+        beta: {
+            agents: {
+                create: mocks.agentCreate,
+                retrieve: vi.fn(),
+                update: vi.fn(),
+            },
+            environments: {
+                list: mocks.environmentList,
+                create: mocks.environmentCreate,
+            },
+            vaults: {
+                create: mocks.vaultCreate,
+                credentials: { create: mocks.credentialCreate },
+            },
+            sessions: {
+                create: mocks.sessionCreate,
+                events: {
+                    stream: mocks.eventStream,
+                    send: mocks.eventSend,
+                },
+            },
+        },
+    } as unknown as Anthropic;
+
+    return { client, mocks };
+};
+
+const createSessionConfig = (
+    overrides: Partial<ManagedAgentSessionConfig> = {},
+): ManagedAgentSessionConfig => ({
+    agentConfig,
+    serviceAccountPat: 'service-account-pat',
+    resourceName: 'org:project',
+    persistedAgentId: null,
+    persistedAgentConfigHash: null,
+    persistedAgentVersion: null,
+    persistedEnvironmentId: null,
+    persistedVaultId: null,
+    onAgentSynced: vi.fn().mockResolvedValue(undefined),
+    onResourcesCreated: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+});
+
+const createRunConfig = (
+    overrides: Partial<ManagedAgentRunConfig> = {},
+): ManagedAgentRunConfig => ({
+    projectName: 'Analytics',
+    sessionTitle: 'Investigate Analytics',
+    initialPrompt: 'Inspect the project',
+    onCustomToolUse: vi.fn().mockResolvedValue('{"ok":true}'),
+    ...overrides,
+});
+
+describe('ManagedAgentClient', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('syncs the supplied agent definition with resource metadata', async () => {
+        const { stream } = createStream([]);
+        const { client, mocks } = createAnthropicClient(stream);
+        const managedAgentClient = new ManagedAgentClient({
+            lightdashConfig,
+            anthropicClient: client,
+        });
+        const sessionConfig = createSessionConfig();
+
+        await expect(managedAgentClient.syncAgent(sessionConfig)).resolves.toBe(
+            'agent-1',
+        );
+        expect(mocks.agentCreate).toHaveBeenCalledWith({
+            ...agentConfig,
+            name: 'Test agent (org:project)',
+            metadata: { lightdash_resource: 'org:project' },
+        });
+        expect(sessionConfig.onAgentSynced).toHaveBeenCalledWith(
+            'agent-1',
+            expect.any(String),
+            1,
+        );
+    });
+
+    it('runs a configured session and emits safe progress events', async () => {
+        const events = [
+            {
+                type: 'agent.message',
+                content: [{ type: 'text', text: 'Working' }],
+            },
+            { type: 'agent.tool_use', name: 'read' },
+            { type: 'agent.mcp_tool_use', name: 'query' },
+            {
+                type: 'agent.custom_tool_use',
+                id: 'tool-use-1',
+                name: 'inspect',
+                input: { target: 'chart' },
+            },
+            {
+                type: 'session.status_idle',
+                stop_reason: { type: 'end_turn' },
+            },
+        ];
+        const { stream } = createStream(events);
+        const { client, mocks } = createAnthropicClient(stream);
+        const managedAgentClient = new ManagedAgentClient({
+            lightdashConfig,
+            anthropicClient: client,
+        });
+        const onProgress = vi.fn();
+        const onCustomToolUse = vi.fn().mockResolvedValue('{"ok":true}');
+        const onSessionCreated = vi.fn();
+
+        await expect(
+            managedAgentClient.runSession(
+                createSessionConfig(),
+                createRunConfig({
+                    onProgress,
+                    onCustomToolUse,
+                    onSessionCreated,
+                }),
+            ),
+        ).resolves.toEqual({
+            status: 'completed',
+            sessionId: 'session-1',
+        });
+
+        expect(mocks.sessionCreate).toHaveBeenCalledWith({
+            agent: 'agent-1',
+            environment_id: 'environment-1',
+            vault_ids: ['vault-1'],
+            title: 'Investigate Analytics',
+        });
+        expect(mocks.eventSend).toHaveBeenNthCalledWith(1, 'session-1', {
+            events: [
+                {
+                    type: 'user.message',
+                    content: [{ type: 'text', text: 'Inspect the project' }],
+                },
+            ],
+        });
+        expect(mocks.eventSend).toHaveBeenNthCalledWith(2, 'session-1', {
+            events: [
+                {
+                    type: 'user.custom_tool_result',
+                    custom_tool_use_id: 'tool-use-1',
+                    content: [{ type: 'text', text: '{"ok":true}' }],
+                },
+            ],
+        });
+        expect(onCustomToolUse).toHaveBeenCalledWith('inspect', {
+            target: 'chart',
+        });
+        expect(onSessionCreated).toHaveBeenCalledWith('session-1');
+        expect(onProgress.mock.calls.map(([event]) => event)).toEqual([
+            { type: 'message' },
+            { type: 'tool_use', source: 'builtin', toolName: 'read' },
+            { type: 'tool_use', source: 'mcp', toolName: 'query' },
+            { type: 'tool_use', source: 'custom', toolName: 'inspect' },
+            { type: 'idle', stopReason: 'end_turn' },
+        ]);
+    });
+
+    it('returns the session ID and aborts the stream on timeout', async () => {
+        vi.useFakeTimers();
+        const { controller, stream } = createPendingStream();
+        const { client, mocks } = createAnthropicClient(stream);
+        const managedAgentClient = new ManagedAgentClient({
+            lightdashConfig,
+            anthropicClient: client,
+        });
+
+        const result = managedAgentClient.runSession(
+            createSessionConfig(),
+            createRunConfig({ timeoutMs: 100 }),
+        );
+        await vi.advanceTimersByTimeAsync(100);
+
+        await expect(result).resolves.toEqual({
+            status: 'timed_out',
+            sessionId: 'session-1',
+            error: '[ManagedAgent] Session timed out after 100ms',
+        });
+        expect(controller.abort).toHaveBeenCalledOnce();
+        expect(mocks.eventSend).toHaveBeenNthCalledWith(2, 'session-1', {
+            events: [{ type: 'user.interrupt' }],
+        });
+    });
+
+    it('does not create resources when the caller already cancelled', async () => {
+        const { stream } = createStream([]);
+        const { client, mocks } = createAnthropicClient(stream);
+        const managedAgentClient = new ManagedAgentClient({
+            lightdashConfig,
+            anthropicClient: client,
+        });
+        const abortController = new AbortController();
+        abortController.abort(new Error('Cancelled before start'));
+
+        await expect(
+            managedAgentClient.runSession(
+                createSessionConfig(),
+                createRunConfig({ abortSignal: abortController.signal }),
+            ),
+        ).rejects.toThrow('Cancelled before start');
+        expect(mocks.agentCreate).not.toHaveBeenCalled();
+        expect(mocks.sessionCreate).not.toHaveBeenCalled();
+        expect(mocks.eventSend).not.toHaveBeenCalled();
+    });
+
+    it('waits for session persistence before starting the stream', async () => {
+        const { stream } = createStream([]);
+        const { client, mocks } = createAnthropicClient(stream);
+        const managedAgentClient = new ManagedAgentClient({
+            lightdashConfig,
+            anthropicClient: client,
+        });
+
+        await expect(
+            managedAgentClient.runSession(
+                createSessionConfig(),
+                createRunConfig({
+                    onSessionCreated: vi
+                        .fn()
+                        .mockRejectedValue(new Error('Persistence failed')),
+                }),
+            ),
+        ).rejects.toThrow('Persistence failed');
+        expect(mocks.eventStream).not.toHaveBeenCalled();
+        expect(mocks.eventSend).not.toHaveBeenCalled();
+    });
+
+    it('continues when progress persistence fails', async () => {
+        const { stream } = createStream([
+            { type: 'agent.tool_use', name: 'read' },
+            {
+                type: 'session.status_idle',
+                stop_reason: { type: 'end_turn' },
+            },
+        ]);
+        const { client } = createAnthropicClient(stream);
+        const managedAgentClient = new ManagedAgentClient({
+            lightdashConfig,
+            anthropicClient: client,
+        });
+
+        await expect(
+            managedAgentClient.runSession(
+                createSessionConfig(),
+                createRunConfig({
+                    onProgress: vi
+                        .fn()
+                        .mockRejectedValue(new Error('Progress failed')),
+                }),
+            ),
+        ).resolves.toEqual({
+            status: 'completed',
+            sessionId: 'session-1',
+        });
+    });
+
+    it('returns custom tool failures to the managed session', async () => {
+        const { stream } = createStream([
+            {
+                type: 'agent.custom_tool_use',
+                id: 'tool-use-1',
+                name: 'inspect',
+                input: {},
+            },
+            {
+                type: 'session.status_idle',
+                stop_reason: { type: 'end_turn' },
+            },
+        ]);
+        const { client, mocks } = createAnthropicClient(stream);
+        const managedAgentClient = new ManagedAgentClient({
+            lightdashConfig,
+            anthropicClient: client,
+        });
+
+        await expect(
+            managedAgentClient.runSession(
+                createSessionConfig(),
+                createRunConfig({
+                    onCustomToolUse: vi
+                        .fn()
+                        .mockRejectedValue(new Error('Tool failed')),
+                }),
+            ),
+        ).resolves.toEqual({
+            status: 'completed',
+            sessionId: 'session-1',
+        });
+
+        expect(mocks.eventSend).toHaveBeenNthCalledWith(2, 'session-1', {
+            events: [
+                {
+                    type: 'user.custom_tool_result',
+                    custom_tool_use_id: 'tool-use-1',
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify({ error: 'Tool failed' }),
+                        },
+                    ],
+                    is_error: true,
+                },
+            ],
+        });
+    });
+
+    it('interrupts the session when the caller cancels', async () => {
+        const { controller: streamController, stream } = createPendingStream();
+        const { client, mocks } = createAnthropicClient(stream);
+        const managedAgentClient = new ManagedAgentClient({
+            lightdashConfig,
+            anthropicClient: client,
+        });
+        const abortController = new AbortController();
+        const result = managedAgentClient.runSession(
+            createSessionConfig(),
+            createRunConfig({ abortSignal: abortController.signal }),
+        );
+        await vi.waitFor(() => expect(mocks.eventStream).toHaveBeenCalled());
+
+        abortController.abort(new Error('Cancelled'));
+
+        await expect(result).resolves.toEqual({
+            status: 'cancelled',
+            sessionId: 'session-1',
+            error: 'Cancelled',
+        });
+        expect(streamController.abort).toHaveBeenCalledOnce();
+        expect(mocks.eventSend).toHaveBeenNthCalledWith(2, 'session-1', {
+            events: [{ type: 'user.interrupt' }],
+        });
+    });
+});

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -4,25 +4,22 @@ import type {
     AgentUpdateParams,
     BetaManagedAgentsAgent,
 } from '@anthropic-ai/sdk/resources/beta/agents';
+import type { BetaManagedAgentsStreamSessionEvents } from '@anthropic-ai/sdk/resources/beta/sessions/events';
 import { ParameterError } from '@lightdash/common';
-import * as Sentry from '@sentry/node';
+import { createHash } from 'crypto';
 import type { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { traceSpan, type TraceSpan } from '../../tracing/tracing';
-import {
-    getManagedAgentConfigHash,
-    renderManagedAgentConfig,
-} from '../services/ManagedAgentService/config/agent';
 
 type ManagedAgentClientConfig = {
     lightdashConfig: LightdashConfig;
+    anthropicClient?: Anthropic;
 };
 
 export type ManagedAgentSessionConfig = {
+    agentConfig: AgentCreateParams;
     serviceAccountPat: string;
     resourceName: string;
-    skillIds: string[];
-    toolSettings: Record<string, boolean>;
     persistedAgentId: string | null;
     persistedAgentConfigHash: string | null;
     persistedAgentVersion: number | null;
@@ -39,10 +36,62 @@ export type ManagedAgentSessionConfig = {
     ) => Promise<void>;
 };
 
-type CustomToolHandler = (
+export type ManagedAgentProgressEvent =
+    | {
+          type: 'message';
+      }
+    | {
+          type: 'tool_use';
+          source: 'builtin' | 'mcp' | 'custom';
+          toolName: string;
+      }
+    | {
+          type: 'idle';
+          stopReason: string | null;
+      };
+
+type ManagedAgentCustomToolHandler = (
     toolName: string,
     input: Record<string, unknown>,
 ) => Promise<string>;
+
+export type ManagedAgentRunConfig = {
+    projectName: string;
+    sessionTitle: string;
+    initialPrompt: string;
+    onCustomToolUse: ManagedAgentCustomToolHandler;
+    onSessionCreated?: (sessionId: string) => Promise<void> | void;
+    onProgress?: (
+        progressEvent: ManagedAgentProgressEvent,
+    ) => Promise<void> | void;
+    abortSignal?: AbortSignal;
+    timeoutMs?: number;
+};
+
+export type ManagedAgentSessionResult =
+    | {
+          status: 'completed';
+          sessionId: string;
+      }
+    | {
+          status: 'cancelled' | 'failed' | 'timed_out';
+          sessionId: string;
+          error: string;
+      };
+
+class ManagedAgentSessionTimeoutError extends Error {}
+
+const renderAgentConfigForResource = (
+    resourceName: string,
+    agentConfig: AgentCreateParams,
+): AgentCreateParams => ({
+    ...agentConfig,
+    name: `${agentConfig.name} (${resourceName})`,
+    metadata: {
+        ...agentConfig.metadata,
+        lightdash_resource: resourceName,
+    },
+});
 
 export class ManagedAgentClient {
     private readonly config: ManagedAgentClientConfig;
@@ -52,6 +101,10 @@ export class ManagedAgentClient {
     }
 
     private getAnthropicClient(): Anthropic {
+        if (this.config.anthropicClient) {
+            return this.config.anthropicClient;
+        }
+
         const { anthropicApiKey } = this.config.lightdashConfig.managedAgent;
         if (!anthropicApiKey) {
             throw new ParameterError(
@@ -62,36 +115,17 @@ export class ManagedAgentClient {
         return new Anthropic({ apiKey: anthropicApiKey });
     }
 
-    private getRenderedAgentConfig(
-        resourceName: string,
-        skillIds: string[],
-        toolSettings: Record<string, boolean>,
-    ): AgentCreateParams {
-        const renderedAgentConfig = renderManagedAgentConfig({
-            lightdashSiteUrl: this.config.lightdashConfig.siteUrl,
-            skillIds,
-            toolSettings,
-        });
-        return {
-            ...renderedAgentConfig,
-            name: `${renderedAgentConfig.name} (${resourceName})`,
-            metadata: {
-                ...renderedAgentConfig.metadata,
-                lightdash_resource: resourceName,
-            },
-        };
-    }
-
     private async ensureAgent(
         beta: Anthropic.Beta,
         sessionConfig: ManagedAgentSessionConfig,
     ): Promise<string> {
-        const desiredAgent = this.getRenderedAgentConfig(
+        const desiredAgent = renderAgentConfigForResource(
             sessionConfig.resourceName,
-            sessionConfig.skillIds,
-            sessionConfig.toolSettings,
+            sessionConfig.agentConfig,
         );
-        const desiredHash = getManagedAgentConfigHash(desiredAgent);
+        const desiredHash = createHash('md5')
+            .update(JSON.stringify(desiredAgent))
+            .digest('hex');
 
         if (
             sessionConfig.persistedAgentId &&
@@ -282,13 +316,10 @@ export class ManagedAgentClient {
 
     async runSession(
         sessionConfig: ManagedAgentSessionConfig,
-        projectName: string,
-        onCustomToolUse: CustomToolHandler,
-        onSessionCreated?: (sessionId: string) => void,
-    ): Promise<{
-        sessionId: string;
-        slackSummary: string | null;
-    }> {
+        runConfig: ManagedAgentRunConfig,
+    ): Promise<ManagedAgentSessionResult> {
+        runConfig.abortSignal?.throwIfAborted();
+
         // Managed-agent sessions run on Anthropic's Agents API (not the Vercel
         // AI SDK), so they need a manual span to show up in tracing alongside
         // the auto-instrumented AI-SDK calls. Token usage isn't surfaced in the
@@ -301,49 +332,51 @@ export class ManagedAgentClient {
                     feature: 'managed-agent',
                     'gen_ai.system': 'anthropic',
                     'lightdash.resource_name': sessionConfig.resourceName,
-                    'lightdash.project_name': projectName,
+                    'lightdash.project_name': runConfig.projectName,
                 },
             },
             (span) =>
-                this.runManagedAgentSession(
-                    sessionConfig,
-                    projectName,
-                    onCustomToolUse,
-                    span,
-                    onSessionCreated,
-                ),
+                this.runManagedAgentSession(sessionConfig, runConfig, span),
         );
     }
 
     private async runManagedAgentSession(
         sessionConfig: ManagedAgentSessionConfig,
-        projectName: string,
-        onCustomToolUse: CustomToolHandler,
+        runConfig: ManagedAgentRunConfig,
         span: TraceSpan,
-        onSessionCreated?: (sessionId: string) => void,
-    ): Promise<{
-        sessionId: string;
-        slackSummary: string | null;
-    }> {
+    ): Promise<ManagedAgentSessionResult> {
+        runConfig.abortSignal?.throwIfAborted();
+
         const client = this.getAnthropicClient();
         const { agentId, environmentId, vaultId } =
             await this.ensureAgentAndEnvironment(client, sessionConfig);
+        runConfig.abortSignal?.throwIfAborted();
 
         const session = await client.beta.sessions.create({
             agent: agentId,
             environment_id: environmentId,
             vault_ids: [vaultId],
-            title: `Health check: ${projectName} — ${new Date().toISOString()}`,
+            title: runConfig.sessionTitle,
         });
+        runConfig.abortSignal?.throwIfAborted();
 
         Logger.info(`[ManagedAgent] Session created: ${session.id}`);
         span.setAttributes({
             'gen_ai.agent.id': agentId,
             'gen_ai.session.id': session.id,
         });
-        onSessionCreated?.(session.id);
+        await runConfig.onSessionCreated?.(session.id);
+        runConfig.abortSignal?.throwIfAborted();
 
         const stream = await client.beta.sessions.events.stream(session.id);
+        if (runConfig.abortSignal?.aborted) {
+            await this.interruptSession(client, session.id, stream.controller);
+            return {
+                status: 'cancelled',
+                sessionId: session.id,
+                error: this.getErrorMessage(runConfig.abortSignal.reason),
+            };
+        }
 
         await client.beta.sessions.events.send(session.id, {
             events: [
@@ -352,39 +385,37 @@ export class ManagedAgentClient {
                     content: [
                         {
                             type: 'text',
-                            text: `Today's date is ${new Date().toISOString().split('T')[0]}. Analyze project "${projectName}". Follow your checklist.`,
+                            text: runConfig.initialPrompt,
                         },
                     ],
                 },
             ],
         });
+        if (runConfig.abortSignal?.aborted) {
+            await this.interruptSession(client, session.id, stream.controller);
+            return {
+                status: 'cancelled',
+                sessionId: session.id,
+                error: this.getErrorMessage(runConfig.abortSignal.reason),
+            };
+        }
 
-        const { sessionTimeoutMs } = this.config.lightdashConfig.managedAgent;
-
-        // Wrap the event loop in a timeout to prevent the scheduler from
-        // blocking indefinitely if the agent stalls or loops.
-        const timeoutPromise = new Promise<never>((_, reject) => {
-            setTimeout(
-                () =>
-                    reject(
-                        new Error(
-                            `[ManagedAgent] Session timed out after ${sessionTimeoutMs}ms`,
-                        ),
-                    ),
-                sessionTimeoutMs,
-            );
-        });
-
-        let slackSummary: string | null = null;
+        const sessionTimeoutMs =
+            runConfig.timeoutMs ??
+            this.config.lightdashConfig.managedAgent.sessionTimeoutMs;
 
         const eventLoop = async () => {
             for await (const event of stream) {
+                try {
+                    await this.emitProgress(event, runConfig.onProgress);
+                } catch (error) {
+                    Logger.warn(
+                        `[ManagedAgent] Progress callback failed: ${this.getErrorMessage(error)}`,
+                    );
+                }
+
                 if (event.type === 'agent.message') {
-                    for (const block of event.content) {
-                        if ('text' in block) {
-                            Logger.debug(`[ManagedAgent] ${block.text}`);
-                        }
-                    }
+                    Logger.debug('[ManagedAgent] Agent message received');
                 } else if (event.type === 'agent.tool_use') {
                     Logger.info(`[ManagedAgent] Built-in tool: ${event.name}`);
                 } else if (event.type === 'agent.mcp_tool_use') {
@@ -393,44 +424,8 @@ export class ManagedAgentClient {
                     Logger.info(
                         `[ManagedAgent] Tool call: ${event.name} (event_id: ${event.id})`,
                     );
-                    if (event.name === 'write_slack_summary') {
-                        const summary =
-                            typeof event.input.summary === 'string'
-                                ? event.input.summary.trim()
-                                : null;
-                        if (summary) {
-                            slackSummary = summary;
-                            Logger.info(
-                                `[ManagedAgent] Captured dedicated Slack summary (${summary.length} chars)`,
-                            );
-                        } else {
-                            Logger.warn(
-                                '[ManagedAgent] write_slack_summary called without a valid summary',
-                            );
-                        }
-                        await client.beta.sessions.events.send(session.id, {
-                            events: [
-                                {
-                                    type: 'user.custom_tool_result',
-                                    custom_tool_use_id: event.id,
-                                    content: [
-                                        {
-                                            type: 'text',
-                                            text: JSON.stringify({
-                                                ok: true,
-                                                summary_length:
-                                                    summary?.length ?? 0,
-                                            }),
-                                        },
-                                    ],
-                                },
-                            ],
-                        });
-                        // eslint-disable-next-line no-continue
-                        continue;
-                    }
                     try {
-                        const result = await onCustomToolUse(
+                        const result = await runConfig.onCustomToolUse(
                             event.name,
                             event.input as Record<string, unknown>,
                         );
@@ -491,19 +486,172 @@ export class ManagedAgentClient {
             }
         };
 
+        let timeoutId: NodeJS.Timeout | undefined;
+        let removeAbortListener: (() => void) | undefined;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(() => {
+                const error = new ManagedAgentSessionTimeoutError(
+                    `[ManagedAgent] Session timed out after ${sessionTimeoutMs}ms`,
+                );
+                void this.interruptSession(
+                    client,
+                    session.id,
+                    stream.controller,
+                ).then(
+                    () => reject(error),
+                    () => reject(error),
+                );
+            }, sessionTimeoutMs);
+        });
+        const abortPromise = runConfig.abortSignal
+            ? new Promise<never>((_, reject) => {
+                  const abort = () => {
+                      const error =
+                          runConfig.abortSignal?.reason ??
+                          new Error('[ManagedAgent] Session aborted');
+                      void this.interruptSession(
+                          client,
+                          session.id,
+                          stream.controller,
+                      ).then(
+                          () => reject(error),
+                          () => reject(error),
+                      );
+                  };
+
+                  if (runConfig.abortSignal?.aborted) {
+                      abort();
+                      return;
+                  }
+
+                  runConfig.abortSignal?.addEventListener('abort', abort, {
+                      once: true,
+                  });
+                  removeAbortListener = () =>
+                      runConfig.abortSignal?.removeEventListener(
+                          'abort',
+                          abort,
+                      );
+              })
+            : null;
+
         try {
-            await Promise.race([eventLoop(), timeoutPromise]);
-        } catch (error) {
-            // Always return the session ID even on timeout so the caller
-            // can still look up actions recorded before the error.
-            Logger.error(
-                `[ManagedAgent] Session ${session.id} error: ${error instanceof Error ? error.message : 'Unknown'}`,
+            await Promise.race(
+                [eventLoop(), timeoutPromise, abortPromise].filter(
+                    (promise): promise is Promise<void> | Promise<never> =>
+                        promise !== null,
+                ),
             );
+            return { status: 'completed', sessionId: session.id };
+        } catch (error) {
+            Logger.error(
+                `[ManagedAgent] Session ${session.id} error: ${this.getErrorMessage(error)}`,
+            );
+            if (!stream.controller.signal.aborted) {
+                await this.interruptSession(
+                    client,
+                    session.id,
+                    stream.controller,
+                );
+            }
+
+            return {
+                status: this.getTerminalStatus(error, runConfig.abortSignal),
+                sessionId: session.id,
+                error: this.getErrorMessage(error),
+            };
+        } finally {
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+            }
+            removeAbortListener?.();
+        }
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async emitProgress(
+        event: BetaManagedAgentsStreamSessionEvents,
+        onProgress: ManagedAgentRunConfig['onProgress'],
+    ): Promise<void> {
+        if (!onProgress) {
+            return;
         }
 
-        return {
-            sessionId: session.id,
-            slackSummary,
-        };
+        if (event.type === 'agent.message') {
+            await onProgress({ type: 'message' });
+            return;
+        }
+
+        if (event.type === 'agent.tool_use') {
+            await onProgress({
+                type: 'tool_use',
+                source: 'builtin',
+                toolName: event.name,
+            });
+            return;
+        }
+
+        if (event.type === 'agent.mcp_tool_use') {
+            await onProgress({
+                type: 'tool_use',
+                source: 'mcp',
+                toolName: event.name,
+            });
+            return;
+        }
+
+        if (event.type === 'agent.custom_tool_use') {
+            await onProgress({
+                type: 'tool_use',
+                source: 'custom',
+                toolName: event.name,
+            });
+            return;
+        }
+
+        if (event.type === 'session.status_idle') {
+            await onProgress({
+                type: 'idle',
+                stopReason: event.stop_reason?.type ?? null,
+            });
+        }
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async interruptSession(
+        client: Anthropic,
+        sessionId: string,
+        streamController: AbortController,
+    ): Promise<void> {
+        try {
+            await client.beta.sessions.events.send(sessionId, {
+                events: [{ type: 'user.interrupt' }],
+            });
+        } catch (error) {
+            Logger.error(
+                `[ManagedAgent] Failed to interrupt session ${sessionId}: ${this.getErrorMessage(error)}`,
+            );
+        } finally {
+            streamController.abort();
+        }
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private getErrorMessage(error: unknown): string {
+        return error instanceof Error ? error.message : 'Unknown error';
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private getTerminalStatus(
+        error: unknown,
+        abortSignal?: AbortSignal,
+    ): 'cancelled' | 'failed' | 'timed_out' {
+        if (abortSignal?.aborted) {
+            return 'cancelled';
+        }
+        if (error instanceof ManagedAgentSessionTimeoutError) {
+            return 'timed_out';
+        }
+        return 'failed';
     }
 }

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -49,6 +49,12 @@ import {
 import { ManagedAgentModel } from '../../models/ManagedAgentModel';
 import type { ServiceAccountModel } from '../../models/ServiceAccountModel';
 import {
+    getAutopilotInitialPrompt,
+    getAutopilotSessionTitle,
+    getAutopilotSlackSummaryResult,
+    renderManagedAgentConfig,
+} from './config/agent';
+import {
     formatManagedAgentToolListResult,
     getManagedAgentToolResultLimit,
     summarizeManagedAgentBrokenContent,
@@ -288,10 +294,13 @@ export class ManagedAgentService extends BaseService {
         const settings = await this.managedAgentModel.getSettings(projectUuid);
 
         return {
+            agentConfig: renderManagedAgentConfig({
+                lightdashSiteUrl: this.lightdashConfig.siteUrl,
+                skillIds: this.lightdashConfig.managedAgent.skillIds,
+                toolSettings: settings?.toolSettings ?? {},
+            }),
             serviceAccountPat: serviceAccountToken,
             resourceName: `${organization.name}:${organization.organizationUuid}:${project.projectUuid}`,
-            skillIds: this.lightdashConfig.managedAgent.skillIds,
-            toolSettings: settings?.toolSettings ?? {},
             persistedAgentId: agentId,
             persistedAgentConfigHash: agentConfigHash,
             persistedAgentVersion: agentVersion,
@@ -721,7 +730,9 @@ export class ManagedAgentService extends BaseService {
                     const chart = await this.savedChartModel.get(
                         targetUuid,
                         undefined,
-                        { deleted: 'any' },
+                        {
+                            deleted: 'any',
+                        },
                     );
                     return await this.canActorViewChart(actor, chart);
                 }
@@ -773,7 +784,9 @@ export class ManagedAgentService extends BaseService {
                         const chart = await this.savedChartModel.get(
                             chartUuid,
                             undefined,
-                            { deleted: 'any' },
+                            {
+                                deleted: 'any',
+                            },
                         );
                         return this.canActorViewChart(actor, chart);
                     },
@@ -1205,37 +1218,65 @@ export class ManagedAgentService extends BaseService {
         const onToolCall = async (
             toolName: string,
             input: Record<string, unknown>,
-        ): Promise<string> =>
-            this.handleToolCall(
+        ): Promise<string> => {
+            if (toolName === 'write_slack_summary') {
+                const summaryResult = getAutopilotSlackSummaryResult(
+                    slackSummary,
+                    input,
+                );
+                slackSummary = summaryResult.summary;
+
+                if (summaryResult.summaryLength > 0) {
+                    this.logger.info(
+                        `Captured dedicated Slack summary (${summaryResult.summaryLength} chars)`,
+                    );
+                } else {
+                    this.logger.warn(
+                        'write_slack_summary called without a valid summary',
+                    );
+                }
+
+                return summaryResult.toolResult;
+            }
+
+            return this.handleToolCall(
                 projectUuid,
                 sessionId,
                 runUuid,
                 toolName,
                 input,
             );
+        };
 
-        const onSessionCreated = (id: string) => {
+        const onSessionCreated = async (id: string) => {
             sessionId = id;
-            void this.managedAgentModel
-                .setRunSessionId(runUuid, id)
-                .catch((e) =>
-                    this.logger.error(
-                        `Failed to set session_id on run ${runUuid}: ${
-                            e instanceof Error ? e.message : 'Unknown'
-                        }`,
-                    ),
+            try {
+                await this.managedAgentModel.setRunSessionId(runUuid, id);
+            } catch (error) {
+                this.logger.error(
+                    `Failed to set session_id on run ${runUuid}: ${error instanceof Error ? error.message : 'Unknown'}`,
                 );
+            }
         };
 
         try {
+            const now = new Date();
             const result = await this.managedAgentClient.runSession(
                 sessionConfig,
-                projectUuid,
-                onToolCall,
-                onSessionCreated,
+                {
+                    projectName: projectUuid,
+                    sessionTitle: getAutopilotSessionTitle(projectUuid, now),
+                    initialPrompt: getAutopilotInitialPrompt(projectUuid, now),
+                    onCustomToolUse: onToolCall,
+                    onSessionCreated,
+                },
             );
             sessionId = result.sessionId;
-            slackSummary = result.slackSummary ?? '';
+            if (result.status !== 'completed') {
+                this.logger.error(
+                    `Heartbeat session ${sessionId} ended with ${result.status}: ${result.error}`,
+                );
+            }
             this.logger.info(`Heartbeat complete for project: ${projectUuid}`);
         } catch (error) {
             this.logger.error(
@@ -1484,7 +1525,9 @@ export class ManagedAgentService extends BaseService {
         try {
             const actions = await this.managedAgentModel.getActions(
                 projectUuid,
-                { sessionId },
+                {
+                    sessionId,
+                },
             );
 
             this.logger.info(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
@@ -1,0 +1,64 @@
+import {
+    getAutopilotInitialPrompt,
+    getAutopilotSessionTitle,
+    getAutopilotSlackSummaryResult,
+    renderManagedAgentConfig,
+} from './agent';
+
+describe('Autopilot managed agent configuration', () => {
+    it('builds the existing session title and initial prompt', () => {
+        const now = new Date('2026-07-13T14:30:00.000Z');
+
+        expect(getAutopilotSessionTitle('project-1', now)).toBe(
+            'Health check: project-1 — 2026-07-13T14:30:00.000Z',
+        );
+        expect(getAutopilotInitialPrompt('project-1', now)).toBe(
+            'Today\'s date is 2026-07-13. Analyze project "project-1". Follow your checklist.',
+        );
+    });
+
+    it('renders project skills and disabled tool settings', () => {
+        const rendered = renderManagedAgentConfig({
+            lightdashSiteUrl: 'https://lightdash.example.com',
+            skillIds: ['skill-1'],
+            toolSettings: { createContent: false },
+        });
+        const customToolNames =
+            rendered.tools
+                ?.filter((tool) => tool.type === 'custom')
+                .map((tool) => tool.name) ?? [];
+
+        expect(rendered.mcp_servers).toEqual([
+            {
+                name: 'lightdash',
+                type: 'url',
+                url: 'https://lightdash.example.com/api/v1/mcp',
+            },
+        ]);
+        expect(rendered.skills).toEqual([
+            { skill_id: 'skill-1', type: 'custom', version: 'latest' },
+        ]);
+        expect(customToolNames).not.toContain('create_content_from_code');
+        expect(rendered.system).toContain('createContent');
+    });
+
+    it('keeps the last valid Slack summary after an invalid call', () => {
+        const valid = getAutopilotSlackSummaryResult('', {
+            summary: '  Healthy project  ',
+        });
+        const invalid = getAutopilotSlackSummaryResult(valid.summary, {
+            summary: '   ',
+        });
+
+        expect(valid).toEqual({
+            summary: 'Healthy project',
+            summaryLength: 15,
+            toolResult: JSON.stringify({ ok: true, summary_length: 15 }),
+        });
+        expect(invalid).toEqual({
+            summary: 'Healthy project',
+            summaryLength: 0,
+            toolResult: JSON.stringify({ ok: true, summary_length: 0 }),
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -1,5 +1,4 @@
 import type { AgentCreateParams } from '@anthropic-ai/sdk/resources/beta/agents';
-import { createHash } from 'crypto';
 import { produce } from 'immer';
 
 export const managedAgentConfig: AgentCreateParams = {
@@ -430,6 +429,38 @@ type RenderManagedAgentConfigArgs = {
     toolSettings?: Record<string, boolean>;
 };
 
+export const getAutopilotSessionTitle = (
+    projectName: string,
+    now: Date,
+): string => `Health check: ${projectName} — ${now.toISOString()}`;
+
+export const getAutopilotInitialPrompt = (
+    projectName: string,
+    now: Date,
+): string =>
+    `Today's date is ${now.toISOString().split('T')[0]}. Analyze project "${projectName}". Follow your checklist.`;
+
+export const getAutopilotSlackSummaryResult = (
+    currentSummary: string,
+    input: Record<string, unknown>,
+): {
+    summary: string;
+    summaryLength: number;
+    toolResult: string;
+} => {
+    const candidate =
+        typeof input.summary === 'string' ? input.summary.trim() : '';
+
+    return {
+        summary: candidate || currentSummary,
+        summaryLength: candidate.length,
+        toolResult: JSON.stringify({
+            ok: true,
+            summary_length: candidate.length,
+        }),
+    };
+};
+
 const managedAgentCapabilityTools = {
     createContent: ['create_content_from_code'],
     modifyExistingContent: [
@@ -503,6 +534,3 @@ export const renderManagedAgentConfig = ({
         }
     });
 };
-
-export const getManagedAgentConfigHash = (agentConfig: AgentCreateParams) =>
-    createHash('md5').update(JSON.stringify(agentConfig)).digest('hex');


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8824/extract-a-reusable-claude-managed-agent-runner

## Summary

Part of [PROD-8824](https://linear.app/lightdash/issue/PROD-8824/extract-a-reusable-claude-managed-agent-runner). Extracts reusable Claude managed-session mechanics from Autopilot policy while preserving Autopilot's agent configuration and run behavior.

## Why

Deep Research needs the existing long-running Claude resource and event lifecycle with a different prompt, tool surface, progress handler, and terminal-state policy. The client previously imported Autopilot's configuration and handled its Slack summary directly, which made a second managed agent require duplicating or branching the client.

## Files touched (5)

- `ManagedAgentClient.ts` — accepts rendered agent/run configuration, emits structural progress, and returns explicit terminal outcomes.
- `ManagedAgentClient.test.ts` — covers synchronization, events, tools, persistence, timeout, cancellation, and failure paths.
- `ManagedAgentService.ts` — becomes the Autopilot adapter for configuration, prompts, summaries, and legacy run-state policy.
- `config/agent.ts` — owns Autopilot-specific title, prompt, summary, tools, and skills.
- `config/agent.test.ts` — locks down Autopilot adapter behavior.

## Pattern

```
Before
ManagedAgentClient ──imports──> Autopilot config and summary policy
        │
        └──────────────> Anthropic session

After
Autopilot service ──injects config/callbacks──> ManagedAgentClient
Deep Research     ──can inject separately────>        │
                                                     └──> Anthropic session
```

1. Render the product-specific agent definition in its owning service.
2. Pass resource configuration separately from per-run title, prompt, callbacks, timeout, and cancellation.
3. Keep agent synchronization, environments, vaults, event streaming, tool-result delivery, and tracing inside the shared client.
4. Return `completed`, `timed_out`, `cancelled`, or `failed` after a session exists.

## Non-trivial bits

- Timeout, cancellation, and event-loop failure send Anthropic's `user.interrupt` before closing the local stream, preventing remote work from continuing with the vault credential.
- Progress exposes only structural message/tool/idle events. It does not expose message contents, tool inputs, tool outputs, or thinking events.
- The session-created callback is awaited before the prompt starts so durable session-ID persistence cannot race execution.
- Autopilot logs non-completed generic outcomes but preserves its existing run-state behavior.
- Live Anthropic validation was not run because it creates external resources and non-deterministic cost; the SDK boundary uses a typed fake.

## Test plan

- [x] `pnpm -F backend typecheck:fast`
- [x] Focused ESLint across all five changed files
- [x] Focused Vitest: 2 files / 11 tests
- [x] Full backend Vitest: 277 files / 4,025 passed / 1 existing skipped
- [x] Pre-commit backend lint, formatter, git-secrets, and unused-export checks
- [ ] CI green

## Diff size

5 files, +844 / -148.