### PR TITLE
feat: add alerts as code

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -1,5 +1,8 @@
 import {
+    AlertAsCode,
     AnyType,
+    ApiAlertAsCodeListResponse,
+    ApiAlertAsCodeUpsertResponse,
     ApiCalculateTotalResponse,
     ApiChartAsCodeListResponse,
     ApiChartAsCodeUpsertResponse,
@@ -27,6 +30,7 @@ import {
     assertRegisteredAccount,
     CalculateTotalFromQuery,
     ChartAsCode,
+    ContentAsCodeType,
     CreateProjectMember,
     DashboardAsCode,
     DbtExposure,
@@ -1557,6 +1561,65 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                     projectUuid,
                     slug,
                     delivery,
+                    force,
+                ),
+        };
+    }
+
+    /**
+     * Get alerts in code representation
+     * @summary List alerts as code
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/alerts/code')
+    @OperationId('getAlertsAsCode')
+    async getAlertsAsCode(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() slugs?: string[],
+    ): Promise<ApiAlertAsCodeListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getCoderService()
+                .getScheduledDeliveries(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    slugs,
+                    ContentAsCodeType.ALERT,
+                ),
+        };
+    }
+
+    /**
+     * Upsert an alert from code representation
+     * @summary Upsert alert as code
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/alerts/{slug}/code')
+    @OperationId('upsertAlertAsCode')
+    async upsertAlertAsCode(
+        @Path() projectUuid: string,
+        @Path() slug: string,
+        @Body() alert: AlertAsCode,
+        @Request() req: express.Request,
+        @Query() force: boolean = false,
+    ): Promise<ApiAlertAsCodeUpsertResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getCoderService()
+                .upsertScheduledDelivery(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    slug,
+                    alert,
                     force,
                 ),
         };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15196,6 +15196,120 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                topMatchingFields:
+                                                                    {
+                                                                        dataType:
+                                                                            'union',
+                                                                        subSchemas:
+                                                                            [
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'nestedObjectLiteral',
+                                                                                        nestedProperties:
+                                                                                            {
+                                                                                                verifiedChartUsage:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                chartUsage:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                                tableName:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
+                                                                                                name: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            },
+                                                                                    },
+                                                                                },
+                                                                                {
+                                                                                    dataType:
+                                                                                        'undefined',
+                                                                                },
+                                                                            ],
+                                                                    },
                                                                 exploreSearchResults:
                                                                     {
                                                                         dataType:
@@ -15356,120 +15470,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             ],
                                                                     },
-                                                                topMatchingFields:
-                                                                    {
-                                                                        dataType:
-                                                                            'union',
-                                                                        subSchemas:
-                                                                            [
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'nestedObjectLiteral',
-                                                                                        nestedProperties:
-                                                                                            {
-                                                                                                verifiedChartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
-                                                                                                tableName:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
-                                                                                                name: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
-                                                                                            },
-                                                                                    },
-                                                                                },
-                                                                                {
-                                                                                    dataType:
-                                                                                        'undefined',
-                                                                                },
-                                                                            ],
-                                                                    },
                                                                 searchQuery: {
                                                                     dataType:
                                                                         'string',
@@ -15528,13 +15528,13 @@ const models: TsoaRoute.Models = {
                                                                                                         'nestedObjectLiteral',
                                                                                                     nestedProperties:
                                                                                                         {
-                                                                                                            totalResults:
+                                                                                                            totalPageCount:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'double',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            totalPageCount:
+                                                                                                            totalResults:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'double',
@@ -15853,6 +15853,130 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 rationale: {
                                                                     dataType:
                                                                         'union',
@@ -15983,130 +16107,6 @@ const models: TsoaRoute.Models = {
                                                                         },
                                                                     required: true,
                                                                 },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
-                                                                    required: true,
-                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -16135,17 +16135,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -16877,6 +16877,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16955,25 +16974,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -34930,6 +34930,146 @@ const models: TsoaRoute.Models = {
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiScheduledDeliveryAsCodeUpsertResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        action: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'PromotionAction.CREATE' },
+                                { ref: 'PromotionAction.UPDATE' },
+                                { ref: 'PromotionAction.NO_CHANGES' },
+                            ],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ContentAsCodeType.ALERT': {
+        dataType: 'refEnum',
+        enums: ['alert'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AlertAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                downloadedAt: { dataType: 'datetime' },
+                parameters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ParametersValuesMap' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                filters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'FiltersInput' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                notificationFrequency: {
+                    ref: 'NotificationFrequency',
+                    required: true,
+                },
+                thresholds: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ThresholdOptions' },
+                    required: true,
+                },
+                resource: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        slug: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['chart'],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                targets: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'ScheduledDeliveryTargetAsCode',
+                    },
+                    required: true,
+                },
+                includeLinks: { dataType: 'boolean', required: true },
+                enabled: { dataType: 'boolean', required: true },
+                timezone: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                cron: { dataType: 'string', required: true },
+                message: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                slug: { dataType: 'string', required: true },
+                version: { dataType: 'double', required: true },
+                contentType: { ref: 'ContentAsCodeType.ALERT', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAlertAsCodeListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        skipped: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'ScheduledDeliveryAsCodeSkip',
+                            },
+                            required: true,
+                        },
+                        alerts: {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'AlertAsCode' },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAlertAsCodeUpsertResponse: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -72358,6 +72498,143 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'upsertScheduledDeliveryAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_getAlertsAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        slugs: {
+            in: 'query',
+            name: 'slugs',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/alerts/code',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getAlertsAsCode,
+        ),
+
+        async function ProjectController_getAlertsAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_getAlertsAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAlertsAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_upsertAlertAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        slug: { in: 'path', name: 'slug', required: true, dataType: 'string' },
+        alert: {
+            in: 'body',
+            name: 'alert',
+            required: true,
+            ref: 'AlertAsCode',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        force: {
+            default: false,
+            in: 'query',
+            name: 'force',
+            dataType: 'boolean',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/alerts/:slug/code',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.upsertAlertAsCode,
+        ),
+
+        async function ProjectController_upsertAlertAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_upsertAlertAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertAlertAsCode',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16776,6 +16776,47 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "topMatchingFields": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "verifiedChartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "tableName": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "fieldType",
+                                                                        "label",
+                                                                        "tableName",
+                                                                        "name"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
@@ -16841,47 +16882,6 @@
                                                                 },
                                                                 "type": "array"
                                                             },
-                                                            "topMatchingFields": {
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "verifiedChartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "label": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "tableName": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "name": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "fieldType",
-                                                                        "label",
-                                                                        "tableName",
-                                                                        "name"
-                                                                    ],
-                                                                    "type": "object"
-                                                                },
-                                                                "type": "array"
-                                                            },
                                                             "searchQuery": {
                                                                 "type": "string"
                                                             }
@@ -16911,11 +16911,11 @@
                                                                     "properties": {
                                                                         "pagination": {
                                                                             "properties": {
-                                                                                "totalResults": {
+                                                                                "totalPageCount": {
                                                                                     "type": "number",
                                                                                     "format": "double"
                                                                                 },
-                                                                                "totalPageCount": {
+                                                                                "totalResults": {
                                                                                     "type": "number",
                                                                                     "format": "double"
                                                                                 },
@@ -16929,8 +16929,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "totalResults",
                                                                                 "totalPageCount",
+                                                                                "totalResults",
                                                                                 "pageSize",
                                                                                 "page"
                                                                             ],
@@ -17082,6 +17082,66 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "fieldType",
+                                                                                "description",
+                                                                                "label",
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "rationale": {
                                                                         "type": "string",
                                                                         "nullable": true
@@ -17147,66 +17207,6 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "fieldValueType",
-                                                                                "caseSensitiveFilters",
-                                                                                "isFromJoinedTable",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "description",
-                                                                                "label",
-                                                                                "fieldId",
-                                                                                "name",
-                                                                                "table"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -17216,9 +17216,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "fields",
                                                                     "rationale",
                                                                     "explore",
-                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -17231,10 +17231,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -17242,8 +17242,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -17564,6 +17564,10 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17600,10 +17604,6 @@
                                                                 },
                                                                 "type": "array"
                                                             },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
@@ -17615,8 +17615,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "fields",
                                                             "searchQuery",
+                                                            "fields",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -35241,6 +35241,170 @@
                 "type": "string"
             },
             "ApiScheduledDeliveryAsCodeUpsertResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "action": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.CREATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.UPDATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.NO_CHANGES"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["action"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ContentAsCodeType.ALERT": {
+                "enum": ["alert"],
+                "type": "string"
+            },
+            "AlertAsCode": {
+                "properties": {
+                    "downloadedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "parameters": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ParametersValuesMap"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "filters": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/FiltersInput"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "notificationFrequency": {
+                        "$ref": "#/components/schemas/NotificationFrequency"
+                    },
+                    "thresholds": {
+                        "items": {
+                            "$ref": "#/components/schemas/ThresholdOptions"
+                        },
+                        "type": "array"
+                    },
+                    "resource": {
+                        "properties": {
+                            "slug": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["chart"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["slug", "type"],
+                        "type": "object"
+                    },
+                    "targets": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScheduledDeliveryTargetAsCode"
+                        },
+                        "type": "array"
+                    },
+                    "includeLinks": {
+                        "type": "boolean"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "timezone": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cron": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentAsCodeType.ALERT"
+                    }
+                },
+                "required": [
+                    "parameters",
+                    "filters",
+                    "notificationFrequency",
+                    "thresholds",
+                    "resource",
+                    "targets",
+                    "includeLinks",
+                    "enabled",
+                    "timezone",
+                    "cron",
+                    "message",
+                    "name",
+                    "slug",
+                    "version",
+                    "contentType"
+                ],
+                "type": "object"
+            },
+            "ApiAlertAsCodeListResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "skipped": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ScheduledDeliveryAsCodeSkip"
+                                },
+                                "type": "array"
+                            },
+                            "alerts": {
+                                "items": {
+                                    "$ref": "#/components/schemas/AlertAsCode"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["skipped", "alerts"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAlertAsCodeUpsertResponse": {
                 "properties": {
                     "results": {
                         "properties": {
@@ -62162,6 +62326,126 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ScheduledDeliveryAsCode"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/alerts/code": {
+            "get": {
+                "operationId": "getAlertsAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAlertAsCodeListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get alerts in code representation",
+                "summary": "List alerts as code",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "slugs",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/alerts/{slug}/code": {
+            "post": {
+                "operationId": "upsertAlertAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAlertAsCodeUpsertResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Upsert an alert from code representation",
+                "summary": "Upsert alert as code",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "slug",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "force",
+                        "required": false,
+                        "schema": {
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AlertAsCode"
                             }
                         }
                     }

--- a/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
@@ -1,10 +1,16 @@
 import { Ability } from '@casl/ability';
 import {
     ContentAsCodeType,
+    FilterOperator,
+    NotificationFrequency,
     OrganizationMemberRole,
     PossibleAbilities,
     PromotionAction,
     SchedulerFormat,
+    ThresholdOperator,
+    type AlertAsCode,
+    type Filters,
+    type FiltersInput,
     type ScheduledDeliveryAsCode,
     type SchedulerAndTargets,
     type SessionUser,
@@ -107,11 +113,83 @@ const delivery: ScheduledDeliveryAsCode = {
     selectedTabs: null,
 };
 
+const alertScheduler: SchedulerAndTargets = {
+    ...scheduler,
+    schedulerUuid: 'alert-scheduler-uuid',
+    slug: 'revenue-alert',
+    name: 'Revenue alert',
+    message: undefined,
+    format: SchedulerFormat.IMAGE,
+    options: { withPdf: false },
+    thresholds: [
+        {
+            fieldId: 'orders_total_revenue',
+            operator: ThresholdOperator.GREATER_THAN,
+            value: 1000,
+        },
+    ],
+    notificationFrequency: NotificationFrequency.ONCE,
+};
+
+const alert: AlertAsCode = {
+    contentType: ContentAsCodeType.ALERT,
+    version: 1,
+    slug: 'revenue-alert',
+    name: 'Revenue alert',
+    message: null,
+    cron: '0 9 * * 1',
+    timezone: 'Europe/Madrid',
+    enabled: true,
+    includeLinks: true,
+    targets: [{ type: 'email', recipient: 'data@example.com' }],
+    resource: { type: 'chart', slug: 'orders' },
+    thresholds: [
+        {
+            fieldId: 'orders_total_revenue',
+            operator: ThresholdOperator.GREATER_THAN,
+            value: 1000,
+        },
+    ],
+    notificationFrequency: NotificationFrequency.ONCE,
+    filters: null,
+    parameters: null,
+};
+
+const runtimeFilters: Filters = {
+    dimensions: {
+        id: 'runtime-group-id',
+        or: [
+            {
+                id: 'runtime-rule-id',
+                operator: FilterOperator.EQUALS,
+                target: { fieldId: 'payments_payment_method' },
+                values: ['credit_card'],
+            },
+        ],
+    },
+};
+
+const portableFilters: FiltersInput = {
+    dimensions: {
+        or: [
+            {
+                operator: FilterOperator.EQUALS,
+                target: { fieldId: 'payments_payment_method' },
+                values: ['credit_card'],
+            },
+        ],
+    },
+};
+
 const buildService = ({
     existing = null,
-}: { existing?: SchedulerAndTargets | null } = {}) => {
+    schedulers = [scheduler],
+}: {
+    existing?: SchedulerAndTargets | null;
+    schedulers?: SchedulerAndTargets[];
+} = {}) => {
     const schedulerModel = {
-        getSchedulerForProject: vi.fn(async () => [scheduler]),
+        getSchedulerForProject: vi.fn(async () => schedulers),
         findSchedulerByProjectSlug: vi.fn(async () => existing),
     };
     const schedulerService = {
@@ -207,6 +285,17 @@ describe('CoderService scheduled deliveries as code', () => {
         expect(result.scheduledDeliveries[0]).not.toHaveProperty('createdBy');
     });
 
+    it('exports a delivery without targets so they can be added as code', async () => {
+        const { service } = buildService({
+            schedulers: [{ ...scheduler, targets: [] }],
+        });
+
+        const result = await service.getScheduledDeliveries(user, projectUuid);
+
+        expect(result.skipped).toEqual([]);
+        expect(result.scheduledDeliveries[0]).toMatchObject({ targets: [] });
+    });
+
     it('makes the uploader the owner when creating a delivery', async () => {
         const { service, savedChartService } = buildService();
 
@@ -289,6 +378,22 @@ describe('CoderService scheduled deliveries as code', () => {
         expect(schedulerService.updateScheduler).not.toHaveBeenCalled();
     });
 
+    it('ignores generated filter IDs when detecting delivery changes', async () => {
+        const { service, schedulerService } = buildService({
+            existing: { ...scheduler, filters: runtimeFilters },
+        });
+
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            delivery.slug,
+            { ...delivery, filters: portableFilters },
+        );
+
+        expect(result).toEqual({ action: PromotionAction.NO_CHANGES });
+        expect(schedulerService.updateScheduler).not.toHaveBeenCalled();
+    });
+
     it('ignores target order and YAML key order when detecting changes', async () => {
         const slackTarget = {
             schedulerSlackTargetUuid: 'slack-target-uuid',
@@ -338,5 +443,133 @@ describe('CoderService scheduled deliveries as code', () => {
 
         expect(result).toEqual({ action: PromotionAction.UPDATE });
         expect(schedulerService.updateScheduler).toHaveBeenCalledOnce();
+    });
+});
+
+describe('CoderService alerts as code', () => {
+    it('exports alerts separately from scheduled deliveries', async () => {
+        const { service } = buildService({ schedulers: [alertScheduler] });
+
+        const alerts = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+            undefined,
+            ContentAsCodeType.ALERT,
+        );
+        const deliveries = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+        );
+
+        expect(alerts.skipped).toEqual([]);
+        expect(alerts.alerts).toHaveLength(1);
+        expect(alerts.alerts[0]).toMatchObject(alert);
+        expect(deliveries).toEqual({ scheduledDeliveries: [], skipped: [] });
+    });
+
+    it('exports an alert without targets so they can be added as code', async () => {
+        const { service } = buildService({
+            schedulers: [{ ...alertScheduler, targets: [] }],
+        });
+
+        const result = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+            undefined,
+            ContentAsCodeType.ALERT,
+        );
+
+        expect(result.skipped).toEqual([]);
+        expect(result.alerts[0]).toMatchObject({ targets: [] });
+    });
+
+    it('updates a targetless alert when a target is added as code', async () => {
+        const { service, schedulerService } = buildService({
+            existing: { ...alertScheduler, targets: [] },
+        });
+
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            alert.slug,
+            alert,
+        );
+
+        expect(result).toEqual({ action: PromotionAction.UPDATE });
+        expect(schedulerService.updateScheduler).toHaveBeenCalledWith(
+            user,
+            alertScheduler.schedulerUuid,
+            expect.objectContaining({
+                targets: [{ recipient: 'data@example.com' }],
+            }),
+        );
+    });
+
+    it('creates an alert with scheduler implementation details', async () => {
+        const { service, savedChartService } = buildService();
+
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            alert.slug,
+            alert,
+        );
+
+        expect(result).toEqual({ action: PromotionAction.CREATE });
+        expect(savedChartService.createScheduler).toHaveBeenCalledWith(
+            user,
+            chartUuid,
+            expect.objectContaining({
+                format: SchedulerFormat.IMAGE,
+                options: { withPdf: false },
+                thresholds: alert.thresholds,
+                notificationFrequency: NotificationFrequency.ONCE,
+            }),
+        );
+    });
+
+    it('does not reschedule an unchanged alert', async () => {
+        const { service, schedulerService } = buildService({
+            existing: alertScheduler,
+        });
+
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            alert.slug,
+            alert,
+        );
+
+        expect(result).toEqual({ action: PromotionAction.NO_CHANGES });
+        expect(schedulerService.updateScheduler).not.toHaveBeenCalled();
+    });
+
+    it('exports portable filters and ignores their generated IDs', async () => {
+        const alertWithFilters = { ...alert, filters: portableFilters };
+        const schedulerWithFilters = {
+            ...alertScheduler,
+            filters: runtimeFilters,
+        };
+        const { service, schedulerService } = buildService({
+            existing: schedulerWithFilters,
+            schedulers: [schedulerWithFilters],
+        });
+
+        const exported = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+            undefined,
+            ContentAsCodeType.ALERT,
+        );
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            alert.slug,
+            alertWithFilters,
+        );
+
+        expect(exported.alerts[0].filters).toEqual(portableFilters);
+        expect(result).toEqual({ action: PromotionAction.NO_CHANGES });
+        expect(schedulerService.updateScheduler).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1,6 +1,9 @@
 import { subject } from '@casl/ability';
 import {
+    AlertAsCode,
     AlreadyExistsError,
+    ApiAlertAsCodeListResponse,
+    ApiAlertAsCodeUpsertResponse,
     ApiChartAsCodeListResponse,
     ApiDashboardAsCodeListResponse,
     ApiScheduledDeliveryAsCodeListResponse,
@@ -40,6 +43,7 @@ import {
     isSchedulerImageOptions,
     isSlackTarget,
     NotFoundError,
+    NotificationFrequency,
     ParameterError,
     Project,
     ProjectType,
@@ -149,6 +153,42 @@ const normalizeFilterIds = (filters: FiltersInput): Filters => ({
     metrics: normalizeFilterGroup(filters.metrics),
     tableCalculations: normalizeFilterGroup(filters.tableCalculations),
 });
+
+const stripFilterGroupItemIds = (
+    item: FilterGroupItemInput,
+): FilterGroupItemInput => {
+    if ('or' in item) {
+        return { or: item.or.map(stripFilterGroupItemIds) };
+    }
+    if ('and' in item) {
+        return { and: item.and.map(stripFilterGroupItemIds) };
+    }
+    const { id, ...filterRule } = item;
+    return filterRule;
+};
+
+const stripFilterIds = (
+    filters: FiltersInput | undefined,
+): FiltersInput | null => {
+    if (!filters) return null;
+    const result: FiltersInput = {};
+    if (filters.dimensions) {
+        result.dimensions = stripFilterGroupItemIds(
+            filters.dimensions,
+        ) as FilterGroupInput;
+    }
+    if (filters.metrics) {
+        result.metrics = stripFilterGroupItemIds(
+            filters.metrics,
+        ) as FilterGroupInput;
+    }
+    if (filters.tableCalculations) {
+        result.tableCalculations = stripFilterGroupItemIds(
+            filters.tableCalculations,
+        ) as FilterGroupInput;
+    }
+    return result;
+};
 
 type AnyChartTile = Extract<
     DashboardTileAsCode | DashboardTile,
@@ -1269,6 +1309,22 @@ export class CoderService extends BaseService {
         return targets;
     }
 
+    private static getScheduledDeliveryTargetKey(
+        target: ScheduledDeliveryTargetAsCode,
+    ): string {
+        switch (target.type) {
+            case 'email':
+                return `${target.type}:${target.recipient}`;
+            case 'slack':
+                return `${target.type}:${target.channel}`;
+            default:
+                return assertUnreachable(
+                    target,
+                    'Unknown scheduled delivery target',
+                );
+        }
+    }
+
     private static getDashboardScheduledDeliveryFiltersWithTileSlugs(
         dashboard: DashboardDAO,
         filters: DashboardFilterRule[] | undefined,
@@ -1399,7 +1455,7 @@ export class CoderService extends BaseService {
         }
         const targets =
             CoderService.getScheduledDeliveryTargetsAsCode(scheduler);
-        if (!targets || targets.length === 0) return null;
+        if (!targets) return null;
         const format = CoderService.getScheduledDeliveryFormat(scheduler);
         if (!format) return null;
 
@@ -1425,7 +1481,7 @@ export class CoderService extends BaseService {
                 ...common,
                 ...format,
                 resource: { type: 'chart', slug: chart.slug },
-                filters: scheduler.filters ?? null,
+                filters: stripFilterIds(scheduler.filters),
                 parameters: scheduler.parameters ?? null,
                 customViewportWidth: null,
                 selectedTabs: null,
@@ -1461,7 +1517,27 @@ export class CoderService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         slugs?: string[],
-    ): Promise<ApiScheduledDeliveryAsCodeListResponse['results']> {
+        contentType?: ContentAsCodeType.SCHEDULED_DELIVERY,
+    ): Promise<ApiScheduledDeliveryAsCodeListResponse['results']>;
+
+    async getScheduledDeliveries(
+        user: SessionUser,
+        projectUuid: string,
+        slugs: string[] | undefined,
+        contentType: ContentAsCodeType.ALERT,
+    ): Promise<ApiAlertAsCodeListResponse['results']>;
+
+    async getScheduledDeliveries(
+        user: SessionUser,
+        projectUuid: string,
+        slugs?: string[],
+        contentType:
+            | ContentAsCodeType.SCHEDULED_DELIVERY
+            | ContentAsCodeType.ALERT = ContentAsCodeType.SCHEDULED_DELIVERY,
+    ): Promise<
+        | ApiScheduledDeliveryAsCodeListResponse['results']
+        | ApiAlertAsCodeListResponse['results']
+    > {
         const project = await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -1481,7 +1557,11 @@ export class CoderService extends BaseService {
             )
         ) {
             throw new ForbiddenError(
-                'You are not allowed to download scheduled deliveries',
+                `You are not allowed to download ${
+                    contentType === ContentAsCodeType.ALERT
+                        ? 'alerts'
+                        : 'scheduled deliveries'
+                }`,
             );
         }
 
@@ -1490,35 +1570,94 @@ export class CoderService extends BaseService {
         const filteredSchedulers = slugs?.length
             ? schedulers.filter((scheduler) => slugs.includes(scheduler.slug))
             : schedulers;
+        const matchingSchedulers = filteredSchedulers.filter((scheduler) =>
+            contentType === ContentAsCodeType.ALERT
+                ? Boolean(scheduler.thresholds?.length)
+                : !scheduler.thresholds?.length,
+        );
         const transformed = await Promise.all(
-            filteredSchedulers.map((scheduler) =>
-                this.transformScheduledDelivery(scheduler),
+            matchingSchedulers.map((scheduler) =>
+                contentType === ContentAsCodeType.ALERT
+                    ? this.transformAlert(scheduler)
+                    : this.transformScheduledDelivery(scheduler),
             ),
         );
-        const scheduledDeliveries: ScheduledDeliveryAsCode[] = [];
-        const skipped: ApiScheduledDeliveryAsCodeListResponse['results']['skipped'] =
-            [];
+        const content: Array<ScheduledDeliveryAsCode | AlertAsCode> = [];
+        const skipped: Array<{ name: string; reason: string }> = [];
+        const contentName =
+            contentType === ContentAsCodeType.ALERT
+                ? 'Alert'
+                : 'Scheduled delivery';
+        const unsupportedReason =
+            contentType === ContentAsCodeType.ALERT
+                ? 'Alerts as code support chart alerts with email or Slack targets'
+                : 'MVP supports chart/dashboard deliveries with email or Slack targets and CSV, XLSX, image, or PDF formats; secret/OAuth-backed targets are excluded';
 
-        filteredSchedulers.forEach((scheduler, index) => {
-            const delivery = transformed[index];
-            if (delivery) {
-                scheduledDeliveries.push(delivery);
+        matchingSchedulers.forEach((scheduler, index) => {
+            const item = transformed[index];
+            if (item) {
+                content.push(item);
             } else {
                 skipped.push({
                     name: scheduler.name,
                     reason: scheduler.slug
-                        ? 'MVP supports chart/dashboard deliveries with email or Slack targets and CSV, XLSX, image, or PDF formats; alerts and secret/OAuth-backed targets are excluded'
-                        : 'Scheduled delivery is missing its portable identity and must be backfilled before export',
+                        ? unsupportedReason
+                        : `${contentName} is missing its portable identity and must be backfilled before export`,
                 });
             }
         });
 
-        return { scheduledDeliveries, skipped };
+        if (contentType === ContentAsCodeType.ALERT) {
+            return { alerts: content as AlertAsCode[], skipped };
+        }
+        return {
+            scheduledDeliveries: content as ScheduledDeliveryAsCode[],
+            skipped,
+        };
+    }
+
+    private async transformAlert(
+        scheduler: SchedulerAndTargets,
+    ): Promise<AlertAsCode | null> {
+        if (
+            !scheduler.slug ||
+            !isChartScheduler(scheduler) ||
+            !scheduler.thresholds?.length ||
+            scheduler.format !== SchedulerFormat.IMAGE
+        ) {
+            return null;
+        }
+        const targets =
+            CoderService.getScheduledDeliveryTargetsAsCode(scheduler);
+        if (!targets) return null;
+
+        const chart = await this.savedChartModel.getSummary(
+            scheduler.savedChartUuid,
+        );
+        return {
+            contentType: ContentAsCodeType.ALERT,
+            version: currentVersion,
+            slug: scheduler.slug,
+            name: scheduler.name,
+            message: scheduler.message ?? null,
+            cron: scheduler.cron,
+            timezone: scheduler.timezone ?? null,
+            enabled: scheduler.enabled,
+            includeLinks: scheduler.includeLinks,
+            targets,
+            resource: { type: 'chart', slug: chart.slug },
+            thresholds: scheduler.thresholds,
+            notificationFrequency:
+                scheduler.notificationFrequency ?? NotificationFrequency.ALWAYS,
+            filters: stripFilterIds(scheduler.filters),
+            parameters: scheduler.parameters ?? null,
+            downloadedAt: new Date(),
+        };
     }
 
     private async getScheduledDeliveryResource(
         projectUuid: string,
-        delivery: ScheduledDeliveryAsCode,
+        delivery: ScheduledDeliveryAsCode | AlertAsCode,
     ): Promise<
         | { type: 'chart'; uuid: string }
         | { type: 'dashboard'; uuid: string; dashboard: DashboardDAO }
@@ -1565,9 +1704,9 @@ export class CoderService extends BaseService {
         };
     }
 
-    private static getScheduledDeliveryTargets(
-        delivery: ScheduledDeliveryAsCode,
-    ): CreateSchedulerTarget[] {
+    private static getScheduledDeliveryTargets(delivery: {
+        targets: ScheduledDeliveryTargetAsCode[];
+    }): CreateSchedulerTarget[] {
         return delivery.targets.map((target) => {
             switch (target.type) {
                 case 'email':
@@ -1595,29 +1734,22 @@ export class CoderService extends BaseService {
         return delivery.resource.type === 'dashboard';
     }
 
-    private static scheduledDeliveriesAreEqual(
-        current: ScheduledDeliveryAsCode,
-        desired: ScheduledDeliveryAsCode,
+    private static scheduledContentIsEqual(
+        current: ScheduledDeliveryAsCode | AlertAsCode,
+        desired: ScheduledDeliveryAsCode | AlertAsCode,
     ): boolean {
-        const getTargetKey = (target: ScheduledDeliveryTargetAsCode) => {
-            switch (target.type) {
-                case 'email':
-                    return `${target.type}:${target.recipient}`;
-                case 'slack':
-                    return `${target.type}:${target.channel}`;
-                default:
-                    return assertUnreachable(
-                        target,
-                        'Unknown scheduled delivery target',
-                    );
-            }
-        };
-        const normalize = (delivery: ScheduledDeliveryAsCode) => {
-            const { downloadedAt, ...rest } = delivery;
+        const normalize = (
+            scheduledContent: ScheduledDeliveryAsCode | AlertAsCode,
+        ) => {
+            const { downloadedAt, ...rest } = scheduledContent;
             return {
                 ...rest,
                 targets: [...rest.targets].sort((left, right) =>
-                    getTargetKey(left).localeCompare(getTargetKey(right)),
+                    CoderService.getScheduledDeliveryTargetKey(
+                        left,
+                    ).localeCompare(
+                        CoderService.getScheduledDeliveryTargetKey(right),
+                    ),
                 ),
             };
         };
@@ -1628,12 +1760,17 @@ export class CoderService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         slug: string,
-        delivery: ScheduledDeliveryAsCode,
+        delivery: ScheduledDeliveryAsCode | AlertAsCode,
         force = false,
-    ): Promise<ApiScheduledDeliveryAsCodeUpsertResponse['results']> {
+    ): Promise<
+        | ApiScheduledDeliveryAsCodeUpsertResponse['results']
+        | ApiAlertAsCodeUpsertResponse['results']
+    > {
+        const isAlert = delivery.contentType === ContentAsCodeType.ALERT;
+        const contentName = isAlert ? 'Alert' : 'Scheduled delivery';
         if (slug !== delivery.slug) {
             throw new ParameterError(
-                `Scheduled delivery slug '${delivery.slug}' does not match path slug '${slug}'`,
+                `${contentName} slug '${delivery.slug}' does not match path slug '${slug}'`,
             );
         }
         const project = await this.projectModel.getSummary(projectUuid);
@@ -1648,7 +1785,9 @@ export class CoderService extends BaseService {
             )
         ) {
             throw new ForbiddenError(
-                'You are not allowed to upload scheduled deliveries',
+                `You are not allowed to upload ${
+                    isAlert ? 'alerts' : 'scheduled deliveries'
+                }`,
             );
         }
 
@@ -1663,24 +1802,27 @@ export class CoderService extends BaseService {
 
         if (
             existing &&
-            ((resource.type === 'chart' &&
-                (!isChartScheduler(existing) ||
-                    existing.savedChartUuid !== resource.uuid)) ||
+            (Boolean(existing.thresholds?.length) !== isAlert ||
+                (resource.type === 'chart' &&
+                    (!isChartScheduler(existing) ||
+                        existing.savedChartUuid !== resource.uuid)) ||
                 (resource.type === 'dashboard' &&
                     (!isDashboardScheduler(existing) ||
                         existing.dashboardUuid !== resource.uuid)))
         ) {
             throw new ParameterError(
-                `Scheduled delivery slug '${slug}' is already used by another resource in this project`,
+                `${contentName} slug '${slug}' is already used by another resource in this project`,
             );
         }
 
         if (existing) {
-            const current = await this.transformScheduledDelivery(existing);
+            const current = isAlert
+                ? await this.transformAlert(existing)
+                : await this.transformScheduledDelivery(existing);
             if (
                 !force &&
                 current &&
-                CoderService.scheduledDeliveriesAreEqual(current, delivery)
+                CoderService.scheduledContentIsEqual(current, delivery)
             ) {
                 return { action: PromotionAction.NO_CHANGES };
             }
@@ -1688,7 +1830,7 @@ export class CoderService extends BaseService {
 
         const targets = CoderService.getScheduledDeliveryTargets(delivery);
         let filters: Filters | DashboardFilterRule[] | undefined;
-        if (CoderService.isChartScheduledDelivery(delivery)) {
+        if (isAlert || CoderService.isChartScheduledDelivery(delivery)) {
             filters = delivery.filters
                 ? normalizeFilterIds(delivery.filters)
                 : undefined;
@@ -1706,27 +1848,35 @@ export class CoderService extends BaseService {
                 'Scheduled delivery resource type does not match its payload',
             );
         }
+        let selectedTabs: string[] | null | undefined;
+        if (isAlert) {
+            selectedTabs = null;
+        } else if (resource.type === 'dashboard' && delivery.selectedTabs) {
+            selectedTabs = delivery.selectedTabs.map((tabSlug) =>
+                CoderService.getDashboardTabUuid(resource.dashboard, tabSlug),
+            );
+        } else {
+            selectedTabs = delivery.selectedTabs;
+        }
+
         const schedulerInput = {
             slug: delivery.slug,
             name: delivery.name,
             message: delivery.message ?? undefined,
             cron: delivery.cron,
             timezone: delivery.timezone ?? undefined,
-            format: delivery.format,
-            options: delivery.options,
+            format: isAlert ? SchedulerFormat.IMAGE : delivery.format,
+            options: isAlert ? { withPdf: false } : delivery.options,
             filters,
             parameters: delivery.parameters ?? undefined,
-            customViewportWidth: delivery.customViewportWidth ?? undefined,
-            selectedTabs:
-                resource.type === 'dashboard' && delivery.selectedTabs
-                    ? delivery.selectedTabs.map((tabSlug) =>
-                          CoderService.getDashboardTabUuid(
-                              resource.dashboard,
-                              tabSlug,
-                          ),
-                      )
-                    : delivery.selectedTabs,
-            thresholds: undefined,
+            customViewportWidth: isAlert
+                ? undefined
+                : (delivery.customViewportWidth ?? undefined),
+            selectedTabs,
+            thresholds: isAlert ? delivery.thresholds : undefined,
+            notificationFrequency: isAlert
+                ? delivery.notificationFrequency
+                : undefined,
             enabled: delivery.enabled,
             includeLinks: delivery.includeLinks,
             targets,

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1,6 +1,9 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-param-reassign */
 import {
+    AlertAsCode,
+    ApiAlertAsCodeListResponse,
+    ApiAlertAsCodeUpsertResponse,
     ApiChartAsCodeListResponse,
     ApiChartAsCodeUpsertResponse,
     ApiChartValidationResponse,
@@ -91,6 +94,7 @@ export type DownloadHandlerOptions = {
     verbose: boolean;
     charts: string[]; // These can be slugs, uuids or urls
     dashboards: string[]; // These can be slugs, uuids or urls
+    alerts: string[];
     scheduledDeliveries: string[];
     apps?: string[]; // specific app UUIDs (enterprise); absent = no explicit selection
     includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
@@ -107,6 +111,7 @@ export type DownloadHandlerOptions = {
     skipSpaces: boolean; // Skip writing space metadata files during download
     skipCharts: boolean; // Skip downloading charts and SQL charts
     skipDashboards: boolean; // Skip downloading dashboards
+    skipAlerts: boolean;
     skipScheduledDeliveries: boolean;
     appsOnly?: boolean; // download only: implies skipCharts + skipDashboards + skipSpaces
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
@@ -860,6 +865,32 @@ export const downloadContent = async (
 const getScheduledDeliveriesFolder = (customPath?: string): string =>
     path.join(getDownloadFolder(customPath), 'scheduled-deliveries');
 
+const getAlertsFolder = (customPath?: string): string =>
+    path.join(getDownloadFolder(customPath), 'alerts');
+
+type ScheduledContentAsCode = ScheduledDeliveryAsCode | AlertAsCode;
+type ScheduledContentType =
+    | ContentAsCodeTypeEnum.SCHEDULED_DELIVERY
+    | ContentAsCodeTypeEnum.ALERT;
+
+const getScheduledContentConfig = (
+    contentType: ScheduledContentType,
+    customPath?: string,
+) =>
+    contentType === ContentAsCodeTypeEnum.ALERT
+        ? {
+              folder: getAlertsFolder(customPath),
+              route: 'alerts',
+              singular: 'alert',
+              plural: 'alerts',
+          }
+        : {
+              folder: getScheduledDeliveriesFolder(customPath),
+              route: 'scheduledDeliveries',
+              singular: 'scheduled delivery',
+              plural: 'scheduled deliveries',
+          };
+
 const getPromoteAction = (action: PromotionAction) => {
     switch (action) {
         case PromotionAction.CREATE:
@@ -876,63 +907,63 @@ const getPromoteAction = (action: PromotionAction) => {
     return 'skipped';
 };
 
-const getScheduledDeliveryResourceFolder = (
-    delivery: ScheduledDeliveryAsCode,
-): string => (delivery.resource.type === 'chart' ? 'charts' : 'dashboards');
-
-const downloadScheduledDeliveries = async (
+const downloadScheduledContent = async (
     projectId: string,
     slugs: string[],
+    contentType: ScheduledContentType,
     customPath?: string,
 ): Promise<number> => {
-    await fs.mkdir(getScheduledDeliveriesFolder(customPath), {
-        recursive: true,
-    });
+    const config = getScheduledContentConfig(contentType, customPath);
+    await fs.mkdir(config.folder, { recursive: true });
     const query = new URLSearchParams(
         slugs.map((slug) => ['slugs', slug] as [string, string]),
     ).toString();
     const results = await lightdashApi<
-        ApiScheduledDeliveryAsCodeListResponse['results']
+        | ApiAlertAsCodeListResponse['results']
+        | ApiScheduledDeliveryAsCodeListResponse['results']
     >({
         method: 'GET',
-        url: `/api/v1/projects/${projectId}/scheduledDeliveries/code${
+        url: `/api/v1/projects/${projectId}/${config.route}/code${
             query ? `?${query}` : ''
         }`,
         body: undefined,
     });
+    const scheduledContent: ScheduledContentAsCode[] =
+        'alerts' in results ? results.alerts : results.scheduledDeliveries;
 
-    for (const delivery of results.scheduledDeliveries) {
+    for (const item of scheduledContent) {
         const outputDir = path.join(
-            getScheduledDeliveriesFolder(customPath),
-            getScheduledDeliveryResourceFolder(delivery),
-            delivery.resource.slug,
+            config.folder,
+            item.resource.type === 'chart' ? 'charts' : 'dashboards',
+            item.resource.slug,
         );
         await fs.mkdir(outputDir, { recursive: true });
         await fs.writeFile(
-            path.join(outputDir, `${delivery.slug}.yml`),
-            yaml.dump(delivery, { quotingType: '"', sortKeys: true }),
+            path.join(outputDir, `${item.slug}.yml`),
+            yaml.dump(item, { quotingType: '"', sortKeys: true }),
         );
     }
 
-    results.skipped.forEach((delivery) =>
+    results.skipped.forEach((item) =>
         GlobalState.debug(
-            `Skipped scheduled delivery "${delivery.name}": ${delivery.reason}`,
+            `Skipped ${config.singular} "${item.name}": ${item.reason}`,
         ),
     );
 
-    return results.scheduledDeliveries.length;
+    return scheduledContent.length;
 };
 
-const readScheduledDeliveryFiles = async (
+const readScheduledContentFiles = async (
+    contentType: ScheduledContentType,
     customPath?: string,
-): Promise<ScheduledDeliveryAsCode[]> => {
-    const folder = getScheduledDeliveriesFolder(customPath);
+): Promise<ScheduledContentAsCode[]> => {
+    const config = getScheduledContentConfig(contentType, customPath);
     try {
-        const entries = await fs.readdir(folder, {
+        const entries = await fs.readdir(config.folder, {
             recursive: true,
             withFileTypes: true,
         });
-        const deliveries: ScheduledDeliveryAsCode[] = [];
+        const scheduledContent: ScheduledContentAsCode[] = [];
         for (const entry of entries) {
             if (
                 entry.isFile() &&
@@ -942,52 +973,57 @@ const readScheduledDeliveryFiles = async (
                 const parsed = yaml.load(
                     await fs.readFile(filePath, 'utf-8'),
                 ) as Record<string, unknown>;
-                if (
-                    parsed.contentType ===
-                    ContentAsCodeTypeEnum.SCHEDULED_DELIVERY
-                ) {
-                    deliveries.push(parsed as ScheduledDeliveryAsCode);
+                if (parsed.contentType === contentType) {
+                    scheduledContent.push(parsed as ScheduledContentAsCode);
                 }
             }
         }
-        return deliveries;
+        return scheduledContent;
     } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
         throw error;
     }
 };
 
-const upsertScheduledDeliveries = async (
+const upsertScheduledContent = async (
     projectId: string,
     slugs: string[],
     changes: Record<string, number>,
     force: boolean,
+    contentType: ScheduledContentType,
     customPath?: string,
 ): Promise<Record<string, number>> => {
-    const deliveries = await readScheduledDeliveryFiles(customPath);
-    GlobalState.log(`Found ${deliveries.length} scheduled delivery files`);
-    const filteredDeliveries = slugs.length
-        ? deliveries.filter((delivery) => slugs.includes(delivery.slug))
-        : deliveries;
+    const config = getScheduledContentConfig(contentType, customPath);
+    const scheduledContent = await readScheduledContentFiles(
+        contentType,
+        customPath,
+    );
+    GlobalState.log(
+        `Found ${scheduledContent.length} ${config.singular} files`,
+    );
+    const filteredContent = slugs.length
+        ? scheduledContent.filter((item) => slugs.includes(item.slug))
+        : scheduledContent;
 
-    for (const delivery of filteredDeliveries) {
+    for (const item of filteredContent) {
         try {
             const result = await lightdashApi<
-                ApiScheduledDeliveryAsCodeUpsertResponse['results']
+                | ApiAlertAsCodeUpsertResponse['results']
+                | ApiScheduledDeliveryAsCodeUpsertResponse['results']
             >({
                 method: 'POST',
-                url: `/api/v1/projects/${projectId}/scheduledDeliveries/${delivery.slug}/code?force=${force}`,
-                body: JSON.stringify(delivery),
+                url: `/api/v1/projects/${projectId}/${config.route}/${item.slug}/code?force=${force}`,
+                body: JSON.stringify(item),
             });
             const action = getPromoteAction(result.action);
-            const key = `scheduled deliveries ${action}`;
+            const key = `${config.plural} ${action}`;
             changes[key] = (changes[key] ?? 0) + 1;
         } catch (error) {
-            changes['scheduled deliveries with errors'] =
-                (changes['scheduled deliveries with errors'] ?? 0) + 1;
+            const errorKey = `${config.plural} with errors`;
+            changes[errorKey] = (changes[errorKey] ?? 0) + 1;
             GlobalState.log(
                 styles.error(
-                    `Error upserting scheduled delivery "${delivery.name}" (${delivery.resource.type}: ${delivery.resource.slug}): ${getErrorMessage(error)}`,
+                    `Error upserting ${config.singular} "${item.name}" (${item.resource.type}: ${item.resource.slug}): ${getErrorMessage(error)}`,
                 ),
             );
         }
@@ -1047,6 +1083,7 @@ export const downloadHandler = async (
         options.skipCharts = true;
         options.skipDashboards = true;
         options.skipSpaces = true;
+        options.skipAlerts = true;
         options.skipScheduledDeliveries = true;
     }
 
@@ -1101,6 +1138,7 @@ export const downloadHandler = async (
         const hasFilters =
             options.charts.length > 0 ||
             options.dashboards.length > 0 ||
+            options.alerts.length > 0 ||
             options.scheduledDeliveries.length > 0;
 
         // When downloading specific charts or dashboards, skip space metadata
@@ -1246,6 +1284,23 @@ export const downloadHandler = async (
             }
         }
 
+        if (!options.skipAlerts) {
+            if (hasFilters && options.alerts.length === 0) {
+                GlobalState.log(
+                    styles.warning(`No alert filters provided, skipping`),
+                );
+            } else {
+                spinner.start(`Downloading alerts`);
+                const alertTotal = await downloadScheduledContent(
+                    projectId,
+                    options.alerts,
+                    ContentAsCodeTypeEnum.ALERT,
+                    options.path,
+                );
+                spinner.succeed(`Downloaded ${alertTotal} alerts`);
+            }
+        }
+
         if (!options.skipScheduledDeliveries) {
             if (hasFilters && options.scheduledDeliveries.length === 0) {
                 GlobalState.log(
@@ -1255,12 +1310,12 @@ export const downloadHandler = async (
                 );
             } else {
                 spinner.start(`Downloading scheduled deliveries`);
-                const scheduledDeliveryTotal =
-                    await downloadScheduledDeliveries(
-                        projectId,
-                        options.scheduledDeliveries,
-                        options.path,
-                    );
+                const scheduledDeliveryTotal = await downloadScheduledContent(
+                    projectId,
+                    options.scheduledDeliveries,
+                    ContentAsCodeTypeEnum.SCHEDULED_DELIVERY,
+                    options.path,
+                );
                 spinner.succeed(
                     `Downloaded ${scheduledDeliveryTotal} scheduled deliveries`,
                 );
@@ -1943,6 +1998,7 @@ export const uploadHandler = async (
         const hasFilters =
             options.charts.length > 0 ||
             options.dashboards.length > 0 ||
+            options.alerts.length > 0 ||
             options.scheduledDeliveries.length > 0;
 
         // Discover loose YAML files (outside charts/ and dashboards/) classified by contentType
@@ -2041,6 +2097,23 @@ export const uploadHandler = async (
             dashboardTotal = total;
         }
 
+        if (!options.skipAlerts) {
+            if (hasFilters && options.alerts.length === 0) {
+                GlobalState.log(
+                    styles.warning(`No alert filters provided, skipping`),
+                );
+            } else {
+                changes = await upsertScheduledContent(
+                    projectId,
+                    options.alerts,
+                    changes,
+                    options.force,
+                    ContentAsCodeTypeEnum.ALERT,
+                    options.path,
+                );
+            }
+        }
+
         if (!options.skipScheduledDeliveries) {
             if (hasFilters && options.scheduledDeliveries.length === 0) {
                 GlobalState.log(
@@ -2049,11 +2122,12 @@ export const uploadHandler = async (
                     ),
                 );
             } else {
-                changes = await upsertScheduledDeliveries(
+                changes = await upsertScheduledContent(
                     projectId,
                     options.scheduledDeliveries,
                     changes,
                     options.force,
+                    ContentAsCodeTypeEnum.SCHEDULED_DELIVERY,
                     options.path,
                 );
             }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -728,6 +728,7 @@ program
         'specify dashboard slugs, uuids or urls to download',
         [],
     )
+    .option('--alerts <slugs...>', 'specify alert slugs to download', [])
     .option(
         '--scheduled-deliveries <slugs...>',
         'specify scheduled delivery slugs to download',
@@ -761,6 +762,7 @@ program
     )
     .option('--skip-charts', 'skip downloading charts', false)
     .option('--skip-dashboards', 'skip downloading dashboards', false)
+    .option('--skip-alerts', 'skip downloading alerts', false)
     .option(
         '--skip-scheduled-deliveries',
         'skip downloading scheduled deliveries',
@@ -806,6 +808,7 @@ program
         'specify dashboard slugs to force upload',
         [],
     )
+    .option('--alerts <slugs...>', 'specify alert slugs to upload', [])
     .option(
         '--scheduled-deliveries <slugs...>',
         'specify scheduled delivery slugs to upload',
@@ -833,6 +836,7 @@ program
         false,
     )
     .option('--public', 'Create new spaces as public instead of private', false)
+    .option('--skip-alerts', 'skip uploading alerts', false)
     .option(
         '--skip-scheduled-deliveries',
         'skip uploading scheduled deliveries',

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -109,6 +109,8 @@ import {
     type MergePullRequestResult,
 } from './ci';
 import {
+    type ApiAlertAsCodeListResponse,
+    type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
     type ApiDashboardAsCodeListResponse,
@@ -1110,6 +1112,8 @@ type ApiResults =
     | ApiGroupListResponse['results']
     | ApiPullRequestsResponse['results']
     | ApiCreateTagResponse['results']
+    | ApiAlertAsCodeListResponse['results']
+    | ApiAlertAsCodeUpsertResponse['results']
     | ApiChartAsCodeListResponse['results']
     | ApiSqlChartAsCodeListResponse['results']
     | ApiDashboardAsCodeListResponse['results']

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -15,6 +15,7 @@ import type {
     DashboardTileTypes,
     FilterRule,
     MetricQuery,
+    NotificationFrequency,
     ParametersValuesMap,
     PromotionChanges,
     SavedChart,
@@ -23,6 +24,7 @@ import type {
     SchedulerImageOptions,
     SchedulerPdfOptions,
     SqlChart,
+    ThresholdOptions,
 } from '..';
 import type { ContentVerificationInfo } from './contentVerification';
 import type { PromotionAction } from './promotion';
@@ -35,6 +37,7 @@ export enum ContentAsCodeType {
     SQL_CHART = 'sql_chart',
     SPACE = 'space',
     SCHEDULED_DELIVERY = 'scheduled_delivery',
+    ALERT = 'alert',
 }
 
 /**
@@ -368,6 +371,46 @@ export type ApiScheduledDeliveryAsCodeListResponse = {
 };
 
 export type ApiScheduledDeliveryAsCodeUpsertResponse = {
+    status: 'ok';
+    results: {
+        action:
+            | PromotionAction.CREATE
+            | PromotionAction.UPDATE
+            | PromotionAction.NO_CHANGES;
+    };
+};
+
+export type AlertAsCode = {
+    contentType: ContentAsCodeType.ALERT;
+    version: number;
+    slug: string;
+    name: string;
+    message: string | null;
+    cron: string;
+    timezone: string | null;
+    enabled: boolean;
+    includeLinks: boolean;
+    targets: ScheduledDeliveryTargetAsCode[];
+    resource: {
+        type: 'chart';
+        slug: string;
+    };
+    thresholds: ThresholdOptions[];
+    notificationFrequency: NotificationFrequency;
+    filters: FiltersInput | null;
+    parameters: ParametersValuesMap | null;
+    downloadedAt?: Date;
+};
+
+export type ApiAlertAsCodeListResponse = {
+    status: 'ok';
+    results: {
+        alerts: AlertAsCode[];
+        skipped: ScheduledDeliveryAsCodeSkip[];
+    };
+};
+
+export type ApiAlertAsCodeUpsertResponse = {
     status: 'ok';
     results: {
         action:


### PR DESCRIPTION
### Closes: [https://linear.app/lightdash/issue/PROD-550/i-want-to-include-scheduled-deliveries-and-alerts-as-part-of](https://linear.app/lightdash/issue/PROD-550/i-want-to-include-scheduled-deliveries-and-alerts-as-part-of)  
  
  
Description

Adds alerts as code as a separate content domain stacked on scheduled deliveries as code.

- Adds an alert-specific YAML contract with thresholds and notification frequency.
- Adds project-scoped alert download and upsert endpoints.
- Stores alerts under `alerts/charts/<chart-slug>/<alert-slug>.yml`.
- Adds `--alerts` and `--skip-alerts` CLI options.
- Reuses scheduler orchestration for permissions, resource resolution, targets, slug collision handling, persistence, and no-change detection while keeping alert and delivery serialization separate.
- Keeps unsupported alert details behind verbose output.

### Validation

- Common, backend, and CLI typechecks and lint.
- 251 backend test files: 3,846 passed, 1 skipped.
- End-to-end CLI validation: download, unchanged upload, forced update, and create-by-changing-slug.
- API and database consistency verified after upload.

Relates: PROD-8817