### PR TITLE
refactor: migrate SpaceSelector to Mantine 8

### DIFF
--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.module.css
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.module.css
@@ -1,0 +1,3 @@
+.treeContainer {
+    overflow: auto;
+}

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -4,8 +4,7 @@ import {
     type ResourceViewItemType,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Paper, TextInput } from '@mantine/core';
+import { Paper, Stack, TextInput } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { useMemo, useState } from 'react';
 import useApp from '../../../providers/App/useApp';
@@ -13,6 +12,7 @@ import AdminContentViewFilter from '../ResourceView/AdminContentViewFilter';
 import Tree from '../Tree/Tree';
 import { type NestableItem } from '../Tree/types';
 import useFuzzyTreeSearch from '../Tree/useFuzzyTreeSearch';
+import styles from './SpaceSelector.module.css';
 
 type SpaceSelectorProps = {
     projectUuid: string | undefined;
@@ -106,7 +106,7 @@ const SpaceSelector = ({
                 placeholder="Search spaces"
             />
 
-            <Paper w="100%" h={400} style={{ overflow: 'auto' }} withBorder>
+            <Paper w="100%" h={400} className={styles.treeContainer} withBorder>
                 <Tree
                     withRootSelectable={isRootSelectionEnabled}
                     data={fuzzyFilteredSpaces ?? filteredSpaces}


### PR DESCRIPTION
Closes:

### Description:
Moves the `overflow: auto` style for the space selector tree container from an inline style to a CSS module class. Also migrates the `Stack` and `Paper` imports to use `@mantine-8/core` consistently.