### PR TITLE
chore: migrate ChartDownloadMenu to mantine-8

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
-import { Group } from '@mantine-8/core';
-import { ActionIcon, Popover, SegmentedControl } from '@mantine/core';
+import { ActionIcon, Group, Popover, SegmentedControl } from '@mantine-8/core';
 import { IconShare2 } from '@tabler/icons-react';
 import {
     memo,

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -6,7 +6,7 @@ import {
     getPivotConfig,
     type ApiScheduledDownloadCsv,
 } from '@lightdash/common';
-import { ActionIcon, Popover } from '@mantine/core';
+import { ActionIcon, Popover } from '@mantine-8/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback } from 'react';
 import useEchartsCartesianConfig from '../../../hooks/echarts/useEchartsCartesianConfig';

--- a/packages/frontend/src/components/common/CollapsableCard/constants.ts
+++ b/packages/frontend/src/components/common/CollapsableCard/constants.ts
@@ -1,8 +1,5 @@
-import {
-    type ActionIconProps,
-    type ButtonProps,
-    type PopoverProps,
-} from '@mantine/core';
+import { type ActionIconProps, type PopoverProps } from '@mantine-8/core';
+import { type ButtonProps } from '@mantine/core';
 
 export const COLLAPSABLE_CARD_BUTTON_PROPS: Omit<ButtonProps, 'children'> = {
     variant: 'default',
@@ -13,7 +10,7 @@ export const COLLAPSABLE_CARD_ACTION_ICON_PROPS: Pick<
     ActionIconProps,
     'variant' | 'size'
 > = {
-    ...COLLAPSABLE_CARD_BUTTON_PROPS,
+    variant: 'default',
     size: 'md',
 };
 


### PR DESCRIPTION
Closes:

### Description:

Migrates `ActionIcon`, `Popover`, and `Group` imports from `@mantine/core` to `@mantine-8/core` in `ResultsCard`, `ChartDownloadMenu`, and `CollapsableCard` constants. As part of this migration, `COLLAPSABLE_CARD_ACTION_ICON_PROPS` no longer spreads `COLLAPSABLE_CARD_BUTTON_PROPS` and instead explicitly defines `variant: 'default'` to avoid spreading incompatible prop types across Mantine versions. `ButtonProps` remains imported from `@mantine/core`.