### PR TITLE
feat(cli): include/exclude spaces in lightdash validate

### DIFF
--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -331,6 +331,8 @@ type CliValidateStarted = BaseTrack & {
         projectId: string;
         isPreview: boolean;
         validationTargets: string[];
+        includedSpacesCount: number;
+        excludedSpacesCount: number;
     };
 };
 /** `success` indicates whether 0 validation errors were found, not whether the process ran without crashing (crashes fire `validate.error` instead). */
@@ -341,6 +343,8 @@ type CliValidateCompleted = BaseTrack & {
         projectId: string;
         isPreview: boolean;
         validationTargets: string[];
+        includedSpacesCount: number;
+        excludedSpacesCount: number;
         durationMs: number;
         success: boolean;
         totalErrors: number;

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -28,6 +28,7 @@ import { getProjectDisableTimestampConversion } from './timestampConversion';
 import {
     filterValidationsBySpace,
     resolveSpaceSelection,
+    SpaceFilterMode,
 } from './validateSpaceFilter';
 
 export const requestValidation = async (
@@ -179,6 +180,23 @@ export const validateHandler = async (
 
     let shouldExitWithError = false;
     try {
+        let spaceFilter:
+            | { mode: SpaceFilterMode; selectedSpaceUuids: Set<string> }
+            | undefined;
+        const spaceFilterSlugs = options.includeSpaces?.length
+            ? options.includeSpaces
+            : options.excludeSpaces;
+        if (spaceFilterSlugs?.length) {
+            const spaces = await getProjectSpaces(projectUuid);
+            spaceFilter = {
+                mode: options.includeSpaces?.length ? 'include' : 'exclude',
+                selectedSpaceUuids: resolveSpaceSelection(
+                    spaces,
+                    spaceFilterSlugs,
+                ),
+            };
+        }
+
         const explores = await compile(options);
         GlobalState.debug(`> Compiled ${explores.length} explores`);
 
@@ -214,22 +232,11 @@ export const validateHandler = async (
 
         let validation = validationWithoutConfigWarnings;
         let spaceFilteredCount = 0;
-        const spaceFilterSlugs = options.includeSpaces?.length
-            ? options.includeSpaces
-            : options.excludeSpaces;
-        if (spaceFilterSlugs?.length) {
-            const spaceFilterMode = options.includeSpaces?.length
-                ? ('include' as const)
-                : ('exclude' as const);
-            const spaces = await getProjectSpaces(projectUuid);
-            const selectedSpaceUuids = resolveSpaceSelection(
-                spaces,
-                spaceFilterSlugs,
-            );
+        if (spaceFilter) {
             validation = filterValidationsBySpace(
                 validationWithoutConfigWarnings,
-                selectedSpaceUuids,
-                spaceFilterMode,
+                spaceFilter.selectedSpaceUuids,
+                spaceFilter.mode,
             );
             spaceFilteredCount =
                 validationWithoutConfigWarnings.length - validation.length;

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -1,6 +1,7 @@
 import {
     ApiJobScheduledResponse,
     ApiJobStatusResponse,
+    ApiSpaceSummaryListResponse,
     ApiValidateResponse,
     Explore,
     ExploreError,
@@ -24,6 +25,10 @@ import * as styles from '../styles';
 import { compile, CompileHandlerOptions } from './compile';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { getProjectDisableTimestampConversion } from './timestampConversion';
+import {
+    filterValidationsBySpace,
+    resolveSpaceSelection,
+} from './validateSpaceFilter';
 
 export const requestValidation = async (
     projectUuid: string,
@@ -50,6 +55,13 @@ export const getValidation = async (projectUuid: string, jobId: string) =>
         body: undefined,
     });
 
+export const getProjectSpaces = async (projectUuid: string) =>
+    lightdashApi<ApiSpaceSummaryListResponse['results']>({
+        method: 'GET',
+        url: `/api/v1/projects/${projectUuid}/spaces`,
+        body: undefined,
+    });
+
 export function delay(ms: number) {
     return new Promise((resolve) => {
         setTimeout(resolve, ms);
@@ -71,6 +83,8 @@ type ValidateHandlerOptions = CompileHandlerOptions & {
     preview: boolean;
     only: ValidationTarget[];
     showChartConfigurationWarnings: boolean;
+    includeSpaces?: string[];
+    excludeSpaces?: string[];
 };
 
 export const waitUntilFinished = async (jobUuid: string): Promise<string> => {
@@ -93,6 +107,12 @@ export const validateHandler = async (
     const options = { ...originalOptions };
     GlobalState.setVerbose(options.verbose);
     await checkLightdashVersion();
+
+    if (options.includeSpaces?.length && options.excludeSpaces?.length) {
+        throw new ParameterError(
+            'Cannot use --include-spaces and --exclude-spaces together',
+        );
+    }
 
     const executionId = uuidv4();
     const startTime = Date.now();
@@ -152,6 +172,8 @@ export const validateHandler = async (
             projectId: projectUuid,
             isPreview,
             validationTargets,
+            includedSpacesCount: options.includeSpaces?.length ?? 0,
+            excludedSpacesCount: options.excludeSpaces?.length ?? 0,
         },
     });
 
@@ -177,15 +199,41 @@ export const validateHandler = async (
         const allValidation = await getValidation(projectUuid, jobId);
 
         // Filter out chart configuration warnings unless explicitly requested
-        const validation = options.showChartConfigurationWarnings
-            ? allValidation
-            : allValidation.filter(
-                  (v) =>
-                      !isChartValidationError(v) ||
-                      v.errorType !== ValidationErrorType.ChartConfiguration,
-              );
+        const validationWithoutConfigWarnings =
+            options.showChartConfigurationWarnings
+                ? allValidation
+                : allValidation.filter(
+                      (v) =>
+                          !isChartValidationError(v) ||
+                          v.errorType !==
+                              ValidationErrorType.ChartConfiguration,
+                  );
 
-        const hiddenWarningsCount = allValidation.length - validation.length;
+        const hiddenWarningsCount =
+            allValidation.length - validationWithoutConfigWarnings.length;
+
+        let validation = validationWithoutConfigWarnings;
+        let spaceFilteredCount = 0;
+        const spaceFilterSlugs = options.includeSpaces?.length
+            ? options.includeSpaces
+            : options.excludeSpaces;
+        if (spaceFilterSlugs?.length) {
+            const spaceFilterMode = options.includeSpaces?.length
+                ? ('include' as const)
+                : ('exclude' as const);
+            const spaces = await getProjectSpaces(projectUuid);
+            const selectedSpaceUuids = resolveSpaceSelection(
+                spaces,
+                spaceFilterSlugs,
+            );
+            validation = filterValidationsBySpace(
+                validationWithoutConfigWarnings,
+                selectedSpaceUuids,
+                spaceFilterMode,
+            );
+            spaceFilteredCount =
+                validationWithoutConfigWarnings.length - validation.length;
+        }
         const tableErrors = validation.filter(isTableValidationError);
         const chartErrors = validation.filter(isChartValidationError);
         const dashboardErrors = validation.filter(isDashboardValidationError);
@@ -197,6 +245,8 @@ export const validateHandler = async (
                 projectId: projectUuid,
                 isPreview,
                 validationTargets,
+                includedSpacesCount: options.includeSpaces?.length ?? 0,
+                excludedSpacesCount: options.excludeSpaces?.length ?? 0,
                 durationMs: Date.now() - startTime,
                 success: validation.length === 0,
                 totalErrors: validation.length,
@@ -214,10 +264,16 @@ export const validateHandler = async (
                           hiddenWarningsCount > 1 ? 's' : ''
                       } hidden, use --show-chart-configuration-warnings to show)`
                     : '';
+            const spaceFilteredMessage =
+                spaceFilteredCount > 0
+                    ? ` (${spaceFilteredCount} error${
+                          spaceFilteredCount > 1 ? 's' : ''
+                      } in filtered-out spaces hidden)`
+                    : '';
             spinner?.succeed(
                 `  Validation finished without errors in ${Math.trunc(
                     elapsedMs / 1000,
-                )}s${hiddenMessage}`,
+                )}s${hiddenMessage}${spaceFilteredMessage}`,
             );
         } else {
             const elapsedMs = Date.now() - startTime;
@@ -256,6 +312,16 @@ export const validateHandler = async (
             ) {
                 console.error(
                     `- Dashboards: ${styleTotalErrors(dashboardErrors.length)}`,
+                );
+            }
+
+            if (spaceFilteredCount > 0) {
+                console.error(
+                    styles.secondary(
+                        `(${spaceFilteredCount} error${
+                            spaceFilteredCount > 1 ? 's' : ''
+                        } in filtered-out spaces hidden)`,
+                    ),
                 );
             }
 

--- a/packages/cli/src/handlers/validateSpaceFilter.test.ts
+++ b/packages/cli/src/handlers/validateSpaceFilter.test.ts
@@ -1,0 +1,141 @@
+import {
+    ParameterError,
+    ValidationErrorType,
+    ValidationResponse,
+    ValidationSourceType,
+} from '@lightdash/common';
+import {
+    filterValidationsBySpace,
+    resolveSpaceSelection,
+} from './validateSpaceFilter';
+
+const space = (
+    uuid: string,
+    slug: string,
+    parentSpaceUuid: string | null = null,
+) => ({ uuid, slug, parentSpaceUuid });
+
+// marketing; archive > archive-2024 > deep-child; second root space also slugged "archive"
+const spaces = [
+    space('s1', 'marketing'),
+    space('s2', 'archive'),
+    space('s3', 'archive-2024', 's2'),
+    space('s4', 'deep-child', 's3'),
+    space('s5', 'archive'),
+];
+
+const base = {
+    validationUuid: 'v1',
+    validationId: null,
+    createdAt: new Date(),
+    error: 'error message',
+    projectUuid: 'p1',
+};
+
+const chartError = (spaceUuid?: string): ValidationResponse =>
+    ({
+        ...base,
+        name: 'chart',
+        errorType: ValidationErrorType.Chart,
+        source: ValidationSourceType.Chart,
+        chartUuid: 'c1',
+        chartViews: 0,
+        spaceUuid,
+    }) as ValidationResponse;
+
+const dashboardError = (spaceUuid?: string): ValidationResponse =>
+    ({
+        ...base,
+        name: 'dashboard',
+        errorType: ValidationErrorType.Chart,
+        source: ValidationSourceType.Dashboard,
+        dashboardUuid: 'd1',
+        dashboardViews: 0,
+        spaceUuid,
+    }) as ValidationResponse;
+
+const tableError = (): ValidationResponse =>
+    ({
+        ...base,
+        name: 'table',
+        errorType: ValidationErrorType.Model,
+        source: ValidationSourceType.Table,
+    }) as ValidationResponse;
+
+describe('resolveSpaceSelection', () => {
+    it('selects a space by slug', () => {
+        expect(resolveSpaceSelection(spaces, ['marketing'])).toEqual(
+            new Set(['s1']),
+        );
+    });
+
+    it('cascades into nested sub-spaces recursively', () => {
+        // s2 selected -> s3 and s4 follow; s5 shares the slug and is also selected
+        expect(resolveSpaceSelection(spaces, ['archive'])).toEqual(
+            new Set(['s2', 's3', 's4', 's5']),
+        );
+    });
+
+    it('selects a mid-tree space with its descendants only', () => {
+        expect(resolveSpaceSelection(spaces, ['archive-2024'])).toEqual(
+            new Set(['s3', 's4']),
+        );
+    });
+
+    it('throws ParameterError listing available slugs on unknown slug', () => {
+        expect(() => resolveSpaceSelection(spaces, ['typo'])).toThrow(
+            ParameterError,
+        );
+        expect(() => resolveSpaceSelection(spaces, ['typo'])).toThrow(
+            /typo.*archive.*marketing/s,
+        );
+    });
+});
+
+describe('filterValidationsBySpace', () => {
+    const selection = new Set(['s2']);
+
+    it('include mode keeps only errors in selected spaces', () => {
+        const kept = filterValidationsBySpace(
+            [chartError('s1'), chartError('s2'), dashboardError('s2')],
+            selection,
+            'include',
+        );
+        expect(kept).toHaveLength(2);
+    });
+
+    it('exclude mode drops errors in selected spaces', () => {
+        const kept = filterValidationsBySpace(
+            [chartError('s1'), chartError('s2'), dashboardError('s2')],
+            selection,
+            'exclude',
+        );
+        expect(kept).toHaveLength(1);
+    });
+
+    it('never filters table errors', () => {
+        expect(
+            filterValidationsBySpace([tableError()], selection, 'include'),
+        ).toHaveLength(1);
+        expect(
+            filterValidationsBySpace([tableError()], selection, 'exclude'),
+        ).toHaveLength(1);
+    });
+
+    it('keeps errors without spaceUuid under exclude, drops them under include', () => {
+        expect(
+            filterValidationsBySpace(
+                [chartError(undefined)],
+                selection,
+                'exclude',
+            ),
+        ).toHaveLength(1);
+        expect(
+            filterValidationsBySpace(
+                [chartError(undefined)],
+                selection,
+                'include',
+            ),
+        ).toHaveLength(0);
+    });
+});

--- a/packages/cli/src/handlers/validateSpaceFilter.ts
+++ b/packages/cli/src/handlers/validateSpaceFilter.ts
@@ -1,0 +1,67 @@
+import {
+    isTableValidationError,
+    ParameterError,
+    SpaceSummary,
+    ValidationResponse,
+} from '@lightdash/common';
+
+export type SpaceFilterMode = 'include' | 'exclude';
+
+type SpaceNode = Pick<SpaceSummary, 'uuid' | 'slug' | 'parentSpaceUuid'>;
+
+/**
+ * Resolves space slugs to the set of matching space uuids, cascading into
+ * all descendant spaces. Slugs are not unique, so every space with a
+ * matching slug is selected. Throws on slugs that match no space.
+ */
+export const resolveSpaceSelection = (
+    spaces: SpaceNode[],
+    slugs: string[],
+): Set<string> => {
+    const unknownSlugs = slugs.filter(
+        (slug) => !spaces.some((s) => s.slug === slug),
+    );
+    if (unknownSlugs.length > 0) {
+        const availableSlugs = [...new Set(spaces.map((s) => s.slug))].sort();
+        throw new ParameterError(
+            `Space slug${
+                unknownSlugs.length > 1 ? 's' : ''
+            } not found in project: ${unknownSlugs.join(
+                ', ',
+            )}. Available space slugs: ${availableSlugs.join(', ')}`,
+        );
+    }
+
+    const childrenByParent = new Map<string, SpaceNode[]>();
+    spaces.forEach((s) => {
+        if (s.parentSpaceUuid) {
+            const siblings = childrenByParent.get(s.parentSpaceUuid) ?? [];
+            siblings.push(s);
+            childrenByParent.set(s.parentSpaceUuid, siblings);
+        }
+    });
+
+    const selected = new Set<string>();
+    const queue = spaces.filter((s) => slugs.includes(s.slug));
+    while (queue.length > 0) {
+        const current = queue.pop()!;
+        if (!selected.has(current.uuid)) {
+            selected.add(current.uuid);
+            queue.push(...(childrenByParent.get(current.uuid) ?? []));
+        }
+    }
+    return selected;
+};
+
+export const filterValidationsBySpace = (
+    validations: ValidationResponse[],
+    selectedSpaceUuids: Set<string>,
+    mode: SpaceFilterMode,
+): ValidationResponse[] =>
+    validations.filter((validation) => {
+        // Table errors are project-level, not in spaces — never filtered
+        if (isTableValidationError(validation)) return true;
+        if (validation.spaceUuid === undefined) return mode === 'exclude';
+        const isSelected = selectedSpaceUuids.has(validation.spaceUuid);
+        return mode === 'include' ? isSelected : !isSelected;
+    });

--- a/packages/cli/src/handlers/validateSpaceFilter.ts
+++ b/packages/cli/src/handlers/validateSpaceFilter.ts
@@ -59,9 +59,10 @@ export const filterValidationsBySpace = (
     mode: SpaceFilterMode,
 ): ValidationResponse[] =>
     validations.filter((validation) => {
+        const { spaceUuid } = validation;
         // Table errors are project-level, not in spaces — never filtered
         if (isTableValidationError(validation)) return true;
-        if (validation.spaceUuid === undefined) return mode === 'exclude';
-        const isSelected = selectedSpaceUuids.has(validation.spaceUuid);
+        if (spaceUuid === undefined) return mode === 'exclude';
+        const isSelected = selectedSpaceUuids.has(spaceUuid);
         return mode === 'include' ? isSelected : !isSelected;
     });

--- a/packages/cli/src/handlers/validateSpaceFilter.ts
+++ b/packages/cli/src/handlers/validateSpaceFilter.ts
@@ -26,7 +26,7 @@ export const resolveSpaceSelection = (
         throw new ParameterError(
             `Space slug${
                 unknownSlugs.length > 1 ? 's' : ''
-            } not found in project: ${unknownSlugs.join(
+            } not found in project (or not visible to your credentials): ${unknownSlugs.join(
                 ', ',
             )}. Available space slugs: ${availableSlugs.join(', ')}`,
         );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1057,6 +1057,14 @@ program
             .choices(Object.values(ValidationTarget))
             .default(Object.values(ValidationTarget)),
     )
+    .option(
+        '--include-spaces <spaceSlugs...>',
+        'Only report validation errors for charts and dashboards in these spaces (and their sub-spaces)',
+    )
+    .option(
+        '--exclude-spaces <spaceSlugs...>',
+        'Skip validation errors for charts and dashboards in these spaces (and their sub-spaces)',
+    )
     .action(validateHandler);
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1059,11 +1059,11 @@ program
     )
     .option(
         '--include-spaces <spaceSlugs...>',
-        'Only report validation errors for charts and dashboards in these spaces (and their sub-spaces)',
+        'Only report validation errors for charts and dashboards in these spaces (and their sub-spaces). Spaces must be visible to your credentials',
     )
     .option(
         '--exclude-spaces <spaceSlugs...>',
-        'Skip validation errors for charts and dashboards in these spaces (and their sub-spaces)',
+        'Skip validation errors for charts and dashboards in these spaces (and their sub-spaces). Spaces must be visible to your credentials',
     )
     .action(validateHandler);
 


### PR DESCRIPTION
## Description

Adds two optional flags to `lightdash validate` that filter chart/dashboard validation errors by space:

- `--include-spaces <spaceSlugs...>` — only report errors from these spaces (and their sub-spaces)
- `--exclude-spaces <spaceSlugs...>` — report everything except these spaces (and their sub-spaces)

Teams keep archive/development spaces whose content frequently has validation errors; this lets CI validate production content only, using the same `spaceSlug` identifiers that appear in `lightdash download` output.

## How it works

Filtering is entirely CLI-side — validation runs unchanged on the server, no API changes. The CLI fetches the project's spaces, resolves the given slugs to a set of space UUIDs (all spaces matching each slug — slugs aren't unique — cascading recursively into sub-spaces via `parentSpaceUuid`), and filters the results before display, error counts, exit code, and analytics.

Semantics:
- Unknown slug → hard error listing available slugs, thrown **before** compiling (a typo'd slug in CI fails in ~1s instead of after a full validation round trip)
- Both flags together → error
- Table errors are never filtered (they're project-level, not in spaces); `--only tables` controls those
- When errors are hidden, output includes `(N errors in filtered-out spaces hidden)`
- Spaces must be visible to the token's credentials — private spaces the caller can't see can't be matched (noted in `--help` and in the unknown-slug error)

## Testing

- 8 new unit tests for the pure helpers (`validateSpaceFilter.ts`): nested cascade, duplicate slugs, unknown-slug error, mode semantics, table-error passthrough
- Verified end-to-end against local dev (jaffle shop): baseline unchanged without flags; exclude hides the errors and flips exit code to 0 with the hidden-count note; include shows only the selected space's errors; both error paths verified
- `pnpm -F cli test` 187/187, `pnpm -F cli typecheck` and `lint` clean

Closes: PROD-2491
Closes: #16445

🤖 Generated with [Claude Code](https://claude.com/claude-code)