### PR TITLE
refactor(frontend): migrate Text to mantine-8

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -34,14 +34,13 @@ import {
     type SavedChart,
     type Series,
 } from '@lightdash/common';
-import { ActionIcon, Box, Group, Menu, Stack } from '@mantine-8/core';
+import { ActionIcon, Box, Group, Menu, Stack, Text } from '@mantine-8/core';
 import {
     Badge,
     HoverCard,
     Portal,
     Tooltip,
     useMantineColorScheme,
-    Text,
 } from '@mantine/core';
 import { useClipboard, useElementSize } from '@mantine/hooks';
 import {

--- a/packages/frontend/src/components/DataOps/index.tsx
+++ b/packages/frontend/src/components/DataOps/index.tsx
@@ -1,6 +1,6 @@
 import { ProjectType } from '@lightdash/common';
-import { Flex } from '@mantine-8/core';
-import { Button, Select, Title, Text } from '@mantine/core';
+import { Flex, Text } from '@mantine-8/core';
+import { Button, Select, Title } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useProject } from '../../hooks/useProject';
 import { useProjects } from '../../hooks/useProjects';

--- a/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
@@ -3,8 +3,8 @@ import {
     ChartKind,
     type CartesianChartDisplay,
 } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
-import { Select, Text } from '@mantine/core';
+import { Box, Group, Text } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { getChartIcon } from '../../common/ResourceIcon/utils';

--- a/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
@@ -1,6 +1,6 @@
 import { ValueLabelPositionOptions } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
-import { Select, Text } from '@mantine/core';
+import { Box, Group, Text } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowLeft,

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -3,8 +3,8 @@ import {
     VizAggregationOptions,
     type VizValuesLayoutOptions,
 } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
-import { Select, Tooltip, useMantineTheme, Text } from '@mantine/core';
+import { Box, Group, Text } from '@mantine-8/core';
+import { Select, Tooltip, useMantineTheme } from '@mantine/core';
 import {
     IconAsterisk,
     IconMathFunction,

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -1,6 +1,6 @@
 import { SortByDirection, type VizSortBy } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { Select, Tooltip, useMantineTheme, Text } from '@mantine/core';
+import { Box, Text } from '@mantine-8/core';
+import { Select, Tooltip, useMantineTheme } from '@mantine/core';
 import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -5,8 +5,8 @@ import {
     type CartesianChartDisplay,
     type ChartKind,
 } from '@lightdash/common';
-import { Box, Flex, Group, Stack } from '@mantine-8/core';
-import { SegmentedControl, TextInput, Text } from '@mantine/core';
+import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
+import { SegmentedControl, TextInput } from '@mantine/core';
 import { IconAlignLeft, IconAlignRight } from '@tabler/icons-react';
 import MantineIcon from '../../common/MantineIcon';
 import ColorSelector from '../../VisualizationConfigs/ColorSelector';

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -6,8 +6,8 @@ import {
     findReplaceableCustomMetrics,
     getMetrics,
 } from '@lightdash/common';
-import { Group, Menu, Stack } from '@mantine-8/core';
-import { ActionIcon, HoverCard, Text } from '@mantine/core';
+import { Group, Menu, Stack, Text } from '@mantine-8/core';
+import { ActionIcon, HoverCard } from '@mantine/core';
 import {
     IconAlertTriangle,
     IconCode,

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -117,24 +117,20 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
             label={
                 isError ? (
                     <Stack gap={2}>
-                        <Highlight
-                            component={Text}
-                            highlight={query ?? ''}
-                            truncate
-                            fz="inherit"
-                        >
-                            {displayLabel}
-                        </Highlight>
-                        {showUnderlyingName && (
-                            <Highlight
-                                component={Text}
-                                highlight={query ?? ''}
-                                truncate
-                                fz="xs"
-                                c="ldGray.7"
-                            >
-                                {explore.name}
+                        <Text truncate fz="sm">
+                            <Highlight component="span" highlight={query ?? ''}>
+                                {displayLabel}
                             </Highlight>
+                        </Text>
+                        {showUnderlyingName && (
+                            <Text truncate fz="xs" c="ldGray.7">
+                                <Highlight
+                                    component="span"
+                                    highlight={query ?? ''}
+                                >
+                                    {explore.name}
+                                </Highlight>
+                            </Text>
                         )}
                     </Stack>
                 ) : (
@@ -146,26 +142,23 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                         offset={0}
                     >
                         <Stack gap={2}>
-                            <Highlight
-                                component={Text}
-                                highlight={query ?? ''}
-                                truncate
-                                fz="sm"
-                                fw={500}
-                                c="ldDark.8"
-                            >
-                                {displayLabel}
-                            </Highlight>
-                            {showUnderlyingName && (
+                            <Text truncate fz="sm" fw={500} c="ldDark.8">
                                 <Highlight
-                                    component={Text}
+                                    component="span"
                                     highlight={query ?? ''}
-                                    truncate
-                                    fz="xs"
-                                    c="ldGray.7"
                                 >
-                                    {explore.name}
+                                    {displayLabel}
                                 </Highlight>
+                            </Text>
+                            {showUnderlyingName && (
+                                <Text truncate fz="xs" c="ldGray.7">
+                                    <Highlight
+                                        component="span"
+                                        highlight={query ?? ''}
+                                    >
+                                        {explore.name}
+                                    </Highlight>
+                                </Text>
                             )}
                         </Stack>
                     </TableItemDetailPreview>

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -12,7 +12,6 @@ import {
     NavLink,
     Paper,
     Stack,
-    Text,
 } from '@mantine-8/core';
 import { useToggle } from '@mantine/hooks';
 import {
@@ -117,20 +116,23 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
             label={
                 isError ? (
                     <Stack gap={2}>
-                        <Text truncate fz="sm">
-                            <Highlight component="span" highlight={query ?? ''}>
-                                {displayLabel}
-                            </Highlight>
-                        </Text>
+                        <Highlight
+                            truncate
+                            fz="sm"
+                            fw={500}
+                            highlight={query ?? ''}
+                        >
+                            {displayLabel}
+                        </Highlight>
                         {showUnderlyingName && (
-                            <Text truncate fz="xs" c="ldGray.7">
-                                <Highlight
-                                    component="span"
-                                    highlight={query ?? ''}
-                                >
-                                    {explore.name}
-                                </Highlight>
-                            </Text>
+                            <Highlight
+                                truncate
+                                fz="xs"
+                                c="ldGray.7"
+                                highlight={query ?? ''}
+                            >
+                                {explore.name}
+                            </Highlight>
                         )}
                     </Stack>
                 ) : (
@@ -142,23 +144,24 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                         offset={0}
                     >
                         <Stack gap={2}>
-                            <Text truncate fz="sm" fw={500} c="ldDark.8">
+                            <Highlight
+                                truncate
+                                fz="sm"
+                                fw={500}
+                                c="ldDark.8"
+                                highlight={query ?? ''}
+                            >
+                                {displayLabel}
+                            </Highlight>
+                            {showUnderlyingName && (
                                 <Highlight
-                                    component="span"
+                                    truncate
+                                    fz="xs"
+                                    c="ldGray.7"
                                     highlight={query ?? ''}
                                 >
-                                    {displayLabel}
+                                    {explore.name}
                                 </Highlight>
-                            </Text>
-                            {showUnderlyingName && (
-                                <Text truncate fz="xs" c="ldGray.7">
-                                    <Highlight
-                                        component="span"
-                                        highlight={query ?? ''}
-                                    >
-                                        {explore.name}
-                                    </Highlight>
-                                </Text>
                             )}
                         </Stack>
                     </TableItemDetailPreview>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -174,6 +174,7 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
                             <Highlight
                                 component={Text}
                                 truncate
+                                fz="sm"
                                 highlight={searchQuery || ''}
                             >
                                 {label}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -1,6 +1,6 @@
 import { hasIntersection } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import { Badge, Highlight, HoverCard, NavLink, Text } from '@mantine/core';
+import { Group, Text } from '@mantine-8/core';
+import { Badge, Highlight, HoverCard, NavLink } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import intersectionBy from 'lodash/intersectionBy';
 import { memo, useCallback, useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -171,14 +171,14 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
                         offset={80}
                     >
                         <HoverCard.Target>
-                            <Highlight
-                                component={Text}
-                                truncate
-                                fz="sm"
-                                highlight={searchQuery || ''}
-                            >
-                                {label}
-                            </Highlight>
+                            <Text truncate fz="sm">
+                                <Highlight
+                                    component="span"
+                                    highlight={searchQuery || ''}
+                                >
+                                    {label}
+                                </Highlight>
+                            </Text>
                         </HoverCard.Target>
                         <HoverCard.Dropdown
                             hidden={!isHover}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -452,15 +452,14 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                         }
                     >
                         <HoverCard.Target>
-                            <Highlight
-                                component={Text}
-                                truncate
-                                fz="sm"
-                                sx={{ flexGrow: 1 }}
-                                highlight={searchQuery || ''}
-                            >
-                                {label}
-                            </Highlight>
+                            <Text truncate fz="sm" style={{ flexGrow: 1 }}>
+                                <Highlight
+                                    component="span"
+                                    highlight={searchQuery || ''}
+                                >
+                                    {label}
+                                </Highlight>
+                            </Text>
                         </HoverCard.Target>
                         <HoverCard.Dropdown
                             hidden={!isHover}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -455,6 +455,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <Highlight
                                 component={Text}
                                 truncate
+                                fz="sm"
                                 sx={{ flexGrow: 1 }}
                                 highlight={searchQuery || ''}
                             >

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -17,14 +17,13 @@ import {
     type FilterableField,
     type Item,
 } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
+import { Group, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Highlight,
     HoverCard,
     NavLink,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import {
     IconAlertTriangle,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -142,7 +142,7 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     return (
         <Group mt="sm" mb="xs" pl={pl} pr="sm" justify="space-between">
             <Group gap="xs">
-                <Text fw={600} c={color}>
+                <Text fz="sm" fw={600} c={color}>
                     {label}
                 </Text>
                 {helpButton && (

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import { ActionIcon, Button, Tooltip, Text } from '@mantine/core';
+import { Group, Text } from '@mantine-8/core';
+import { ActionIcon, Button, Tooltip } from '@mantine/core';
 import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
@@ -70,7 +70,7 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
             tableMetadata={tableMetadata}
         >
             <Group gap="xs" wrap="nowrap">
-                <Text truncate fw={600}>
+                <Text truncate fz="sm" fw={600}>
                     {table.label}
                 </Text>
                 {!isExpanded && (

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
@@ -1,5 +1,5 @@
-import { Group } from '@mantine-8/core';
-import { NavLink, Text, useMantineTheme } from '@mantine/core';
+import { Group, Text } from '@mantine-8/core';
+import { NavLink, useMantineTheme } from '@mantine/core';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { TableItemDetailPreview } from '../ItemDetailPreview';
@@ -74,7 +74,7 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
                     {table.label}
                 </Text>
                 {!isExpanded && (
-                    <Text size="xs" color="ldGray.6" fw={400}>
+                    <Text size="xs" c="ldGray.6" fw={400}>
                         {fieldCount} {fieldCount === 1 ? 'field' : 'fields'}
                     </Text>
                 )}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -1,12 +1,11 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
+import { Group, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Divider,
     Loader,
     ScrollArea,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { lazy, Suspense, useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -4,7 +4,7 @@ import {
     type Job,
     type JobStep,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Alert,
@@ -13,7 +13,6 @@ import {
     Loader,
     Title,
     type DefaultMantineColor,
-    Text,
 } from '@mantine/core';
 import { useInterval } from '@mantine/hooks';
 import {

--- a/packages/frontend/src/components/NavBar/NotificationsMenu/ValidationErrorNotification.tsx
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/ValidationErrorNotification.tsx
@@ -13,7 +13,7 @@ const ValidationErrorNotificationDescription: FC<{
     const validationTimeAgo = useTimeAgo(lastValidatedAt);
 
     return (
-        <Text fz="xs">
+        <Text fz="sm">
             New validation completed {validationTimeAgo} with {numberOfErrors}{' '}
             errors
         </Text>

--- a/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
@@ -159,7 +159,7 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
                 {!hasValidationNotifications &&
                     !hasDashboardCommentsNotifications &&
                     !hasAiReviewNotifications && (
-                        <Menu.Item>No notifications</Menu.Item>
+                        <Menu.Item fz="sm">No notifications</Menu.Item>
                     )}
             </Menu.Dropdown>
         </Menu>

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -1,5 +1,5 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
@@ -11,7 +11,6 @@ import {
     TextInput,
     Tooltip,
     type ScrollAreaProps,
-    Text,
 } from '@mantine/core';
 import { IconCheck, IconRefresh } from '@tabler/icons-react';
 import React, { useEffect, type FC, type ReactNode } from 'react';

--- a/packages/frontend/src/components/ProjectConnection/Inputs/StartOfWeekSelect.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/StartOfWeekSelect.tsx
@@ -1,4 +1,5 @@
-import { Alert, Select, Text } from '@mantine/core';
+import { Text } from '@mantine-8/core';
+import { Alert, Select } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep1.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep1.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import { Button, Tooltip, Text } from '@mantine/core';
+import { Stack, Text } from '@mantine-8/core';
+import { Button, Tooltip } from '@mantine/core';
 import { Prism } from '@mantine/prism';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { type FC } from 'react';

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
@@ -3,8 +3,8 @@ import {
     TimeFrames,
     type OrganizationProject,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Avatar, Button, LoadingOverlay, Tabs, Text } from '@mantine/core';
+import { Stack, Text } from '@mantine-8/core';
+import { Avatar, Button, LoadingOverlay, Tabs } from '@mantine/core';
 import { useOs } from '@mantine/hooks';
 import { Prism } from '@mantine/prism';
 import { IconChevronLeft, IconClock } from '@tabler/icons-react';

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import { Avatar, Button, Text } from '@mantine/core';
+import { Stack, Text } from '@mantine-8/core';
+import { Avatar, Button } from '@mantine/core';
 import {
     IconChecklist,
     IconChevronLeft,

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { ProjectType } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Alert, SimpleGrid, Text } from '@mantine/core';
+import { Stack, Text } from '@mantine-8/core';
+import { Alert, SimpleGrid } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -1,6 +1,6 @@
 import { ProjectType, type DbtProjectType } from '@lightdash/common';
-import { Flex, Stack } from '@mantine-8/core';
-import { Avatar, TextInput, Title, Text } from '@mantine/core';
+import { Flex, Stack, Text } from '@mantine-8/core';
+import { Avatar, TextInput, Title } from '@mantine/core';
 import { type FC } from 'react';
 import useApp from '../../providers/App/useApp';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,5 +1,5 @@
 import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import type { SelectItem } from '@mantine/core';
 import {
     Anchor,
@@ -13,7 +13,6 @@ import {
     Switch,
     TextInput,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconCheck, IconExclamationCircle } from '@tabler/icons-react';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -2,7 +2,7 @@ import {
     DatabricksAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
@@ -11,7 +11,6 @@ import {
     Select,
     TextInput,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import { IconCheck, IconPlus, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -1,5 +1,5 @@
 import { SnowflakeAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     Anchor,
     Button,
@@ -10,7 +10,6 @@ import {
     Select,
     TextInput,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
 import { useState, type FC } from 'react';

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { hasIntersection, TableSelectionType } from '@lightdash/common';
-import { Box, Flex, Stack } from '@mantine-8/core';
+import { Box, Flex, Stack, Text } from '@mantine-8/core';
 import {
     Anchor,
     Button,
@@ -11,7 +11,6 @@ import {
     Radio,
     ScrollArea,
     Title,
-    Text,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/components/Settings/CreateProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/CreateProjectSettings.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine-8/core';
-import { Title, Text } from '@mantine/core';
+import { Stack, Text } from '@mantine-8/core';
+import { Title } from '@mantine/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Flex } from '@mantine-8/core';
-import { Button, Text } from '@mantine/core';
+import { Box, Flex, Text } from '@mantine-8/core';
+import { Button } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -6,7 +6,7 @@ import {
     validateOrganizationEmailDomains,
     type AllowedEmailDomains,
 } from '@lightdash/common';
-import { Flex, Stack } from '@mantine-8/core';
+import { Flex, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Button,
@@ -14,7 +14,6 @@ import {
     Select,
     Title,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,5 +1,5 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { Flex, Group } from '@mantine-8/core';
+import { Flex, Group, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
@@ -8,7 +8,6 @@ import {
     Menu,
     Paper,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -1,13 +1,5 @@
-import { Box, Flex, Group, Stack } from '@mantine-8/core';
-import {
-    Alert,
-    Avatar,
-    Button,
-    Loader,
-    Title,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
+import { Alert, Avatar, Button, Loader, Title, Tooltip } from '@mantine/core';
 import {
     IconAlertCircle,
     IconClock,

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Flex, Group, Stack } from '@mantine-8/core';
-import { Alert, Avatar, Button, Loader, Title, Text } from '@mantine/core';
+import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
+import { Alert, Avatar, Button, Loader, Title } from '@mantine/core';
 import { IconAlertCircle, IconRefresh, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import gitlabIcon from '../../../svgs/gitlab-icon.svg';

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import { ActionIcon, Paper, Table, Text } from '@mantine/core';
+import { Group, Text } from '@mantine-8/core';
+import { ActionIcon, Paper, Table } from '@mantine/core';
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { Button, LoadingOverlay, Title, Text } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
+import { Button, LoadingOverlay, Title } from '@mantine/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -9,7 +9,7 @@ import {
     XAxisSort,
     type ItemsMap,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     Button,
     Checkbox,
@@ -17,7 +17,6 @@ import {
     SegmentedControl,
     Select,
     Switch,
-    Text,
 } from '@mantine/core';
 import {
     IconChartBar,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Flex, Group } from '@mantine-8/core';
-import { Button, Loader, useMantineTheme, Text } from '@mantine/core';
+import { Flex, Group, Text } from '@mantine-8/core';
+import { Button, Loader, useMantineTheme } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
@@ -6,14 +6,13 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Collapse,
     Select,
     TextInput,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
@@ -8,8 +8,8 @@ import {
     type ResultRow,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Group, ScrollArea, Stack } from '@mantine-8/core';
-import { Divider, SegmentedControl, Text } from '@mantine/core';
+import { Box, Group, ScrollArea, Stack, Text } from '@mantine-8/core';
+import { Divider, SegmentedControl } from '@mantine/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import ColorSelector from '../../ColorSelector';
 import { ChartConditionalFormatting } from './ChartConditionalFormatting';

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -7,8 +7,8 @@ import {
     type DataAppVizField,
     type Item,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { MantineProvider, useMantineColorScheme, Text } from '@mantine/core';
+import { Stack, Text } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
@@ -9,13 +9,12 @@ import {
     type SankeyNodeLayout,
     type TableCalculation,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Stack, Text } from '@mantine-8/core';
 import {
     MantineProvider,
     SegmentedControl,
     Tabs,
     useMantineColorScheme,
-    Text,
 } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -10,14 +10,8 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Accordion, Center, Group, Stack } from '@mantine-8/core';
-import {
-    SegmentedControl,
-    Select,
-    TextInput,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Accordion, Center, Group, Stack, Text } from '@mantine-8/core';
+import { SegmentedControl, Select, TextInput, Tooltip } from '@mantine/core';
 import differenceBy from 'lodash/differenceBy';
 import { useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
@@ -8,8 +8,8 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
-import { Grid, NumberInput, Switch, Tooltip, Text } from '@mantine/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
+import { Grid, NumberInput, Switch, Tooltip } from '@mantine/core';
 import { IconHelpCircle } from '@tabler/icons-react';
 import FieldSelect from '../../common/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/common/Filters/FieldLabel.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldLabel.tsx
@@ -7,20 +7,25 @@ import {
     type Field,
     type TableCalculation,
 } from '@lightdash/common';
-import { Text } from '@mantine-8/core';
+import { Text, type TextProps } from '@mantine-8/core';
 import { type FC } from 'react';
 
 interface FieldLabelProps {
     item: Field | TableCalculation | AdditionalMetric | CustomDimension;
     hideTableName?: boolean;
+    fz?: TextProps['fz'];
 }
 
-const FieldLabel: FC<FieldLabelProps> = ({ item, hideTableName = false }) => {
+const FieldLabel: FC<FieldLabelProps> = ({
+    item,
+    hideTableName = false,
+    fz,
+}) => {
     return (
-        <Text span>
+        <Text span fz={fz}>
             {!hideTableName && isField(item) ? `${item.tableLabel} ` : ''}
 
-            <Text span fw={500}>
+            <Text span fz={fz} fw={500}>
                 {isCustomDimension(item)
                     ? item.name
                     : isField(item) || isAdditionalMetric(item)

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -10,8 +10,8 @@ import {
     type BaseFilterRule,
     type DateFilterRule,
 } from '@lightdash/common';
-import { Flex } from '@mantine-8/core';
-import { NumberInput, Text } from '@mantine/core';
+import { Flex, Text } from '@mantine-8/core';
+import { NumberInput } from '@mantine/core';
 import dayjs from 'dayjs';
 import { type FilterInputsProps } from '.';
 import useFiltersContext from '../useFiltersContext';

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
@@ -1,5 +1,5 @@
-import { Group } from '@mantine-8/core';
-import { MultiSelect, type MultiSelectProps, Text } from '@mantine/core';
+import { Group, Text } from '@mantine-8/core';
+import { MultiSelect, type MultiSelectProps } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import uniq from 'lodash/uniq';
 import { useCallback, useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
@@ -1,12 +1,6 @@
 import { formatDate, TimeFrames } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    Popover,
-    TextInput,
-    type MantineTheme,
-    type Sx,
-    Text,
-} from '@mantine/core';
+import { Stack, Text } from '@mantine-8/core';
+import { Popover, TextInput, type MantineTheme, type Sx } from '@mantine/core';
 import { MonthPicker, type MonthPickerProps } from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
 import dayjs from 'dayjs';

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -1,5 +1,5 @@
 import { isDimension, type FilterableItem } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Highlight,
@@ -10,7 +10,6 @@ import {
     Tooltip,
     type MultiSelectProps,
     type MultiSelectValueProps,
-    Text,
 } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import {

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -2,8 +2,8 @@ import {
     assertUnreachable,
     type ConditionalFormattingTextStyle,
 } from '@lightdash/common';
-import { Box, type BoxProps as BoxPropsBase } from '@mantine-8/core';
-import { Tooltip, useMantineTheme, Text } from '@mantine/core';
+import { Box, type BoxProps as BoxPropsBase, Text } from '@mantine-8/core';
+import { Tooltip, useMantineTheme } from '@mantine/core';
 import { getHotkeyHandler, useClipboard, useId } from '@mantine/hooks';
 import { type PolymorphicComponentProps } from '@mantine/utils';
 import debounce from 'lodash/debounce';

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -7,8 +7,7 @@ import {
     type ItemsMap,
     type ResultValue,
 } from '@lightdash/common';
-import { Menu, type MenuProps } from '@mantine-8/core';
-import { Text } from '@mantine/core';
+import { Menu, type MenuProps, Text } from '@mantine-8/core';
 import { IconArrowBarToDown, IconCopy } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import { useLocation, useParams } from 'react-router';

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -27,8 +27,8 @@ import {
     type ResultValue,
     type SortField,
 } from '@lightdash/common';
-import { Box, Group, Menu, type BoxProps } from '@mantine-8/core';
-import { Button, Skeleton, Text, useMantineColorScheme } from '@mantine/core';
+import { Box, Group, Menu, type BoxProps, Text } from '@mantine-8/core';
+import { Button, Skeleton, useMantineColorScheme } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import {
     flexRender,

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,7 +13,7 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
+import { Box, Group, Text } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
 import {
     ActionIcon,
@@ -23,7 +23,6 @@ import {
     TextInput,
     Tooltip,
     useMantineTheme,
-    Text,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {

--- a/packages/frontend/src/components/common/Table/TablePagination/index.tsx
+++ b/packages/frontend/src/components/common/Table/TablePagination/index.tsx
@@ -1,4 +1,5 @@
-import { SegmentedControl, Text } from '@mantine/core';
+import { Text } from '@mantine-8/core';
+import { SegmentedControl } from '@mantine/core';
 import { type FC } from 'react';
 import PaginateControl from '../../PaginateControl';
 import { DEFAULT_PAGE_SIZE } from '../constants';

--- a/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/PresetsForm/AudienceInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/PresetsForm/AudienceInput.tsx
@@ -1,5 +1,5 @@
-import { Flex, Stack } from '@mantine-8/core';
-import { ActionIcon, TextInput, type SystemProp, Text } from '@mantine/core';
+import { Flex, Stack, Text } from '@mantine-8/core';
+import { ActionIcon, TextInput, type SystemProp } from '@mantine/core';
 import { type UseFormReturnType } from '@mantine/form';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
 import {

--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiTableCalculationInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiTableCalculationInput.tsx
@@ -1,5 +1,6 @@
 import type { GeneratedTableCalculation } from '@lightdash/common';
-import { ActionIcon, Text } from '@mantine/core';
+import { Text } from '@mantine-8/core';
+import { ActionIcon } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import { IconArrowUp } from '@tabler/icons-react';
 import { type Editor } from '@tiptap/react';

--- a/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
@@ -1,5 +1,5 @@
-import { Box, Group } from '@mantine-8/core';
-import { ActionIcon, Textarea, Text } from '@mantine/core';
+import { Box, Group, Text } from '@mantine-8/core';
+import { ActionIcon, Textarea } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import { IconArrowUp, IconSparkles } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Group, Stack } from '@mantine-8/core';
-import { Anchor, Button, TextInput, Title, Text } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
+import { Anchor, Button, TextInput, Title } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -7,7 +7,7 @@ import {
     type DashboardFilterRule,
     type FilterRule,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Button,
@@ -17,7 +17,6 @@ import {
     TextInput,
     Tooltip,
     type PopoverProps,
-    Text,
 } from '@mantine/core';
 import { IconHelpCircle, IconX } from '@tabler/icons-react';
 import { useEffect, useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -471,6 +471,8 @@ const TileFilterConfiguration: FC<Props> = ({
                                                     )}
                                                 />
                                                 <Text
+                                                    fz="sm"
+                                                    fw={500}
                                                     c={
                                                         value.invalidField
                                                             ? 'red'

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -634,7 +634,7 @@ const TileFilterConfiguration: FC<Props> = ({
                 checked={isAllChecked}
                 indeterminate={isIndeterminate}
                 label={
-                    <Text fw={500}>
+                    <Text fz="sm" fw={500}>
                         Select all{' '}
                         {isIndeterminate
                             ? ` (${

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -14,7 +14,7 @@ import {
     type DashboardTile,
     type Field,
 } from '@lightdash/common';
-import { Box, Flex, Group, Stack } from '@mantine-8/core';
+import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Checkbox,
@@ -23,7 +23,6 @@ import {
     Tooltip,
     useMantineTheme,
     type PopoverProps,
-    Text,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -465,11 +465,11 @@ const FilterConfiguration: FC<Props> = ({
                             <Group gap="xs">
                                 <FieldIcon item={selectedField} />
                                 {originalFilterRule?.label && !isEditMode ? (
-                                    <Text span fw={500}>
+                                    <Text span fz="sm" fw={500}>
                                         {originalFilterRule.label}
                                     </Text>
                                 ) : (
-                                    <FieldLabel item={selectedField} />
+                                    <FieldLabel item={selectedField} fz="sm" />
                                 )}
                             </Group>
                         ) : (
@@ -480,11 +480,11 @@ const FilterConfiguration: FC<Props> = ({
                                     color={'#0E5A8A'}
                                 />
                                 {originalFilterRule?.label && !isEditMode ? (
-                                    <Text span fw={500}>
+                                    <Text span fz="sm" fw={500}>
                                         {originalFilterRule.label}
                                     </Text>
                                 ) : (
-                                    <Text span fw={500}>
+                                    <Text span fz="sm" fw={500}>
                                         {draftFilterRule?.target.fieldId ||
                                             'SQL column'}
                                     </Text>

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -19,14 +19,13 @@ import {
     type DashboardTile,
     type ResultColumn,
 } from '@lightdash/common';
-import { Box, Flex, Group, Stack } from '@mantine-8/core';
+import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
 import {
     Button,
     Select,
     Tabs,
     Tooltip,
     type PopoverProps,
-    Text,
 } from '@mantine/core';
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';

--- a/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
@@ -4,8 +4,7 @@ import {
     getItemId,
     type FilterDashboardToRule,
 } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
-import { Text } from '@mantine/core';
+import { Menu, Text } from '@mantine-8/core';
 import { IconFilter } from '@tabler/icons-react';
 import isNil from 'lodash/isNil';
 import { type FC } from 'react';

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
@@ -1,6 +1,6 @@
 import type { CatalogMetricsTreeEdge } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
-import { Button, useMantineTheme, Text } from '@mantine/core';
+import { Box, Group, Text } from '@mantine-8/core';
+import { Button, useMantineTheme } from '@mantine/core';
 import { IconLayoutGridRemove } from '@tabler/icons-react';
 import {
     Background,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -1,5 +1,5 @@
 import { getErrorMessage, type CatalogItem } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Button,
@@ -9,7 +9,6 @@ import {
     TextInput,
     Tooltip,
     UnstyledButton,
-    Text,
 } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import { IconCode, IconDots, IconTrash } from '@tabler/icons-react';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -1,11 +1,10 @@
 import { type CatalogField, type Tag } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
 import {
     Button,
     Popover,
     UnstyledButton,
     useMantineTheme,
-    Text,
 } from '@mantine/core';
 import differenceBy from 'lodash/differenceBy';
 import filter from 'lodash/filter';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
@@ -1,6 +1,6 @@
 import { type CatalogField } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { useMantineTheme, Text } from '@mantine/core';
+import { Box, Text } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import MarkdownPreview, {
     type MarkdownPreviewProps,
 } from '@uiw/react-markdown-preview';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,6 +1,6 @@
 import { SpotlightTableColumns, type CatalogField } from '@lightdash/common';
-import { Box, Flex, Group } from '@mantine-8/core';
-import { Button, Text } from '@mantine/core';
+import { Box, Flex, Group, Text } from '@mantine-8/core';
+import { Button } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus, IconUser } from '@tabler/icons-react';
 import { useMemo } from 'react';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,13 +1,12 @@
 import { subject } from '@casl/ability';
 import { CatalogCategoryFilterMode, isCompileJob } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Button,
     Popover,
     useMantineTheme,
     type ButtonProps,
-    Text,
 } from '@mantine/core';
 import { useClickOutside, useDisclosure } from '@mantine/hooks';
 import { IconRefresh, IconSparkles, IconX } from '@tabler/icons-react';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,8 +5,8 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box, Center, Group } from '@mantine-8/core';
-import { Anchor, Divider, Paper, useMantineTheme, Text } from '@mantine/core';
+import { Box, Center, Group, Text } from '@mantine-8/core';
+import { Anchor, Divider, Paper, useMantineTheme } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowsSort,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -512,23 +512,23 @@ export const MetricsTable: FC<MetricsTableProps> = ({
         renderBottomToolbar: () => (
             <Box
                 p={`${theme.spacing.sm} ${theme.spacing.xl} ${theme.spacing.md} ${theme.spacing.xl}`}
-                fz="xs"
-                fw={500}
                 color="ldGray.8"
                 style={{
                     borderTop: `1px solid ${theme.colors.ldGray[3]}`,
                 }}
             >
                 {isFetching ? (
-                    <Text>Loading more...</Text>
+                    <Text fz="sm" fw={500}>
+                        Loading more...
+                    </Text>
                 ) : (
                     <Group gap="two">
-                        <Text>
+                        <Text fz="sm" fw={500}>
                             {hasNextPage
                                 ? 'Scroll for more metrics'
                                 : 'All metrics loaded'}
                         </Text>
-                        <Text fw={400} c="ldGray.6">
+                        <Text fz="sm" fw={400} c="ldGray.6">
                             {hasNextPage
                                 ? `(${flatData.length} loaded)`
                                 : `(${flatData.length})`}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -20,7 +20,14 @@ import {
     type CatalogCategoryFilterMode,
     type CatalogField,
 } from '@lightdash/common';
-import { Box, Center, Group, Stack, type GroupProps } from '@mantine-8/core';
+import {
+    Box,
+    Center,
+    Group,
+    Stack,
+    type GroupProps,
+    Text,
+} from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
@@ -30,7 +37,6 @@ import {
     SegmentedControl,
     TextInput,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import {
     IconEye,

--- a/packages/frontend/src/features/metricsCatalog/components/SelectItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/SelectItem.tsx
@@ -1,5 +1,4 @@
-import { Box } from '@mantine-8/core';
-import { Text } from '@mantine/core';
+import { Box, Text } from '@mantine-8/core';
 import { mergeRefs, useHover } from '@mantine/hooks';
 import { forwardRef, type ComponentPropsWithoutRef } from 'react';
 

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -5,16 +5,8 @@ import {
     type MetricExplorerQuery,
     type MetricWithAssociatedTimeDimension,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    Loader,
-    Paper,
-    Radio,
-    Select,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
+import { Anchor, Loader, Paper, Radio, Select, Tooltip } from '@mantine/core';
 import { IconCalendar, IconStack } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useCallback, type FC } from 'react';

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -175,7 +175,7 @@ export const MetricExploreComparison: FC<Props> = ({
                                                 />
                                             </Paper>
 
-                                            <Text c="ldGray.7" fw={500}>
+                                            <Text fz="sm" c="ldGray.7" fw={500}>
                                                 {comparison.label}
                                             </Text>
                                         </Group>

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -4,7 +4,7 @@ import {
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
 import {
     Button,
     Divider,
@@ -13,7 +13,6 @@ import {
     TextInput,
     Tooltip,
     UnstyledButton,
-    Text,
 } from '@mantine/core';
 import { DatePicker, MonthPicker, YearPicker } from '@mantine/dates';
 import { useCallback, useEffect, useRef, type FC } from 'react';

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -4,8 +4,8 @@ import {
     type CompiledDimension,
     type FilterRule,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { Button, Select, Text } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
+import { Button, Select } from '@mantine/core';
 import { IconFilter, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
@@ -1,5 +1,5 @@
 import { type CompiledDimension } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     Highlight,
     Loader,
@@ -7,7 +7,6 @@ import {
     ScrollArea,
     Tooltip,
     type MultiSelectProps,
-    Text,
 } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import uniq from 'lodash/uniq';

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -5,8 +5,8 @@ import {
     type CompiledDimension,
     type MetricExplorerQuery,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
-import { Alert, Button, Loader, Select, Tooltip, Text } from '@mantine/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
+import { Alert, Button, Loader, Select, Tooltip } from '@mantine/core';
 import { IconInfoCircle, IconX } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useMemo, type FC } from 'react';

--- a/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
@@ -29,6 +29,7 @@ const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
             }
         >
             <Text
+                fz="sm"
                 ta="right"
                 mb="one"
                 fw={500}
@@ -79,7 +80,7 @@ export const AiReviewNotifications: FC<Props> = ({ notifications }) => {
                     p="xs"
                     key={notification.notificationId}
                     onClick={() => handleOnNotificationClick(notification)}
-                    fz="xs"
+                    fz="sm"
                 >
                     <NotificationTime createdAt={notification.createdAt} />
                     <Group gap={6} wrap="nowrap" align="center">
@@ -92,7 +93,7 @@ export const AiReviewNotifications: FC<Props> = ({ notifications }) => {
                                     : theme.colors.teal[5],
                             }}
                         />
-                        <Text className={classes.notificationMessage}>
+                        <Text fz="sm" className={classes.notificationMessage}>
                             {notification.message}
                         </Text>
                     </Group>

--- a/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
@@ -1,6 +1,6 @@
 import { type NotificationAiReview } from '@lightdash/common';
-import { Group, Menu } from '@mantine-8/core';
-import { Tooltip, useMantineTheme, Text } from '@mantine/core';
+import { Group, Menu, Text } from '@mantine-8/core';
+import { Tooltip, useMantineTheme } from '@mantine/core';
 import { IconCircleFilled } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useCallback, type FC } from 'react';

--- a/packages/frontend/src/features/notifications/components/DashboardCommentsNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/DashboardCommentsNotifications.tsx
@@ -1,6 +1,6 @@
 import { type NotificationDashboardComment } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
-import { Tooltip, useMantineTheme, Text } from '@mantine/core';
+import { Menu, Text } from '@mantine-8/core';
+import { Tooltip, useMantineTheme } from '@mantine/core';
 import { IconCircleFilled } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useCallback, type FC } from 'react';

--- a/packages/frontend/src/features/notifications/components/DashboardCommentsNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/DashboardCommentsNotifications.tsx
@@ -31,6 +31,7 @@ const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
             }
         >
             <Text
+                fz="sm"
                 ta="right"
                 mb="one"
                 fw={500}
@@ -99,11 +100,11 @@ export const DashboardCommentsNotifications: FC<Props> = ({
                         />
                     }
                     onClick={() => handleOnNotificationClick(notification)}
-                    fz="xs"
+                    fz="sm"
                 >
                     <>
                         <NotificationTime createdAt={notification.createdAt} />
-                        <Text className={classes.notificationMessage}>
+                        <Text fz="sm" className={classes.notificationMessage}>
                             {notification.message}
                         </Text>
                     </>

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -482,7 +482,7 @@ export const ContentPanel: FC = () => {
                                                     >
                                                         <SqlEditorPreferencesPopover />
 
-                                                        <Text>SQL</Text>
+                                                        <Text fz="sm">SQL</Text>
                                                     </Group>
                                                 </Tooltip>
                                             ),
@@ -509,7 +509,9 @@ export const ContentPanel: FC = () => {
                                                                 IconChartHistogram
                                                             }
                                                         />
-                                                        <Text>Chart</Text>
+                                                        <Text fz="sm">
+                                                            Chart
+                                                        </Text>
                                                     </Group>
                                                 </Tooltip>
                                             ),

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -8,7 +8,7 @@ import {
     type VizTableHeaderSortConfig,
     formatSql,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Indicator,
@@ -17,7 +17,6 @@ import {
     SegmentedControl,
     Tooltip,
     Transition,
-    Text,
 } from '@mantine/core';
 import { useElementSize, useHotkeys } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';

--- a/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
@@ -3,8 +3,8 @@ import {
     DownloadFileType,
     type VizTableConfig,
 } from '@lightdash/common';
-import { Center, Stack } from '@mantine-8/core';
-import { ActionIcon, Popover, SegmentedControl, Text } from '@mantine/core';
+import { Center, Stack, Text } from '@mantine-8/core';
+import { ActionIcon, Popover, SegmentedControl } from '@mantine/core';
 import { IconDownload, IconPhoto, IconTableExport } from '@tabler/icons-react';
 import { memo, useState } from 'react';
 import ChartDownloadOptions from '../../../../components/common/ChartDownload/ChartDownloadOptions';

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Button, Menu, Paper, Tooltip, Text } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
+import { ActionIcon, Button, Menu, Paper, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditorPreferencesPopover.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditorPreferencesPopover.tsx
@@ -1,6 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Popover, SegmentedControl, Text } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
+import { ActionIcon, Popover, SegmentedControl } from '@mantine/core';
 import { IconCodeCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     HoverCard,
@@ -6,7 +6,6 @@ import {
     Tooltip,
     UnstyledButton,
     useMantineTheme,
-    Text,
 } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { Editor } from '@monaco-editor/react';

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -64,21 +64,19 @@ const TableField: FC<{
                 label={field.name}
                 disabled={!isTruncated}
             >
-                <Highlight
+                <Text
                     ref={truncatedRef}
-                    component={Text}
                     fw={500}
                     p={4}
                     fz={13}
                     c="ldGray.7"
-                    sx={{
-                        flex: 1,
-                    }}
-                    highlight={search || ''}
+                    style={{ flex: 1 }}
                     truncate
                 >
-                    {field.name}
-                </Highlight>
+                    <Highlight component="span" highlight={search || ''}>
+                        {field.name}
+                    </Highlight>
+                </Text>
             </Tooltip>
             <Text fz={12} c="ldGray.5">
                 {field.type}

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Group, Stack } from '@mantine-8/core';
+import { Box, Center, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     CopyButton,
@@ -7,7 +7,6 @@ import {
     ScrollArea,
     TextInput,
     Tooltip,
-    Text,
 } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
 import { IconCopy, IconSearch, IconX } from '@tabler/icons-react';

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -1,5 +1,12 @@
 import { PartitionType, type PartitionColumn } from '@lightdash/common';
-import { Box, Center, Group, Stack, type BoxProps } from '@mantine-8/core';
+import {
+    Box,
+    Center,
+    Group,
+    Stack,
+    type BoxProps,
+    Text,
+} from '@mantine-8/core';
 import {
     ActionIcon,
     CopyButton,
@@ -9,7 +16,6 @@ import {
     TextInput,
     Tooltip,
     UnstyledButton,
-    Text,
 } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
 import {

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -127,19 +127,21 @@ const TableItem: FC<TableItemProps> = memo(
                         }}
                     >
                         {search.length > 2 ? (
-                            <Highlight
+                            <Text
                                 ref={truncatedRef}
-                                component={Text}
-                                highlight={search || ''}
                                 truncate
-                                sx={{
-                                    flex: 1,
-                                }}
+                                fz="sm"
+                                style={{ flex: 1 }}
                             >
-                                {table}
-                            </Highlight>
+                                <Highlight
+                                    component="span"
+                                    highlight={search || ''}
+                                >
+                                    {table}
+                                </Highlight>
+                            </Text>
                         ) : (
-                            <Text>{table}</Text>
+                            <Text fz="sm">{table}</Text>
                         )}
                     </Tooltip>
                 </UnstyledButton>

--- a/packages/frontend/src/features/sqlRunner/components/TablesPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TablesPanel.tsx
@@ -1,5 +1,5 @@
-import { Box } from '@mantine-8/core';
-import { LoadingOverlay, Text } from '@mantine/core';
+import { Box, Text } from '@mantine-8/core';
+import { LoadingOverlay } from '@mantine/core';
 import { useTimeout } from '@mantine/hooks';
 import { IconGripHorizontal } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -2,14 +2,8 @@ import type {
     ApiError,
     GeneratedFormulaTableCalculation,
 } from '@lightdash/common';
-import { Box, Button, Flex } from '@mantine-8/core';
-import {
-    Alert,
-    Anchor,
-    ScrollArea,
-    useMantineTheme,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Flex, Text } from '@mantine-8/core';
+import { Alert, Anchor, ScrollArea, useMantineTheme } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { IconAlertCircle, IconSparkles, IconWand } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';

--- a/packages/frontend/src/features/tableCalculation/components/TemplateViewer/TemplateViewer.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TemplateViewer/TemplateViewer.tsx
@@ -5,8 +5,8 @@ import {
     WindowFunctionType,
     type TableCalculationTemplate,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { Badge, MultiSelect, Text } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
+import { Badge, MultiSelect } from '@mantine/core';
 import { useCallback, useMemo, type FC } from 'react';
 import { useColumns } from '../../../../hooks/useColumns';
 import { selectDimensions, useExplorerSelector } from '../../../explorer/store';

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -8,7 +8,7 @@ import {
     SEED_ORG_1_ADMIN_PASSWORD,
     type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Box, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
@@ -18,7 +18,6 @@ import {
     PasswordInput,
     TextInput,
     Title,
-    Text,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useTimeout } from '@mantine/hooks';

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -11,7 +11,8 @@ import {
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
-import { Skeleton, Text } from '@mantine/core';
+import { Text } from '@mantine-8/core';
+import { Skeleton } from '@mantine/core';
 import { captureException } from '@sentry/react';
 import type { CellContext } from '@tanstack/react-table';
 import {

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,5 +1,5 @@
 import { LightdashMode, type ApiErrorDetail } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
@@ -8,7 +8,6 @@ import {
     Modal,
     Tooltip,
     useMantineTheme,
-    Text,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { IconCheck, IconCopy, IconSpeakerphone } from '@tabler/icons-react';

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -1,6 +1,6 @@
 import { getEmailSchema } from '@lightdash/common';
-import { Center, Stack } from '@mantine-8/core';
-import { Anchor, Button, List, TextInput, Title, Text } from '@mantine/core';
+import { Center, Stack, Text } from '@mantine-8/core';
+import { Anchor, Button, List, TextInput, Title } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -1,12 +1,5 @@
-import { Box, Center, Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    Button,
-    Card,
-    PasswordInput,
-    Title,
-    Text,
-} from '@mantine/core';
+import { Box, Center, Stack, Text } from '@mantine-8/core';
+import { Anchor, Button, Card, PasswordInput, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -3,16 +3,8 @@ import {
     type UserActivity as UserActivityResponse,
     type UserWithCount,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    Button,
-    Card,
-    Table,
-    Title,
-    Tooltip,
-    Text,
-} from '@mantine/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
+import { Anchor, Button, Card, Table, Title, Tooltip } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';

--- a/packages/frontend/src/utils/roleAccessWarnings.tsx
+++ b/packages/frontend/src/utils/roleAccessWarnings.tsx
@@ -5,7 +5,7 @@ import {
     type ProjectMemberRole,
     type RoleAssignment,
 } from '@lightdash/common';
-import { Text } from '@mantine/core';
+import { Text } from '@mantine-8/core';
 import { type ReactNode } from 'react';
 
 export const systemRolesOrder: string[] = Object.values(OrganizationMemberRole);


### PR DESCRIPTION
## What & why

Migrates `Text` from Mantine 6 (`@mantine/core`) to Mantine 8 (`@mantine-8/core`) across all 91 remaining import sites (242 rendered tags).

## Changes

- Moves every remaining `Text` import to the v8 alias.
- Preserves existing `span`, `fz`, `ff`, `inherit`, `size`, and style-prop combinations unchanged.
- Changes the single deprecated `color="ldGray.6"` usage to `c="ldGray.6"`.
- Explicitly sets `fz="sm"` on four Explore tree primary-label paths to preserve the previously inherited 14px sidebar typography.
- Leaves zero v6 `Text` imports.

## Regression analysis

Mantine 6 `Text` defaults to a `div`; Mantine 8 defaults to a `p`. The 205 default-root usages were statically audited: none are directly nested in native `p`, `span`, `a`, `button`, or `label`; most sit under `Group` or `Stack`. Mantine 8 `Text` also resets paragraph margin to zero.

Mantine 6 `Text` without `size` inherits font size, while Mantine 8 defaults to `md`. Explicit sizing is preserved, and context-dependent unsized text was reviewed. The Explore tree labels now mirror existing `ExploreNavLink` precedent with `fz="sm"`.

`span`, `fz`, `ff`, and `inherit` combinations are established Mantine 8 patterns already used throughout the frontend. In particular, `fz` remains `fz` rather than being changed to `size`, since `size` also controls line height.

## Verification

- `pnpm -F frontend typecheck:fast`
- `pnpm -F frontend build:fast`
- `pnpm -F frontend test` — 119 files, 979 tests
- `pnpm -F frontend lint` — 0 errors (3 pre-existing warnings)
- `pnpm -F frontend format`
- `pnpm tsx scripts/count-mantine-imports.ts` — 528 v6 / 1108 v8 declarations; 67.7% v8

Relates: #25239