### PR TITLE
feat: add Google Sheets syncs as code

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -15,6 +15,8 @@ import {
     ApiErrorPayload,
     ApiGetProjectGroupAccesses,
     ApiGetProjectMemberResponse,
+    ApiGoogleSheetsSyncAsCodeListResponse,
+    ApiGoogleSheetsSyncAsCodeUpsertResponse,
     ApiPreviewExpirationProjectSettingsResponse,
     ApiPreviewExpiresAtResponse,
     ApiProjectAccessListResponse,
@@ -38,6 +40,7 @@ import {
     ForbiddenError,
     getErrorMessage,
     getRequestMethod,
+    GoogleSheetsSyncAsCode,
     isDuplicateDashboardParams,
     LightdashRequestMethodHeader,
     ParameterError,
@@ -1620,6 +1623,65 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                     projectUuid,
                     slug,
                     alert,
+                    force,
+                ),
+        };
+    }
+
+    /**
+     * Get Google Sheets syncs in code representation
+     * @summary List Google Sheets syncs as code
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/googleSheets/code')
+    @OperationId('getGoogleSheetsSyncsAsCode')
+    async getGoogleSheetsSyncsAsCode(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() slugs?: string[],
+    ): Promise<ApiGoogleSheetsSyncAsCodeListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getCoderService()
+                .getScheduledDeliveries(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    slugs,
+                    ContentAsCodeType.GOOGLE_SHEETS_SYNC,
+                ),
+        };
+    }
+
+    /**
+     * Upsert a Google Sheets sync from code representation
+     * @summary Upsert Google Sheets sync as code
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/googleSheets/{slug}/code')
+    @OperationId('upsertGoogleSheetsSyncAsCode')
+    async upsertGoogleSheetsSyncAsCode(
+        @Path() projectUuid: string,
+        @Path() slug: string,
+        @Body() googleSheetsSync: GoogleSheetsSyncAsCode,
+        @Request() req: express.Request,
+        @Query() force: boolean = false,
+    ): Promise<ApiGoogleSheetsSyncAsCodeUpsertResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getCoderService()
+                .upsertScheduledDelivery(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    slug,
+                    googleSheetsSync,
                     force,
                 ),
         };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -35095,6 +35095,263 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ContentAsCodeType.GOOGLE_SHEETS_SYNC': {
+        dataType: 'refEnum',
+        enums: ['google_sheets_sync'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GoogleSheetsSyncAsCodeBase: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                downloadedAt: { dataType: 'datetime' },
+                destination: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        tabName: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        url: { dataType: 'string', required: true },
+                        organizationName: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                        spreadsheetName: { dataType: 'string', required: true },
+                        spreadsheetId: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                includeLinks: { dataType: 'boolean', required: true },
+                enabled: { dataType: 'boolean', required: true },
+                timezone: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                cron: { dataType: 'string', required: true },
+                message: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                slug: { dataType: 'string', required: true },
+                version: { dataType: 'double', required: true },
+                contentType: {
+                    ref: 'ContentAsCodeType.GOOGLE_SHEETS_SYNC',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartGoogleSheetsSyncAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'GoogleSheetsSyncAsCodeBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        selectedTabs: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        customViewportWidth: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        parameters: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ParametersValuesMap' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        filters: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'FiltersInput' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        resource: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                slug: { dataType: 'string', required: true },
+                                type: {
+                                    dataType: 'enum',
+                                    enums: ['chart'],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardGoogleSheetsSyncAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'GoogleSheetsSyncAsCodeBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        selectedTabs: {
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'array',
+                                    array: { dataType: 'string' },
+                                },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        customViewportWidth: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'double' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        parameters: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ParametersValuesMap' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        filters: {
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'array',
+                                    array: {
+                                        dataType: 'refAlias',
+                                        ref: 'Omit_DashboardFilterRule.id_',
+                                    },
+                                },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        resource: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                slug: { dataType: 'string', required: true },
+                                type: {
+                                    dataType: 'enum',
+                                    enums: ['dashboard'],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GoogleSheetsSyncAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ChartGoogleSheetsSyncAsCode' },
+                { ref: 'DashboardGoogleSheetsSyncAsCode' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGoogleSheetsSyncAsCodeListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        skipped: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'ScheduledDeliveryAsCodeSkip',
+                            },
+                            required: true,
+                        },
+                        googleSheetsSyncs: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'GoogleSheetsSyncAsCode',
+                            },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGoogleSheetsSyncAsCodeUpsertResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        action: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'PromotionAction.CREATE' },
+                                { ref: 'PromotionAction.UPDATE' },
+                                { ref: 'PromotionAction.NO_CHANGES' },
+                            ],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiChartAsCodeUpsertResponse: {
         dataType: 'refAlias',
         type: {
@@ -72635,6 +72892,143 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'upsertAlertAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_getGoogleSheetsSyncsAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        slugs: {
+            in: 'query',
+            name: 'slugs',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/googleSheets/code',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getGoogleSheetsSyncsAsCode,
+        ),
+
+        async function ProjectController_getGoogleSheetsSyncsAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_getGoogleSheetsSyncsAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getGoogleSheetsSyncsAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_upsertGoogleSheetsSyncAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        slug: { in: 'path', name: 'slug', required: true, dataType: 'string' },
+        googleSheetsSync: {
+            in: 'body',
+            name: 'googleSheetsSync',
+            required: true,
+            ref: 'GoogleSheetsSyncAsCode',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        force: {
+            default: false,
+            in: 'query',
+            name: 'force',
+            dataType: 'boolean',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/googleSheets/:slug/code',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.upsertGoogleSheetsSyncAsCode,
+        ),
+
+        async function ProjectController_upsertGoogleSheetsSyncAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_upsertGoogleSheetsSyncAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertGoogleSheetsSyncAsCode',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -35434,6 +35434,277 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ContentAsCodeType.GOOGLE_SHEETS_SYNC": {
+                "enum": ["google_sheets_sync"],
+                "type": "string"
+            },
+            "GoogleSheetsSyncAsCodeBase": {
+                "properties": {
+                    "downloadedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "destination": {
+                        "properties": {
+                            "tabName": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "organizationName": {
+                                "type": "string"
+                            },
+                            "spreadsheetName": {
+                                "type": "string"
+                            },
+                            "spreadsheetId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tabName",
+                            "url",
+                            "organizationName",
+                            "spreadsheetName",
+                            "spreadsheetId"
+                        ],
+                        "type": "object"
+                    },
+                    "includeLinks": {
+                        "type": "boolean"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "timezone": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cron": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentAsCodeType.GOOGLE_SHEETS_SYNC"
+                    }
+                },
+                "required": [
+                    "destination",
+                    "includeLinks",
+                    "enabled",
+                    "timezone",
+                    "cron",
+                    "message",
+                    "name",
+                    "slug",
+                    "version",
+                    "contentType"
+                ],
+                "type": "object"
+            },
+            "ChartGoogleSheetsSyncAsCode": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/GoogleSheetsSyncAsCodeBase"
+                    },
+                    {
+                        "properties": {
+                            "selectedTabs": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "customViewportWidth": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "parameters": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/ParametersValuesMap"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "filters": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/FiltersInput"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "resource": {
+                                "properties": {
+                                    "slug": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": ["chart"],
+                                        "nullable": false
+                                    }
+                                },
+                                "required": ["slug", "type"],
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "selectedTabs",
+                            "customViewportWidth",
+                            "parameters",
+                            "filters",
+                            "resource"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "DashboardGoogleSheetsSyncAsCode": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/GoogleSheetsSyncAsCodeBase"
+                    },
+                    {
+                        "properties": {
+                            "selectedTabs": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "nullable": true
+                            },
+                            "customViewportWidth": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            },
+                            "parameters": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/ParametersValuesMap"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "filters": {
+                                "items": {
+                                    "$ref": "#/components/schemas/Omit_DashboardFilterRule.id_"
+                                },
+                                "type": "array",
+                                "nullable": true
+                            },
+                            "resource": {
+                                "properties": {
+                                    "slug": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": ["dashboard"],
+                                        "nullable": false
+                                    }
+                                },
+                                "required": ["slug", "type"],
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "selectedTabs",
+                            "customViewportWidth",
+                            "parameters",
+                            "filters",
+                            "resource"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "GoogleSheetsSyncAsCode": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ChartGoogleSheetsSyncAsCode"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DashboardGoogleSheetsSyncAsCode"
+                    }
+                ]
+            },
+            "ApiGoogleSheetsSyncAsCodeListResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "skipped": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ScheduledDeliveryAsCodeSkip"
+                                },
+                                "type": "array"
+                            },
+                            "googleSheetsSyncs": {
+                                "items": {
+                                    "$ref": "#/components/schemas/GoogleSheetsSyncAsCode"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["skipped", "googleSheetsSyncs"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiGoogleSheetsSyncAsCodeUpsertResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "action": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.CREATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.UPDATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.NO_CHANGES"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["action"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "ApiChartAsCodeUpsertResponse": {
                 "properties": {
                     "results": {
@@ -45102,7 +45373,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3367.0",
+        "version": "0.3368.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -62446,6 +62717,126 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/AlertAsCode"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/googleSheets/code": {
+            "get": {
+                "operationId": "getGoogleSheetsSyncsAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGoogleSheetsSyncAsCodeListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get Google Sheets syncs in code representation",
+                "summary": "List Google Sheets syncs as code",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "slugs",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/googleSheets/{slug}/code": {
+            "post": {
+                "operationId": "upsertGoogleSheetsSyncAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGoogleSheetsSyncAsCodeUpsertResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Upsert a Google Sheets sync from code representation",
+                "summary": "Upsert Google Sheets sync as code",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "slug",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "force",
+                        "required": false,
+                        "schema": {
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GoogleSheetsSyncAsCode"
                             }
                         }
                     }

--- a/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
@@ -11,6 +11,7 @@ import {
     type AlertAsCode,
     type Filters,
     type FiltersInput,
+    type GoogleSheetsSyncAsCode,
     type ScheduledDeliveryAsCode,
     type SchedulerAndTargets,
     type SessionUser,
@@ -22,6 +23,7 @@ import { CoderService } from './CoderService';
 const projectUuid = 'project-uuid';
 const organizationUuid = 'organization-uuid';
 const chartUuid = 'chart-uuid';
+const dashboardUuid = 'dashboard-uuid';
 
 const user: SessionUser = {
     userUuid: 'uploader-uuid',
@@ -52,6 +54,11 @@ const user: SessionUser = {
         {
             action: 'manage',
             subject: 'ScheduledDeliveries',
+            conditions: { projectUuid, organizationUuid },
+        },
+        {
+            action: 'manage',
+            subject: 'GoogleSheets',
             conditions: { projectUuid, organizationUuid },
         },
     ]),
@@ -155,6 +162,72 @@ const alert: AlertAsCode = {
     parameters: null,
 };
 
+const googleSheetsScheduler: SchedulerAndTargets = {
+    ...scheduler,
+    schedulerUuid: 'google-sheets-scheduler-uuid',
+    slug: 'orders-sheet',
+    name: 'Orders sheet',
+    message: undefined,
+    format: SchedulerFormat.GSHEETS,
+    options: {
+        gdriveId: 'spreadsheet-id',
+        gdriveName: 'Orders',
+        gdriveOrganizationName: 'Test organization',
+        url: 'https://docs.google.com/spreadsheets/d/spreadsheet-id/edit',
+        tabName: 'Orders data',
+    },
+    includeLinks: false,
+    targets: [],
+};
+
+const googleSheetsSync: GoogleSheetsSyncAsCode = {
+    contentType: ContentAsCodeType.GOOGLE_SHEETS_SYNC,
+    version: 1,
+    slug: 'orders-sheet',
+    name: 'Orders sheet',
+    message: null,
+    cron: '0 9 * * 1',
+    timezone: 'Europe/Madrid',
+    enabled: true,
+    includeLinks: false,
+    destination: {
+        spreadsheetId: 'spreadsheet-id',
+        spreadsheetName: 'Orders',
+        organizationName: 'Test organization',
+        url: 'https://docs.google.com/spreadsheets/d/spreadsheet-id/edit',
+        tabName: 'Orders data',
+    },
+    resource: { type: 'chart', slug: 'orders' },
+    filters: null,
+    parameters: null,
+    customViewportWidth: null,
+    selectedTabs: null,
+};
+
+const dashboardGoogleSheetsScheduler: SchedulerAndTargets = {
+    ...googleSheetsScheduler,
+    schedulerUuid: 'dashboard-google-sheets-scheduler-uuid',
+    slug: 'dashboard-sheet',
+    name: 'Dashboard sheet',
+    savedChartUuid: null,
+    savedChartName: null,
+    dashboardUuid,
+    dashboardName: 'Orders dashboard',
+    filters: undefined,
+    customViewportWidth: undefined,
+    selectedTabs: null,
+};
+
+const dashboardGoogleSheetsSync: GoogleSheetsSyncAsCode = {
+    ...googleSheetsSync,
+    slug: 'dashboard-sheet',
+    name: 'Dashboard sheet',
+    resource: { type: 'dashboard', slug: 'orders-dashboard' },
+    filters: null,
+    customViewportWidth: null,
+    selectedTabs: null,
+};
+
 const runtimeFilters: Filters = {
     dimensions: {
         id: 'runtime-group-id',
@@ -199,6 +272,9 @@ const buildService = ({
     const savedChartService = {
         createScheduler: vi.fn(async () => scheduler),
     };
+    const dashboardService = {
+        createScheduler: vi.fn(async () => dashboardGoogleSheetsScheduler),
+    };
 
     const service = new CoderService({
         lightdashConfig: lightdashConfigMock,
@@ -217,19 +293,34 @@ const buildService = ({
             find: vi.fn(async () => [{ uuid: chartUuid, slug: 'orders' }]),
         } as never,
         savedSqlModel: {} as never,
-        dashboardModel: {} as never,
+        dashboardModel: {
+            find: vi.fn(async () => [
+                { uuid: dashboardUuid, slug: 'orders-dashboard' },
+            ]),
+            getByIdOrSlug: vi.fn(async () => ({
+                uuid: dashboardUuid,
+                slug: 'orders-dashboard',
+                tabs: [],
+                tiles: [],
+            })),
+        } as never,
         spaceModel: {} as never,
         schedulerModel: schedulerModel as never,
         schedulerService: schedulerService as never,
         savedChartService: savedChartService as never,
-        dashboardService: {} as never,
+        dashboardService: dashboardService as never,
         schedulerClient: {} as never,
         promoteService: {} as never,
         spacePermissionService: {} as never,
         contentVerificationModel: {} as never,
     });
 
-    return { service, schedulerService, savedChartService };
+    return {
+        service,
+        schedulerService,
+        savedChartService,
+        dashboardService,
+    };
 };
 
 describe('CoderService scheduled deliveries as code', () => {
@@ -571,5 +662,193 @@ describe('CoderService alerts as code', () => {
         expect(exported.alerts[0].filters).toEqual(portableFilters);
         expect(result).toEqual({ action: PromotionAction.NO_CHANGES });
         expect(schedulerService.updateScheduler).not.toHaveBeenCalled();
+    });
+});
+
+describe('CoderService Google Sheets syncs as code', () => {
+    it('exports Google Sheets syncs separately from deliveries and alerts', async () => {
+        const { service } = buildService({
+            schedulers: [googleSheetsScheduler],
+        });
+
+        const googleSheets = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+            undefined,
+            ContentAsCodeType.GOOGLE_SHEETS_SYNC,
+        );
+        const deliveries = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+        );
+        const alerts = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+            undefined,
+            ContentAsCodeType.ALERT,
+        );
+
+        expect(googleSheets.skipped).toEqual([]);
+        expect(googleSheets.googleSheetsSyncs).toHaveLength(1);
+        expect(googleSheets.googleSheetsSyncs[0]).toMatchObject(
+            googleSheetsSync,
+        );
+        expect(deliveries).toEqual({ scheduledDeliveries: [], skipped: [] });
+        expect(alerts).toEqual({ alerts: [], skipped: [] });
+    });
+
+    it('reports unsupported SQL syncs without mixing them into other domains', async () => {
+        const sqlSync: SchedulerAndTargets = {
+            ...googleSheetsScheduler,
+            savedChartUuid: null,
+            savedChartName: null,
+            savedSqlUuid: 'saved-sql-uuid',
+            savedSqlName: 'Saved SQL',
+        };
+        const { service } = buildService({ schedulers: [sqlSync] });
+
+        const result = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+            undefined,
+            ContentAsCodeType.GOOGLE_SHEETS_SYNC,
+        );
+
+        expect(result.googleSheetsSyncs).toEqual([]);
+        expect(result.skipped).toEqual([
+            {
+                name: sqlSync.name,
+                reason: 'Google Sheets sync as code supports chart and dashboard resources',
+            },
+        ]);
+    });
+
+    it('creates a sync with Google Sheets scheduler options and no targets', async () => {
+        const { service, savedChartService } = buildService();
+
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            googleSheetsSync.slug,
+            googleSheetsSync,
+        );
+
+        expect(result).toEqual({ action: PromotionAction.CREATE });
+        expect(savedChartService.createScheduler).toHaveBeenCalledWith(
+            user,
+            chartUuid,
+            expect.objectContaining({
+                format: SchedulerFormat.GSHEETS,
+                options: {
+                    gdriveId: 'spreadsheet-id',
+                    gdriveName: 'Orders',
+                    gdriveOrganizationName: 'Test organization',
+                    url: 'https://docs.google.com/spreadsheets/d/spreadsheet-id/edit',
+                    tabName: 'Orders data',
+                },
+                targets: [],
+            }),
+        );
+    });
+
+    it('round-trips dashboard syncs through dashboard slugs', async () => {
+        const { service, dashboardService } = buildService({
+            schedulers: [dashboardGoogleSheetsScheduler],
+        });
+
+        const exported = await service.getScheduledDeliveries(
+            user,
+            projectUuid,
+            undefined,
+            ContentAsCodeType.GOOGLE_SHEETS_SYNC,
+        );
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            dashboardGoogleSheetsSync.slug,
+            dashboardGoogleSheetsSync,
+        );
+
+        expect(exported.googleSheetsSyncs[0]).toMatchObject(
+            dashboardGoogleSheetsSync,
+        );
+        expect(result).toEqual({ action: PromotionAction.CREATE });
+        expect(dashboardService.createScheduler).toHaveBeenCalledWith(
+            user,
+            dashboardUuid,
+            expect.objectContaining({
+                format: SchedulerFormat.GSHEETS,
+                targets: [],
+            }),
+        );
+    });
+
+    it('does not reschedule an unchanged sync', async () => {
+        const { service, schedulerService } = buildService({
+            existing: googleSheetsScheduler,
+        });
+
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            googleSheetsSync.slug,
+            googleSheetsSync,
+        );
+
+        expect(result).toEqual({ action: PromotionAction.NO_CHANGES });
+        expect(schedulerService.updateScheduler).not.toHaveBeenCalled();
+    });
+
+    it('updates the destination and preserves ownership semantics', async () => {
+        const { service, schedulerService } = buildService({
+            existing: googleSheetsScheduler,
+        });
+        const updated = {
+            ...googleSheetsSync,
+            destination: {
+                ...googleSheetsSync.destination,
+                tabName: 'Updated orders',
+            },
+        };
+
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            updated.slug,
+            updated,
+        );
+
+        expect(result).toEqual({ action: PromotionAction.UPDATE });
+        expect(schedulerService.updateScheduler).toHaveBeenCalledWith(
+            user,
+            googleSheetsScheduler.schedulerUuid,
+            expect.objectContaining({
+                options: expect.objectContaining({
+                    tabName: 'Updated orders',
+                }),
+            }),
+        );
+        expect(schedulerService.updateScheduler).toHaveBeenCalledWith(
+            user,
+            googleSheetsScheduler.schedulerUuid,
+            expect.not.objectContaining({ createdBy: expect.anything() }),
+        );
+    });
+
+    it('forces an unchanged sync update', async () => {
+        const { service, schedulerService } = buildService({
+            existing: googleSheetsScheduler,
+        });
+
+        const result = await service.upsertScheduledDelivery(
+            user,
+            projectUuid,
+            googleSheetsSync.slug,
+            googleSheetsSync,
+            true,
+        );
+
+        expect(result).toEqual({ action: PromotionAction.UPDATE });
+        expect(schedulerService.updateScheduler).toHaveBeenCalledOnce();
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -6,11 +6,14 @@ import {
     ApiAlertAsCodeUpsertResponse,
     ApiChartAsCodeListResponse,
     ApiDashboardAsCodeListResponse,
+    ApiGoogleSheetsSyncAsCodeListResponse,
+    ApiGoogleSheetsSyncAsCodeUpsertResponse,
     ApiScheduledDeliveryAsCodeListResponse,
     ApiScheduledDeliveryAsCodeUpsertResponse,
     assertUnreachable,
     ChartAsCode,
     ChartAsCodeInternalization,
+    ChartGoogleSheetsSyncAsCode,
     ChartScheduledDeliveryAsCode,
     ChartSummary,
     ContentAsCodeType,
@@ -23,6 +26,7 @@ import {
     DashboardChartTileAsCode,
     DashboardDAO,
     DashboardFilterRule,
+    DashboardGoogleSheetsSyncAsCode,
     DashboardMarkdownTileAsCode,
     DashboardScheduledDeliveryAsCode,
     DashboardSqlChartTileAsCode,
@@ -40,6 +44,7 @@ import {
     isGoogleChatTarget,
     isMsTeamsTarget,
     isSchedulerCsvOptions,
+    isSchedulerGsheetsOptions,
     isSchedulerImageOptions,
     isSlackTarget,
     NotFoundError,
@@ -73,6 +78,7 @@ import {
     type FilterRule,
     type Filters,
     type FiltersInput,
+    type GoogleSheetsSyncAsCode,
     type SpaceSummaryBase,
 } from '@lightdash/common';
 import isEqual from 'lodash/isEqual';
@@ -1513,6 +1519,103 @@ export class CoderService extends BaseService {
         return null;
     }
 
+    private async transformGoogleSheetsSync(
+        scheduler: SchedulerAndTargets,
+    ): Promise<GoogleSheetsSyncAsCode | null> {
+        if (
+            !scheduler.slug ||
+            scheduler.format !== SchedulerFormat.GSHEETS ||
+            scheduler.thresholds?.length ||
+            !isSchedulerGsheetsOptions(scheduler.options)
+        ) {
+            return null;
+        }
+
+        const common = {
+            contentType: ContentAsCodeType.GOOGLE_SHEETS_SYNC as const,
+            version: currentVersion,
+            slug: scheduler.slug,
+            name: scheduler.name,
+            message: scheduler.message ?? null,
+            cron: scheduler.cron,
+            timezone: scheduler.timezone ?? null,
+            enabled: scheduler.enabled,
+            includeLinks: scheduler.includeLinks,
+            destination: {
+                spreadsheetId: scheduler.options.gdriveId,
+                spreadsheetName: scheduler.options.gdriveName,
+                organizationName: scheduler.options.gdriveOrganizationName,
+                url: scheduler.options.url,
+                tabName: scheduler.options.tabName ?? null,
+            },
+            downloadedAt: new Date(),
+        };
+
+        if (isChartScheduler(scheduler)) {
+            const chart = await this.savedChartModel.getSummary(
+                scheduler.savedChartUuid,
+            );
+            return {
+                ...common,
+                resource: { type: 'chart', slug: chart.slug },
+                filters: stripFilterIds(scheduler.filters),
+                parameters: scheduler.parameters ?? null,
+                customViewportWidth: null,
+                selectedTabs: null,
+            };
+        }
+
+        if (isDashboardScheduler(scheduler)) {
+            const dashboard = await this.dashboardModel.getByIdOrSlug(
+                scheduler.dashboardUuid,
+            );
+            return {
+                ...common,
+                resource: { type: 'dashboard', slug: dashboard.slug },
+                filters:
+                    CoderService.getDashboardScheduledDeliveryFiltersWithTileSlugs(
+                        dashboard,
+                        scheduler.filters,
+                    ),
+                parameters: scheduler.parameters ?? null,
+                customViewportWidth: scheduler.customViewportWidth ?? null,
+                selectedTabs:
+                    scheduler.selectedTabs?.map((tabUuid) =>
+                        CoderService.getDashboardTabSlug(dashboard, tabUuid),
+                    ) ?? null,
+            };
+        }
+
+        return null;
+    }
+
+    private static getScheduledContentNames(
+        contentType:
+            | ContentAsCodeType.SCHEDULED_DELIVERY
+            | ContentAsCodeType.ALERT
+            | ContentAsCodeType.GOOGLE_SHEETS_SYNC,
+    ): { singular: string; plural: string } {
+        switch (contentType) {
+            case ContentAsCodeType.SCHEDULED_DELIVERY:
+                return {
+                    singular: 'Scheduled delivery',
+                    plural: 'scheduled deliveries',
+                };
+            case ContentAsCodeType.ALERT:
+                return { singular: 'Alert', plural: 'alerts' };
+            case ContentAsCodeType.GOOGLE_SHEETS_SYNC:
+                return {
+                    singular: 'Google Sheets sync',
+                    plural: 'Google Sheets syncs',
+                };
+            default:
+                return assertUnreachable(
+                    contentType,
+                    'Unknown scheduled content type',
+                );
+        }
+    }
+
     async getScheduledDeliveries(
         user: SessionUser,
         projectUuid: string,
@@ -1530,13 +1633,22 @@ export class CoderService extends BaseService {
     async getScheduledDeliveries(
         user: SessionUser,
         projectUuid: string,
+        slugs: string[] | undefined,
+        contentType: ContentAsCodeType.GOOGLE_SHEETS_SYNC,
+    ): Promise<ApiGoogleSheetsSyncAsCodeListResponse['results']>;
+
+    async getScheduledDeliveries(
+        user: SessionUser,
+        projectUuid: string,
         slugs?: string[],
         contentType:
             | ContentAsCodeType.SCHEDULED_DELIVERY
-            | ContentAsCodeType.ALERT = ContentAsCodeType.SCHEDULED_DELIVERY,
+            | ContentAsCodeType.ALERT
+            | ContentAsCodeType.GOOGLE_SHEETS_SYNC = ContentAsCodeType.SCHEDULED_DELIVERY,
     ): Promise<
         | ApiScheduledDeliveryAsCodeListResponse['results']
         | ApiAlertAsCodeListResponse['results']
+        | ApiGoogleSheetsSyncAsCodeListResponse['results']
     > {
         const project = await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
@@ -1554,14 +1666,20 @@ export class CoderService extends BaseService {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
-            )
+            ) ||
+            (contentType === ContentAsCodeType.GOOGLE_SHEETS_SYNC &&
+                auditedAbility.cannot(
+                    'manage',
+                    subject('GoogleSheets', {
+                        projectUuid,
+                        organizationUuid: project.organizationUuid,
+                    }),
+                ))
         ) {
+            const { plural } =
+                CoderService.getScheduledContentNames(contentType);
             throw new ForbiddenError(
-                `You are not allowed to download ${
-                    contentType === ContentAsCodeType.ALERT
-                        ? 'alerts'
-                        : 'scheduled deliveries'
-                }`,
+                `You are not allowed to download ${plural}`,
             );
         }
 
@@ -1570,28 +1688,51 @@ export class CoderService extends BaseService {
         const filteredSchedulers = slugs?.length
             ? schedulers.filter((scheduler) => slugs.includes(scheduler.slug))
             : schedulers;
-        const matchingSchedulers = filteredSchedulers.filter((scheduler) =>
-            contentType === ContentAsCodeType.ALERT
-                ? Boolean(scheduler.thresholds?.length)
-                : !scheduler.thresholds?.length,
-        );
+        const matchingSchedulers = filteredSchedulers.filter((scheduler) => {
+            switch (contentType) {
+                case ContentAsCodeType.ALERT:
+                    return Boolean(scheduler.thresholds?.length);
+                case ContentAsCodeType.GOOGLE_SHEETS_SYNC:
+                    return (
+                        !scheduler.thresholds?.length &&
+                        scheduler.format === SchedulerFormat.GSHEETS
+                    );
+                case ContentAsCodeType.SCHEDULED_DELIVERY:
+                    return (
+                        !scheduler.thresholds?.length &&
+                        scheduler.format !== SchedulerFormat.GSHEETS
+                    );
+                default:
+                    return assertUnreachable(
+                        contentType,
+                        'Unknown scheduled content type',
+                    );
+            }
+        });
         const transformed = await Promise.all(
-            matchingSchedulers.map((scheduler) =>
-                contentType === ContentAsCodeType.ALERT
-                    ? this.transformAlert(scheduler)
-                    : this.transformScheduledDelivery(scheduler),
-            ),
+            matchingSchedulers.map((scheduler) => {
+                switch (contentType) {
+                    case ContentAsCodeType.ALERT:
+                        return this.transformAlert(scheduler);
+                    case ContentAsCodeType.GOOGLE_SHEETS_SYNC:
+                        return this.transformGoogleSheetsSync(scheduler);
+                    case ContentAsCodeType.SCHEDULED_DELIVERY:
+                        return this.transformScheduledDelivery(scheduler);
+                    default:
+                        return assertUnreachable(
+                            contentType,
+                            'Unknown scheduled content type',
+                        );
+                }
+            }),
         );
-        const content: Array<ScheduledDeliveryAsCode | AlertAsCode> = [];
+        const content: Array<
+            ScheduledDeliveryAsCode | AlertAsCode | GoogleSheetsSyncAsCode
+        > = [];
         const skipped: Array<{ name: string; reason: string }> = [];
-        const contentName =
-            contentType === ContentAsCodeType.ALERT
-                ? 'Alert'
-                : 'Scheduled delivery';
-        const unsupportedReason =
-            contentType === ContentAsCodeType.ALERT
-                ? 'Alerts as code support chart alerts with email or Slack targets'
-                : 'MVP supports chart/dashboard deliveries with email or Slack targets and CSV, XLSX, image, or PDF formats; secret/OAuth-backed targets are excluded';
+        const { singular: contentName } =
+            CoderService.getScheduledContentNames(contentType);
+        const unsupportedReason = `${contentName} as code supports chart and dashboard resources`;
 
         matchingSchedulers.forEach((scheduler, index) => {
             const item = transformed[index];
@@ -1609,6 +1750,12 @@ export class CoderService extends BaseService {
 
         if (contentType === ContentAsCodeType.ALERT) {
             return { alerts: content as AlertAsCode[], skipped };
+        }
+        if (contentType === ContentAsCodeType.GOOGLE_SHEETS_SYNC) {
+            return {
+                googleSheetsSyncs: content as GoogleSheetsSyncAsCode[],
+                skipped,
+            };
         }
         return {
             scheduledDeliveries: content as ScheduledDeliveryAsCode[],
@@ -1657,7 +1804,10 @@ export class CoderService extends BaseService {
 
     private async getScheduledDeliveryResource(
         projectUuid: string,
-        delivery: ScheduledDeliveryAsCode | AlertAsCode,
+        delivery:
+            | ScheduledDeliveryAsCode
+            | AlertAsCode
+            | GoogleSheetsSyncAsCode,
     ): Promise<
         | { type: 'chart'; uuid: string }
         | { type: 'dashboard'; uuid: string; dashboard: DashboardDAO }
@@ -1734,24 +1884,53 @@ export class CoderService extends BaseService {
         return delivery.resource.type === 'dashboard';
     }
 
+    private static isChartScheduledContent(
+        delivery:
+            | ScheduledDeliveryAsCode
+            | AlertAsCode
+            | GoogleSheetsSyncAsCode,
+    ): delivery is
+        | ChartScheduledDeliveryAsCode
+        | AlertAsCode
+        | ChartGoogleSheetsSyncAsCode {
+        return delivery.resource.type === 'chart';
+    }
+
+    private static isDashboardScheduledContent(
+        delivery:
+            | ScheduledDeliveryAsCode
+            | AlertAsCode
+            | GoogleSheetsSyncAsCode,
+    ): delivery is
+        | DashboardScheduledDeliveryAsCode
+        | DashboardGoogleSheetsSyncAsCode {
+        return delivery.resource.type === 'dashboard';
+    }
+
     private static scheduledContentIsEqual(
-        current: ScheduledDeliveryAsCode | AlertAsCode,
-        desired: ScheduledDeliveryAsCode | AlertAsCode,
+        current: ScheduledDeliveryAsCode | AlertAsCode | GoogleSheetsSyncAsCode,
+        desired: ScheduledDeliveryAsCode | AlertAsCode | GoogleSheetsSyncAsCode,
     ): boolean {
         const normalize = (
-            scheduledContent: ScheduledDeliveryAsCode | AlertAsCode,
+            scheduledContent:
+                | ScheduledDeliveryAsCode
+                | AlertAsCode
+                | GoogleSheetsSyncAsCode,
         ) => {
             const { downloadedAt, ...rest } = scheduledContent;
-            return {
-                ...rest,
-                targets: [...rest.targets].sort((left, right) =>
-                    CoderService.getScheduledDeliveryTargetKey(
-                        left,
-                    ).localeCompare(
-                        CoderService.getScheduledDeliveryTargetKey(right),
+            if ('targets' in rest) {
+                return {
+                    ...rest,
+                    targets: [...rest.targets].sort((left, right) =>
+                        CoderService.getScheduledDeliveryTargetKey(
+                            left,
+                        ).localeCompare(
+                            CoderService.getScheduledDeliveryTargetKey(right),
+                        ),
                     ),
-                ),
-            };
+                };
+            }
+            return rest;
         };
         return isEqual(normalize(current), normalize(desired));
     }
@@ -1760,14 +1939,21 @@ export class CoderService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         slug: string,
-        delivery: ScheduledDeliveryAsCode | AlertAsCode,
+        delivery:
+            | ScheduledDeliveryAsCode
+            | AlertAsCode
+            | GoogleSheetsSyncAsCode,
         force = false,
     ): Promise<
         | ApiScheduledDeliveryAsCodeUpsertResponse['results']
         | ApiAlertAsCodeUpsertResponse['results']
+        | ApiGoogleSheetsSyncAsCodeUpsertResponse['results']
     > {
         const isAlert = delivery.contentType === ContentAsCodeType.ALERT;
-        const contentName = isAlert ? 'Alert' : 'Scheduled delivery';
+        const isGoogleSheetsSync =
+            delivery.contentType === ContentAsCodeType.GOOGLE_SHEETS_SYNC;
+        const { singular: contentName, plural: contentPlural } =
+            CoderService.getScheduledContentNames(delivery.contentType);
         if (slug !== delivery.slug) {
             throw new ParameterError(
                 `${contentName} slug '${delivery.slug}' does not match path slug '${slug}'`,
@@ -1785,9 +1971,7 @@ export class CoderService extends BaseService {
             )
         ) {
             throw new ForbiddenError(
-                `You are not allowed to upload ${
-                    isAlert ? 'alerts' : 'scheduled deliveries'
-                }`,
+                `You are not allowed to upload ${contentPlural}`,
             );
         }
 
@@ -1803,6 +1987,9 @@ export class CoderService extends BaseService {
         if (
             existing &&
             (Boolean(existing.thresholds?.length) !== isAlert ||
+                isGoogleSheetsSync !==
+                    (!existing.thresholds?.length &&
+                        existing.format === SchedulerFormat.GSHEETS) ||
                 (resource.type === 'chart' &&
                     (!isChartScheduler(existing) ||
                         existing.savedChartUuid !== resource.uuid)) ||
@@ -1816,9 +2003,27 @@ export class CoderService extends BaseService {
         }
 
         if (existing) {
-            const current = isAlert
-                ? await this.transformAlert(existing)
-                : await this.transformScheduledDelivery(existing);
+            let current:
+                | ScheduledDeliveryAsCode
+                | AlertAsCode
+                | GoogleSheetsSyncAsCode
+                | null;
+            switch (delivery.contentType) {
+                case ContentAsCodeType.ALERT:
+                    current = await this.transformAlert(existing);
+                    break;
+                case ContentAsCodeType.GOOGLE_SHEETS_SYNC:
+                    current = await this.transformGoogleSheetsSync(existing);
+                    break;
+                case ContentAsCodeType.SCHEDULED_DELIVERY:
+                    current = await this.transformScheduledDelivery(existing);
+                    break;
+                default:
+                    current = assertUnreachable(
+                        delivery,
+                        'Unknown scheduled content type',
+                    );
+            }
             if (
                 !force &&
                 current &&
@@ -1828,14 +2033,16 @@ export class CoderService extends BaseService {
             }
         }
 
-        const targets = CoderService.getScheduledDeliveryTargets(delivery);
+        const targets = isGoogleSheetsSync
+            ? []
+            : CoderService.getScheduledDeliveryTargets(delivery);
         let filters: Filters | DashboardFilterRule[] | undefined;
-        if (isAlert || CoderService.isChartScheduledDelivery(delivery)) {
+        if (CoderService.isChartScheduledContent(delivery)) {
             filters = delivery.filters
                 ? normalizeFilterIds(delivery.filters)
                 : undefined;
         } else if (
-            CoderService.isDashboardScheduledDelivery(delivery) &&
+            CoderService.isDashboardScheduledContent(delivery) &&
             resource.type === 'dashboard'
         ) {
             filters =
@@ -1849,7 +2056,7 @@ export class CoderService extends BaseService {
             );
         }
         let selectedTabs: string[] | null | undefined;
-        if (isAlert) {
+        if (isAlert || delivery.resource.type === 'chart') {
             selectedTabs = null;
         } else if (resource.type === 'dashboard' && delivery.selectedTabs) {
             selectedTabs = delivery.selectedTabs.map((tabSlug) =>
@@ -1859,14 +2066,45 @@ export class CoderService extends BaseService {
             selectedTabs = delivery.selectedTabs;
         }
 
+        const formatAndOptions = (() => {
+            switch (delivery.contentType) {
+                case ContentAsCodeType.ALERT:
+                    return {
+                        format: SchedulerFormat.IMAGE,
+                        options: { withPdf: false },
+                    };
+                case ContentAsCodeType.GOOGLE_SHEETS_SYNC:
+                    return {
+                        format: SchedulerFormat.GSHEETS,
+                        options: {
+                            gdriveId: delivery.destination.spreadsheetId,
+                            gdriveName: delivery.destination.spreadsheetName,
+                            gdriveOrganizationName:
+                                delivery.destination.organizationName,
+                            url: delivery.destination.url,
+                            tabName: delivery.destination.tabName ?? undefined,
+                        },
+                    };
+                case ContentAsCodeType.SCHEDULED_DELIVERY:
+                    return {
+                        format: delivery.format,
+                        options: delivery.options,
+                    };
+                default:
+                    return assertUnreachable(
+                        delivery,
+                        'Unknown scheduled content type',
+                    );
+            }
+        })();
+
         const schedulerInput = {
             slug: delivery.slug,
             name: delivery.name,
             message: delivery.message ?? undefined,
             cron: delivery.cron,
             timezone: delivery.timezone ?? undefined,
-            format: isAlert ? SchedulerFormat.IMAGE : delivery.format,
-            options: isAlert ? { withPdf: false } : delivery.options,
+            ...formatAndOptions,
             filters,
             parameters: delivery.parameters ?? undefined,
             customViewportWidth: isAlert

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -11,6 +11,8 @@ import {
     ApiDashboardAsCodeListResponse,
     ApiDashboardValidationResponse,
     ApiEmbedProjectAppsResponse,
+    ApiGoogleSheetsSyncAsCodeListResponse,
+    ApiGoogleSheetsSyncAsCodeUpsertResponse,
     ApiImportAppCodeResponse,
     ApiScheduledDeliveryAsCodeListResponse,
     ApiScheduledDeliveryAsCodeUpsertResponse,
@@ -23,6 +25,7 @@ import {
     DashboardAsCode,
     generateSlug,
     getErrorMessage,
+    GoogleSheetsSyncAsCode,
     LightdashError,
     ParameterError,
     Project,
@@ -95,6 +98,7 @@ export type DownloadHandlerOptions = {
     charts: string[]; // These can be slugs, uuids or urls
     dashboards: string[]; // These can be slugs, uuids or urls
     alerts: string[];
+    googleSheets: string[];
     scheduledDeliveries: string[];
     apps?: string[]; // specific app UUIDs (enterprise); absent = no explicit selection
     includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
@@ -112,6 +116,7 @@ export type DownloadHandlerOptions = {
     skipCharts: boolean; // Skip downloading charts and SQL charts
     skipDashboards: boolean; // Skip downloading dashboards
     skipAlerts: boolean;
+    skipGoogleSheets: boolean;
     skipScheduledDeliveries: boolean;
     appsOnly?: boolean; // download only: implies skipCharts + skipDashboards + skipSpaces
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
@@ -868,28 +873,51 @@ const getScheduledDeliveriesFolder = (customPath?: string): string =>
 const getAlertsFolder = (customPath?: string): string =>
     path.join(getDownloadFolder(customPath), 'alerts');
 
-type ScheduledContentAsCode = ScheduledDeliveryAsCode | AlertAsCode;
+const getGoogleSheetsFolder = (customPath?: string): string =>
+    path.join(getDownloadFolder(customPath), 'google-sheets');
+
+type ScheduledContentAsCode =
+    | ScheduledDeliveryAsCode
+    | AlertAsCode
+    | GoogleSheetsSyncAsCode;
 type ScheduledContentType =
     | ContentAsCodeTypeEnum.SCHEDULED_DELIVERY
-    | ContentAsCodeTypeEnum.ALERT;
+    | ContentAsCodeTypeEnum.ALERT
+    | ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC;
 
 const getScheduledContentConfig = (
     contentType: ScheduledContentType,
     customPath?: string,
-) =>
-    contentType === ContentAsCodeTypeEnum.ALERT
-        ? {
-              folder: getAlertsFolder(customPath),
-              route: 'alerts',
-              singular: 'alert',
-              plural: 'alerts',
-          }
-        : {
-              folder: getScheduledDeliveriesFolder(customPath),
-              route: 'scheduledDeliveries',
-              singular: 'scheduled delivery',
-              plural: 'scheduled deliveries',
-          };
+) => {
+    switch (contentType) {
+        case ContentAsCodeTypeEnum.ALERT:
+            return {
+                folder: getAlertsFolder(customPath),
+                route: 'alerts',
+                singular: 'alert',
+                plural: 'alerts',
+            };
+        case ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC:
+            return {
+                folder: getGoogleSheetsFolder(customPath),
+                route: 'googleSheets',
+                singular: 'Google Sheets sync',
+                plural: 'Google Sheets syncs',
+            };
+        case ContentAsCodeTypeEnum.SCHEDULED_DELIVERY:
+            return {
+                folder: getScheduledDeliveriesFolder(customPath),
+                route: 'scheduledDeliveries',
+                singular: 'scheduled delivery',
+                plural: 'scheduled deliveries',
+            };
+        default:
+            return assertUnreachable(
+                contentType,
+                'Unknown scheduled content type',
+            );
+    }
+};
 
 const getPromoteAction = (action: PromotionAction) => {
     switch (action) {
@@ -920,6 +948,7 @@ const downloadScheduledContent = async (
     ).toString();
     const results = await lightdashApi<
         | ApiAlertAsCodeListResponse['results']
+        | ApiGoogleSheetsSyncAsCodeListResponse['results']
         | ApiScheduledDeliveryAsCodeListResponse['results']
     >({
         method: 'GET',
@@ -928,8 +957,14 @@ const downloadScheduledContent = async (
         }`,
         body: undefined,
     });
-    const scheduledContent: ScheduledContentAsCode[] =
-        'alerts' in results ? results.alerts : results.scheduledDeliveries;
+    let scheduledContent: ScheduledContentAsCode[];
+    if ('alerts' in results) {
+        scheduledContent = results.alerts;
+    } else if ('googleSheetsSyncs' in results) {
+        scheduledContent = results.googleSheetsSyncs;
+    } else {
+        scheduledContent = results.scheduledDeliveries;
+    }
 
     for (const item of scheduledContent) {
         const outputDir = path.join(
@@ -1009,6 +1044,7 @@ const upsertScheduledContent = async (
         try {
             const result = await lightdashApi<
                 | ApiAlertAsCodeUpsertResponse['results']
+                | ApiGoogleSheetsSyncAsCodeUpsertResponse['results']
                 | ApiScheduledDeliveryAsCodeUpsertResponse['results']
             >({
                 method: 'POST',
@@ -1084,6 +1120,7 @@ export const downloadHandler = async (
         options.skipDashboards = true;
         options.skipSpaces = true;
         options.skipAlerts = true;
+        options.skipGoogleSheets = true;
         options.skipScheduledDeliveries = true;
     }
 
@@ -1139,6 +1176,7 @@ export const downloadHandler = async (
             options.charts.length > 0 ||
             options.dashboards.length > 0 ||
             options.alerts.length > 0 ||
+            options.googleSheets.length > 0 ||
             options.scheduledDeliveries.length > 0;
 
         // When downloading specific charts or dashboards, skip space metadata
@@ -1318,6 +1356,27 @@ export const downloadHandler = async (
                 );
                 spinner.succeed(
                     `Downloaded ${scheduledDeliveryTotal} scheduled deliveries`,
+                );
+            }
+        }
+
+        if (!options.skipGoogleSheets) {
+            if (hasFilters && options.googleSheets.length === 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `No Google Sheets sync filters provided, skipping`,
+                    ),
+                );
+            } else {
+                spinner.start(`Downloading Google Sheets syncs`);
+                const googleSheetsTotal = await downloadScheduledContent(
+                    projectId,
+                    options.googleSheets,
+                    ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC,
+                    options.path,
+                );
+                spinner.succeed(
+                    `Downloaded ${googleSheetsTotal} Google Sheets ${googleSheetsTotal === 1 ? 'sync' : 'syncs'}`,
                 );
             }
         }
@@ -1999,6 +2058,7 @@ export const uploadHandler = async (
             options.charts.length > 0 ||
             options.dashboards.length > 0 ||
             options.alerts.length > 0 ||
+            options.googleSheets.length > 0 ||
             options.scheduledDeliveries.length > 0;
 
         // Discover loose YAML files (outside charts/ and dashboards/) classified by contentType
@@ -2128,6 +2188,25 @@ export const uploadHandler = async (
                     changes,
                     options.force,
                     ContentAsCodeTypeEnum.SCHEDULED_DELIVERY,
+                    options.path,
+                );
+            }
+        }
+
+        if (!options.skipGoogleSheets) {
+            if (hasFilters && options.googleSheets.length === 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `No Google Sheets sync filters provided, skipping`,
+                    ),
+                );
+            } else {
+                changes = await upsertScheduledContent(
+                    projectId,
+                    options.googleSheets,
+                    changes,
+                    options.force,
+                    ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC,
                     options.path,
                 );
             }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -730,6 +730,11 @@ program
     )
     .option('--alerts <slugs...>', 'specify alert slugs to download', [])
     .option(
+        '--google-sheets <slugs...>',
+        'specify Google Sheets sync slugs to download',
+        [],
+    )
+    .option(
         '--scheduled-deliveries <slugs...>',
         'specify scheduled delivery slugs to download',
         [],
@@ -763,6 +768,11 @@ program
     .option('--skip-charts', 'skip downloading charts', false)
     .option('--skip-dashboards', 'skip downloading dashboards', false)
     .option('--skip-alerts', 'skip downloading alerts', false)
+    .option(
+        '--skip-google-sheets',
+        'skip downloading Google Sheets syncs',
+        false,
+    )
     .option(
         '--skip-scheduled-deliveries',
         'skip downloading scheduled deliveries',
@@ -810,6 +820,11 @@ program
     )
     .option('--alerts <slugs...>', 'specify alert slugs to upload', [])
     .option(
+        '--google-sheets <slugs...>',
+        'specify Google Sheets sync slugs to upload',
+        [],
+    )
+    .option(
         '--scheduled-deliveries <slugs...>',
         'specify scheduled delivery slugs to upload',
         [],
@@ -837,6 +852,7 @@ program
     )
     .option('--public', 'Create new spaces as public instead of private', false)
     .option('--skip-alerts', 'skip uploading alerts', false)
+    .option('--skip-google-sheets', 'skip uploading Google Sheets syncs', false)
     .option(
         '--skip-scheduled-deliveries',
         'skip uploading scheduled deliveries',

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -114,6 +114,8 @@ import {
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
     type ApiDashboardAsCodeListResponse,
+    type ApiGoogleSheetsSyncAsCodeListResponse,
+    type ApiGoogleSheetsSyncAsCodeUpsertResponse,
     type ApiScheduledDeliveryAsCodeListResponse,
     type ApiScheduledDeliveryAsCodeUpsertResponse,
     type ApiSqlChartAsCodeListResponse,
@@ -1117,6 +1119,8 @@ type ApiResults =
     | ApiChartAsCodeListResponse['results']
     | ApiSqlChartAsCodeListResponse['results']
     | ApiDashboardAsCodeListResponse['results']
+    | ApiGoogleSheetsSyncAsCodeListResponse['results']
+    | ApiGoogleSheetsSyncAsCodeUpsertResponse['results']
     | ApiScheduledDeliveryAsCodeListResponse['results']
     | ApiScheduledDeliveryAsCodeUpsertResponse['results']
     | ApiChartAsCodeUpsertResponse['results']

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -38,6 +38,7 @@ export enum ContentAsCodeType {
     SPACE = 'space',
     SCHEDULED_DELIVERY = 'scheduled_delivery',
     ALERT = 'alert',
+    GOOGLE_SHEETS_SYNC = 'google_sheets_sync',
 }
 
 /**
@@ -411,6 +412,70 @@ export type ApiAlertAsCodeListResponse = {
 };
 
 export type ApiAlertAsCodeUpsertResponse = {
+    status: 'ok';
+    results: {
+        action:
+            | PromotionAction.CREATE
+            | PromotionAction.UPDATE
+            | PromotionAction.NO_CHANGES;
+    };
+};
+
+type GoogleSheetsSyncAsCodeBase = {
+    contentType: ContentAsCodeType.GOOGLE_SHEETS_SYNC;
+    version: number;
+    slug: string;
+    name: string;
+    message: string | null;
+    cron: string;
+    timezone: string | null;
+    enabled: boolean;
+    includeLinks: boolean;
+    destination: {
+        spreadsheetId: string;
+        spreadsheetName: string;
+        organizationName: string;
+        url: string;
+        tabName: string | null;
+    };
+    downloadedAt?: Date;
+};
+
+export type ChartGoogleSheetsSyncAsCode = GoogleSheetsSyncAsCodeBase & {
+    resource: {
+        type: 'chart';
+        slug: string;
+    };
+    filters: FiltersInput | null;
+    parameters: ParametersValuesMap | null;
+    customViewportWidth: null;
+    selectedTabs: null;
+};
+
+export type DashboardGoogleSheetsSyncAsCode = GoogleSheetsSyncAsCodeBase & {
+    resource: {
+        type: 'dashboard';
+        slug: string;
+    };
+    filters: Omit<DashboardFilterRule, 'id'>[] | null;
+    parameters: ParametersValuesMap | null;
+    customViewportWidth: number | null;
+    selectedTabs: string[] | null;
+};
+
+export type GoogleSheetsSyncAsCode =
+    | ChartGoogleSheetsSyncAsCode
+    | DashboardGoogleSheetsSyncAsCode;
+
+export type ApiGoogleSheetsSyncAsCodeListResponse = {
+    status: 'ok';
+    results: {
+        googleSheetsSyncs: GoogleSheetsSyncAsCode[];
+        skipped: ScheduledDeliveryAsCodeSkip[];
+    };
+};
+
+export type ApiGoogleSheetsSyncAsCodeUpsertResponse = {
     status: 'ok';
     results: {
         action:


### PR DESCRIPTION
## ![CleanShot 2026-07-13 at 17.50.24@2x.png](https://app.graphite.com/user-attachments/assets/d5b9b746-d796-482b-833a-f481c7e3f248.png)

Closes: [https://linear.app/lightdash/issue/PROD-8834/google-sync-as-code](https://linear.app/lightdash/issue/PROD-8834/google-sync-as-code)

## Summary

- add Google Sheets syncs as a separate content-as-code domain under `google-sheets/`
- support chart and dashboard syncs using portable resource slugs and explicit spreadsheet destination metadata
- add `--google-sheets` and `--skip-google-sheets` to CLI download and upload
- reuse scheduler project-scoped slugs, permissions, ownership semantics, collision handling, no-change detection, forced updates, and filter/tab portability
- keep Google OAuth validation intact: uploads require the PAT user to have Google Sheets permission and access to the referenced spreadsheet

## Validation

- common, backend, and CLI typechecks, lint, and formatting
- 23 focused backend cases covering delivery, alert, and Google Sheets scheduler domains
- 187 CLI tests
- PAT-authenticated CLI: existing download, unchanged upload, forced update, create by new slug, normal update, chart and dashboard syncs, filtered round-trip download, and zero-sync download/upload
- API and database verification of destination metadata, resource slug resolution, owner, disabled state, empty targets, schedule, timezone, message, filters, parameters, and selected tabs

Relates: PROD-8817