### PR TITLE
feat(deep-research): add durable run lifecycle

### DIFF
--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -1,0 +1,116 @@
+import {
+    assertRegisteredAccount,
+    type ApiAiDeepResearchEventsResponse,
+    type ApiAiDeepResearchRunResponse,
+    type ApiErrorPayload,
+    type UUID,
+} from '@lightdash/common';
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { AiDeepResearchService } from '../services/AiDeepResearchService/AiDeepResearchService';
+
+@Route('/api/v1/ee/projects/{projectUuid}/ai-deep-research')
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class AiDeepResearchController extends BaseController {
+    /**
+     * Get the durable state and result of a Deep Research run.
+     * @summary Get Deep Research run
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{aiDeepResearchRunUuid}')
+    @OperationId('getAiDeepResearchRun')
+    async getRun(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() aiDeepResearchRunUuid: UUID,
+    ): Promise<ApiAiDeepResearchRunResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiDeepResearchService().getRun(
+                toSessionUser(req.account),
+                projectUuid,
+                aiDeepResearchRunUuid,
+            ),
+        };
+    }
+
+    /**
+     * List persisted progress for a Deep Research run in chronological order.
+     * @summary List Deep Research events
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{aiDeepResearchRunUuid}/events')
+    @OperationId('listAiDeepResearchEvents')
+    async listEvents(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() aiDeepResearchRunUuid: UUID,
+        @Query() cursor?: string,
+        @Query() limit?: number,
+    ): Promise<ApiAiDeepResearchEventsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiDeepResearchService().listEvents({
+                user: toSessionUser(req.account),
+                projectUuid,
+                aiDeepResearchRunUuid,
+                cursor,
+                limit,
+            }),
+        };
+    }
+
+    /**
+     * Cancel a queued run immediately or request cancellation for a running run.
+     * @summary Cancel Deep Research run
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{aiDeepResearchRunUuid}/cancel')
+    @OperationId('cancelAiDeepResearchRun')
+    async cancelRun(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() aiDeepResearchRunUuid: UUID,
+    ): Promise<ApiAiDeepResearchRunResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiDeepResearchService().cancelRun(
+                toSessionUser(req.account),
+                projectUuid,
+                aiDeepResearchRunUuid,
+            ),
+        };
+    }
+
+    protected getAiDeepResearchService() {
+        return this.services.getAiDeepResearchService<AiDeepResearchService>();
+    }
+}

--- a/packages/backend/src/ee/database/entities/aiDeepResearch.ts
+++ b/packages/backend/src/ee/database/entities/aiDeepResearch.ts
@@ -1,0 +1,78 @@
+import {
+    type AiDeepResearchBudget,
+    type AiDeepResearchEventPayload,
+    type AiDeepResearchEventType,
+    type AiDeepResearchReport,
+    type AiDeepResearchRunStatus,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const AiDeepResearchRunsTableName = 'ai_deep_research_runs';
+
+export type DbAiDeepResearchRun = {
+    ai_deep_research_run_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    created_by_user_uuid: string;
+    ai_thread_uuid: string | null;
+    prompt_uuid: string | null;
+    tool_call_id: string | null;
+    prompt: string;
+    status: AiDeepResearchRunStatus;
+    claude_session_id: string | null;
+    result: AiDeepResearchReport | null;
+    budget_snapshot: AiDeepResearchBudget;
+    error_message: string | null;
+    cancellation_requested_at: Date | null;
+    started_at: Date | null;
+    completed_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiDeepResearchRunsTable = Knex.CompositeTableType<
+    DbAiDeepResearchRun,
+    Pick<
+        DbAiDeepResearchRun,
+        | 'organization_uuid'
+        | 'project_uuid'
+        | 'created_by_user_uuid'
+        | 'ai_thread_uuid'
+        | 'prompt_uuid'
+        | 'tool_call_id'
+        | 'prompt'
+        | 'budget_snapshot'
+    >,
+    Partial<
+        Pick<
+            DbAiDeepResearchRun,
+            | 'status'
+            | 'claude_session_id'
+            | 'result'
+            | 'error_message'
+            | 'cancellation_requested_at'
+            | 'started_at'
+            | 'completed_at'
+            | 'updated_at'
+        >
+    >
+>;
+
+export const AiDeepResearchEventsTableName = 'ai_deep_research_events';
+
+export type DbAiDeepResearchEvent = {
+    ai_deep_research_event_uuid: string;
+    ai_deep_research_run_uuid: string;
+    event_type: AiDeepResearchEventType;
+    payload: AiDeepResearchEventPayload;
+    created_at: Date;
+};
+
+export type AiDeepResearchEventsTable = Knex.CompositeTableType<
+    DbAiDeepResearchEvent,
+    Pick<
+        DbAiDeepResearchEvent,
+        'ai_deep_research_run_uuid' | 'event_type' | 'payload'
+    > &
+        Partial<Pick<DbAiDeepResearchEvent, 'created_at'>>
+>;

--- a/packages/backend/src/ee/database/migrations/20260713150000_add_ai_deep_research_runs.ts
+++ b/packages/backend/src/ee/database/migrations/20260713150000_add_ai_deep_research_runs.ts
@@ -1,0 +1,62 @@
+import { AI_DEEP_RESEARCH_RUN_STATUSES } from '@lightdash/common';
+import { Knex } from 'knex';
+
+const AiDeepResearchRunsTableName = 'ai_deep_research_runs';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiDeepResearchRunsTableName, (table) => {
+        table
+            .uuid('ai_deep_research_run_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table.uuid('created_by_user_uuid').notNullable();
+        table
+            .uuid('ai_thread_uuid')
+            .references('ai_thread_uuid')
+            .inTable('ai_thread')
+            .onDelete('SET NULL');
+        table.text('prompt_uuid');
+        table.text('tool_call_id');
+        table.text('prompt').notNullable();
+        table
+            .text('status')
+            .notNullable()
+            .defaultTo('queued')
+            .checkIn([...AI_DEEP_RESEARCH_RUN_STATUSES]);
+        table.text('claude_session_id');
+        table.jsonb('result');
+        table.jsonb('budget_snapshot').notNullable();
+        table.text('error_message');
+        table.timestamp('cancellation_requested_at', { useTz: false });
+        table.timestamp('started_at', { useTz: false });
+        table.timestamp('completed_at', { useTz: false });
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['organization_uuid', 'created_at']);
+        table.index(['project_uuid', 'created_at']);
+        table.index(['status', 'updated_at']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTable(AiDeepResearchRunsTableName);
+}

--- a/packages/backend/src/ee/database/migrations/20260713150100_add_ai_deep_research_events.ts
+++ b/packages/backend/src/ee/database/migrations/20260713150100_add_ai_deep_research_events.ts
@@ -1,0 +1,39 @@
+import { AI_DEEP_RESEARCH_EVENT_TYPES } from '@lightdash/common';
+import { Knex } from 'knex';
+
+const AiDeepResearchRunsTableName = 'ai_deep_research_runs';
+const AiDeepResearchEventsTableName = 'ai_deep_research_events';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiDeepResearchEventsTableName, (table) => {
+        table
+            .uuid('ai_deep_research_event_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_deep_research_run_uuid')
+            .notNullable()
+            .references('ai_deep_research_run_uuid')
+            .inTable(AiDeepResearchRunsTableName)
+            .onDelete('CASCADE');
+        table
+            .text('event_type')
+            .notNullable()
+            .checkIn([...AI_DEEP_RESEARCH_EVENT_TYPES]);
+        table.jsonb('payload').notNullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index([
+            'ai_deep_research_run_uuid',
+            'created_at',
+            'ai_deep_research_event_uuid',
+        ]);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTable(AiDeepResearchEventsTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -31,6 +31,7 @@ import { AiAgentDocumentModel } from './models/AiAgentDocumentModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from './models/AiAgentReviewNotificationModel';
+import { AiDeepResearchRunModel } from './models/AiDeepResearchRunModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
 import { AiRouterModel } from './models/AiRouterModel';
 import { AiWritebackRunModel } from './models/AiWritebackRunModel';
@@ -62,6 +63,7 @@ import { AiAgentReviewClassifierService } from './services/AiAgentReviewClassifi
 import { AiAgentReviewNotificationService } from './services/AiAgentReviewNotificationService';
 import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiAgentToolsService } from './services/AiAgentToolsService/AiAgentToolsService';
+import { AiDeepResearchService } from './services/AiDeepResearchService/AiDeepResearchService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
 import { AiRouterService } from './services/AiRouterService/AiRouterService';
 import { AiService } from './services/AiService/AiService';
@@ -122,6 +124,15 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
+            aiDeepResearchService: ({ models, clients }) =>
+                new AiDeepResearchService({
+                    aiDeepResearchRunModel:
+                        models.getAiDeepResearchRunModel<AiDeepResearchRunModel>(),
+                    projectModel: models.getProjectModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
+                    schedulerClient:
+                        clients.getSchedulerClient() as CommercialSchedulerClient,
+                }),
             projectContextService: ({ models }) =>
                 new ProjectContextService({
                     projectModel: models.getProjectModel(),
@@ -844,6 +855,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiWritebackThreadModel({ database }),
             aiWritebackRunModel: ({ database }) =>
                 new AiWritebackRunModel({ database }),
+            aiDeepResearchRunModel: ({ database }) =>
+                new AiDeepResearchRunModel({ database }),
             sandboxRegistryModel: ({ database }) =>
                 new SandboxRegistryModel({ database }),
             projectCiStatusModel: ({ database }) =>
@@ -920,6 +933,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 aiAgentService: context.serviceRepository.getAiAgentService(),
                 aiWritebackService:
                     context.serviceRepository.getAiWritebackService<AiWritebackService>(),
+                aiDeepResearchService:
+                    context.serviceRepository.getAiDeepResearchService<AiDeepResearchService>(),
                 catalogService: context.serviceRepository.getCatalogService(),
                 encryptionUtil: context.utils.getEncryptionUtil(),
                 msTeamsClient: context.clients.getMsTeamsClient(),

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -1,0 +1,188 @@
+import {
+    SEED_ORG_1,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+    type AiDeepResearchBudget,
+    type AiDeepResearchReport,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { getTestContext } from '../../vitest.setup.integration';
+import {
+    AiDeepResearchEventsTableName,
+    AiDeepResearchRunsTableName,
+    type DbAiDeepResearchRun,
+} from '../database/entities/aiDeepResearch';
+import { AiDeepResearchRunModel } from './AiDeepResearchRunModel';
+
+const budget: AiDeepResearchBudget = {
+    maxRuntimeMs: 60_000,
+    maxTokens: 10_000,
+    maxToolCalls: 20,
+    maxWarehouseQueries: 10,
+    maxResultRows: 1_000,
+};
+
+const report: AiDeepResearchReport = {
+    summary: 'Summary',
+    findings: [],
+    caveats: [],
+    scope: 'Last month',
+    unresolvedQuestions: [],
+    nextSteps: [],
+};
+
+describe('AiDeepResearchRunModel integration', () => {
+    let database: Knex;
+    let model: AiDeepResearchRunModel;
+    const runUuids = new Set<string>();
+
+    beforeAll(() => {
+        database = getTestContext().db;
+        model = new AiDeepResearchRunModel({ database });
+    });
+
+    afterEach(async () => {
+        if (runUuids.size === 0) {
+            return;
+        }
+        await database(AiDeepResearchRunsTableName)
+            .whereIn('ai_deep_research_run_uuid', [...runUuids])
+            .delete();
+        runUuids.clear();
+    });
+
+    const createRun = async (): Promise<DbAiDeepResearchRun> => {
+        const run = await model.create({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            aiThreadUuid: null,
+            promptUuid: null,
+            toolCallId: null,
+            prompt: `Integration race ${crypto.randomUUID()}`,
+            budget,
+        });
+        runUuids.add(run.ai_deep_research_run_uuid);
+        return run;
+    };
+
+    const getEventSequence = async (runUuid: string): Promise<string[]> => {
+        const events = await database(AiDeepResearchEventsTableName)
+            .select('event_type', 'payload')
+            .where('ai_deep_research_run_uuid', runUuid)
+            .orderBy('created_at', 'asc')
+            .orderBy('ai_deep_research_event_uuid', 'asc');
+        return events.map(({ event_type: eventType, payload }) =>
+            eventType === 'status_changed'
+                ? `${eventType}:${String(payload.status)}`
+                : eventType,
+        );
+    };
+
+    it('allows exactly one worker to claim a queued run', async () => {
+        const run = await createRun();
+
+        const claims = await Promise.all([
+            model.claimQueuedRun(run.ai_deep_research_run_uuid),
+            model.claimQueuedRun(run.ai_deep_research_run_uuid),
+        ]);
+
+        expect(claims.filter(Boolean)).toHaveLength(1);
+        expect(
+            await model.findByUuid(run.ai_deep_research_run_uuid),
+        ).toMatchObject({ status: 'running' });
+        expect(await getEventSequence(run.ai_deep_research_run_uuid)).toEqual([
+            'status_changed:queued',
+            'status_changed:running',
+        ]);
+    });
+
+    it('settles a claim and cancellation race without losing cancellation', async () => {
+        const run = await createRun();
+
+        await Promise.all([
+            model.claimQueuedRun(run.ai_deep_research_run_uuid),
+            model.requestCancellation(run.ai_deep_research_run_uuid),
+        ]);
+
+        const racedRun = await model.findByUuid(run.ai_deep_research_run_uuid);
+        if (racedRun?.status === 'running') {
+            expect(racedRun.cancellation_requested_at).not.toBeNull();
+            await model.markCancelled(run.ai_deep_research_run_uuid);
+        }
+
+        expect(
+            await model.findByUuid(run.ai_deep_research_run_uuid),
+        ).toMatchObject({ status: 'cancelled' });
+        expect(await getEventSequence(run.ai_deep_research_run_uuid)).toEqual(
+            racedRun?.status === 'running'
+                ? [
+                      'status_changed:queued',
+                      'status_changed:running',
+                      'cancellation_requested',
+                      'status_changed:cancelled',
+                  ]
+                : [
+                      'status_changed:queued',
+                      'cancellation_requested',
+                      'status_changed:cancelled',
+                  ],
+        );
+    });
+
+    it('keeps completion and cancellation terminal under contention', async () => {
+        const run = await createRun();
+        await model.claimQueuedRun(run.ai_deep_research_run_uuid);
+
+        await Promise.all([
+            model.markCompleted(run.ai_deep_research_run_uuid, report),
+            model.requestCancellation(run.ai_deep_research_run_uuid),
+        ]);
+
+        const racedRun = await model.findByUuid(run.ai_deep_research_run_uuid);
+        if (racedRun?.status === 'running') {
+            expect(racedRun.cancellation_requested_at).not.toBeNull();
+            await model.markCancelled(run.ai_deep_research_run_uuid);
+        }
+
+        const terminalRun = await model.findByUuid(
+            run.ai_deep_research_run_uuid,
+        );
+        expect(['completed', 'cancelled']).toContain(terminalRun?.status);
+        expect(await getEventSequence(run.ai_deep_research_run_uuid)).toEqual(
+            terminalRun?.status === 'completed'
+                ? [
+                      'status_changed:queued',
+                      'status_changed:running',
+                      'status_changed:completed',
+                  ]
+                : [
+                      'status_changed:queued',
+                      'status_changed:running',
+                      'cancellation_requested',
+                      'status_changed:cancelled',
+                  ],
+        );
+    });
+
+    it('fails a stale running run and records one terminal event', async () => {
+        const run = await createRun();
+        await model.claimQueuedRun(run.ai_deep_research_run_uuid);
+        await database(AiDeepResearchRunsTableName)
+            .where('ai_deep_research_run_uuid', run.ai_deep_research_run_uuid)
+            .update({ updated_at: database.raw("now() - interval '2 hours'") });
+
+        const staleRuns = await model.markStaleRunsAsFailed(75, 'stale');
+
+        expect(staleRuns).toHaveLength(1);
+        expect(staleRuns[0]).toMatchObject({
+            ai_deep_research_run_uuid: run.ai_deep_research_run_uuid,
+            status: 'failed',
+        });
+        expect(await getEventSequence(run.ai_deep_research_run_uuid)).toEqual([
+            'status_changed:queued',
+            'status_changed:running',
+            'status_changed:failed',
+        ]);
+    });
+});

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -1,0 +1,176 @@
+import { type AiDeepResearchReport } from '@lightdash/common';
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    AiDeepResearchEventsTableName,
+    AiDeepResearchRunsTableName,
+} from '../database/entities/aiDeepResearch';
+import { AiDeepResearchRunModel } from './AiDeepResearchRunModel';
+
+const RUN_UUID = '00000000-0000-0000-0000-000000000001';
+const EVENT_UUID = '00000000-0000-0000-0000-000000000002';
+
+const report: AiDeepResearchReport = {
+    summary: 'Summary',
+    findings: [],
+    caveats: [],
+    scope: 'Last month',
+    unresolvedQuestions: [],
+    nextSteps: [],
+};
+
+const runRow = (overrides: Record<string, unknown> = {}) => ({
+    ai_deep_research_run_uuid: RUN_UUID,
+    status: 'running',
+    ...overrides,
+});
+
+describe('AiDeepResearchRunModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AiDeepResearchRunModel({
+        database: database as unknown as Knex,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('claims a queued run only when cancellation has not been requested', async () => {
+        tracker.on.update(AiDeepResearchRunsTableName).responseOnce([runRow()]);
+        tracker.on.insert(AiDeepResearchEventsTableName).responseOnce([]);
+
+        const run = await model.claimQueuedRun(RUN_UUID);
+
+        expect(run).toEqual(runRow());
+        const [update] = tracker.history.update;
+        expect(update.sql).toContain('set "status" = $1');
+        expect(update.sql).toContain('"cancellation_requested_at" is null');
+        expect(update.bindings).toEqual(
+            expect.arrayContaining(['queued', 'running', RUN_UUID]),
+        );
+        expect(tracker.history.insert[0].bindings).toEqual(
+            expect.arrayContaining([
+                RUN_UUID,
+                'status_changed',
+                JSON.stringify({ status: 'running' }),
+            ]),
+        );
+    });
+
+    it('scopes user-facing lookups by organization and project', async () => {
+        tracker.on.select(AiDeepResearchRunsTableName).responseOnce([]);
+
+        await model.findByUuidScoped({
+            aiDeepResearchRunUuid: RUN_UUID,
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+        });
+
+        expect(tracker.history.select[0].bindings).toEqual([
+            RUN_UUID,
+            'organization-1',
+            'project-1',
+            1,
+        ]);
+    });
+
+    it('does not overwrite a cancellation request with completion', async () => {
+        tracker.on.update(AiDeepResearchRunsTableName).responseOnce([]);
+
+        const updated = await model.markCompleted(RUN_UUID, report);
+
+        expect(updated).toBe(false);
+        const [update] = tracker.history.update;
+        expect(update.sql).toContain('"cancellation_requested_at" is null');
+        expect(update.bindings).toEqual(
+            expect.arrayContaining(['running', 'completed', RUN_UUID]),
+        );
+        expect(tracker.history.insert).toHaveLength(0);
+    });
+
+    it('cancels a queued run immediately and records both lifecycle events', async () => {
+        tracker.on
+            .update(AiDeepResearchRunsTableName)
+            .responseOnce([runRow({ status: 'cancelled' })]);
+        tracker.on.insert(AiDeepResearchEventsTableName).response([]);
+
+        const run = await model.requestCancellation(RUN_UUID);
+
+        expect(run).toEqual(runRow({ status: 'cancelled' }));
+        expect(tracker.history.update).toHaveLength(1);
+        expect(tracker.history.update[0].bindings).toEqual(
+            expect.arrayContaining(['queued', 'cancelled', RUN_UUID]),
+        );
+        expect(tracker.history.insert).toHaveLength(2);
+        expect(tracker.history.insert[0].bindings).toContain(
+            'cancellation_requested',
+        );
+        expect(tracker.history.insert[1].bindings).toContain('status_changed');
+    });
+
+    it('records a cancellation request without declaring a running job cancelled', async () => {
+        const requestedAt = new Date('2026-07-13T12:01:00.000Z');
+        tracker.on.update(AiDeepResearchRunsTableName).responseOnce([]);
+        tracker.on
+            .update(AiDeepResearchRunsTableName)
+            .responseOnce([runRow({ cancellation_requested_at: requestedAt })]);
+        tracker.on.insert(AiDeepResearchEventsTableName).responseOnce([]);
+
+        const run = await model.requestCancellation(RUN_UUID);
+
+        expect(run).toEqual(runRow({ cancellation_requested_at: requestedAt }));
+        expect(tracker.history.update).toHaveLength(2);
+        expect(tracker.history.update[1].bindings).toEqual(
+            expect.arrayContaining(['running', RUN_UUID]),
+        );
+        expect(tracker.history.insert).toHaveLength(1);
+        expect(tracker.history.insert[0].bindings).toContain(
+            'cancellation_requested',
+        );
+    });
+
+    it('uses a stable created-at and uuid keyset for event pagination', async () => {
+        tracker.on.select(AiDeepResearchEventsTableName).responseOnce([]);
+        const createdAt = new Date('2026-07-13T12:00:00.000Z');
+
+        await model.listEvents({
+            aiDeepResearchRunUuid: RUN_UUID,
+            cursor: { createdAt, eventUuid: EVENT_UUID },
+            limit: 20,
+        });
+
+        const [select] = tracker.history.select;
+        expect(select.sql).toContain(
+            '(created_at, ai_deep_research_event_uuid) > ($2, $3)',
+        );
+        expect(select.sql).toContain('order by "created_at" asc');
+        expect(select.sql).toContain(
+            '"ai_deep_research_event_uuid" asc limit $4',
+        );
+        expect(select.bindings).toEqual([RUN_UUID, createdAt, EVENT_UUID, 21]);
+    });
+
+    it('fails only stale running jobs and records a terminal event per run', async () => {
+        tracker.on
+            .update(AiDeepResearchRunsTableName)
+            .responseOnce([
+                runRow(),
+                runRow({ ai_deep_research_run_uuid: 'run-2' }),
+            ]);
+        tracker.on.insert(AiDeepResearchEventsTableName).response([]);
+
+        const runs = await model.markStaleRunsAsFailed(75, 'stale');
+
+        expect(runs).toHaveLength(2);
+        const [update] = tracker.history.update;
+        expect(update.bindings).toEqual(
+            expect.arrayContaining(['running', 75, 'failed', 'stale']),
+        );
+        expect(tracker.history.insert).toHaveLength(2);
+    });
+});

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -1,0 +1,442 @@
+import {
+    type AiDeepResearchBudget,
+    type AiDeepResearchEventPayload,
+    type AiDeepResearchEventPayloadMap,
+    type AiDeepResearchEventType,
+    type AiDeepResearchProgress,
+    type AiDeepResearchReport,
+    type AiDeepResearchRunStatus,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    AiDeepResearchEventsTable,
+    AiDeepResearchEventsTableName,
+    AiDeepResearchRunsTable,
+    AiDeepResearchRunsTableName,
+    type DbAiDeepResearchEvent,
+    type DbAiDeepResearchRun,
+} from '../database/entities/aiDeepResearch';
+
+type Dependencies = {
+    database: Knex;
+};
+
+type CreateAiDeepResearchRun = {
+    organizationUuid: string;
+    projectUuid: string;
+    createdByUserUuid: string;
+    aiThreadUuid: string | null;
+    promptUuid: string | null;
+    toolCallId: string | null;
+    prompt: string;
+    budget: AiDeepResearchBudget;
+};
+
+type EventCursor = {
+    createdAt: Date;
+    eventUuid: string;
+};
+
+type Queryable = Knex | Knex.Transaction;
+
+export class AiDeepResearchRunModel {
+    private readonly database: Knex;
+
+    constructor({ database }: Dependencies) {
+        this.database = database;
+    }
+
+    private static async insertEvent<EventType extends AiDeepResearchEventType>(
+        database: Queryable,
+        aiDeepResearchRunUuid: string,
+        eventType: EventType,
+        payload: AiDeepResearchEventPayloadMap[EventType],
+    ): Promise<void> {
+        await database<AiDeepResearchEventsTable>(
+            AiDeepResearchEventsTableName,
+        ).insert({
+            ai_deep_research_run_uuid: aiDeepResearchRunUuid,
+            event_type: eventType,
+            payload: payload as AiDeepResearchEventPayload,
+            created_at: database.raw('clock_timestamp()') as unknown as Date,
+        });
+    }
+
+    async create(data: CreateAiDeepResearchRun): Promise<DbAiDeepResearchRun> {
+        return this.database.transaction(async (transaction) => {
+            const [run] = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .insert({
+                    organization_uuid: data.organizationUuid,
+                    project_uuid: data.projectUuid,
+                    created_by_user_uuid: data.createdByUserUuid,
+                    ai_thread_uuid: data.aiThreadUuid,
+                    prompt_uuid: data.promptUuid,
+                    tool_call_id: data.toolCallId,
+                    prompt: data.prompt,
+                    budget_snapshot: data.budget,
+                })
+                .returning('*');
+
+            await AiDeepResearchRunModel.insertEvent(
+                transaction,
+                run.ai_deep_research_run_uuid,
+                'status_changed',
+                { status: 'queued' },
+            );
+            return run;
+        });
+    }
+
+    async findByUuid(
+        aiDeepResearchRunUuid: string,
+    ): Promise<DbAiDeepResearchRun | undefined> {
+        return this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+            .first();
+    }
+
+    async findByUuidScoped(args: {
+        aiDeepResearchRunUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+    }): Promise<DbAiDeepResearchRun | undefined> {
+        return this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .where('ai_deep_research_run_uuid', args.aiDeepResearchRunUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .where('project_uuid', args.projectUuid)
+            .first();
+    }
+
+    async claimQueuedRun(
+        aiDeepResearchRunUuid: string,
+    ): Promise<DbAiDeepResearchRun | undefined> {
+        return this.database.transaction(async (transaction) => {
+            const [run] = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .where('status', 'queued')
+                .whereNull('cancellation_requested_at')
+                .update({
+                    status: 'running',
+                    started_at: transaction.fn.now() as unknown as Date,
+                    updated_at: transaction.fn.now() as unknown as Date,
+                })
+                .returning('*');
+
+            if (!run) {
+                return undefined;
+            }
+
+            await AiDeepResearchRunModel.insertEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'status_changed',
+                { status: 'running' },
+            );
+            return run;
+        });
+    }
+
+    async setClaudeSessionId(
+        aiDeepResearchRunUuid: string,
+        claudeSessionId: string,
+    ): Promise<boolean> {
+        const updated = await this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+            .where('status', 'running')
+            .update({
+                claude_session_id: claudeSessionId,
+                updated_at: this.database.fn.now() as unknown as Date,
+            });
+        return updated > 0;
+    }
+
+    async touch(aiDeepResearchRunUuid: string): Promise<boolean> {
+        const updated = await this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+            .where('status', 'running')
+            .update({
+                updated_at: this.database.fn.now() as unknown as Date,
+            });
+        return updated > 0;
+    }
+
+    private async markWithReport(
+        aiDeepResearchRunUuid: string,
+        status: 'completed' | 'partially_completed',
+        report: AiDeepResearchReport,
+    ): Promise<boolean> {
+        return this.database.transaction(async (transaction) => {
+            const [run] = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .where('status', 'running')
+                .whereNull('cancellation_requested_at')
+                .update({
+                    status,
+                    result: report,
+                    error_message: null,
+                    completed_at: transaction.fn.now() as unknown as Date,
+                    updated_at: transaction.fn.now() as unknown as Date,
+                })
+                .returning('*');
+
+            if (!run) {
+                return false;
+            }
+
+            await AiDeepResearchRunModel.insertEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'status_changed',
+                { status },
+            );
+            return true;
+        });
+    }
+
+    async markCompleted(
+        aiDeepResearchRunUuid: string,
+        report: AiDeepResearchReport,
+    ): Promise<boolean> {
+        return this.markWithReport(aiDeepResearchRunUuid, 'completed', report);
+    }
+
+    async markPartiallyCompleted(
+        aiDeepResearchRunUuid: string,
+        report: AiDeepResearchReport,
+    ): Promise<boolean> {
+        return this.markWithReport(
+            aiDeepResearchRunUuid,
+            'partially_completed',
+            report,
+        );
+    }
+
+    async markFailed(
+        aiDeepResearchRunUuid: string,
+        errorMessage: string,
+    ): Promise<boolean> {
+        return this.database.transaction(async (transaction) => {
+            const [run] = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .whereIn('status', ['queued', 'running'])
+                .update({
+                    status: 'failed',
+                    error_message: errorMessage,
+                    completed_at: transaction.fn.now() as unknown as Date,
+                    updated_at: transaction.fn.now() as unknown as Date,
+                })
+                .returning('*');
+
+            if (!run) {
+                return false;
+            }
+
+            await AiDeepResearchRunModel.insertEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'status_changed',
+                { status: 'failed' },
+            );
+            return true;
+        });
+    }
+
+    async markCancelled(aiDeepResearchRunUuid: string): Promise<boolean> {
+        return this.database.transaction(async (transaction) => {
+            const [run] = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .where('status', 'running')
+                .whereNotNull('cancellation_requested_at')
+                .update({
+                    status: 'cancelled',
+                    completed_at: transaction.fn.now() as unknown as Date,
+                    updated_at: transaction.fn.now() as unknown as Date,
+                })
+                .returning('*');
+
+            if (!run) {
+                return false;
+            }
+
+            await AiDeepResearchRunModel.insertEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'status_changed',
+                { status: 'cancelled' },
+            );
+            return true;
+        });
+    }
+
+    async requestCancellation(
+        aiDeepResearchRunUuid: string,
+    ): Promise<DbAiDeepResearchRun | undefined> {
+        return this.database.transaction(async (transaction) => {
+            const now = transaction.fn.now() as unknown as Date;
+            const [queuedRun] = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .where('status', 'queued')
+                .whereNull('cancellation_requested_at')
+                .update({
+                    status: 'cancelled',
+                    cancellation_requested_at: now,
+                    completed_at: now,
+                    updated_at: now,
+                })
+                .returning('*');
+
+            if (queuedRun) {
+                await AiDeepResearchRunModel.insertEvent(
+                    transaction,
+                    aiDeepResearchRunUuid,
+                    'cancellation_requested',
+                    {},
+                );
+                await AiDeepResearchRunModel.insertEvent(
+                    transaction,
+                    aiDeepResearchRunUuid,
+                    'status_changed',
+                    { status: 'cancelled' },
+                );
+                return queuedRun;
+            }
+
+            const [runningRun] = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .where('status', 'running')
+                .whereNull('cancellation_requested_at')
+                .update({
+                    cancellation_requested_at: now,
+                    updated_at: now,
+                })
+                .returning('*');
+
+            if (runningRun) {
+                await AiDeepResearchRunModel.insertEvent(
+                    transaction,
+                    aiDeepResearchRunUuid,
+                    'cancellation_requested',
+                    {},
+                );
+                return runningRun;
+            }
+
+            return transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .first();
+        });
+    }
+
+    async appendProgressEvent(
+        aiDeepResearchRunUuid: string,
+        progress: AiDeepResearchProgress,
+    ): Promise<boolean> {
+        return this.database.transaction(async (transaction) => {
+            const run = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .where('status', 'running')
+                .forUpdate()
+                .first();
+
+            if (!run) {
+                return false;
+            }
+
+            await AiDeepResearchRunModel.insertEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'progress',
+                { progress },
+            );
+            return true;
+        });
+    }
+
+    async listEvents(args: {
+        aiDeepResearchRunUuid: string;
+        cursor: EventCursor | null;
+        limit: number;
+    }): Promise<DbAiDeepResearchEvent[]> {
+        const query = this.database<AiDeepResearchEventsTable>(
+            AiDeepResearchEventsTableName,
+        ).where('ai_deep_research_run_uuid', args.aiDeepResearchRunUuid);
+
+        const pageQuery = args.cursor
+            ? query.andWhere(
+                  this.database.raw(
+                      '(created_at, ai_deep_research_event_uuid) > (?, ?)',
+                      [args.cursor.createdAt, args.cursor.eventUuid],
+                  ),
+              )
+            : query;
+
+        return pageQuery
+            .orderBy('created_at', 'asc')
+            .orderBy('ai_deep_research_event_uuid', 'asc')
+            .limit(args.limit + 1);
+    }
+
+    async markStaleRunsAsFailed(
+        thresholdMinutes: number,
+        errorMessage: string,
+    ): Promise<DbAiDeepResearchRun[]> {
+        return this.database.transaction(async (transaction) => {
+            const runs = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('status', 'running')
+                .andWhere(
+                    'updated_at',
+                    '<',
+                    transaction.raw("now() - (? * interval '1 minute')", [
+                        thresholdMinutes,
+                    ]),
+                )
+                .update({
+                    status: 'failed',
+                    error_message: errorMessage,
+                    completed_at: transaction.fn.now() as unknown as Date,
+                    updated_at: transaction.fn.now() as unknown as Date,
+                })
+                .returning('*');
+
+            await Promise.all(
+                runs.map((run) =>
+                    AiDeepResearchRunModel.insertEvent(
+                        transaction,
+                        run.ai_deep_research_run_uuid,
+                        'status_changed',
+                        { status: 'failed' },
+                    ),
+                ),
+            );
+            return runs;
+        });
+    }
+}

--- a/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
@@ -1,4 +1,8 @@
-import { aiAgentReviewRunAt } from './SchedulerClient';
+import { AnyType, EE_SCHEDULER_TASKS } from '@lightdash/common';
+import {
+    aiAgentReviewRunAt,
+    CommercialSchedulerClient,
+} from './SchedulerClient';
 
 describe('aiAgentReviewRunAt', () => {
     const now = new Date('2026-06-04T11:33:48.000Z');
@@ -13,5 +17,32 @@ describe('aiAgentReviewRunAt', () => {
     it('runs response_saved reviews immediately', () => {
         const runAt = aiAgentReviewRunAt('response_saved', now);
         expect(runAt.getTime()).toBe(now.getTime());
+    });
+});
+
+describe('CommercialSchedulerClient.aiDeepResearch', () => {
+    it('enqueues one uniquely keyed attempt per durable run', async () => {
+        const addJob = vi.fn().mockResolvedValue({ id: 'job-1' });
+        const client = Object.create(
+            CommercialSchedulerClient.prototype,
+        ) as CommercialSchedulerClient;
+        client.graphileUtils = Promise.resolve({ addJob } as AnyType);
+        const payload = {
+            aiDeepResearchRunUuid: 'run-1',
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            userUuid: 'user-1',
+        };
+
+        await client.aiDeepResearch(payload);
+
+        expect(addJob).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH,
+            payload,
+            expect.objectContaining({
+                maxAttempts: 1,
+                jobKey: 'ai-deep-research:run-1',
+            }),
+        );
     });
 });

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -6,6 +6,7 @@ import {
     AiAgentReviewRemediationPreviewJobPayload,
     AiAgentReviewRemediationRunJobPayload,
     AiAgentReviewWritebackJobPayload,
+    AiDeepResearchPipelineJobPayload,
     AiWritebackPipelineJobPayload,
     AppBuildFromSourceJobPayload,
     AppGeneratePipelineJobPayload,
@@ -211,6 +212,20 @@ export class CommercialSchedulerClient extends SchedulerClient {
                 runAt: new Date(),
                 maxAttempts: 1,
                 jobKey: `ai-writeback:${payload.aiWritebackRunUuid}`,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiDeepResearch(payload: AiDeepResearchPipelineJobPayload) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH,
+            payload,
+            {
+                runAt: new Date(),
+                maxAttempts: 1,
+                jobKey: `ai-deep-research:${payload.aiDeepResearchRunUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -23,6 +23,7 @@ import { AiAgentAdminService } from '../services/AiAgentAdminService';
 import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
 import { type AiAgentReviewNotificationService } from '../services/AiAgentReviewNotificationService';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
+import { type AiDeepResearchService } from '../services/AiDeepResearchService/AiDeepResearchService';
 import type { AiWritebackService } from '../services/AiWritebackService/AiWritebackService';
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import type { EmbedService } from '../services/EmbedService/EmbedService';
@@ -37,10 +38,12 @@ const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 const AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 const AI_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000;
+const AI_DEEP_RESEARCH_TIMEOUT_MS = 60 * 60 * 1000;
 
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentService: AiAgentService;
     aiWritebackService: AiWritebackService;
+    aiDeepResearchService: AiDeepResearchService;
     aiAgentReviewClassifierService: AiAgentReviewClassifierService;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
@@ -59,6 +62,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly aiAgentService: AiAgentService;
 
     protected readonly aiWritebackService: AiWritebackService;
+
+    protected readonly aiDeepResearchService: AiDeepResearchService;
 
     protected readonly aiAgentReviewClassifierService: AiAgentReviewClassifierService;
 
@@ -88,6 +93,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         super(args);
         this.aiAgentService = args.aiAgentService;
         this.aiWritebackService = args.aiWritebackService;
+        this.aiDeepResearchService = args.aiDeepResearchService;
         this.aiAgentReviewClassifierService =
             args.aiAgentReviewClassifierService;
         this.aiAgentReviewClassifierModel = args.aiAgentReviewClassifierModel;
@@ -121,6 +127,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 pattern: '*/2 * * * *', // Every 2 minutes
                 options: {
                     backfillPeriod: 5 * 60 * 1000, // 5 min
+                    maxAttempts: 1,
+                },
+            },
+            {
+                task: EE_SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS,
+                pattern: '*/2 * * * *',
+                options: {
+                    backfillPeriod: 5 * 60 * 1000,
                     maxAttempts: 1,
                 },
             },
@@ -504,6 +518,31 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     },
                 );
             },
+            [EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH]: async (payload, helpers) => {
+                const abortController = new AbortController();
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.aiDeepResearchService.executeRun(
+                                payload,
+                                abortController.signal,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    AI_DEEP_RESEARCH_TIMEOUT_MS,
+                    async (_job, error) => {
+                        abortController.abort(error);
+                        await this.aiDeepResearchService.markRunTimedOut(
+                            payload.aiDeepResearchRunUuid,
+                        );
+                    },
+                );
+            },
             [EE_SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: async (
                 payload,
                 helpers,
@@ -567,6 +606,10 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     }
                 }
             },
+            [EE_SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS]:
+                async () => {
+                    await this.aiDeepResearchService.sweepStaleRuns();
+                },
             [EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: async (payload) => {
                 await sendReviewNotification({
                     siteUrl: this.lightdashConfig.siteUrl,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1,0 +1,435 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import {
+    AnyType,
+    FeatureFlags,
+    NotFoundError,
+    ParameterError,
+    type AiDeepResearchBudget,
+    type AiDeepResearchReport,
+    type MemberAbility,
+    type SessionUser,
+} from '@lightdash/common';
+import { AiDeepResearchService } from './AiDeepResearchService';
+
+const budget: AiDeepResearchBudget = {
+    maxRuntimeMs: 60_000,
+    maxTokens: 10_000,
+    maxToolCalls: 20,
+    maxWarehouseQueries: 10,
+    maxResultRows: 1_000,
+};
+
+const report: AiDeepResearchReport = {
+    summary: 'Summary',
+    findings: [],
+    caveats: [],
+    scope: 'Last month',
+    unresolvedQuestions: [],
+    nextSteps: [],
+};
+
+const userWithProjectAccess = (): SessionUser => {
+    const { build, can } = new AbilityBuilder<MemberAbility>(Ability);
+    can('view', 'Project', {
+        organizationUuid: 'org-1',
+        projectUuid: 'project-1',
+    });
+    return {
+        userUuid: 'user-1',
+        organizationUuid: 'org-1',
+        organizationName: 'Acme',
+        organizationCreatedAt: new Date(),
+        role: 'member',
+        ability: build(),
+    } as AnyType;
+};
+
+const runRow = (overrides: Record<string, unknown> = {}) => ({
+    ai_deep_research_run_uuid: 'run-1',
+    organization_uuid: 'org-1',
+    project_uuid: 'project-1',
+    created_by_user_uuid: 'user-1',
+    ai_thread_uuid: null,
+    prompt_uuid: null,
+    tool_call_id: null,
+    prompt: 'Investigate revenue',
+    status: 'queued',
+    claude_session_id: null,
+    result: null,
+    budget_snapshot: budget,
+    error_message: null,
+    cancellation_requested_at: null,
+    started_at: null,
+    completed_at: null,
+    created_at: new Date('2026-07-13T12:00:00.000Z'),
+    updated_at: new Date('2026-07-13T12:00:00.000Z'),
+    ...overrides,
+});
+
+const buildService = (
+    overrides: {
+        model?: Record<string, unknown>;
+        projectModel?: Record<string, unknown>;
+        featureFlagModel?: Record<string, unknown>;
+        schedulerClient?: Record<string, unknown>;
+        executor?: AnyType;
+    } = {},
+) => {
+    const model = {
+        create: vi.fn().mockResolvedValue(runRow()),
+        findByUuid: vi.fn().mockResolvedValue(runRow()),
+        findByUuidScoped: vi.fn().mockResolvedValue(runRow()),
+        claimQueuedRun: vi
+            .fn()
+            .mockResolvedValue(runRow({ status: 'running' })),
+        markCompleted: vi.fn().mockResolvedValue(true),
+        markPartiallyCompleted: vi.fn().mockResolvedValue(true),
+        markFailed: vi.fn().mockResolvedValue(true),
+        markCancelled: vi.fn().mockResolvedValue(true),
+        requestCancellation: vi.fn().mockResolvedValue(
+            runRow({
+                status: 'cancelled',
+                cancellation_requested_at: new Date(),
+                completed_at: new Date(),
+            }),
+        ),
+        listEvents: vi.fn().mockResolvedValue([]),
+        appendProgressEvent: vi.fn().mockResolvedValue(true),
+        setClaudeSessionId: vi.fn().mockResolvedValue(true),
+        touch: vi.fn().mockResolvedValue(true),
+        markStaleRunsAsFailed: vi.fn().mockResolvedValue([]),
+        ...overrides.model,
+    };
+    const projectModel = {
+        getSummary: vi.fn().mockResolvedValue({ organizationUuid: 'org-1' }),
+        ...overrides.projectModel,
+    };
+    const featureFlagModel = {
+        get: vi.fn().mockResolvedValue({
+            id: FeatureFlags.AiDeepResearch,
+            enabled: true,
+        }),
+        ...overrides.featureFlagModel,
+    };
+    const schedulerClient = {
+        aiDeepResearch: vi.fn().mockResolvedValue({ jobId: 'job-1' }),
+        ...overrides.schedulerClient,
+    };
+    const executor =
+        overrides.executor ??
+        vi.fn().mockResolvedValue({
+            status: 'completed',
+            report,
+        });
+    const service = new AiDeepResearchService({
+        aiDeepResearchRunModel: model as AnyType,
+        projectModel: projectModel as AnyType,
+        featureFlagModel: featureFlagModel as AnyType,
+        schedulerClient: schedulerClient as AnyType,
+        executor,
+    });
+    return {
+        service,
+        model,
+        projectModel,
+        featureFlagModel,
+        schedulerClient,
+        executor,
+    };
+};
+
+describe('AiDeepResearchService', () => {
+    describe('createRun', () => {
+        it('persists the run before enqueueing a uniquely addressable job', async () => {
+            const { service, model, schedulerClient, featureFlagModel } =
+                buildService();
+
+            const run = await service.createRun({
+                user: userWithProjectAccess(),
+                projectUuid: 'project-1',
+                prompt: '  Investigate revenue  ',
+                budget,
+            });
+
+            expect(model.create).toHaveBeenCalledWith({
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                createdByUserUuid: 'user-1',
+                aiThreadUuid: null,
+                promptUuid: null,
+                toolCallId: null,
+                prompt: 'Investigate revenue',
+                budget,
+            });
+            expect(schedulerClient.aiDeepResearch).toHaveBeenCalledWith({
+                aiDeepResearchRunUuid: 'run-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                userUuid: 'user-1',
+            });
+            expect(featureFlagModel.get).toHaveBeenCalledWith({
+                user: expect.objectContaining({ userUuid: 'user-1' }),
+                featureFlagId: FeatureFlags.AiDeepResearch,
+            });
+            expect(run.status).toBe('queued');
+        });
+
+        it('marks the durable run failed when enqueueing fails', async () => {
+            const error = new Error('queue unavailable');
+            const { service, model } = buildService({
+                schedulerClient: {
+                    aiDeepResearch: vi.fn().mockRejectedValue(error),
+                },
+            });
+
+            await expect(
+                service.createRun({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    prompt: 'Investigate revenue',
+                    budget,
+                }),
+            ).rejects.toThrow('queue unavailable');
+            expect(model.markFailed).toHaveBeenCalledWith(
+                'run-1',
+                'Deep Research could not finish. Please try again.',
+            );
+        });
+
+        it('rejects invalid budget snapshots before persistence', async () => {
+            const { service, model } = buildService();
+
+            await expect(
+                service.createRun({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    prompt: 'Investigate revenue',
+                    budget: { ...budget, maxTokens: 0 },
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(model.create).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('access and cancellation', () => {
+        it('does not expose a run through a different project path', async () => {
+            const { service, model, projectModel } = buildService({
+                model: {
+                    findByUuidScoped: vi.fn().mockResolvedValue(undefined),
+                },
+            });
+
+            await expect(
+                service.getRun(
+                    userWithProjectAccess(),
+                    'another-project',
+                    'run-1',
+                ),
+            ).rejects.toBeInstanceOf(NotFoundError);
+            expect(model.findByUuidScoped).toHaveBeenCalledWith({
+                aiDeepResearchRunUuid: 'run-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'another-project',
+            });
+            expect(projectModel.getSummary).not.toHaveBeenCalled();
+        });
+
+        it('returns the model cancellation outcome for queued runs', async () => {
+            const { service, model } = buildService();
+
+            const run = await service.cancelRun(
+                userWithProjectAccess(),
+                'project-1',
+                'run-1',
+            );
+
+            expect(model.requestCancellation).toHaveBeenCalledWith('run-1');
+            expect(run.status).toBe('cancelled');
+            expect(run.cancellationRequestedAt).not.toBeNull();
+        });
+
+        it("does not expose another creator's run to a project viewer", async () => {
+            const { service, projectModel } = buildService({
+                model: {
+                    findByUuidScoped: vi
+                        .fn()
+                        .mockResolvedValue(
+                            runRow({ created_by_user_uuid: 'user-2' }),
+                        ),
+                },
+            });
+
+            await expect(
+                service.getRun(userWithProjectAccess(), 'project-1', 'run-1'),
+            ).rejects.toBeInstanceOf(NotFoundError);
+            expect(projectModel.getSummary).not.toHaveBeenCalled();
+        });
+
+        it("does not let a project viewer cancel another creator's run", async () => {
+            const { service, model } = buildService({
+                model: {
+                    findByUuidScoped: vi
+                        .fn()
+                        .mockResolvedValue(
+                            runRow({ created_by_user_uuid: 'user-2' }),
+                        ),
+                },
+            });
+
+            await expect(
+                service.cancelRun(
+                    userWithProjectAccess(),
+                    'project-1',
+                    'run-1',
+                ),
+            ).rejects.toBeInstanceOf(NotFoundError);
+            expect(model.requestCancellation).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('executeRun', () => {
+        it('skips duplicate delivery after another worker claims the run', async () => {
+            const executor = vi.fn();
+            const { service, model } = buildService({
+                model: { claimQueuedRun: vi.fn().mockResolvedValue(undefined) },
+                executor,
+            });
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            expect(executor).not.toHaveBeenCalled();
+            expect(model.markCompleted).not.toHaveBeenCalled();
+        });
+
+        it('persists an explicit completed executor result', async () => {
+            const { service, model } = buildService();
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            expect(model.markCompleted).toHaveBeenCalledWith('run-1', report);
+        });
+
+        it('lets a concurrent cancellation request win over completion', async () => {
+            const { service, model } = buildService({
+                model: {
+                    markCompleted: vi.fn().mockResolvedValue(false),
+                    findByUuid: vi.fn().mockResolvedValue(
+                        runRow({
+                            status: 'running',
+                            cancellation_requested_at: new Date(),
+                        }),
+                    ),
+                },
+            });
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            expect(model.markCancelled).toHaveBeenCalledWith('run-1');
+        });
+
+        it('persists executor failures and keeps the job failed', async () => {
+            const error = new Error('executor failed');
+            const { service, model } = buildService({
+                executor: vi.fn().mockRejectedValue(error),
+            });
+
+            await expect(
+                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
+            ).rejects.toThrow('executor failed');
+            expect(model.markFailed).toHaveBeenCalledWith(
+                'run-1',
+                'Deep Research could not finish. Please try again.',
+            );
+        });
+
+        it('passes an abort signal to the executor', async () => {
+            const abortController = new AbortController();
+            const { service, executor } = buildService();
+
+            await service.executeRun(
+                { aiDeepResearchRunUuid: 'run-1' },
+                abortController.signal,
+            );
+
+            expect(executor).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    ai_deep_research_run_uuid: 'run-1',
+                }),
+                { signal: abortController.signal },
+            );
+        });
+    });
+
+    describe('listEvents', () => {
+        it('uses an opaque keyset cursor and excludes the lookahead row', async () => {
+            const { service, model } = buildService({
+                model: {
+                    listEvents: vi.fn().mockResolvedValue([
+                        {
+                            ai_deep_research_event_uuid: 'event-1',
+                            ai_deep_research_run_uuid: 'run-1',
+                            event_type: 'status_changed',
+                            payload: { status: 'queued' },
+                            created_at: new Date('2026-07-13T12:00:00.000Z'),
+                        },
+                        {
+                            ai_deep_research_event_uuid: 'event-2',
+                            ai_deep_research_run_uuid: 'run-1',
+                            event_type: 'status_changed',
+                            payload: { status: 'running' },
+                            created_at: new Date('2026-07-13T12:01:00.000Z'),
+                        },
+                    ]),
+                },
+            });
+
+            const page = await service.listEvents({
+                user: userWithProjectAccess(),
+                projectUuid: 'project-1',
+                aiDeepResearchRunUuid: 'run-1',
+                limit: 1,
+            });
+
+            expect(page.events).toHaveLength(1);
+            expect(page.nextCursor).not.toBeNull();
+            expect(model.listEvents).toHaveBeenCalledWith({
+                aiDeepResearchRunUuid: 'run-1',
+                cursor: null,
+                limit: 1,
+            });
+        });
+
+        it('rejects malformed cursors', async () => {
+            const { service } = buildService();
+
+            await expect(
+                service.listEvents({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    aiDeepResearchRunUuid: 'run-1',
+                    cursor: 'not-a-cursor',
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+        });
+
+        it('rejects a cursor with a non-UUID event identifier', async () => {
+            const { service, model } = buildService();
+            const cursor = Buffer.from(
+                JSON.stringify({
+                    createdAt: '2026-07-13T12:00:00.000Z',
+                    eventUuid: 'not-a-uuid',
+                }),
+            ).toString('base64url');
+
+            await expect(
+                service.listEvents({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    aiDeepResearchRunUuid: 'run-1',
+                    cursor,
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(model.listEvents).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -1,0 +1,510 @@
+import { subject } from '@casl/ability';
+import {
+    FeatureFlags,
+    ForbiddenError,
+    getErrorMessage,
+    isAiDeepResearchRunTerminal,
+    isUserWithOrg,
+    NotFoundError,
+    ParameterError,
+    type AiDeepResearchBudget,
+    type AiDeepResearchEvent,
+    type AiDeepResearchEventPayloadMap,
+    type AiDeepResearchEventsPage,
+    type AiDeepResearchJobPayload,
+    type AiDeepResearchProgress,
+    type AiDeepResearchReport,
+    type AiDeepResearchRun,
+    type SessionUser,
+} from '@lightdash/common';
+import { validate as isValidUuid } from 'uuid';
+import { type FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { BaseService } from '../../../services/BaseService';
+import {
+    type DbAiDeepResearchEvent,
+    type DbAiDeepResearchRun,
+} from '../../database/entities/aiDeepResearch';
+import { type AiDeepResearchRunModel } from '../../models/AiDeepResearchRunModel';
+import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
+
+const MAX_EVENT_PAGE_SIZE = 100;
+const DEFAULT_EVENT_PAGE_SIZE = 50;
+const STALE_RUN_THRESHOLD_MINUTES = 75;
+const STALE_RUN_ERROR_MESSAGE =
+    'Deep Research stopped unexpectedly before it could finish.';
+const FAILED_RUN_ERROR_MESSAGE =
+    'Deep Research could not finish. Please try again.';
+const TIMED_OUT_RUN_ERROR_MESSAGE =
+    'Deep Research took too long to finish. Please try again.';
+
+export type AiDeepResearchExecutorResult =
+    | { status: 'completed'; report: AiDeepResearchReport }
+    | { status: 'partially_completed'; report: AiDeepResearchReport }
+    | { status: 'failed'; errorMessage: string }
+    | { status: 'cancelled' };
+
+export type AiDeepResearchExecutor = (
+    run: DbAiDeepResearchRun,
+    context: { signal: AbortSignal },
+) => Promise<AiDeepResearchExecutorResult>;
+
+type Dependencies = {
+    aiDeepResearchRunModel: AiDeepResearchRunModel;
+    projectModel: ProjectModel;
+    featureFlagModel: FeatureFlagModel;
+    schedulerClient: CommercialSchedulerClient;
+    executor?: AiDeepResearchExecutor;
+};
+
+type EventCursorPayload = {
+    createdAt: string;
+    eventUuid: string;
+};
+
+const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => ({
+    aiDeepResearchRunUuid: row.ai_deep_research_run_uuid,
+    projectUuid: row.project_uuid,
+    status: row.status,
+    result: row.result,
+    budget: row.budget_snapshot,
+    errorMessage: row.error_message,
+    cancellationRequestedAt:
+        row.cancellation_requested_at?.toISOString() ?? null,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+    startedAt: row.started_at?.toISOString() ?? null,
+    completedAt: row.completed_at?.toISOString() ?? null,
+});
+
+const toEvent = (row: DbAiDeepResearchEvent): AiDeepResearchEvent => {
+    const event = {
+        aiDeepResearchEventUuid: row.ai_deep_research_event_uuid,
+        aiDeepResearchRunUuid: row.ai_deep_research_run_uuid,
+        createdAt: row.created_at.toISOString(),
+    };
+
+    switch (row.event_type) {
+        case 'status_changed':
+            return {
+                ...event,
+                eventType: row.event_type,
+                payload:
+                    row.payload as AiDeepResearchEventPayloadMap['status_changed'],
+            };
+        case 'cancellation_requested':
+            return {
+                ...event,
+                eventType: row.event_type,
+                payload:
+                    row.payload as AiDeepResearchEventPayloadMap['cancellation_requested'],
+            };
+        case 'progress':
+            return {
+                ...event,
+                eventType: row.event_type,
+                payload:
+                    row.payload as AiDeepResearchEventPayloadMap['progress'],
+            };
+        default:
+            throw new Error('Unknown Deep Research event type');
+    }
+};
+
+const encodeEventCursor = (event: AiDeepResearchEvent): string =>
+    Buffer.from(
+        JSON.stringify({
+            createdAt: event.createdAt,
+            eventUuid: event.aiDeepResearchEventUuid,
+        } satisfies EventCursorPayload),
+    ).toString('base64url');
+
+const decodeEventCursor = (
+    cursor: string | undefined,
+): { createdAt: Date; eventUuid: string } | null => {
+    if (!cursor) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(
+            Buffer.from(cursor, 'base64url').toString('utf8'),
+        );
+        if (
+            typeof parsed !== 'object' ||
+            parsed === null ||
+            !('createdAt' in parsed) ||
+            !('eventUuid' in parsed) ||
+            typeof parsed.createdAt !== 'string' ||
+            typeof parsed.eventUuid !== 'string'
+        ) {
+            throw new Error('Invalid cursor payload');
+        }
+
+        const createdAt = new Date(parsed.createdAt);
+        if (
+            Number.isNaN(createdAt.getTime()) ||
+            !isValidUuid(parsed.eventUuid)
+        ) {
+            throw new Error('Invalid cursor values');
+        }
+        return { createdAt, eventUuid: parsed.eventUuid };
+    } catch {
+        throw new ParameterError('Invalid Deep Research event cursor');
+    }
+};
+
+const assertValidBudget = (budget: AiDeepResearchBudget): void => {
+    if (
+        Object.values(budget).some(
+            (value) => !Number.isInteger(value) || value <= 0,
+        )
+    ) {
+        throw new ParameterError(
+            'Deep Research budget limits must be positive integers',
+        );
+    }
+};
+
+export class AiDeepResearchService extends BaseService {
+    private readonly aiDeepResearchRunModel: AiDeepResearchRunModel;
+
+    private readonly projectModel: ProjectModel;
+
+    private readonly featureFlagModel: FeatureFlagModel;
+
+    private readonly schedulerClient: CommercialSchedulerClient;
+
+    private readonly executor: AiDeepResearchExecutor | undefined;
+
+    constructor({
+        aiDeepResearchRunModel,
+        projectModel,
+        featureFlagModel,
+        schedulerClient,
+        executor,
+    }: Dependencies) {
+        super();
+        this.aiDeepResearchRunModel = aiDeepResearchRunModel;
+        this.projectModel = projectModel;
+        this.featureFlagModel = featureFlagModel;
+        this.schedulerClient = schedulerClient;
+        this.executor = executor;
+    }
+
+    private async assertCanViewProject(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const ability = this.createAuditedAbility(user);
+        if (
+            ability.cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private async findCreatorOwnedRun(
+        user: SessionUser,
+        projectUuid: string,
+        aiDeepResearchRunUuid: string,
+    ): Promise<DbAiDeepResearchRun> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+
+        const run = await this.aiDeepResearchRunModel.findByUuidScoped({
+            aiDeepResearchRunUuid,
+            organizationUuid: user.organizationUuid,
+            projectUuid,
+        });
+        if (!run || run.created_by_user_uuid !== user.userUuid) {
+            throw new NotFoundError(
+                `Deep Research run ${aiDeepResearchRunUuid} not found`,
+            );
+        }
+
+        await this.assertCanViewProject(user, projectUuid);
+        return run;
+    }
+
+    async createRun(args: {
+        user: SessionUser;
+        projectUuid: string;
+        prompt: string;
+        budget: AiDeepResearchBudget;
+        aiThreadUuid?: string;
+        promptUuid?: string;
+        toolCallId?: string;
+    }): Promise<AiDeepResearchRun> {
+        if (!isUserWithOrg(args.user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        if (args.prompt.trim().length === 0) {
+            throw new ParameterError('Deep Research prompt is required');
+        }
+        assertValidBudget(args.budget);
+
+        await this.assertCanViewProject(args.user, args.projectUuid);
+        const featureFlag = await this.featureFlagModel.get({
+            user: args.user,
+            featureFlagId: FeatureFlags.AiDeepResearch,
+        });
+        if (!featureFlag.enabled) {
+            throw new ForbiddenError('Deep Research is not enabled');
+        }
+
+        const run = await this.aiDeepResearchRunModel.create({
+            organizationUuid: args.user.organizationUuid,
+            projectUuid: args.projectUuid,
+            createdByUserUuid: args.user.userUuid,
+            aiThreadUuid: args.aiThreadUuid ?? null,
+            promptUuid: args.promptUuid ?? null,
+            toolCallId: args.toolCallId ?? null,
+            prompt: args.prompt.trim(),
+            budget: args.budget,
+        });
+
+        try {
+            await this.schedulerClient.aiDeepResearch({
+                aiDeepResearchRunUuid: run.ai_deep_research_run_uuid,
+                organizationUuid: run.organization_uuid,
+                projectUuid: run.project_uuid,
+                userUuid: run.created_by_user_uuid,
+            });
+        } catch (error) {
+            this.logger.error(
+                `Failed to enqueue Deep Research run ${run.ai_deep_research_run_uuid}: ${getErrorMessage(error)}`,
+            );
+            await this.aiDeepResearchRunModel.markFailed(
+                run.ai_deep_research_run_uuid,
+                FAILED_RUN_ERROR_MESSAGE,
+            );
+            throw error;
+        }
+
+        return toRun(run);
+    }
+
+    async getRun(
+        user: SessionUser,
+        projectUuid: string,
+        aiDeepResearchRunUuid: string,
+    ): Promise<AiDeepResearchRun> {
+        return toRun(
+            await this.findCreatorOwnedRun(
+                user,
+                projectUuid,
+                aiDeepResearchRunUuid,
+            ),
+        );
+    }
+
+    async listEvents(args: {
+        user: SessionUser;
+        projectUuid: string;
+        aiDeepResearchRunUuid: string;
+        cursor?: string;
+        limit?: number;
+    }): Promise<AiDeepResearchEventsPage> {
+        await this.findCreatorOwnedRun(
+            args.user,
+            args.projectUuid,
+            args.aiDeepResearchRunUuid,
+        );
+
+        const limit = args.limit ?? DEFAULT_EVENT_PAGE_SIZE;
+        if (
+            !Number.isInteger(limit) ||
+            limit < 1 ||
+            limit > MAX_EVENT_PAGE_SIZE
+        ) {
+            throw new ParameterError(
+                `Deep Research event limit must be between 1 and ${MAX_EVENT_PAGE_SIZE}`,
+            );
+        }
+
+        const rows = await this.aiDeepResearchRunModel.listEvents({
+            aiDeepResearchRunUuid: args.aiDeepResearchRunUuid,
+            cursor: decodeEventCursor(args.cursor),
+            limit,
+        });
+        const events = rows.slice(0, limit).map(toEvent);
+        return {
+            events,
+            nextCursor:
+                rows.length > limit && events.length > 0
+                    ? encodeEventCursor(events[events.length - 1])
+                    : null,
+        };
+    }
+
+    async cancelRun(
+        user: SessionUser,
+        projectUuid: string,
+        aiDeepResearchRunUuid: string,
+    ): Promise<AiDeepResearchRun> {
+        await this.findCreatorOwnedRun(
+            user,
+            projectUuid,
+            aiDeepResearchRunUuid,
+        );
+        const run = await this.aiDeepResearchRunModel.requestCancellation(
+            aiDeepResearchRunUuid,
+        );
+        if (!run) {
+            throw new NotFoundError(
+                `Deep Research run ${aiDeepResearchRunUuid} not found`,
+            );
+        }
+        return toRun(run);
+    }
+
+    async executeRun(
+        payload: AiDeepResearchJobPayload,
+        signal: AbortSignal = new AbortController().signal,
+    ): Promise<void> {
+        const run = await this.aiDeepResearchRunModel.claimQueuedRun(
+            payload.aiDeepResearchRunUuid,
+        );
+        if (!run) {
+            this.logger.info(
+                `Deep Research run ${payload.aiDeepResearchRunUuid} was already claimed or is terminal`,
+            );
+            return;
+        }
+
+        if (!this.executor) {
+            await this.aiDeepResearchRunModel.markFailed(
+                payload.aiDeepResearchRunUuid,
+                'Deep Research executor is not configured',
+            );
+            throw new Error('Deep Research executor is not configured');
+        }
+
+        try {
+            const result = await this.executor(run, { signal });
+            if (result.status === 'completed') {
+                const completed =
+                    await this.aiDeepResearchRunModel.markCompleted(
+                        payload.aiDeepResearchRunUuid,
+                        result.report,
+                    );
+                if (!completed) {
+                    await this.markCancelledAfterCompletedExecution(
+                        payload.aiDeepResearchRunUuid,
+                    );
+                }
+                return;
+            }
+            if (result.status === 'partially_completed') {
+                const completed =
+                    await this.aiDeepResearchRunModel.markPartiallyCompleted(
+                        payload.aiDeepResearchRunUuid,
+                        result.report,
+                    );
+                if (!completed) {
+                    await this.markCancelledAfterCompletedExecution(
+                        payload.aiDeepResearchRunUuid,
+                    );
+                }
+                return;
+            }
+            if (result.status === 'failed') {
+                this.logger.error(
+                    `Deep Research run ${payload.aiDeepResearchRunUuid} failed: ${result.errorMessage}`,
+                );
+                await this.aiDeepResearchRunModel.markFailed(
+                    payload.aiDeepResearchRunUuid,
+                    FAILED_RUN_ERROR_MESSAGE,
+                );
+                return;
+            }
+
+            const cancelled = await this.aiDeepResearchRunModel.markCancelled(
+                payload.aiDeepResearchRunUuid,
+            );
+            if (!cancelled) {
+                await this.aiDeepResearchRunModel.markFailed(
+                    payload.aiDeepResearchRunUuid,
+                    'Deep Research stopped without a cancellation request',
+                );
+            }
+        } catch (error) {
+            this.logger.error(
+                `Deep Research run ${payload.aiDeepResearchRunUuid} threw: ${getErrorMessage(error)}`,
+            );
+            await this.aiDeepResearchRunModel.markFailed(
+                payload.aiDeepResearchRunUuid,
+                FAILED_RUN_ERROR_MESSAGE,
+            );
+            throw error;
+        }
+    }
+
+    private async markCancelledAfterCompletedExecution(
+        aiDeepResearchRunUuid: string,
+    ): Promise<void> {
+        const run = await this.aiDeepResearchRunModel.findByUuid(
+            aiDeepResearchRunUuid,
+        );
+        if (
+            run &&
+            !isAiDeepResearchRunTerminal(run.status) &&
+            run.cancellation_requested_at
+        ) {
+            await this.aiDeepResearchRunModel.markCancelled(
+                aiDeepResearchRunUuid,
+            );
+        }
+    }
+
+    async markRunTimedOut(aiDeepResearchRunUuid: string): Promise<boolean> {
+        return this.aiDeepResearchRunModel.markFailed(
+            aiDeepResearchRunUuid,
+            TIMED_OUT_RUN_ERROR_MESSAGE,
+        );
+    }
+
+    async setClaudeSessionId(
+        aiDeepResearchRunUuid: string,
+        claudeSessionId: string,
+    ): Promise<boolean> {
+        return this.aiDeepResearchRunModel.setClaudeSessionId(
+            aiDeepResearchRunUuid,
+            claudeSessionId,
+        );
+    }
+
+    async appendProgressEvent(
+        aiDeepResearchRunUuid: string,
+        progress: AiDeepResearchProgress,
+    ): Promise<boolean> {
+        return this.aiDeepResearchRunModel.appendProgressEvent(
+            aiDeepResearchRunUuid,
+            progress,
+        );
+    }
+
+    async touch(aiDeepResearchRunUuid: string): Promise<boolean> {
+        return this.aiDeepResearchRunModel.touch(aiDeepResearchRunUuid);
+    }
+
+    async sweepStaleRuns(): Promise<number> {
+        const runs = await this.aiDeepResearchRunModel.markStaleRunsAsFailed(
+            STALE_RUN_THRESHOLD_MINUTES,
+            STALE_RUN_ERROR_MESSAGE,
+        );
+        if (runs.length > 0) {
+            this.logger.warn(
+                `Swept ${runs.length} stale Deep Research run(s) after ${STALE_RUN_THRESHOLD_MINUTES} minutes`,
+            );
+        }
+        return runs.length;
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -139,6 +139,8 @@ import { AiAgentScopedDocumentController } from './../ee/controllers/aiAgentScop
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiController } from './../ee/controllers/aiController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AiDeepResearchController } from './../ee/controllers/AiDeepResearchController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiRouterController } from './../ee/controllers/aiRouterController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiWritebackController } from './../ee/controllers/AiWritebackController';
@@ -15285,17 +15287,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15385,18 +15387,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15409,10 +15399,22 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                             },
@@ -15559,21 +15561,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -15592,6 +15579,21 @@ const models: TsoaRoute.Models = {
                                                                                                 enums: [
                                                                                                     'success',
                                                                                                 ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
                                                                                             },
                                                                                             {
                                                                                                 dataType:
@@ -15683,17 +15685,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15909,29 +15911,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15952,7 +15931,30 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -15963,12 +15965,12 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                name: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                table: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -16039,18 +16041,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16063,10 +16053,22 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                         },
@@ -16270,13 +16272,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 uuid: {
@@ -16754,13 +16756,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -16833,15 +16835,15 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['timeout'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['rejected'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16956,17 +16958,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -16985,14 +16987,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
@@ -23246,6 +23248,404 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchRunStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['queued'] },
+                { dataType: 'enum', enums: ['running'] },
+                { dataType: 'enum', enums: ['failed'] },
+                { dataType: 'enum', enums: ['completed'] },
+                { dataType: 'enum', enums: ['partially_completed'] },
+                { dataType: 'enum', enums: ['cancelled'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchConfidence: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['low'] },
+                { dataType: 'enum', enums: ['medium'] },
+                { dataType: 'enum', enums: ['high'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchEvidence: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                sourceUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                sourceLabel: { dataType: 'string', required: true },
+                sourceType: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['lightdash'] },
+                        { dataType: 'enum', enums: ['warehouse'] },
+                        { dataType: 'enum', enums: ['web'] },
+                    ],
+                    required: true,
+                },
+                description: { dataType: 'string', required: true },
+                title: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchFinding: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                evidence: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiDeepResearchEvidence',
+                    },
+                    required: true,
+                },
+                confidence: { ref: 'AiDeepResearchConfidence', required: true },
+                summary: { dataType: 'string', required: true },
+                title: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchReport: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                nextSteps: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                unresolvedQuestions: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                scope: { dataType: 'string', required: true },
+                caveats: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                findings: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiDeepResearchFinding',
+                    },
+                    required: true,
+                },
+                summary: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchBudget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                maxResultRows: { dataType: 'double', required: true },
+                maxWarehouseQueries: { dataType: 'double', required: true },
+                maxToolCalls: { dataType: 'double', required: true },
+                maxTokens: { dataType: 'double', required: true },
+                maxRuntimeMs: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchRun: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                completedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                startedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                updatedAt: { dataType: 'string', required: true },
+                createdAt: { dataType: 'string', required: true },
+                cancellationRequestedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                errorMessage: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                budget: { ref: 'AiDeepResearchBudget', required: true },
+                result: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiDeepResearchReport' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { ref: 'AiDeepResearchRunStatus', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                aiDeepResearchRunUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiDeepResearchRun_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiDeepResearchRun', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiDeepResearchRunResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiDeepResearchRun_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchPhase: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['planning'] },
+                { dataType: 'enum', enums: ['investigating'] },
+                { dataType: 'enum', enums: ['validating'] },
+                { dataType: 'enum', enums: ['synthesizing'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchActivity: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['lightdash_metadata'] },
+                { dataType: 'enum', enums: ['warehouse_query'] },
+                { dataType: 'enum', enums: ['web_search'] },
+                { dataType: 'enum', enums: ['web_fetch'] },
+                { dataType: 'enum', enums: ['reporting'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchProgress: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                total: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                current: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                activity: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiDeepResearchActivity' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                phase: { ref: 'AiDeepResearchPhase', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchEvent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        createdAt: { dataType: 'string', required: true },
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                status: {
+                                    ref: 'AiDeepResearchRunStatus',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['status_changed'],
+                            required: true,
+                        },
+                        aiDeepResearchRunUuid: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                        aiDeepResearchEventUuid: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        createdAt: { dataType: 'string', required: true },
+                        payload: {
+                            ref: 'Record_string.never_',
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['cancellation_requested'],
+                            required: true,
+                        },
+                        aiDeepResearchRunUuid: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                        aiDeepResearchEventUuid: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        createdAt: { dataType: 'string', required: true },
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                progress: {
+                                    ref: 'AiDeepResearchProgress',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['progress'],
+                            required: true,
+                        },
+                        aiDeepResearchRunUuid: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                        aiDeepResearchEventUuid: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchEventsPage: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                nextCursor: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                events: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiDeepResearchEvent' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiDeepResearchEventsPage_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiDeepResearchEventsPage', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiDeepResearchEventsResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiDeepResearchEventsPage_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_AiAgentThreadSummary_AiAgentUser-and-_slackUserId-string-or-null--email-string-or-null__.user-or-createdAt-or-createdFrom-or-title-or-uuid_':
@@ -30436,9 +30836,11 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['appGeneratePipeline'] },
                 { dataType: 'enum', enums: ['appBuildFromSource'] },
                 { dataType: 'enum', enums: ['aiWritebackPipeline'] },
+                { dataType: 'enum', enums: ['aiDeepResearch'] },
                 { dataType: 'enum', enums: ['aiAgentEditDbtProjectPipeline'] },
                 { dataType: 'enum', enums: ['sweepStaleAppLocks'] },
                 { dataType: 'enum', enums: ['sweepStaleAiWritebackRuns'] },
+                { dataType: 'enum', enums: ['sweepStaleAiDeepResearchRuns'] },
                 { dataType: 'enum', enums: ['cleanMcpToolCalls'] },
                 { dataType: 'enum', enums: ['handleScheduledDelivery'] },
                 { dataType: 'enum', enums: ['sendSlackNotification'] },
@@ -33790,7 +34192,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33800,7 +34202,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -33810,7 +34212,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -33823,7 +34225,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -34492,7 +34894,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34502,7 +34904,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34512,7 +34914,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34525,7 +34927,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -60030,6 +60432,209 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listProjectRepositories',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiDeepResearchController_getRun: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        aiDeepResearchRunUuid: {
+            in: 'path',
+            name: 'aiDeepResearchRunUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/ai-deep-research/:aiDeepResearchRunUuid',
+        ...fetchMiddlewares<RequestHandler>(AiDeepResearchController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiDeepResearchController.prototype.getRun,
+        ),
+
+        async function AiDeepResearchController_getRun(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiDeepResearchController_getRun,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiDeepResearchController>(
+                        AiDeepResearchController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getRun',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiDeepResearchController_listEvents: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        aiDeepResearchRunUuid: {
+            in: 'path',
+            name: 'aiDeepResearchRunUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        cursor: { in: 'query', name: 'cursor', dataType: 'string' },
+        limit: { in: 'query', name: 'limit', dataType: 'double' },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/ai-deep-research/:aiDeepResearchRunUuid/events',
+        ...fetchMiddlewares<RequestHandler>(AiDeepResearchController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiDeepResearchController.prototype.listEvents,
+        ),
+
+        async function AiDeepResearchController_listEvents(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiDeepResearchController_listEvents,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiDeepResearchController>(
+                        AiDeepResearchController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listEvents',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiDeepResearchController_cancelRun: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        aiDeepResearchRunUuid: {
+            in: 'path',
+            name: 'aiDeepResearchRunUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/ai-deep-research/:aiDeepResearchRunUuid/cancel',
+        ...fetchMiddlewares<RequestHandler>(AiDeepResearchController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiDeepResearchController.prototype.cancelRun,
+        ),
+
+        async function AiDeepResearchController_cancelRun(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiDeepResearchController_cancelRun,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiDeepResearchController>(
+                        AiDeepResearchController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'cancelRun',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16797,10 +16797,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -16809,8 +16809,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -16833,28 +16833,28 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
-                                                                                    },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "operator": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "required",
-                                                                                    "tableName",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "operator"
+                                                                                    "tableName",
+                                                                                    "operator",
+                                                                                    "required"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -16936,15 +16936,15 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "status": {
                                                                             "type": "string",
                                                                             "enum": [
                                                                                 "error",
                                                                                 "success"
                                                                             ]
+                                                                        },
+                                                                        "error": {
+                                                                            "type": "string"
                                                                         },
                                                                         "results": {
                                                                             "items": {
@@ -16967,10 +16967,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -16979,8 +16979,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -17102,27 +17102,27 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "label": {
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "metric",
+                                                                                        "dimension"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "table": {
+                                                                                "name": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
@@ -17131,12 +17131,12 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "fieldType",
                                                                                 "description",
-                                                                                "label",
+                                                                                "fieldType",
+                                                                                "table",
                                                                                 "fieldId",
-                                                                                "name",
-                                                                                "table"
+                                                                                "label",
+                                                                                "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -17156,28 +17156,28 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
-                                                                                        },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
                                                                                         },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "operator": {
                                                                                             "type": "string"
+                                                                                        },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
-                                                                                        "required",
-                                                                                        "tableName",
                                                                                         "fieldRef",
                                                                                         "fieldId",
-                                                                                        "operator"
+                                                                                        "tableName",
+                                                                                        "operator",
+                                                                                        "required"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -17326,13 +17326,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     },
                                                     "uuid": {
                                                         "type": "string"
@@ -17345,8 +17345,8 @@
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "uuid",
                                                     "name"
                                                 ],
@@ -17508,13 +17508,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -17522,8 +17522,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -17551,9 +17551,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
+                                                            "rejected",
                                                             "success",
-                                                            "timeout",
-                                                            "rejected"
+                                                            "timeout"
                                                         ]
                                                     }
                                                 },
@@ -17584,10 +17584,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17596,8 +17596,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -17607,8 +17607,8 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "dimension",
                                                                     "metric",
+                                                                    "dimension",
                                                                     null
                                                                 ],
                                                                 "nullable": true
@@ -23570,6 +23570,405 @@
                 "required": ["results", "status"],
                 "type": "object",
                 "description": "The repositories the agent can read for a project, used by the chat input's\n`@`-mention repository picker. This is the same union the agent's repo VFS\nmounts (the org installation's repos plus the linked user's own), gated by the\nproject's `view:SourceCode` ability — unlike the org-wide `/github/repos/list`\nendpoint, it never exposes repo names to users without source-code access."
+            },
+            "AiDeepResearchRunStatus": {
+                "type": "string",
+                "enum": [
+                    "queued",
+                    "running",
+                    "failed",
+                    "completed",
+                    "partially_completed",
+                    "cancelled"
+                ]
+            },
+            "AiDeepResearchConfidence": {
+                "type": "string",
+                "enum": ["low", "medium", "high"]
+            },
+            "AiDeepResearchEvidence": {
+                "properties": {
+                    "sourceUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "sourceLabel": {
+                        "type": "string"
+                    },
+                    "sourceType": {
+                        "type": "string",
+                        "enum": ["lightdash", "warehouse", "web"]
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "sourceUrl",
+                    "sourceLabel",
+                    "sourceType",
+                    "description",
+                    "title"
+                ],
+                "type": "object"
+            },
+            "AiDeepResearchFinding": {
+                "properties": {
+                    "evidence": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiDeepResearchEvidence"
+                        },
+                        "type": "array"
+                    },
+                    "confidence": {
+                        "$ref": "#/components/schemas/AiDeepResearchConfidence"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "required": ["evidence", "confidence", "summary", "title"],
+                "type": "object"
+            },
+            "AiDeepResearchReport": {
+                "properties": {
+                    "nextSteps": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "unresolvedQuestions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "scope": {
+                        "type": "string"
+                    },
+                    "caveats": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "findings": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiDeepResearchFinding"
+                        },
+                        "type": "array"
+                    },
+                    "summary": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "nextSteps",
+                    "unresolvedQuestions",
+                    "scope",
+                    "caveats",
+                    "findings",
+                    "summary"
+                ],
+                "type": "object"
+            },
+            "AiDeepResearchBudget": {
+                "properties": {
+                    "maxResultRows": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "maxWarehouseQueries": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "maxToolCalls": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "maxTokens": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "maxRuntimeMs": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": [
+                    "maxResultRows",
+                    "maxWarehouseQueries",
+                    "maxToolCalls",
+                    "maxTokens",
+                    "maxRuntimeMs"
+                ],
+                "type": "object"
+            },
+            "AiDeepResearchRun": {
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "cancellationRequestedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "errorMessage": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "budget": {
+                        "$ref": "#/components/schemas/AiDeepResearchBudget"
+                    },
+                    "result": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiDeepResearchReport"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/AiDeepResearchRunStatus"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "aiDeepResearchRunUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "completedAt",
+                    "startedAt",
+                    "updatedAt",
+                    "createdAt",
+                    "cancellationRequestedAt",
+                    "errorMessage",
+                    "budget",
+                    "result",
+                    "status",
+                    "projectUuid",
+                    "aiDeepResearchRunUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiDeepResearchRun_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiDeepResearchRun"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiDeepResearchRunResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiDeepResearchRun_"
+            },
+            "AiDeepResearchPhase": {
+                "type": "string",
+                "enum": [
+                    "planning",
+                    "investigating",
+                    "validating",
+                    "synthesizing"
+                ]
+            },
+            "AiDeepResearchActivity": {
+                "type": "string",
+                "enum": [
+                    "lightdash_metadata",
+                    "warehouse_query",
+                    "web_search",
+                    "web_fetch",
+                    "reporting"
+                ]
+            },
+            "AiDeepResearchProgress": {
+                "properties": {
+                    "total": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "current": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "activity": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiDeepResearchActivity"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "phase": {
+                        "$ref": "#/components/schemas/AiDeepResearchPhase"
+                    }
+                },
+                "required": ["total", "current", "activity", "phase"],
+                "type": "object"
+            },
+            "AiDeepResearchEvent": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "createdAt": {
+                                "type": "string"
+                            },
+                            "payload": {
+                                "properties": {
+                                    "status": {
+                                        "$ref": "#/components/schemas/AiDeepResearchRunStatus"
+                                    }
+                                },
+                                "required": ["status"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["status_changed"],
+                                "nullable": false
+                            },
+                            "aiDeepResearchRunUuid": {
+                                "type": "string"
+                            },
+                            "aiDeepResearchEventUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "createdAt",
+                            "payload",
+                            "eventType",
+                            "aiDeepResearchRunUuid",
+                            "aiDeepResearchEventUuid"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "createdAt": {
+                                "type": "string"
+                            },
+                            "payload": {
+                                "$ref": "#/components/schemas/Record_string.never_"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["cancellation_requested"],
+                                "nullable": false
+                            },
+                            "aiDeepResearchRunUuid": {
+                                "type": "string"
+                            },
+                            "aiDeepResearchEventUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "createdAt",
+                            "payload",
+                            "eventType",
+                            "aiDeepResearchRunUuid",
+                            "aiDeepResearchEventUuid"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "createdAt": {
+                                "type": "string"
+                            },
+                            "payload": {
+                                "properties": {
+                                    "progress": {
+                                        "$ref": "#/components/schemas/AiDeepResearchProgress"
+                                    }
+                                },
+                                "required": ["progress"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["progress"],
+                                "nullable": false
+                            },
+                            "aiDeepResearchRunUuid": {
+                                "type": "string"
+                            },
+                            "aiDeepResearchEventUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "createdAt",
+                            "payload",
+                            "eventType",
+                            "aiDeepResearchRunUuid",
+                            "aiDeepResearchEventUuid"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiDeepResearchEventsPage": {
+                "properties": {
+                    "nextCursor": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "events": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiDeepResearchEvent"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["nextCursor", "events"],
+                "type": "object"
+            },
+            "ApiSuccess_AiDeepResearchEventsPage_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiDeepResearchEventsPage"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiDeepResearchEventsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiDeepResearchEventsPage_"
             },
             "Pick_AiAgentThreadSummary_AiAgentUser-and-_slackUserId-string-or-null--email-string-or-null__.user-or-createdAt-or-createdFrom-or-title-or-uuid_": {
                 "properties": {
@@ -30660,9 +31059,11 @@
                     "appGeneratePipeline",
                     "appBuildFromSource",
                     "aiWritebackPipeline",
+                    "aiDeepResearch",
                     "aiAgentEditDbtProjectPipeline",
                     "sweepStaleAppLocks",
                     "sweepStaleAiWritebackRuns",
+                    "sweepStaleAiDeepResearchRuns",
                     "cleanMcpToolCalls",
                     "handleScheduledDelivery",
                     "sendSlackNotification",
@@ -34239,22 +34640,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -34822,22 +35223,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -45102,7 +45503,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3367.0",
+        "version": "0.3368.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -148,6 +148,7 @@ export type ModelManifest = {
     aiAgentDocumentModel: unknown;
     aiWritebackThreadModel: unknown;
     aiWritebackRunModel: unknown;
+    aiDeepResearchRunModel: unknown;
     sandboxRegistryModel: unknown;
     projectCiStatusModel: unknown;
     aiAgentReviewClassifierModel: unknown;
@@ -800,6 +801,10 @@ export class ModelRepository
 
     public getAiWritebackRunModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiWritebackRunModel');
+    }
+
+    public getAiDeepResearchRunModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiDeepResearchRunModel');
     }
 
     public getSandboxRegistryModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -256,8 +256,14 @@ const getTagsForTask: {
     }),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
     [SCHEDULER_TASKS.SWEEP_STALE_AI_WRITEBACK_RUNS]: () => ({}),
+    [SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: () => ({}),
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
+    [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,
         'project.uuid': payload.projectUuid,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -148,6 +148,7 @@ interface ServiceManifest {
     permissionsService: PermissionsService;
     /** An implementation signature for these services are not available at this stage */
     aiWritebackService: unknown;
+    aiDeepResearchService: unknown;
     aiAgentReviewNotificationService: unknown;
     writebackPreviewService: unknown;
     previewDeploySetupService: unknown;
@@ -1341,6 +1342,12 @@ export class ServiceRepository
         AiWritebackServiceImplT,
     >(): AiWritebackServiceImplT {
         return this.getService('aiWritebackService');
+    }
+
+    public getAiDeepResearchService<
+        AiDeepResearchServiceImplT,
+    >(): AiDeepResearchServiceImplT {
+        return this.getService('aiDeepResearchService');
     }
 
     public getPreviewDeploySetupService<

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -1,0 +1,163 @@
+import { type ApiSuccess } from '../../types/api/success';
+
+export const AI_DEEP_RESEARCH_RUN_STATUSES = [
+    'queued',
+    'running',
+    'completed',
+    'partially_completed',
+    'failed',
+    'cancelled',
+] as const;
+
+export type AiDeepResearchRunStatus =
+    (typeof AI_DEEP_RESEARCH_RUN_STATUSES)[number];
+
+export const AI_DEEP_RESEARCH_TERMINAL_STATUSES = [
+    'completed',
+    'partially_completed',
+    'failed',
+    'cancelled',
+] as const satisfies readonly AiDeepResearchRunStatus[];
+
+export type AiDeepResearchTerminalStatus =
+    (typeof AI_DEEP_RESEARCH_TERMINAL_STATUSES)[number];
+
+export const isAiDeepResearchRunTerminal = (
+    status: AiDeepResearchRunStatus,
+): status is AiDeepResearchTerminalStatus =>
+    AI_DEEP_RESEARCH_TERMINAL_STATUSES.includes(
+        status as AiDeepResearchTerminalStatus,
+    );
+
+export type AiDeepResearchBudget = {
+    maxRuntimeMs: number;
+    maxTokens: number;
+    maxToolCalls: number;
+    maxWarehouseQueries: number;
+    maxResultRows: number;
+};
+
+export type AiDeepResearchConfidence = 'low' | 'medium' | 'high';
+
+export type AiDeepResearchEvidence = {
+    title: string;
+    description: string;
+    sourceType: 'lightdash' | 'warehouse' | 'web';
+    sourceLabel: string;
+    sourceUrl: string | null;
+};
+
+export type AiDeepResearchFinding = {
+    title: string;
+    summary: string;
+    confidence: AiDeepResearchConfidence;
+    evidence: AiDeepResearchEvidence[];
+};
+
+export type AiDeepResearchReport = {
+    summary: string;
+    findings: AiDeepResearchFinding[];
+    caveats: string[];
+    scope: string;
+    unresolvedQuestions: string[];
+    nextSteps: string[];
+};
+
+export const AI_DEEP_RESEARCH_EVENT_TYPES = [
+    'status_changed',
+    'cancellation_requested',
+    'progress',
+] as const;
+
+export type AiDeepResearchEventType =
+    (typeof AI_DEEP_RESEARCH_EVENT_TYPES)[number];
+
+export const AI_DEEP_RESEARCH_PHASES = [
+    'planning',
+    'investigating',
+    'validating',
+    'synthesizing',
+] as const;
+
+export type AiDeepResearchPhase = (typeof AI_DEEP_RESEARCH_PHASES)[number];
+
+export const AI_DEEP_RESEARCH_ACTIVITIES = [
+    'lightdash_metadata',
+    'warehouse_query',
+    'web_search',
+    'web_fetch',
+    'reporting',
+] as const;
+
+export type AiDeepResearchActivity =
+    (typeof AI_DEEP_RESEARCH_ACTIVITIES)[number];
+
+export type AiDeepResearchProgress = {
+    phase: AiDeepResearchPhase;
+    activity: AiDeepResearchActivity | null;
+    current: number | null;
+    total: number | null;
+};
+
+export type AiDeepResearchEventPayloadMap = {
+    status_changed: { status: AiDeepResearchRunStatus };
+    cancellation_requested: Record<string, never>;
+    progress: { progress: AiDeepResearchProgress };
+};
+
+export type AiDeepResearchEventPayload =
+    | { status: AiDeepResearchRunStatus }
+    | Record<string, never>
+    | { progress: AiDeepResearchProgress };
+
+// TSOA cannot resolve the equivalent mapped/indexed discriminated union.
+export type AiDeepResearchEvent =
+    | {
+          aiDeepResearchEventUuid: string;
+          aiDeepResearchRunUuid: string;
+          eventType: 'status_changed';
+          payload: { status: AiDeepResearchRunStatus };
+          createdAt: string;
+      }
+    | {
+          aiDeepResearchEventUuid: string;
+          aiDeepResearchRunUuid: string;
+          eventType: 'cancellation_requested';
+          payload: Record<string, never>;
+          createdAt: string;
+      }
+    | {
+          aiDeepResearchEventUuid: string;
+          aiDeepResearchRunUuid: string;
+          eventType: 'progress';
+          payload: { progress: AiDeepResearchProgress };
+          createdAt: string;
+      };
+
+export type AiDeepResearchRun = {
+    aiDeepResearchRunUuid: string;
+    projectUuid: string;
+    status: AiDeepResearchRunStatus;
+    result: AiDeepResearchReport | null;
+    budget: AiDeepResearchBudget;
+    errorMessage: string | null;
+    cancellationRequestedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+    startedAt: string | null;
+    completedAt: string | null;
+};
+
+export type AiDeepResearchEventsPage = {
+    events: AiDeepResearchEvent[];
+    nextCursor: string | null;
+};
+
+export type ApiAiDeepResearchRunResponse = ApiSuccess<AiDeepResearchRun>;
+
+export type ApiAiDeepResearchEventsResponse =
+    ApiSuccess<AiDeepResearchEventsPage>;
+
+export type AiDeepResearchJobPayload = {
+    aiDeepResearchRunUuid: string;
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -1,4 +1,5 @@
 export * from './AiAgent';
+export * from './aiDeepResearch/types';
 export * from './aiWriteback/types';
 export * from './externalConnections/types';
 export * from './AiRouter';

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -120,6 +120,11 @@ export enum FeatureFlags {
     AiAutopilot = 'ai-autopilot',
 
     /**
+     * Enable long-running, read-only Deep Research investigations from AI chat.
+     */
+    AiDeepResearch = 'ai-deep-research',
+
+    /**
      * @deprecated Rolled out to all customers. Keep for persisted feature flag config only.
      */
     AiAgentRevamp = 'ai-agent-revamp',

--- a/packages/common/src/types/schedulerTaskList.test.ts
+++ b/packages/common/src/types/schedulerTaskList.test.ts
@@ -5,3 +5,10 @@ test('SEND_REVIEW_NOTIFICATION task is registered', () => {
         'sendReviewNotification',
     );
 });
+
+test('AI_DEEP_RESEARCH tasks are registered', () => {
+    expect(EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH).toBe('aiDeepResearch');
+    expect(EE_SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS).toBe(
+        'sweepStaleAiDeepResearchRuns',
+    );
+});

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -6,6 +6,7 @@ import {
     type AiAgentReviewRemediationPreviewJobPayload,
     type AiAgentReviewRemediationRunJobPayload,
     type AiAgentReviewWritebackJobPayload,
+    type AiDeepResearchJobPayload,
     type AiWritebackSource,
     type ChartReference,
     type DataAppClaudeModel,
@@ -80,6 +81,9 @@ export type AiWritebackPipelineJobPayload = TraceTaskBase & {
     source: AiWritebackSource;
 };
 
+export type AiDeepResearchPipelineJobPayload = TraceTaskBase &
+    AiDeepResearchJobPayload;
+
 export type AiAgentEditDbtProjectPipelineJobPayload = TraceTaskBase & {
     aiWritebackRunUuid: string;
     // Serializes back-to-back edits in the same thread: the pipeline job runs on
@@ -110,9 +114,11 @@ export const EE_SCHEDULER_TASKS = {
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
     APP_BUILD_FROM_SOURCE: 'appBuildFromSource',
     AI_WRITEBACK_PIPELINE: 'aiWritebackPipeline',
+    AI_DEEP_RESEARCH: 'aiDeepResearch',
     AI_AGENT_EDIT_DBT_PROJECT_PIPELINE: 'aiAgentEditDbtProjectPipeline',
     SWEEP_STALE_APP_LOCKS: 'sweepStaleAppLocks',
     SWEEP_STALE_AI_WRITEBACK_RUNS: 'sweepStaleAiWritebackRuns',
+    SWEEP_STALE_AI_DEEP_RESEARCH_RUNS: 'sweepStaleAiDeepResearchRuns',
     CLEAN_MCP_TOOL_CALLS: 'cleanMcpToolCalls',
 } as const;
 
@@ -213,8 +219,10 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.APP_BUILD_FROM_SOURCE]: AppBuildFromSourceJobPayload;
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
     [SCHEDULER_TASKS.SWEEP_STALE_AI_WRITEBACK_RUNS]: TraceTaskBase;
+    [SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS]: TraceTaskBase;
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
+    [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: AiAgentEditDbtProjectPipelineJobPayload;
 }
 
@@ -233,8 +241,10 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.APP_BUILD_FROM_SOURCE]: AppBuildFromSourceJobPayload;
     [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.SWEEP_STALE_AI_WRITEBACK_RUNS]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
+    [EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: AiAgentEditDbtProjectPipelineJobPayload;
 }
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8825/add-the-aideepresearch-run-lifecycle

## Summary

Adds the durable, read-only lifecycle foundation for Deep Research runs. The feature persists long-running work before enqueueing it, records structural progress, and exposes creator-only status, event, and cancellation endpoints without calling Claude or changing Autopilot.

## How it works

### Backend

- Adds the `ai-deep-research` feature flag, which defaults off and gates new run creation.
- Persists runs and ordered lifecycle events in dedicated `ai_deep_research_runs` and `ai_deep_research_events` tables.
- Enqueues a single-attempt Graphile job keyed by run UUID, atomically claims queued work, and recovers enqueue, execution, timeout, and stale-worker failures.
- Keeps the executor injectable and passes an `AbortSignal`, so the dedicated Claude client can land separately.
- Scopes run lookup by organization and project, then restricts reads and cancellation to the run creator.
- Returns structural progress only; prompts, user identifiers, organization identifiers, Claude session IDs, and tool payloads remain private.

```text
createRun
   │
   ├─ persist queued run + event
   └─ enqueue ai-deep-research:<run UUID>
                         │
                  atomic claim
                         │
                  executor seam
                         │
          ┌──────────────┼──────────────┐
       complete        cancel          fail
          └──────── transactional run + event log
                                │
                       poll status/events
```

## Regression analysis

| Group | Effect |
|---|---|
| Users without the flag | No behavior change. |
| Users with the flag | Lifecycle creation is available to future internal callers; no UI invokes it in this PR. |
| Other project members | Cannot read or cancel another creator's run, even with its UUID. |
| Existing AI chat, Autopilot, and Managed Agents | Unchanged. |

## Migration

```bash
pnpm -F backend migrate
```

Adds the run and event tables with status/event checks, project and organization foreign keys, cancellation and terminal timestamps, budget snapshots, and compound polling/stale-run indexes.

## Test plan

- [x] Backend unit suite: 277 files, 4,038 passed, 1 skipped.
- [x] Common unit suite: 104 files, 2,778 passed, 1 skipped.
- [x] PostgreSQL contention suite: duplicate claim, claim/cancel, completion/cancel, and stale recovery all pass with exact event sequences.
- [x] Backend and common fast typechecks, full lint, and format checks pass.
- [x] Both migrations apply, roll back to zero, and reapply with the expected checks, indexes, and foreign keys.
- [x] London live API: creator read, event pagination, malformed cursor, wrong project, unauthenticated access, queued/running cancellation, and duplicate cancellation behave as expected.

## Example payloads

Run status:

```json
{
  "aiDeepResearchRunUuid": "run-uuid",
  "projectUuid": "project-uuid",
  "status": "running",
  "result": null,
  "budget": {
    "maxRuntimeMs": 3600000,
    "maxTokens": 100000,
    "maxToolCalls": 100,
    "maxWarehouseQueries": 25,
    "maxResultRows": 10000
  },
  "errorMessage": null,
  "cancellationRequestedAt": null
}
```

Structural progress event:

```json
{
  "eventType": "progress",
  "payload": {
    "progress": {
      "phase": "investigating",
      "activity": "warehouse_query",
      "current": 3,
      "total": 8
    }
  }
}
```

## Follow-ups (separate PRs)

- [PROD-8830](https://linear.app/lightdash/issue/PROD-8830/add-a-dedicated-aideepresearch-managed-agent-client) adds the dedicated Claude managed-agent client and connects cancellation to session interruption.

🤖 Generated with [Codex](https://openai.com/codex/)
