### PR TITLE
fix: guard data-app theme size to prevent apply timeouts

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -14,6 +14,7 @@ import { subject } from '@casl/ability';
 import {
     assertEmbeddedAuth,
     assertUnreachable,
+    checkThemeLimits,
     DATA_APP_CLAUDE_MODELS,
     DATA_APP_VIZ_TEMPLATE,
     dataAppVizJsonSchema,
@@ -31,10 +32,12 @@ import {
     ParameterError,
     QueryExecutionContext,
     sanitizeAppPackageJsonScripts,
+    themeLimitMessage,
     TooManyRequestsError,
     validateDataAppCode,
     validateDataAppDependencies,
     type AnonymousAccount,
+    type ApiOrganizationDesign,
     type AppBuildFromSourceJobPayload,
     type AppChartReference,
     type AppClarification,
@@ -2050,6 +2053,22 @@ export class AppGenerateService extends BaseService {
         ];
     }
 
+    /**
+     * Reject a theme that exceeds the asset-count/total-size guardrails before
+     * it reaches the (expensive, timeout-prone) build pipeline. Themes are
+     * normally capped at upload time, but a theme can predate the guardrails or
+     * be an org default the caller didn't choose — so we re-check here and turn
+     * it into a synchronous, actionable error instead of a silent build timeout.
+     */
+    private static assertThemeWithinLimits(
+        design: ApiOrganizationDesign,
+    ): void {
+        const violation = checkThemeLimits(design.files);
+        if (violation) {
+            throw new ParameterError(themeLimitMessage(violation, design.name));
+        }
+    }
+
     private static buildThemeChangePrompt(themeName: string | null): string {
         const target = themeName
             ? `the active organization theme "${themeName}"`
@@ -3156,6 +3175,32 @@ export class AppGenerateService extends BaseService {
         // always lands clean. When `payload.designUuid` is absent/null
         // the helper short-circuits and `effective-skill.md` is
         // byte-identical to the baseline `/app/skill.md`.
+        // Backstop for the upload-time and enqueue-time guardrails: a theme can
+        // grow between enqueue and worker pickup (or a job may predate the
+        // guardrails). Fail fast with the specific limit message instead of
+        // copying everything into the sandbox and running the build to timeout.
+        if (payload.designUuid) {
+            const design =
+                await this.organizationDesignModel.findInOrganization(
+                    payload.organizationUuid,
+                    payload.designUuid,
+                );
+            const violation = design ? checkThemeLimits(design.files) : null;
+            if (design && violation) {
+                const message = themeLimitMessage(violation, design.name);
+                this.logger.warn(
+                    `App ${appUuid}: theme ${payload.designUuid} exceeds the size cap at build time (${violation.bytes} > ${violation.limit} bytes); failing fast — ${message}`,
+                );
+                await this.markError(
+                    appUuid,
+                    version,
+                    new Error(message),
+                    message,
+                );
+                return;
+            }
+        }
+
         const designCopy = await copyDesignIntoSandbox({
             sandbox,
             s3Client,
@@ -4313,6 +4358,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             const orgDefault =
                 await this.organizationDesignModel.getDefault(organizationUuid);
             if (orgDefault) {
+                AppGenerateService.assertThemeWithinLimits(orgDefault);
                 resolvedDesignUuid = orgDefault.designUuid;
                 designSnapshot = {
                     designUuid: orgDefault.designUuid,
@@ -4329,6 +4375,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             if (!picked) {
                 throw new ParameterError(`Theme not found: ${designUuidInput}`);
             }
+            AppGenerateService.assertThemeWithinLimits(picked);
             resolvedDesignUuid = picked.designUuid;
             designSnapshot = {
                 designUuid: picked.designUuid,
@@ -4493,6 +4540,10 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                     effectiveDesignUuid,
                 );
             if (design) {
+                // Inherited themes are copied into the sandbox on every
+                // iteration too, so enforce the guardrails regardless of
+                // whether this iteration is an explicit theme change.
+                AppGenerateService.assertThemeWithinLimits(design);
                 designSnapshot = {
                     designUuid: design.designUuid,
                     name: design.name,

--- a/packages/backend/src/ee/services/AppGenerateService/appContext.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appContext.test.ts
@@ -2,13 +2,9 @@ import {
     CONTEXT_PREFIX,
     contextFile,
     promptHistoryToMarkdown,
-    THEME_ASSET_CAP,
 } from './appContext';
 
 describe('appContext helpers', () => {
-    it('caps theme assets at 30', () => {
-        expect(THEME_ASSET_CAP).toBe(30);
-    });
     it('prefixes and base64-encodes a context file', () => {
         const f = contextFile('semantic-layer.yml', 'models: []');
         expect(f.path).toBe(`${CONTEXT_PREFIX}semantic-layer.yml`);

--- a/packages/backend/src/ee/services/AppGenerateService/appContext.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appContext.ts
@@ -1,7 +1,6 @@
 import { type DataAppContextFile } from '@lightdash/common';
 
 export const CONTEXT_PREFIX = '.lightdash/context/';
-export const THEME_ASSET_CAP = 30;
 
 export const contextFile = (
     relPath: string,

--- a/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.test.ts
@@ -135,12 +135,15 @@ describe('readDesignForDownload', () => {
         expect(s3Client.send).toHaveBeenCalledTimes(3);
     });
 
-    it('(c) returns 0 assets and skippedAssetCount=31 when design has 31 assets, with instructions still present', async () => {
+    it('(c) returns 0 assets and skippedAssetCount when assets exceed the total-size cap, with instructions still present', async () => {
         const { readDesignForDownload } =
             await import('./readDesignForDownload');
-        const assetFiles = Array.from({ length: 31 }, (_, i) =>
-            makeDesignFile('css', i),
-        );
+        // 11 x 10 MB = 110 MB of assets, over the 100 MB cap. File count is
+        // irrelevant now — only aggregate size triggers the skip.
+        const assetFiles = Array.from({ length: 11 }, (_, i) => ({
+            ...makeDesignFile('image', i),
+            sizeBytes: 10 * 1024 * 1024,
+        }));
         const instructionFile = makeDesignFile('instruction', 1);
         const files = [...assetFiles, instructionFile];
         const design = makeDesign(files);
@@ -158,7 +161,7 @@ describe('readDesignForDownload', () => {
         });
 
         expect(result.assets).toHaveLength(0);
-        expect(result.skippedAssetCount).toBe(31);
+        expect(result.skippedAssetCount).toBe(11);
         // Instructions should still be present (instruction file was read + cap note appended)
         expect(result.instructions).not.toBeNull();
         expect(result.instructions?.path).toBe(

--- a/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/readDesignForDownload.ts
@@ -1,9 +1,13 @@
 import { type S3Client } from '@aws-sdk/client-s3';
-import { type DataAppThemeContext } from '@lightdash/common';
+import {
+    getThemeTotalBytes,
+    MAX_THEME_TOTAL_BYTES,
+    type DataAppThemeContext,
+} from '@lightdash/common';
 import type { Logger } from 'winston';
 import type { OrganizationDesignModel } from '../../../models/OrganizationDesignModel';
 import { designS3Key } from '../../../services/OrganizationDesignService/OrganizationDesignService';
-import { contextFile, THEME_ASSET_CAP } from './appContext';
+import { contextFile } from './appContext';
 import { readS3ObjectAsBuffer } from './s3Utils';
 
 export async function readDesignForDownload(args: {
@@ -62,19 +66,28 @@ export async function readDesignForDownload(args: {
         instructionParts.push(design.extraInstructions);
     }
 
-    const assetCount = assetFiles.length;
-    if (assetCount > THEME_ASSET_CAP) {
+    const assetBytes = getThemeTotalBytes(assetFiles);
+    if (assetBytes > MAX_THEME_TOTAL_BYTES) {
+        const mb = (n: number) => Math.round(n / (1024 * 1024));
         logger.warn(
-            `Theme ${design.designUuid}: ${assetCount} assets exceed cap of ${THEME_ASSET_CAP}; skipping all assets`,
+            `Theme ${design.designUuid}: assets total ${mb(
+                assetBytes,
+            )} MB, exceed cap of ${mb(
+                MAX_THEME_TOTAL_BYTES,
+            )} MB; skipping all assets`,
         );
         instructionParts.push(
-            `> **Note**: ${assetCount} theme asset(s) were skipped because they exceed the download cap of ${THEME_ASSET_CAP}.`,
+            `> **Note**: ${assetFiles.length} theme asset(s) (${mb(
+                assetBytes,
+            )} MB) were skipped because they exceed the download cap of ${mb(
+                MAX_THEME_TOTAL_BYTES,
+            )} MB.`,
         );
         const instructionText = instructionParts.join('\n\n---\n\n');
         return {
             instructions: contextFile('theme/instructions.md', instructionText),
             assets: [],
-            skippedAssetCount: assetCount,
+            skippedAssetCount: assetFiles.length,
         };
     }
 

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
@@ -13,12 +13,15 @@ import {
     ApiOrganizationDesignFile,
     assertIsAccountWithOrg,
     assertRegisteredAccount,
+    checkThemeLimits,
     ForbiddenError,
+    MAX_THEME_FILE_BYTES,
     MissingConfigError,
     NotFoundError,
     ORGANIZATION_DESIGN_FILE_KINDS,
     OrganizationDesignFileKind,
     ParameterError,
+    themeLimitMessage,
     type Account,
 } from '@lightdash/common';
 import createDOMPurify from 'dompurify';
@@ -34,8 +37,6 @@ type OrganizationDesignServiceArguments = {
     lightdashConfig: LightdashConfig;
     organizationDesignModel: OrganizationDesignModel;
 };
-
-const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB per file
 
 /**
  * Allowed filename extensions for each kind. Filename extension is the
@@ -486,17 +487,34 @@ export class OrganizationDesignService extends BaseService {
         },
     ): Promise<ApiOrganizationDesignFile> {
         const { organizationUuid, userUuid } = this.assertCanManage(account);
-        await this.loadOwned(organizationUuid, designUuid);
+        const design = await this.loadOwned(organizationUuid, designUuid);
 
         const kind = ensureValidKind(input.kind);
         const filename = ensureValidFilename(input.filename);
         ensureFilenameMatchesKind(filename, kind);
 
+        // Reject uploads that would push the theme past its asset-count/total-
+        // size guardrails, so a theme can't grow large enough to time out the
+        // data-app pipeline when applied. `contentLength` is an upper bound on
+        // the stored size (SVG sanitization can only shrink it), so this never
+        // under-counts. Checked before reading any bytes off the wire.
+        const prospectiveViolation = checkThemeLimits([
+            ...design.files,
+            { sizeBytes: input.contentLength },
+        ]);
+        if (prospectiveViolation) {
+            throw new ParameterError(
+                themeLimitMessage(prospectiveViolation, design.name),
+            );
+        }
+
         // Reject obviously-too-big uploads before reading a single byte off
         // the wire. The streaming cap below still enforces the limit against
         // the actual payload in case Content-Length is wrong or absent.
-        if (input.contentLength > MAX_FILE_BYTES) {
-            throw new ParameterError(`File exceeds ${MAX_FILE_BYTES} bytes`);
+        if (input.contentLength > MAX_THEME_FILE_BYTES) {
+            throw new ParameterError(
+                `File exceeds ${MAX_THEME_FILE_BYTES} bytes`,
+            );
         }
 
         // Buffer the body with a hard cap. We need the full Buffer anyway so
@@ -508,9 +526,9 @@ export class OrganizationDesignService extends BaseService {
         for await (const chunk of input.body) {
             const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
             total += buf.length;
-            if (total > MAX_FILE_BYTES) {
+            if (total > MAX_THEME_FILE_BYTES) {
                 throw new ParameterError(
-                    `File exceeds ${MAX_FILE_BYTES} bytes`,
+                    `File exceeds ${MAX_THEME_FILE_BYTES} bytes`,
                 );
             }
             chunks.push(buf);

--- a/packages/common/src/ee/designs/types.ts
+++ b/packages/common/src/ee/designs/types.ts
@@ -62,3 +62,52 @@ export type ApiOrganizationDesignsResponse = ApiSuccess<
 
 export type ApiOrganizationDesignFileResponse =
     ApiSuccess<ApiOrganizationDesignFile>;
+
+/**
+ * Guardrails on how large a theme can grow. A theme's files are streamed into
+ * the data-app sandbox on every generation, so an oversized theme times out on
+ * the copy when a build applies it.
+ *
+ * The binding constraint is total bytes (large images), NOT file count — a
+ * theme with many small text files is cheap, while a handful of big images is
+ * not. So we cap aggregate size only; there is intentionally no file-count cap.
+ * `MAX_THEME_FILE_BYTES` bounds any single file. Enforced at upload time and
+ * re-checked before a build starts.
+ */
+export const MAX_THEME_TOTAL_BYTES = 100 * 1024 * 1024; // 100 MB across all files
+export const MAX_THEME_FILE_BYTES = 10 * 1024 * 1024; // 10 MB per file
+
+export type ThemeLimitViolation = { bytes: number; limit: number };
+
+export const getThemeTotalBytes = (
+    files: Pick<ApiOrganizationDesignFile, 'sizeBytes'>[],
+): number => files.reduce((sum, f) => sum + f.sizeBytes, 0);
+
+/**
+ * Returns the total-size limit if a set of theme files exceeds it, or null
+ * when within limits.
+ */
+export const checkThemeLimits = (
+    files: Pick<ApiOrganizationDesignFile, 'sizeBytes'>[],
+): ThemeLimitViolation | null => {
+    const bytes = getThemeTotalBytes(files);
+    if (bytes > MAX_THEME_TOTAL_BYTES) {
+        return { bytes, limit: MAX_THEME_TOTAL_BYTES };
+    }
+    return null;
+};
+
+const formatThemeMb = (bytes: number): string =>
+    `${Math.round(bytes / (1024 * 1024))} MB`;
+
+export const themeLimitMessage = (
+    violation: ThemeLimitViolation,
+    themeName: string | null,
+): string => {
+    const label = themeName ? `Theme "${themeName}"` : 'This theme';
+    return `${label} totals ${formatThemeMb(
+        violation.bytes,
+    )} of assets, above the limit of ${formatThemeMb(
+        violation.limit,
+    )}. Remove some assets and try again.`;
+};

--- a/packages/frontend/src/features/organizationDesigns/components/DesignDetailPanel.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/DesignDetailPanel.tsx
@@ -1,4 +1,7 @@
 import {
+    checkThemeLimits,
+    getThemeTotalBytes,
+    MAX_THEME_TOTAL_BYTES,
     type ApiOrganizationDesign,
     type ApiOrganizationDesignFile,
 } from '@lightdash/common';
@@ -21,6 +24,7 @@ import {
 import { useForm } from '@mantine/form';
 import { IconCheck, IconDownload, IconTrash } from '@tabler/icons-react';
 import { useEffect, useRef, useState, type FC } from 'react';
+import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
 import {
     useClearDefaultOrganizationDesign,
@@ -124,6 +128,12 @@ const DesignForm: FC<{ design: ApiOrganizationDesign }> = ({ design }) => {
     const [pendingDeleteUuid, setPendingDeleteUuid] = useState<string | null>(
         null,
     );
+
+    // Theme size guardrail: files are streamed into the sandbox on each build,
+    // so an oversized theme times out when applied. Surface the budget as it fills.
+    const totalBytes = getThemeTotalBytes(design.files);
+    const limitViolation = checkThemeLimits(design.files);
+    const nearLimit = totalBytes >= MAX_THEME_TOTAL_BYTES * 0.8;
 
     const trimmedName = form.values.name.trim();
     const trimmedDescription = form.values.description.trim();
@@ -299,7 +309,17 @@ const DesignForm: FC<{ design: ApiOrganizationDesign }> = ({ design }) => {
             {/* Right column: files */}
             <Stack gap="md" flex={1}>
                 <Box>
-                    <Title order={6}>Files</Title>
+                    <Group justify="space-between" align="baseline">
+                        <Title order={6}>Files</Title>
+                        <Text
+                            size="xs"
+                            c={limitViolation ? 'red.6' : 'ldGray.6'}
+                        >
+                            {design.files.length} files ·{' '}
+                            {formatBytes(totalBytes)} /{' '}
+                            {formatBytes(MAX_THEME_TOTAL_BYTES)}
+                        </Text>
+                    </Group>
                     <Text size="sm" c="ldGray.6" mt={4}>
                         Drag &amp; drop CSS, font, image, or markdown
                         instruction files. They&apos;ll be picked up
@@ -307,7 +327,27 @@ const DesignForm: FC<{ design: ApiOrganizationDesign }> = ({ design }) => {
                     </Text>
                 </Box>
 
-                <DesignFileUpload designUuid={design.designUuid} />
+                {(limitViolation || nearLimit) && (
+                    <Callout variant="warning">
+                        {limitViolation
+                            ? `This theme is over the ${formatBytes(
+                                  MAX_THEME_TOTAL_BYTES,
+                              )} limit (currently ${formatBytes(
+                                  totalBytes,
+                              )}). Apps won't apply it until you remove some assets.`
+                            : `This theme is getting large (${formatBytes(
+                                  totalBytes,
+                              )} of ${formatBytes(
+                                  MAX_THEME_TOTAL_BYTES,
+                              )}). Large themes are slower to generate and can fail to apply — keep only the assets you need.`}
+                    </Callout>
+                )}
+
+                <DesignFileUpload
+                    designUuid={design.designUuid}
+                    themeName={design.name}
+                    existingFiles={design.files}
+                />
 
                 {design.files.length === 0 ? (
                     <Text size="sm" c="ldGray.6" ta="center" py="md">

--- a/packages/frontend/src/features/organizationDesigns/components/DesignFileUpload.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/DesignFileUpload.tsx
@@ -1,4 +1,10 @@
-import { type OrganizationDesignFileKind } from '@lightdash/common';
+import {
+    checkThemeLimits,
+    MAX_THEME_FILE_BYTES,
+    themeLimitMessage,
+    type ApiOrganizationDesignFile,
+    type OrganizationDesignFileKind,
+} from '@lightdash/common';
 import { Box, FileButton, Group, Loader, Stack, Text } from '@mantine-8/core';
 import { IconUpload } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
@@ -46,22 +52,36 @@ const inferKind = (filename: string): OrganizationDesignFileKind | null => {
     return EXTENSION_TO_KIND[lower.slice(dot)] ?? null;
 };
 
+const formatMb = (bytes: number): string =>
+    `${Math.round(bytes / (1024 * 1024))} MB`;
+
 type Props = {
     designUuid: string;
+    themeName: string;
+    existingFiles: ApiOrganizationDesignFile[];
 };
 
-export const DesignFileUpload: FC<Props> = ({ designUuid }) => {
+export const DesignFileUpload: FC<Props> = ({
+    designUuid,
+    themeName,
+    existingFiles,
+}) => {
     const uploadFile = useUploadDesignFile();
     const { showToastError } = useToaster();
     const [isDragging, setIsDragging] = useState(false);
 
     const handleFiles = (files: File[]) => {
-        // Upload sequentially so the backend's `Content-Length` accounting and
-        // the optimistic toast feedback stay readable. Parallel uploads would
-        // race the parent-design `updated_at` bumps in any case.
-        const uploadNext = (index: number) => {
-            if (index >= files.length) return;
-            const file = files[index];
+        // Validate against the theme guardrails client-side before uploading.
+        // The backend enforces the same limits, but rejecting a large upload
+        // mid-flight resets the connection and surfaces as a generic network
+        // error instead of the real message — so catch it here and never send
+        // a doomed upload. `accepted` seeds the running tally from the theme's
+        // stored files and grows across this batch.
+        const accepted: Pick<ApiOrganizationDesignFile, 'sizeBytes'>[] =
+            existingFiles.map((f) => ({ sizeBytes: f.sizeBytes }));
+        const queue: { file: File; kind: OrganizationDesignFileKind }[] = [];
+
+        for (const file of files) {
             const kind = inferKind(file.name);
             if (!kind) {
                 showToastError({
@@ -69,9 +89,38 @@ export const DesignFileUpload: FC<Props> = ({ designUuid }) => {
                     subtitle:
                         'Allowed: .css, .md, .png, .jpg, .jpeg, .gif, .webp, .svg, .woff, .woff2, .ttf, .otf',
                 });
-                uploadNext(index + 1);
-                return;
+                continue;
             }
+            if (file.size > MAX_THEME_FILE_BYTES) {
+                showToastError({
+                    title: `${file.name} is too large`,
+                    subtitle: `Files must be under ${formatMb(
+                        MAX_THEME_FILE_BYTES,
+                    )}.`,
+                });
+                continue;
+            }
+            const violation = checkThemeLimits([
+                ...accepted,
+                { sizeBytes: file.size },
+            ]);
+            if (violation) {
+                showToastError({
+                    title: `Can't add ${file.name}`,
+                    subtitle: themeLimitMessage(violation, themeName),
+                });
+                continue;
+            }
+            accepted.push({ sizeBytes: file.size });
+            queue.push({ file, kind });
+        }
+
+        // Upload sequentially so the backend's `Content-Length` accounting and
+        // the optimistic toast feedback stay readable. Parallel uploads would
+        // race the parent-design `updated_at` bumps in any case.
+        const uploadNext = (index: number) => {
+            if (index >= queue.length) return;
+            const { file, kind } = queue[index];
             uploadFile.mutate(
                 { designUuid, file, kind, filename: file.name },
                 {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3,6 +3,7 @@ import {
     ChartKind,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
     FeatureFlags,
+    isApiError,
     isAppVersionInProgress,
     type ApiAppVersionSummary,
     type AppChartReference,
@@ -1145,14 +1146,16 @@ const AppGenerate: FC = () => {
                     },
                     onError: (err: unknown) => {
                         setThemeChipOverride(null);
+                        const themeErrorMessage = isApiError(err)
+                            ? err.error.message
+                            : err instanceof Error
+                              ? err.message
+                              : 'Failed to apply theme';
                         setLocalMessages((prev) => [
                             ...prev,
                             {
                                 role: 'assistant',
-                                content:
-                                    err instanceof Error
-                                        ? err.message
-                                        : 'Failed to apply theme',
+                                content: themeErrorMessage,
                                 imagePreviewUrls: [],
                                 imageResourceIds: [],
                                 charts: [],
@@ -1568,14 +1571,18 @@ const AppGenerate: FC = () => {
             }
         },
         onError: (err: unknown) => {
+            // The mutation rejects with an ApiError object (not an Error
+            // instance), so read its message before falling back.
+            const errorMessage = isApiError(err)
+                ? err.error.message
+                : err instanceof Error
+                  ? err.message
+                  : 'Failed to generate app';
             setLocalMessages((prev) => [
                 ...prev,
                 {
                     role: 'assistant' as const,
-                    content:
-                        err instanceof Error
-                            ? err.message
-                            : 'Failed to generate app',
+                    content: errorMessage,
                     imagePreviewUrls: [],
                     imageResourceIds: [],
                     charts: [],


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8685/data-apps-time-out-when-applying-a-theme-with-too-many-uploaded-assets


### Description:
Applying a Data App theme with too many/too-large uploaded assets ran the generation pipeline to its timeout with no clear feedback. A theme's files are streamed into the sandbox and re-read on every build, so an oversized theme times out on the copy.

Add a 100MB total-size guardrail (bytes are the binding constraint, not file count) enforced at four layers, all failing fast with a specific message: upload validation, client-side pre-check, apply-time preflight, and a pipeline backstop. The download path now skips assets by total size too.

Also surface ApiError messages in the app generate/apply-theme UI instead of a generic "Failed to generate app".


## Testing


### Trying to upload too much to the design:
<img width="457" height="92" alt="Screenshot 2026-07-13 at 15 51 18" src="https://github.com/user-attachments/assets/9bbe4d53-f8fc-4e5c-9b89-7a48fc70ea3a" />

### Using a design that is too large:
E.g. a design created before the limit existed.

<img width="775" height="233" alt="Screenshot 2026-07-13 at 15 59 16" src="https://github.com/user-attachments/assets/299a1cec-0301-4cf2-8cbc-0443f487dfda" />
