### PR TITLE
feat(deep-research): add Claude managed agent client

### DIFF
--- a/packages/backend/src/ee/clients/AiDeepResearchClient.test.ts
+++ b/packages/backend/src/ee/clients/AiDeepResearchClient.test.ts
@@ -1,0 +1,782 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type { AgentCreateParams } from '@anthropic-ai/sdk/resources/beta/agents';
+import type { EnvironmentCreateParams } from '@anthropic-ai/sdk/resources/beta/environments';
+import type { BetaManagedAgentsSessionEvent } from '@anthropic-ai/sdk/resources/beta/sessions/events';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import {
+    AiDeepResearchClient,
+    type AiDeepResearchSessionConfig,
+} from './AiDeepResearchClient';
+
+type SessionEventInput<T> = T extends BetaManagedAgentsSessionEvent
+    ? Omit<T, 'id' | 'processed_at'>
+    : never;
+
+const event = (
+    value: SessionEventInput<BetaManagedAgentsSessionEvent>,
+): BetaManagedAgentsSessionEvent =>
+    ({
+        id: crypto.randomUUID(),
+        processed_at: new Date().toISOString(),
+        ...value,
+    }) as BetaManagedAgentsSessionEvent;
+
+const asyncIterable = <T>(items: T[]): AsyncIterable<T> => ({
+    async *[Symbol.asyncIterator]() {
+        yield* items;
+    },
+});
+
+const stream = (events: BetaManagedAgentsSessionEvent[]) => ({
+    controller: new AbortController(),
+    async *[Symbol.asyncIterator]() {
+        yield* events;
+    },
+});
+
+const endTurn = event({
+    type: 'session.status_idle',
+    stop_reason: { type: 'end_turn' },
+});
+
+const createAnthropicMock = (
+    streams: BetaManagedAgentsSessionEvent[][] = [[endTurn]],
+) => {
+    type AgentResource = {
+        id: string;
+        version: number;
+        metadata?: Record<string, string>;
+    };
+    type EnvironmentResource = {
+        id: string;
+        metadata?: Record<string, string>;
+    };
+    type SendPayload = { events: Array<{ type: string }> };
+    type RequestOptions = {
+        signal: AbortSignal;
+        timeout?: number;
+        maxRetries?: number;
+    };
+
+    const agentsList = vi.fn(
+        (_params?: unknown, _options?: unknown): AsyncIterable<AgentResource> =>
+            asyncIterable([]),
+    );
+    const agentsCreate = vi.fn(
+        async (
+            _params: AgentCreateParams,
+            _options?: unknown,
+        ): Promise<AgentResource> => ({
+            id: 'agent-1',
+            version: 7,
+            metadata: {},
+        }),
+    );
+    const environmentsList = vi.fn(
+        (
+            _params?: unknown,
+            _options?: unknown,
+        ): AsyncIterable<EnvironmentResource> => asyncIterable([]),
+    );
+    const environmentsCreate = vi.fn(
+        async (
+            _params: EnvironmentCreateParams,
+            _options?: unknown,
+        ): Promise<EnvironmentResource> => ({
+            id: 'environment-1',
+            metadata: {},
+        }),
+    );
+    const vaultsCreate = vi.fn().mockResolvedValue({ id: 'vault-1' });
+    const vaultsDelete = vi.fn().mockResolvedValue({
+        id: 'vault-1',
+        type: 'vault_deleted',
+    });
+    const credentialsCreate = vi.fn().mockResolvedValue({ id: 'credential-1' });
+    const sessionsCreate = vi.fn().mockResolvedValue({ id: 'session-1' });
+    const eventsSend = vi.fn(
+        async (
+            _sessionId: string,
+            _payload: SendPayload,
+            _options?: RequestOptions,
+        ) => ({ data: [] }),
+    );
+    const eventsStream = vi.fn(
+        (_sessionId: string, _params: unknown, _options: RequestOptions) =>
+            Promise.resolve(stream(streams.shift() ?? [])),
+    );
+    const eventsList = vi.fn(
+        (
+            _sessionId: string,
+            _params: unknown,
+            _options: RequestOptions,
+        ): AsyncIterable<BetaManagedAgentsSessionEvent> => asyncIterable([]),
+    );
+
+    const client = {
+        beta: {
+            agents: { list: agentsList, create: agentsCreate },
+            environments: {
+                list: environmentsList,
+                create: environmentsCreate,
+            },
+            vaults: {
+                create: vaultsCreate,
+                delete: vaultsDelete,
+                credentials: { create: credentialsCreate },
+            },
+            sessions: {
+                create: sessionsCreate,
+                events: {
+                    send: eventsSend,
+                    stream: eventsStream,
+                    list: eventsList,
+                },
+            },
+        },
+    } as unknown as Anthropic;
+
+    return {
+        client,
+        agentsList,
+        agentsCreate,
+        environmentsList,
+        environmentsCreate,
+        vaultsCreate,
+        vaultsDelete,
+        credentialsCreate,
+        sessionsCreate,
+        eventsSend,
+        eventsStream,
+        eventsList,
+    };
+};
+
+const createConfig = (
+    overrides: Partial<AiDeepResearchSessionConfig> = {},
+): AiDeepResearchSessionConfig => ({
+    agent: {
+        name: 'Deep Research',
+        model: 'claude-opus-4-6',
+        system: 'Investigate the question.',
+    },
+    environment: {
+        name: 'Deep Research',
+        config: {
+            type: 'cloud',
+            networking: { type: 'limited', allow_mcp_servers: true },
+        },
+    },
+    vault: { display_name: 'Deep Research run' },
+    credentials: [
+        {
+            display_name: 'Lightdash PAT',
+            auth: {
+                type: 'static_bearer',
+                mcp_server_url: 'https://lightdash.example/api/v1/mcp',
+                token: 'secret-token',
+            },
+        },
+    ],
+    sessionTitle: 'Investigate revenue changes',
+    prompt: 'Why did revenue change?',
+    timeoutMs: 60_000,
+    interruptTimeoutMs: 1_000,
+    signal: new AbortController().signal,
+    onSessionCreated: vi.fn().mockResolvedValue(undefined),
+    onCustomToolUse: vi.fn().mockResolvedValue('tool result'),
+    ...overrides,
+});
+
+const createClient = (anthropicClient: Anthropic) =>
+    new AiDeepResearchClient({
+        lightdashConfig: lightdashConfigMock,
+        anthropicClient,
+    });
+
+describe('AiDeepResearchClient', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('persists the session ID before sending the prompt and only completes on end_turn', async () => {
+        const anthropic = createAnthropicMock();
+        const order: string[] = [];
+        const config = createConfig({
+            onSessionCreated: vi.fn(async () => {
+                order.push('persisted');
+            }),
+        });
+        anthropic.eventsSend.mockImplementation(async (_id, payload) => {
+            const sentEvent = payload.events[0];
+            if (sentEvent.type === 'user.message') {
+                order.push('prompted');
+            }
+            return { data: [] };
+        });
+        anthropic.eventsStream.mockImplementation(async () => {
+            order.push('streamed');
+            return stream([endTurn]);
+        });
+
+        const result = await createClient(anthropic.client).runSession(config);
+
+        expect(result).toEqual({
+            status: 'completed',
+            sessionId: 'session-1',
+        });
+        expect(order).toEqual(['persisted', 'streamed', 'prompted']);
+        expect(anthropic.vaultsDelete).toHaveBeenCalledWith(
+            'vault-1',
+            {},
+            expect.objectContaining({ maxRetries: 2 }),
+        );
+        expect(anthropic.sessionsCreate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                agent: { type: 'agent', id: 'agent-1', version: 7 },
+                environment_id: 'environment-1',
+                vault_ids: ['vault-1'],
+                title: config.sessionTitle,
+            }),
+            expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        );
+    });
+
+    it('reuses exact agent and environment configs but creates a fresh credential vault per run', async () => {
+        const first = createAnthropicMock();
+        const client = createClient(first.client);
+        const firstConfig = createConfig();
+
+        await client.runSession(firstConfig);
+        const createdAgent = first.agentsCreate.mock.calls[0][0];
+        const createdEnvironment = first.environmentsCreate.mock.calls[0][0];
+        first.agentsList.mockImplementation(() =>
+            asyncIterable([
+                { id: 'agent-1', version: 7, metadata: createdAgent.metadata },
+            ]),
+        );
+        first.environmentsList.mockImplementation(() =>
+            asyncIterable([
+                { id: 'environment-1', metadata: createdEnvironment.metadata },
+            ]),
+        );
+        first.vaultsCreate
+            .mockResolvedValueOnce({ id: 'vault-2' })
+            .mockResolvedValueOnce({ id: 'vault-3' });
+        first.eventsStream.mockImplementation(() =>
+            Promise.resolve(stream([endTurn])),
+        );
+
+        await client.runSession(
+            createConfig({
+                credentials: [
+                    {
+                        display_name: 'Lightdash PAT',
+                        auth: {
+                            type: 'static_bearer',
+                            mcp_server_url:
+                                'https://lightdash.example/api/v1/mcp',
+                            token: 'rotated-secret-token',
+                        },
+                    },
+                ],
+            }),
+        );
+
+        expect(first.agentsCreate).toHaveBeenCalledTimes(1);
+        expect(first.environmentsCreate).toHaveBeenCalledTimes(1);
+        expect(first.vaultsCreate).toHaveBeenCalledTimes(2);
+        expect(first.credentialsCreate).toHaveBeenLastCalledWith(
+            'vault-2',
+            expect.objectContaining({
+                auth: expect.objectContaining({
+                    token: 'rotated-secret-token',
+                }),
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('does not send a prompt when persisting the session ID fails', async () => {
+        const anthropic = createAnthropicMock();
+        const result = await createClient(anthropic.client).runSession(
+            createConfig({
+                onSessionCreated: vi
+                    .fn()
+                    .mockRejectedValue(new Error('database unavailable')),
+            }),
+        );
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            sessionId: 'session-1',
+            reason: 'session_id_persistence_failed',
+        });
+        expect(anthropic.eventsSend).toHaveBeenCalledWith(
+            'session-1',
+            { events: [{ type: 'user.interrupt' }] },
+            expect.anything(),
+        );
+        expect(anthropic.eventsSend).not.toHaveBeenCalledWith(
+            'session-1',
+            expect.objectContaining({
+                events: [expect.objectContaining({ type: 'user.message' })],
+            }),
+            expect.anything(),
+        );
+    });
+
+    it.each([
+        {
+            name: 'retry exhaustion on an idle event',
+            terminalEvent: event({
+                type: 'session.status_idle',
+                stop_reason: { type: 'retries_exhausted' },
+            }),
+            reason: 'retries_exhausted',
+        },
+        {
+            name: 'retry exhaustion on an error event',
+            terminalEvent: event({
+                type: 'session.error',
+                error: {
+                    type: 'model_overloaded_error',
+                    message: 'overloaded',
+                    retry_status: { type: 'exhausted' },
+                },
+            }),
+            reason: 'retries_exhausted',
+        },
+        {
+            name: 'a terminal Claude error',
+            terminalEvent: event({
+                type: 'session.error',
+                error: {
+                    type: 'model_request_failed_error',
+                    message: 'model failed',
+                    retry_status: { type: 'terminal' },
+                },
+            }),
+            reason: 'claude_error',
+        },
+        {
+            name: 'session termination',
+            terminalEvent: event({ type: 'session.status_terminated' }),
+            reason: 'terminated',
+        },
+    ])('fails deliberately for $name', async ({ terminalEvent, reason }) => {
+        const anthropic = createAnthropicMock([[terminalEvent]]);
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig(),
+        );
+
+        expect(result).toMatchObject({ status: 'failed', reason });
+    });
+
+    it('reports structural progress without exposing model or tool content', async () => {
+        const progress = vi.fn().mockResolvedValue(undefined);
+        const anthropic = createAnthropicMock([
+            [
+                event({
+                    type: 'session.error',
+                    error: {
+                        type: 'model_overloaded_error',
+                        message: 'sensitive provider details',
+                        retry_status: { type: 'retrying' },
+                    },
+                }),
+                event({ type: 'agent.thinking' }),
+                event({
+                    type: 'agent.tool_use',
+                    name: 'web_search',
+                    input: { query: 'sensitive query' },
+                }),
+                endTurn,
+            ],
+        ]);
+
+        await createClient(anthropic.client).runSession(
+            createConfig({ onProgress: progress }),
+        );
+
+        expect(progress.mock.calls).toEqual([
+            [{ type: 'retrying' }],
+            [{ type: 'thinking' }],
+            [{ type: 'tool_use', source: 'built_in', name: 'web_search' }],
+        ]);
+        expect(JSON.stringify(progress.mock.calls)).not.toContain('sensitive');
+    });
+
+    it('recovers a terminal event from persisted history after stream EOF', async () => {
+        const anthropic = createAnthropicMock([[]]);
+        anthropic.eventsList.mockImplementation(() => asyncIterable([endTurn]));
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig(),
+        );
+
+        expect(result.status).toBe('completed');
+        expect(anthropic.eventsList).toHaveBeenCalledOnce();
+    });
+
+    it('handles an unresolved persisted custom tool call after stream EOF', async () => {
+        const persistedToolUse = event({
+            type: 'agent.custom_tool_use',
+            name: 'query_lightdash',
+            input: { query: 'select 1' },
+        });
+        const anthropic = createAnthropicMock([[], [endTurn]]);
+        anthropic.eventsList
+            .mockImplementationOnce(() => asyncIterable([persistedToolUse]))
+            .mockImplementationOnce(() => asyncIterable([]));
+        const onCustomToolUse = vi.fn().mockResolvedValue('result');
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig({ onCustomToolUse }),
+        );
+
+        expect(result.status).toBe('completed');
+        expect(onCustomToolUse).toHaveBeenCalledOnce();
+        expect(anthropic.eventsSend).toHaveBeenCalledWith(
+            'session-1',
+            expect.objectContaining({
+                events: [
+                    expect.objectContaining({
+                        type: 'user.custom_tool_result',
+                        custom_tool_use_id: persistedToolUse.id,
+                    }),
+                ],
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('fails after bounded reconnects when EOF has no terminal event', async () => {
+        const anthropic = createAnthropicMock([[], [], [], []]);
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig(),
+        );
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'unexpected_eof',
+        });
+        expect(anthropic.eventsStream).toHaveBeenCalledTimes(4);
+        expect(anthropic.eventsList).toHaveBeenCalledTimes(4);
+        expect(anthropic.eventsSend).toHaveBeenCalledWith(
+            'session-1',
+            { events: [{ type: 'user.interrupt' }] },
+            expect.anything(),
+        );
+    });
+
+    it('maps stream transport errors without reporting completion', async () => {
+        const anthropic = createAnthropicMock();
+        anthropic.eventsStream.mockRejectedValue(new Error('socket failed'));
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig(),
+        );
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'transport_error',
+        });
+        expect(anthropic.eventsSend).toHaveBeenCalledWith(
+            'session-1',
+            { events: [{ type: 'user.interrupt' }] },
+            expect.anything(),
+        );
+    });
+
+    it('aborts the initial stream when sending the prompt fails', async () => {
+        const anthropic = createAnthropicMock();
+        const initialStream = stream([]);
+        anthropic.eventsStream.mockResolvedValue(initialStream);
+        anthropic.eventsSend.mockImplementation(async (_id, payload) => {
+            if (payload.events[0].type === 'user.message') {
+                throw new Error('prompt send failed');
+            }
+            return { data: [] };
+        });
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig(),
+        );
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'transport_error',
+        });
+        expect(initialStream.controller.signal.aborted).toBe(true);
+    });
+
+    it('reconciles history and reconnects after a transient stream failure', async () => {
+        const anthropic = createAnthropicMock();
+        anthropic.eventsStream
+            .mockImplementationOnce(async () => ({
+                controller: new AbortController(),
+                async *[Symbol.asyncIterator]() {
+                    throw new Error('stream disconnected');
+                    yield endTurn;
+                },
+            }))
+            .mockImplementationOnce(async () => stream([endTurn]));
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig(),
+        );
+
+        expect(result.status).toBe('completed');
+        expect(anthropic.eventsList).toHaveBeenCalledOnce();
+        expect(anthropic.eventsStream).toHaveBeenCalledTimes(2);
+    });
+
+    it('bounds a stalled session ID persistence callback with the run timeout', async () => {
+        vi.useFakeTimers();
+        const anthropic = createAnthropicMock();
+        const resultPromise = createClient(anthropic.client).runSession(
+            createConfig({
+                timeoutMs: 100,
+                onSessionCreated: vi.fn(
+                    async (_sessionId, signal): Promise<void> =>
+                        new Promise<void>((_resolve, reject) => {
+                            signal.addEventListener('abort', () =>
+                                reject(signal.reason),
+                            );
+                        }),
+                ),
+            }),
+        );
+
+        await vi.advanceTimersByTimeAsync(100);
+        const result = await resultPromise;
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'timed_out',
+        });
+        expect(anthropic.eventsSend).toHaveBeenCalledWith(
+            'session-1',
+            { events: [{ type: 'user.interrupt' }] },
+            expect.anything(),
+        );
+    });
+
+    it('surfaces credential vault cleanup failures', async () => {
+        const anthropic = createAnthropicMock();
+        anthropic.vaultsDelete.mockRejectedValue(new Error('delete failed'));
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig(),
+        );
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'vault_cleanup_failed',
+        });
+    });
+
+    it('cancels locally before any remote resources exist', async () => {
+        const anthropic = createAnthropicMock();
+        const controller = new AbortController();
+        controller.abort();
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig({ signal: controller.signal }),
+        );
+
+        expect(result).toEqual({ status: 'cancelled', sessionId: null });
+        expect(anthropic.agentsList).not.toHaveBeenCalled();
+    });
+
+    it('interrupts Claude before reporting an in-flight cancellation', async () => {
+        const anthropic = createAnthropicMock([[]]);
+        const controller = new AbortController();
+        const config = createConfig({
+            signal: controller.signal,
+            onSessionCreated: vi.fn(async () => {
+                controller.abort(new Error('cancel requested'));
+            }),
+        });
+
+        const result = await createClient(anthropic.client).runSession(config);
+
+        expect(result).toEqual({
+            status: 'cancelled',
+            sessionId: 'session-1',
+        });
+        expect(anthropic.eventsSend).toHaveBeenCalledWith(
+            'session-1',
+            { events: [{ type: 'user.interrupt' }] },
+            expect.objectContaining({ maxRetries: 0, timeout: 1_000 }),
+        );
+    });
+
+    it('fails cancellation when the remote interrupt is rejected', async () => {
+        const anthropic = createAnthropicMock([[]]);
+        const controller = new AbortController();
+        anthropic.eventsSend.mockImplementation(async (_id, payload) => {
+            if (payload.events[0].type === 'user.interrupt') {
+                throw new Error('interrupt rejected');
+            }
+            return { data: [] };
+        });
+        const config = createConfig({
+            signal: controller.signal,
+            onSessionCreated: vi.fn(async () => {
+                controller.abort();
+            }),
+        });
+
+        const result = await createClient(anthropic.client).runSession(config);
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'interrupt_failed',
+        });
+    });
+
+    it('fails cancellation when the bounded interrupt times out', async () => {
+        vi.useFakeTimers();
+        const anthropic = createAnthropicMock([[]]);
+        const controller = new AbortController();
+        anthropic.eventsSend.mockImplementation(
+            async (_id, payload, options) => {
+                if (payload.events[0].type === 'user.interrupt') {
+                    return new Promise((_resolve, reject) => {
+                        options?.signal.addEventListener('abort', () =>
+                            reject(options.signal.reason),
+                        );
+                    });
+                }
+                return { data: [] };
+            },
+        );
+        const resultPromise = createClient(anthropic.client).runSession(
+            createConfig({
+                signal: controller.signal,
+                interruptTimeoutMs: 50,
+                onSessionCreated: vi.fn(async () => {
+                    controller.abort();
+                }),
+            }),
+        );
+
+        await vi.advanceTimersByTimeAsync(50);
+        const result = await resultPromise;
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'interrupt_failed',
+        });
+    });
+
+    it('interrupts Claude and reports a timeout as failure', async () => {
+        vi.useFakeTimers();
+        const anthropic = createAnthropicMock();
+        anthropic.eventsStream.mockImplementation(
+            async (_id, _params, options) => ({
+                controller: new AbortController(),
+                async *[Symbol.asyncIterator]() {
+                    yield await new Promise<BetaManagedAgentsSessionEvent>(
+                        (_resolve, reject) => {
+                            options.signal.addEventListener('abort', () =>
+                                reject(options.signal.reason),
+                            );
+                        },
+                    );
+                },
+            }),
+        );
+        const resultPromise = createClient(anthropic.client).runSession(
+            createConfig({ timeoutMs: 100 }),
+        );
+
+        await vi.advanceTimersByTimeAsync(100);
+        const result = await resultPromise;
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'timed_out',
+        });
+        expect(anthropic.eventsSend).toHaveBeenCalledWith(
+            'session-1',
+            { events: [{ type: 'user.interrupt' }] },
+            expect.anything(),
+        );
+    });
+
+    it('passes cancellation into custom tools and suppresses their result', async () => {
+        const toolUse = event({
+            type: 'agent.custom_tool_use',
+            name: 'query_lightdash',
+            input: { query: 'select secret' },
+        });
+        const anthropic = createAnthropicMock([[toolUse]]);
+        const controller = new AbortController();
+        const onCustomToolUse = vi.fn(
+            async ({ signal }: { signal: AbortSignal }) => {
+                controller.abort();
+                expect(signal.aborted).toBe(true);
+                return 'must not be sent';
+            },
+        );
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig({ signal: controller.signal, onCustomToolUse }),
+        );
+
+        expect(result.status).toBe('cancelled');
+        expect(onCustomToolUse).toHaveBeenCalledOnce();
+        expect(anthropic.eventsSend).not.toHaveBeenCalledWith(
+            'session-1',
+            expect.objectContaining({
+                events: [
+                    expect.objectContaining({
+                        type: 'user.custom_tool_result',
+                    }),
+                ],
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('does not send a conflicting second result when tool result delivery fails', async () => {
+        const toolUse = event({
+            type: 'agent.custom_tool_use',
+            name: 'query_lightdash',
+            input: { query: 'select 1' },
+        });
+        const anthropic = createAnthropicMock([[toolUse]]);
+        anthropic.eventsList.mockImplementation(() => asyncIterable([toolUse]));
+        const onCustomToolUse = vi.fn().mockResolvedValue('result');
+        anthropic.eventsSend.mockImplementation(async (_id, payload) => {
+            if (payload.events[0].type === 'user.custom_tool_result') {
+                throw new Error('ambiguous transport failure');
+            }
+            return { data: [] };
+        });
+
+        const result = await createClient(anthropic.client).runSession(
+            createConfig({ onCustomToolUse }),
+        );
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            reason: 'transport_error',
+        });
+        const resultSends = anthropic.eventsSend.mock.calls.filter(
+            ([, payload]) =>
+                payload.events[0].type === 'user.custom_tool_result',
+        );
+        expect(resultSends.length).toBeGreaterThan(1);
+        expect(
+            new Set(resultSends.map(([, payload]) => JSON.stringify(payload)))
+                .size,
+        ).toBe(1);
+        expect(onCustomToolUse).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/backend/src/ee/clients/AiDeepResearchClient.ts
+++ b/packages/backend/src/ee/clients/AiDeepResearchClient.ts
@@ -1,0 +1,838 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { AgentCreateParams } from '@anthropic-ai/sdk/resources/beta/agents';
+import type { EnvironmentCreateParams } from '@anthropic-ai/sdk/resources/beta/environments';
+import type { BetaManagedAgentsSessionEvent } from '@anthropic-ai/sdk/resources/beta/sessions/events';
+import type { CredentialCreateParams } from '@anthropic-ai/sdk/resources/beta/vaults/credentials';
+import type { VaultCreateParams } from '@anthropic-ai/sdk/resources/beta/vaults/vaults';
+import { ParameterError } from '@lightdash/common';
+import { createHash } from 'crypto';
+import type { LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+
+const FEATURE_METADATA = {
+    lightdash_feature: 'ai-deep-research',
+};
+const CONFIG_HASH_METADATA_KEY = 'lightdash_config_hash';
+const MAX_STREAM_RECONNECTS = 3;
+
+export type AiDeepResearchProgressEvent =
+    | { type: 'session_running' }
+    | { type: 'session_rescheduled' }
+    | { type: 'retrying' }
+    | { type: 'thinking' }
+    | { type: 'context_compacted' }
+    | { type: 'tool_use'; source: 'built_in' | 'mcp' | 'custom'; name: string };
+
+export type AiDeepResearchFailureReason =
+    | 'setup_failed'
+    | 'session_id_persistence_failed'
+    | 'claude_error'
+    | 'retries_exhausted'
+    | 'terminated'
+    | 'unexpected_eof'
+    | 'transport_error'
+    | 'timed_out'
+    | 'interrupt_failed'
+    | 'vault_cleanup_failed';
+
+export type AiDeepResearchClientResult =
+    | { status: 'completed'; sessionId: string }
+    | { status: 'cancelled'; sessionId: string | null }
+    | {
+          status: 'failed';
+          sessionId: string | null;
+          reason: AiDeepResearchFailureReason;
+          errorMessage: string;
+      };
+
+export type AiDeepResearchSessionConfig = {
+    agent: AgentCreateParams;
+    environment: EnvironmentCreateParams;
+    vault: VaultCreateParams;
+    credentials: CredentialCreateParams[];
+    sessionTitle: string;
+    prompt: string;
+    timeoutMs: number;
+    interruptTimeoutMs: number;
+    signal: AbortSignal;
+    onSessionCreated: (sessionId: string, signal: AbortSignal) => Promise<void>;
+    onCustomToolUse: (args: {
+        toolName: string;
+        input: Record<string, unknown>;
+        signal: AbortSignal;
+    }) => Promise<string>;
+    onProgress?: (event: AiDeepResearchProgressEvent) => Promise<void>;
+};
+
+type AiDeepResearchClientConfig = {
+    lightdashConfig: LightdashConfig;
+    anthropicClient?: Anthropic;
+};
+
+type TerminalResult =
+    | { status: 'completed' }
+    | {
+          status: 'failed';
+          reason: Extract<
+              AiDeepResearchFailureReason,
+              | 'claude_error'
+              | 'retries_exhausted'
+              | 'terminated'
+              | 'unexpected_eof'
+              | 'transport_error'
+          >;
+          errorMessage: string;
+      };
+
+type SessionEventStream = Awaited<
+    ReturnType<Anthropic['beta']['sessions']['events']['stream']>
+>;
+
+type CustomToolOutcome = { content: string; isError: boolean };
+type CustomToolState = {
+    outcomes: Map<string, CustomToolOutcome>;
+    deliveredIds: Set<string>;
+};
+
+const canonicalize = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+        return value.map(canonicalize);
+    }
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value)
+                .sort(([left], [right]) => left.localeCompare(right))
+                .map(([key, entry]) => [key, canonicalize(entry)]),
+        );
+    }
+    return value;
+};
+
+const getConfigHash = (value: unknown): string =>
+    createHash('sha256')
+        .update(JSON.stringify(canonicalize(value)))
+        .digest('hex');
+
+const getErrorMessage = (error: unknown): string =>
+    error instanceof Error ? error.message : 'Unknown error';
+
+const failed = (
+    sessionId: string | null,
+    reason: AiDeepResearchFailureReason,
+    errorMessage: string,
+): AiDeepResearchClientResult => ({
+    status: 'failed',
+    sessionId,
+    reason,
+    errorMessage,
+});
+
+const waitForAbort = (signal: AbortSignal): Promise<never> =>
+    new Promise((_, reject) => {
+        if (signal.aborted) {
+            reject(signal.reason);
+            return;
+        }
+        signal.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+        });
+    });
+
+export class AiDeepResearchClient {
+    private readonly config: AiDeepResearchClientConfig;
+
+    constructor(config: AiDeepResearchClientConfig) {
+        this.config = config;
+    }
+
+    private getAnthropicClient(): Anthropic {
+        if (this.config.anthropicClient) {
+            return this.config.anthropicClient;
+        }
+
+        const { anthropicApiKey } = this.config.lightdashConfig.managedAgent;
+        if (!anthropicApiKey) {
+            throw new ParameterError(
+                'ANTHROPIC_API_KEY is required for Deep Research',
+            );
+        }
+        return new Anthropic({ apiKey: anthropicApiKey });
+    }
+
+    private static withConfigMetadata<
+        T extends AgentCreateParams | EnvironmentCreateParams,
+    >(config: T): T {
+        return {
+            ...config,
+            metadata: {
+                ...config.metadata,
+                ...FEATURE_METADATA,
+                [CONFIG_HASH_METADATA_KEY]: getConfigHash(config),
+            },
+        };
+    }
+
+    private static async findByConfigHash<
+        T extends { metadata?: Record<string, string> },
+    >(resources: AsyncIterable<T>, hash: string): Promise<T | null> {
+        for await (const resource of resources) {
+            if (
+                resource.metadata?.lightdash_feature ===
+                    FEATURE_METADATA.lightdash_feature &&
+                resource.metadata?.[CONFIG_HASH_METADATA_KEY] === hash
+            ) {
+                return resource;
+            }
+        }
+        return null;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async ensureResources(
+        client: Anthropic,
+        config: AiDeepResearchSessionConfig,
+        signal: AbortSignal,
+        onVaultCreated: (vaultId: string) => void,
+    ): Promise<{
+        agentId: string;
+        agentVersion: number;
+        environmentId: string;
+        vaultId: string;
+    }> {
+        const agentHash = getConfigHash(config.agent);
+        const desiredAgent = AiDeepResearchClient.withConfigMetadata(
+            config.agent,
+        );
+        const existingAgent = await AiDeepResearchClient.findByConfigHash(
+            client.beta.agents.list({}, { signal }),
+            agentHash,
+        );
+        const agent =
+            existingAgent ??
+            (await client.beta.agents.create(desiredAgent, { signal }));
+
+        const environmentHash = getConfigHash(config.environment);
+        const desiredEnvironment = AiDeepResearchClient.withConfigMetadata(
+            config.environment,
+        );
+        const existingEnvironment = await AiDeepResearchClient.findByConfigHash(
+            client.beta.environments.list({}, { signal }),
+            environmentHash,
+        );
+        const environment =
+            existingEnvironment ??
+            (await client.beta.environments.create(desiredEnvironment, {
+                signal,
+            }));
+
+        const vault = await client.beta.vaults.create(
+            {
+                ...config.vault,
+                metadata: {
+                    ...config.vault.metadata,
+                    ...FEATURE_METADATA,
+                },
+            },
+            { signal },
+        );
+        onVaultCreated(vault.id);
+        await Promise.all(
+            config.credentials.map((credential) =>
+                client.beta.vaults.credentials.create(vault.id, credential, {
+                    signal,
+                }),
+            ),
+        );
+
+        if (
+            !('id' in agent) ||
+            !('version' in agent) ||
+            !('id' in environment)
+        ) {
+            throw new Error('Claude returned an invalid managed resource');
+        }
+
+        return {
+            agentId: agent.id,
+            agentVersion: agent.version,
+            environmentId: environment.id,
+            vaultId: vault.id,
+        };
+    }
+
+    private static classifyTerminalEvent(
+        event: BetaManagedAgentsSessionEvent,
+    ): TerminalResult | null {
+        if (event.type === 'session.status_idle') {
+            if (event.stop_reason.type === 'end_turn') {
+                return { status: 'completed' };
+            }
+            if (event.stop_reason.type === 'retries_exhausted') {
+                return {
+                    status: 'failed',
+                    reason: 'retries_exhausted',
+                    errorMessage: 'Claude exhausted its retry budget',
+                };
+            }
+        }
+        if (event.type === 'session.error') {
+            const retryStatus = event.error.retry_status.type;
+            if (retryStatus === 'exhausted') {
+                return {
+                    status: 'failed',
+                    reason: 'retries_exhausted',
+                    errorMessage: event.error.message,
+                };
+            }
+            if (retryStatus === 'terminal') {
+                return {
+                    status: 'failed',
+                    reason: 'claude_error',
+                    errorMessage: event.error.message,
+                };
+            }
+        }
+        if (
+            event.type === 'session.status_terminated' ||
+            event.type === 'session.deleted'
+        ) {
+            return {
+                status: 'failed',
+                reason: 'terminated',
+                errorMessage: 'Claude terminated the session',
+            };
+        }
+        return null;
+    }
+
+    private static getProgressEvent(
+        event: BetaManagedAgentsSessionEvent,
+    ): AiDeepResearchProgressEvent | null {
+        switch (event.type) {
+            case 'session.status_running':
+                return { type: 'session_running' };
+            case 'session.status_rescheduled':
+                return { type: 'session_rescheduled' };
+            case 'session.error':
+                return event.error.retry_status.type === 'retrying'
+                    ? { type: 'retrying' }
+                    : null;
+            case 'agent.thinking':
+                return { type: 'thinking' };
+            case 'agent.thread_context_compacted':
+                return { type: 'context_compacted' };
+            case 'agent.tool_use':
+                return {
+                    type: 'tool_use',
+                    source: 'built_in',
+                    name: event.name,
+                };
+            case 'agent.mcp_tool_use':
+                return { type: 'tool_use', source: 'mcp', name: event.name };
+            case 'agent.custom_tool_use':
+                return {
+                    type: 'tool_use',
+                    source: 'custom',
+                    name: event.name,
+                };
+            default:
+                return null;
+        }
+    }
+
+    private static async emitProgress(
+        event: BetaManagedAgentsSessionEvent,
+        callback: AiDeepResearchSessionConfig['onProgress'],
+    ): Promise<void> {
+        const progress = AiDeepResearchClient.getProgressEvent(event);
+        if (progress && callback) {
+            await callback(progress);
+        }
+    }
+
+    private static async handleCustomToolUse(
+        client: Anthropic,
+        sessionId: string,
+        event: Extract<
+            BetaManagedAgentsSessionEvent,
+            { type: 'agent.custom_tool_use' }
+        >,
+        config: AiDeepResearchSessionConfig,
+        signal: AbortSignal,
+        state: CustomToolState,
+    ): Promise<void> {
+        if (state.deliveredIds.has(event.id)) {
+            return;
+        }
+
+        let outcome = state.outcomes.get(event.id);
+        if (!outcome) {
+            try {
+                outcome = {
+                    content: await config.onCustomToolUse({
+                        toolName: event.name,
+                        input: event.input,
+                        signal,
+                    }),
+                    isError: false,
+                };
+            } catch (error) {
+                outcome = {
+                    content: JSON.stringify({ error: getErrorMessage(error) }),
+                    isError: true,
+                };
+            }
+            state.outcomes.set(event.id, outcome);
+        }
+        signal.throwIfAborted();
+        await client.beta.sessions.events.send(
+            sessionId,
+            {
+                events: [
+                    {
+                        type: 'user.custom_tool_result',
+                        custom_tool_use_id: event.id,
+                        content: [{ type: 'text', text: outcome.content }],
+                        is_error: outcome.isError,
+                    },
+                ],
+            },
+            { signal },
+        );
+        state.deliveredIds.add(event.id);
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async inspectPersistedEvents(
+        client: Anthropic,
+        sessionId: string,
+        config: AiDeepResearchSessionConfig,
+        signal: AbortSignal,
+        customToolState: CustomToolState,
+    ): Promise<TerminalResult | null> {
+        const events: BetaManagedAgentsSessionEvent[] = [];
+        for await (const event of client.beta.sessions.events.list(
+            sessionId,
+            {},
+            { signal },
+        )) {
+            events.push(event);
+            const terminal = AiDeepResearchClient.classifyTerminalEvent(event);
+            if (terminal) {
+                return terminal;
+            }
+        }
+
+        const resolvedCustomToolUseIds = new Set(
+            events
+                .filter(
+                    (
+                        event,
+                    ): event is Extract<
+                        BetaManagedAgentsSessionEvent,
+                        { type: 'user.custom_tool_result' }
+                    > => event.type === 'user.custom_tool_result',
+                )
+                .map((event) => event.custom_tool_use_id),
+        );
+        for (const resolvedId of resolvedCustomToolUseIds) {
+            customToolState.deliveredIds.add(resolvedId);
+        }
+        for (const event of events) {
+            if (
+                event.type === 'agent.custom_tool_use' &&
+                !customToolState.deliveredIds.has(event.id) &&
+                !resolvedCustomToolUseIds.has(event.id)
+            ) {
+                // Persisted tool calls must be handled sequentially to preserve
+                // the agent's event ordering after a stream reconnect.
+                // eslint-disable-next-line no-await-in-loop
+                await AiDeepResearchClient.handleCustomToolUse(
+                    client,
+                    sessionId,
+                    event,
+                    config,
+                    signal,
+                    customToolState,
+                );
+            }
+        }
+        return null;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async consumeStream(
+        client: Anthropic,
+        sessionId: string,
+        config: AiDeepResearchSessionConfig,
+        signal: AbortSignal,
+        customToolState: CustomToolState,
+        existingStream?: SessionEventStream,
+    ): Promise<TerminalResult | null> {
+        const stream =
+            existingStream ??
+            (await client.beta.sessions.events.stream(
+                sessionId,
+                {},
+                { signal },
+            ));
+        const abortStream = () => stream.controller.abort(signal.reason);
+        signal.addEventListener('abort', abortStream, { once: true });
+        try {
+            for await (const streamedEvent of stream) {
+                const event = streamedEvent as BetaManagedAgentsSessionEvent;
+                signal.throwIfAborted();
+                await AiDeepResearchClient.emitProgress(
+                    event,
+                    config.onProgress,
+                );
+                const terminal =
+                    AiDeepResearchClient.classifyTerminalEvent(event);
+                if (terminal) {
+                    return terminal;
+                }
+                if (event.type === 'agent.custom_tool_use') {
+                    await AiDeepResearchClient.handleCustomToolUse(
+                        client,
+                        sessionId,
+                        event,
+                        config,
+                        signal,
+                        customToolState,
+                    );
+                }
+            }
+            return null;
+        } finally {
+            signal.removeEventListener('abort', abortStream);
+            stream.controller.abort();
+        }
+    }
+
+    private async awaitTerminalResult(
+        client: Anthropic,
+        sessionId: string,
+        config: AiDeepResearchSessionConfig,
+        signal: AbortSignal,
+        initialStream: SessionEventStream,
+    ): Promise<TerminalResult> {
+        const customToolState: CustomToolState = {
+            outcomes: new Map(),
+            deliveredIds: new Set(),
+        };
+        let lastTransportError: unknown = null;
+        for (let attempt = 0; attempt <= MAX_STREAM_RECONNECTS; attempt += 1) {
+            try {
+                // Streams must be consumed and classified before reconnecting.
+                // eslint-disable-next-line no-await-in-loop
+                const result = await this.consumeStream(
+                    client,
+                    sessionId,
+                    config,
+                    signal,
+                    customToolState,
+                    attempt === 0 ? initialStream : undefined,
+                );
+                if (result) {
+                    return result;
+                }
+            } catch (error) {
+                signal.throwIfAborted();
+                lastTransportError = error;
+            }
+
+            // eslint-disable-next-line no-await-in-loop
+            const persistedResult = await this.inspectPersistedEvents(
+                client,
+                sessionId,
+                config,
+                signal,
+                customToolState,
+            );
+            if (persistedResult) {
+                return persistedResult;
+            }
+        }
+
+        if (lastTransportError) {
+            return {
+                status: 'failed',
+                reason: 'transport_error',
+                errorMessage: getErrorMessage(lastTransportError),
+            };
+        }
+        return {
+            status: 'failed',
+            reason: 'unexpected_eof',
+            errorMessage:
+                'Claude event stream ended without a terminal session event',
+        };
+    }
+
+    private static async interruptSession(
+        client: Anthropic,
+        sessionId: string,
+        timeoutMs: number,
+    ): Promise<void> {
+        const controller = new AbortController();
+        const timer = setTimeout(
+            () => controller.abort(new Error('Claude interrupt timed out')),
+            timeoutMs,
+        );
+        try {
+            await client.beta.sessions.events.send(
+                sessionId,
+                { events: [{ type: 'user.interrupt' }] },
+                {
+                    signal: controller.signal,
+                    timeout: timeoutMs,
+                    maxRetries: 0,
+                },
+            );
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+
+    private static async deleteVault(
+        client: Anthropic,
+        vaultId: string,
+        timeoutMs: number,
+    ): Promise<void> {
+        const controller = new AbortController();
+        const timer = setTimeout(
+            () => controller.abort(new Error('Claude vault cleanup timed out')),
+            timeoutMs,
+        );
+        try {
+            await client.beta.vaults.delete(
+                vaultId,
+                {},
+                {
+                    signal: controller.signal,
+                    timeout: timeoutMs,
+                    maxRetries: 2,
+                },
+            );
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+
+    async runSession(
+        config: AiDeepResearchSessionConfig,
+    ): Promise<AiDeepResearchClientResult> {
+        if (config.signal.aborted) {
+            return { status: 'cancelled', sessionId: null };
+        }
+
+        let client: Anthropic;
+        try {
+            client = this.getAnthropicClient();
+        } catch (error) {
+            return failed(null, 'setup_failed', getErrorMessage(error));
+        }
+
+        const timeoutController = new AbortController();
+        const timeout = setTimeout(
+            () =>
+                timeoutController.abort(
+                    new Error(
+                        `Deep Research timed out after ${config.timeoutMs}ms`,
+                    ),
+                ),
+            config.timeoutMs,
+        );
+        const signal = AbortSignal.any([
+            config.signal,
+            timeoutController.signal,
+        ]);
+        let sessionId: string | null = null;
+        let vaultId: string | null = null;
+        let unconsumedStream: SessionEventStream | null = null;
+
+        const finish = async (
+            result: AiDeepResearchClientResult,
+        ): Promise<AiDeepResearchClientResult> => {
+            if (!vaultId) {
+                return result;
+            }
+            try {
+                await AiDeepResearchClient.deleteVault(
+                    client,
+                    vaultId,
+                    config.interruptTimeoutMs,
+                );
+                return result;
+            } catch (error) {
+                return failed(
+                    sessionId,
+                    'vault_cleanup_failed',
+                    `Could not remove Claude credentials: ${getErrorMessage(error)}`,
+                );
+            }
+        };
+
+        const interrupt =
+            async (): Promise<AiDeepResearchClientResult | null> => {
+                if (!sessionId) {
+                    return null;
+                }
+                try {
+                    await AiDeepResearchClient.interruptSession(
+                        client,
+                        sessionId,
+                        config.interruptTimeoutMs,
+                    );
+                    return null;
+                } catch (error) {
+                    return failed(
+                        sessionId,
+                        'interrupt_failed',
+                        `Could not confirm Claude stopped: ${getErrorMessage(error)}`,
+                    );
+                }
+            };
+
+        try {
+            const resources = await this.ensureResources(
+                client,
+                config,
+                signal,
+                (createdVaultId) => {
+                    vaultId = createdVaultId;
+                },
+            );
+            const session = await client.beta.sessions.create(
+                {
+                    agent: {
+                        type: 'agent',
+                        id: resources.agentId,
+                        version: resources.agentVersion,
+                    },
+                    environment_id: resources.environmentId,
+                    vault_ids: [resources.vaultId],
+                    title: config.sessionTitle,
+                    metadata: FEATURE_METADATA,
+                },
+                { signal },
+            );
+            sessionId = session.id;
+
+            try {
+                await Promise.race([
+                    config.onSessionCreated(sessionId, signal),
+                    waitForAbort(signal),
+                ]);
+            } catch (error) {
+                if (signal.aborted) {
+                    throw error;
+                }
+                const interruptFailure = await interrupt();
+                return await finish(
+                    interruptFailure ??
+                        failed(
+                            sessionId,
+                            'session_id_persistence_failed',
+                            getErrorMessage(error),
+                        ),
+                );
+            }
+
+            unconsumedStream = await client.beta.sessions.events.stream(
+                sessionId,
+                {},
+                { signal },
+            );
+
+            await client.beta.sessions.events.send(
+                sessionId,
+                {
+                    events: [
+                        {
+                            type: 'user.message',
+                            content: [{ type: 'text', text: config.prompt }],
+                        },
+                    ],
+                },
+                { signal },
+            );
+
+            const terminalResult = this.awaitTerminalResult(
+                client,
+                sessionId,
+                config,
+                signal,
+                unconsumedStream,
+            );
+            unconsumedStream = null;
+            const result = await Promise.race([
+                terminalResult,
+                waitForAbort(signal),
+            ]);
+            if (result.status === 'completed') {
+                return await finish({ status: 'completed', sessionId });
+            }
+            if (
+                result.reason === 'unexpected_eof' ||
+                result.reason === 'transport_error'
+            ) {
+                const interruptFailure = await interrupt();
+                if (interruptFailure) {
+                    return await finish(interruptFailure);
+                }
+            }
+            return await finish(
+                failed(sessionId, result.reason, result.errorMessage),
+            );
+        } catch (error) {
+            if (signal.aborted) {
+                if (!sessionId) {
+                    return await finish(
+                        config.signal.aborted
+                            ? { status: 'cancelled', sessionId: null }
+                            : failed(
+                                  null,
+                                  'timed_out',
+                                  getErrorMessage(signal.reason),
+                              ),
+                    );
+                }
+                const interruptFailure = await interrupt();
+                if (interruptFailure) {
+                    return await finish(interruptFailure);
+                }
+                return await finish(
+                    config.signal.aborted
+                        ? { status: 'cancelled', sessionId }
+                        : failed(
+                              sessionId,
+                              'timed_out',
+                              getErrorMessage(signal.reason),
+                          ),
+                );
+            }
+
+            if (sessionId) {
+                const interruptFailure = await interrupt();
+                if (interruptFailure) {
+                    return await finish(interruptFailure);
+                }
+            }
+
+            Logger.warn(
+                `[AiDeepResearch] Session failed: ${getErrorMessage(error)}`,
+            );
+            return await finish(
+                failed(
+                    sessionId,
+                    sessionId ? 'transport_error' : 'setup_failed',
+                    getErrorMessage(error),
+                ),
+            );
+        } finally {
+            unconsumedStream?.controller.abort();
+            clearTimeout(timeout);
+        }
+    }
+}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8830/add-a-dedicated-aideepresearch-managed-agent-client

## Summary

PR 2 of 3 for [PROD-8830](https://linear.app/lightdash/issue/PROD-8830/add-a-dedicated-aideepresearch-managed-agent-client). Adds the dedicated Claude managed-agent client that PR3 can connect to the durable Deep Research run lifecycle.

Stacks on top of PR1 ([#25443](https://github.com/lightdash/lightdash/pull/25443), already merged), which landed durable run persistence, scheduling, cancellation state, progress events, and the executor seam.

## Changes

- Reconciles reusable Claude agent and environment resources by a canonical configuration hash.
- Creates fresh credentials for every run and deletes the credential vault on every exit path.
- Persists the Claude session ID before opening the stream and sending the prompt.
- Treats only explicit `end_turn` as completion and maps Claude error, exhausted, terminated, transport, EOF, timeout, and cancellation outcomes deliberately.
- Reconciles persisted history and reconnects dropped streams without re-executing custom tools.
- Sends bounded remote interrupts before reporting cancellation or any unconfirmed post-prompt failure.
- Emits structural progress only; model text, thinking content, tool payloads, and credentials never enter progress events or logs.

## Session lifecycle

```text
agent + environment ──reconcile──┐
fresh credential vault ──────────┼─→ create session → persist ID → open stream → prompt
                                 │                                      │
                                 └──────────────────────────────────────┤
                                                                        ├─ end_turn → complete
                                                                        ├─ dropped stream → history → reconnect
                                                                        └─ cancel/failure → interrupt → delete vault
```

## Scope

This PR does not change Autopilot and does not wire the production Deep Research executor. PR3 supplies the agent definition, prompt, short-lived Lightdash credential, tools, and report generation.

## Test plan

- [x] `pnpm -F backend typecheck:fast --pretty false`
- [x] `pnpm -F backend linter src/ee/clients/AiDeepResearchClient.ts src/ee/clients/AiDeepResearchClient.test.ts`
- [x] `pnpm -F backend formatter src/ee/clients/AiDeepResearchClient.ts src/ee/clients/AiDeepResearchClient.test.ts --check`
- [x] `pnpm -F backend test --run src/ee/clients/AiDeepResearchClient.test.ts` (23 passed)
- [x] Live Claude smoke: explicit completion, acknowledged cancellation, and timeout after session creation

🤖 Generated with [Codex](https://openai.com/codex/)
