### PR TITLE
feat: gate scheduled deliveries on unmet dashboard filter requirements

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     FilterOperator,
     FilterType,
     getFilterTypeFromItem,
@@ -39,9 +40,11 @@ import FiltersProvider from '../../../../components/common/Filters/FiltersProvid
 import useFiltersContext from '../../../../components/common/Filters/useFiltersContext';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useProject } from '../../../../hooks/useProject';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useDashboardContext from '../../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../../providers/Dashboard/useDashboardTileStatusContext';
 import { hasSavedFilterValueChanged } from '../../../dashboardFilters/FilterConfiguration/utils';
+import { getSchedulerFilterRequirements } from '../../utils/filterRequirements';
 
 const isValidFilterOperator = (value: unknown): value is FilterOperator =>
     Object.values(FilterOperator).includes(value as FilterOperator);
@@ -75,6 +78,7 @@ const FilterSummaryLabel: FC<
 type SchedulerFilterItemProps = {
     dashboardFilter: DashboardFilterRule;
     schedulerFilter?: DashboardFilterRule;
+    isMissingRequiredValue: boolean;
     onChange: (schedulerFilter: DashboardFilterRule) => void;
     onRevert: () => void;
     hasChanged: boolean;
@@ -85,6 +89,7 @@ type SchedulerFilterItemProps = {
 const FilterItem: FC<SchedulerFilterItemProps> = ({
     dashboardFilter,
     schedulerFilter,
+    isMissingRequiredValue,
     onChange,
     onRevert,
     hasChanged,
@@ -162,14 +167,11 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                             isDisabled={isDisabled}
                         />
                     )}
-                    {dashboardFilter.required &&
-                        !isEditing &&
-                        (!schedulerFilter?.values ||
-                            schedulerFilter?.values?.length === 0) && (
-                            <Text fz="sm" color="red">
-                                *
-                            </Text>
-                        )}
+                    {isMissingRequiredValue && !isEditing && (
+                        <Text fz="sm" color="red">
+                            *
+                        </Text>
+                    )}
                     {tilesWithFilter && tilesWithFilter.length > 0 && (
                         <Tooltip
                             label={`Applies to: ${tilesWithFilter.join(', ')}`}
@@ -347,6 +349,12 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
 
     const tileNamesById = useDashboardTileStatusContext((c) => c.tileNamesById);
 
+    const { data: filterRequirementsFlag } = useServerFeatureFlag(
+        FeatureFlags.DashboardFilterRequirements,
+    );
+    const isFilterRequirementsEnabled =
+        filterRequirementsFlag?.enabled === true;
+
     const { savedFiltersInDashboard, savedFiltersNotInDashboard } =
         useMemo(() => {
             const inDashboard: typeof savedFilters = [];
@@ -426,10 +434,32 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
         );
     }
 
-    const requiredFiltersWithoutValues = (draftFilters ?? []).filter(
-        (filter) =>
-            filter.required && (!filter.values || filter.values.length === 0),
+    const { unmetRequirements, filtersWithUnmetRequirements } =
+        getSchedulerFilterRequirements(
+            currentDashboardFilters,
+            draftFilters,
+            isFilterRequirementsEnabled,
+        );
+    const unmetFilterIds = new Set(
+        filtersWithUnmetRequirements.map((filter) => filter.id),
     );
+    const hasUnmetSingles = unmetRequirements.some(
+        (requirement) => requirement.type === 'single',
+    );
+    const hasUnmetGroups = unmetRequirements.some(
+        (requirement) => requirement.type === 'group',
+    );
+    const isMissingRequiredValue = (
+        dashboardFilter: DashboardFilterRule,
+        schedulerFilter: DashboardFilterRule | undefined,
+    ) =>
+        isFilterRequirementsEnabled
+            ? unmetFilterIds.has(dashboardFilter.id)
+            : Boolean(
+                  dashboardFilter.required &&
+                  (!schedulerFilter?.values ||
+                      schedulerFilter?.values?.length === 0),
+              );
 
     return (
         <FiltersProvider<Record<string, FilterableDimension>>
@@ -442,9 +472,15 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
             {(draftFilters?.length ?? 0) + savedFiltersNotInDashboard?.length >
             0 ? (
                 <Stack mb="sm">
-                    {requiredFiltersWithoutValues.length > 0 && (
+                    {hasUnmetSingles && (
                         <Text fz="xs" color="ldGray.6">
                             All required filters must have values
+                        </Text>
+                    )}
+                    {hasUnmetGroups && (
+                        <Text fz="xs" color="ldGray.6">
+                            Set a value for at least one filter in each
+                            requirement group
                         </Text>
                     )}
                     {draftFilters?.map((filter) => {
@@ -465,6 +501,10 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
                                 key={filter.id}
                                 dashboardFilter={originalFilter}
                                 schedulerFilter={filter}
+                                isMissingRequiredValue={isMissingRequiredValue(
+                                    originalFilter,
+                                    filter,
+                                )}
                                 onChange={(updatedFilter) =>
                                     handleUpdateSchedulerFilter(
                                         updatedFilter,
@@ -519,6 +559,10 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
                                     key={filter.id}
                                     dashboardFilter={filter}
                                     schedulerFilter={schedulerFilter}
+                                    isMissingRequiredValue={isMissingRequiredValue(
+                                        filter,
+                                        schedulerFilter,
+                                    )}
                                     onChange={(updatedFilter) =>
                                         handleUpdateSchedulerFilter(
                                             updatedFilter,

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     getMetricsFromItemsMap,
     getTableCalculationsFromItemsMap,
     isNumericItem,
@@ -6,17 +7,19 @@ import {
     type ApiError,
     type CreateSchedulerAndTargets,
     type CreateSchedulerAndTargetsWithoutIds,
+    type DashboardFilters,
     type ItemsMap,
     type ParametersValuesMap,
     type SchedulerAndTargets,
 } from '@lightdash/common';
 import { type UseMutationResult } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAiAgentButtonVisibility } from '../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useDashboardQuery } from '../../../hooks/dashboard/useDashboard';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useUser from '../../../hooks/user/useUser';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { isInvalidCronExpression } from '../../../utils/fieldValidators';
@@ -30,6 +33,7 @@ import {
     type SchedulerFormValues,
 } from '../components/SchedulerForm/schedulerFormContext';
 import { Limit } from '../components/types';
+import { getSchedulerFilterRequirements } from '../utils/filterRequirements';
 import { useScheduler, useSendNowScheduler } from './useScheduler';
 import {
     useSchedulerAiAugmentation,
@@ -142,6 +146,21 @@ export const useSchedulerFormModal = ({
     const isDashboardTabsAvailable =
         dashboard?.tabs !== undefined && dashboard.tabs.length > 1;
 
+    const { data: filterRequirementsFlag } = useServerFeatureFlag(
+        FeatureFlags.DashboardFilterRequirements,
+    );
+    const isFilterRequirementsEnabled =
+        filterRequirementsFlag?.enabled === true;
+
+    // The form's validate closure is captured once, so it reads the saved
+    // filters and flag through refs updated on every render.
+    const savedDashboardFiltersRef = useRef<DashboardFilters | undefined>(
+        undefined,
+    );
+    savedDashboardFiltersRef.current = dashboard?.filters;
+    const isFilterRequirementsEnabledRef = useRef(false);
+    isFilterRequirementsEnabledRef.current = isFilterRequirementsEnabled;
+
     // Use the explicitly passed parameter values
     const dashboardParameterValues = currentParameterValues || {};
 
@@ -193,13 +212,14 @@ export const useSchedulerFormModal = ({
                     // Dashboard filters are undefined/null for charts
                     return null;
                 }
-                const requiredFiltersWithoutValues = value.filter(
-                    (filter) =>
-                        filter.required &&
-                        (!filter.values || filter.values.length === 0),
-                );
+                const { filtersWithUnmetRequirements } =
+                    getSchedulerFilterRequirements(
+                        savedDashboardFiltersRef.current,
+                        value,
+                        isFilterRequirementsEnabledRef.current,
+                    );
 
-                if (requiredFiltersWithoutValues.length > 0) {
+                if (filtersWithUnmetRequirements.length > 0) {
                     return `Required filters must have values`;
                 }
                 return null;
@@ -236,12 +256,12 @@ export const useSchedulerFormModal = ({
     const isThresholdAlertWithNoFields =
         isThresholdAlert && Object.keys(numericMetrics).length === 0;
 
-    const requiredFiltersWithoutValues = (
-        form.values.dashboardFilters ?? []
-    ).filter(
-        (filter) =>
-            filter.required && (!filter.values || filter.values.length === 0),
-    );
+    const { filtersWithUnmetRequirements: requiredFiltersWithoutValues } =
+        getSchedulerFilterRequirements(
+            dashboard?.filters,
+            form.values.dashboardFilters,
+            isFilterRequirementsEnabled,
+        );
 
     // Sync form values when data is loaded. The AI augmentation is omitted —
     // it loads via a separate query and is synced by the effect below, so a

--- a/packages/frontend/src/features/scheduler/utils/filterRequirements.test.ts
+++ b/packages/frontend/src/features/scheduler/utils/filterRequirements.test.ts
@@ -1,0 +1,229 @@
+import {
+    FilterOperator,
+    type DashboardFilterRule,
+    type DashboardFilters,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getSchedulerFilterRequirements } from './filterRequirements';
+
+const rule = (
+    overrides: Partial<DashboardFilterRule> & Pick<DashboardFilterRule, 'id'>,
+): DashboardFilterRule => ({
+    target: { fieldId: `field_${overrides.id}`, tableName: 'orders' },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    label: undefined,
+    tileTargets: {},
+    ...overrides,
+});
+
+const dashboardFilters = (
+    dimensions: DashboardFilterRule[],
+    metrics: DashboardFilterRule[] = [],
+): DashboardFilters => ({ dimensions, metrics, tableCalculations: [] });
+
+describe('getSchedulerFilterRequirements', () => {
+    describe('flag off (main parity)', () => {
+        it('flags required scheduler filters without values', () => {
+            const required = rule({ id: 'a', required: true });
+            const { filtersWithUnmetRequirements, unmetRequirements } =
+                getSchedulerFilterRequirements(
+                    dashboardFilters([required]),
+                    [required],
+                    false,
+                );
+            expect(filtersWithUnmetRequirements).toEqual([required]);
+            expect(unmetRequirements).toEqual([
+                { type: 'single', filter: required },
+            ]);
+        });
+
+        it('does not flag required filters with values', () => {
+            const filters = [
+                rule({
+                    id: 'a',
+                    required: true,
+                    values: ['x'],
+                    disabled: false,
+                }),
+            ];
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters(filters),
+                    filters,
+                    false,
+                ).filtersWithUnmetRequirements,
+            ).toEqual([]);
+        });
+
+        it('ignores unmet groups', () => {
+            const members = [
+                rule({ id: 'a', requiredGroupId: 'g1' }),
+                rule({ id: 'b', requiredGroupId: 'g1' }),
+            ];
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters(members),
+                    members,
+                    false,
+                ).filtersWithUnmetRequirements,
+            ).toEqual([]);
+        });
+
+        it('evaluates scheduler filters only, ignoring the saved dashboard', () => {
+            const required = rule({ id: 'a', required: true });
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters([required]),
+                    [],
+                    false,
+                ).filtersWithUnmetRequirements,
+            ).toEqual([]);
+        });
+    });
+
+    describe('flag on', () => {
+        const groupMembers = [
+            rule({ id: 'a', requiredGroupId: 'g1' }),
+            rule({ id: 'b', requiredGroupId: 'g1' }),
+        ];
+
+        it('flags every member of a fully valueless group', () => {
+            const { unmetRequirements, filtersWithUnmetRequirements } =
+                getSchedulerFilterRequirements(
+                    dashboardFilters(groupMembers),
+                    [],
+                    true,
+                );
+            expect(unmetRequirements).toEqual([
+                { type: 'group', groupId: 'g1', filters: groupMembers },
+            ]);
+            expect(filtersWithUnmetRequirements.map((f) => f.id)).toEqual([
+                'a',
+                'b',
+            ]);
+        });
+
+        it('is satisfied when an override provides a value for any member', () => {
+            const override = rule({
+                id: 'a',
+                values: ['card'],
+                disabled: false,
+            });
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters(groupMembers),
+                    [override],
+                    true,
+                ).filtersWithUnmetRequirements,
+            ).toEqual([]);
+        });
+
+        it('stays unmet for an enabled override with empty values', () => {
+            const override = rule({ id: 'a', values: [], disabled: false });
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters(groupMembers),
+                    [override],
+                    true,
+                ).filtersWithUnmetRequirements,
+            ).toHaveLength(2);
+        });
+
+        it('stays unmet when an override tries to strip the group id', () => {
+            const override = rule({
+                id: 'a',
+                requiredGroupId: undefined,
+                values: [],
+                disabled: false,
+            });
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters(groupMembers),
+                    [override],
+                    true,
+                ).filtersWithUnmetRequirements,
+            ).toHaveLength(2);
+        });
+
+        it('is satisfied by a value-less operator on a member', () => {
+            const override = rule({
+                id: 'a',
+                operator: FilterOperator.NULL,
+                values: [],
+                disabled: false,
+            });
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters(groupMembers),
+                    [override],
+                    true,
+                ).filtersWithUnmetRequirements,
+            ).toEqual([]);
+        });
+
+        it('flags unmet required singles from the saved dashboard even with no overrides', () => {
+            const required = rule({ id: 'a', required: true });
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters([required]),
+                    [],
+                    true,
+                ).filtersWithUnmetRequirements.map((f) => f.id),
+            ).toEqual(['a']);
+        });
+
+        it('does not flag required singles with a saved default value', () => {
+            const required = rule({
+                id: 'a',
+                required: true,
+                values: ['x'],
+                disabled: false,
+            });
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters([required]),
+                    [],
+                    true,
+                ).filtersWithUnmetRequirements,
+            ).toEqual([]);
+        });
+
+        it('includes unmet requirements on saved metric filters', () => {
+            const metric = rule({ id: 'm', required: true });
+            expect(
+                getSchedulerFilterRequirements(
+                    dashboardFilters([], [metric]),
+                    [],
+                    true,
+                ).filtersWithUnmetRequirements.map((f) => f.id),
+            ).toEqual(['m']);
+        });
+
+        it('returns a rule once when it is both required and a group member', () => {
+            const both = rule({
+                id: 'a',
+                required: true,
+                requiredGroupId: 'g1',
+            });
+            const sibling = rule({ id: 'b', requiredGroupId: 'g1' });
+            const { filtersWithUnmetRequirements } =
+                getSchedulerFilterRequirements(
+                    dashboardFilters([both, sibling]),
+                    [],
+                    true,
+                );
+            expect(
+                filtersWithUnmetRequirements.filter((f) => f.id === 'a'),
+            ).toHaveLength(1);
+        });
+
+        it('returns nothing without saved dashboard filters', () => {
+            expect(
+                getSchedulerFilterRequirements(undefined, [], true)
+                    .filtersWithUnmetRequirements,
+            ).toEqual([]);
+        });
+    });
+});

--- a/packages/frontend/src/features/scheduler/utils/filterRequirements.ts
+++ b/packages/frontend/src/features/scheduler/utils/filterRequirements.ts
@@ -1,0 +1,69 @@
+import {
+    applyDimensionOverrides,
+    getUnmetFilterRequirements,
+    type DashboardFilterRule,
+    type DashboardFilters,
+    type UnmetFilterRequirement,
+} from '@lightdash/common';
+
+export type SchedulerFilterRequirements = {
+    unmetRequirements: UnmetFilterRequirement[];
+    filtersWithUnmetRequirements: DashboardFilterRule[];
+};
+
+/**
+ * Filter requirements that block a delivery. Flag off keeps the legacy test
+ * (required scheduler filters with no values). Flag on evaluates what the
+ * delivery will actually run with — the saved dashboard rules overlaid with
+ * the scheduler overrides — so an unmet any-of group blocks like an unmet
+ * required filter, and dropping a rule from the overrides can't skip the
+ * check.
+ */
+export const getSchedulerFilterRequirements = (
+    savedDashboardFilters: DashboardFilters | undefined,
+    schedulerFilters: DashboardFilterRule[] | undefined,
+    isFilterRequirementsEnabled: boolean,
+): SchedulerFilterRequirements => {
+    if (!isFilterRequirementsEnabled) {
+        const unmetSingles = (schedulerFilters ?? []).filter(
+            (filter) =>
+                filter.required &&
+                (!filter.values || filter.values.length === 0),
+        );
+        return {
+            unmetRequirements: unmetSingles.map((filter) => ({
+                type: 'single',
+                filter,
+            })),
+            filtersWithUnmetRequirements: unmetSingles,
+        };
+    }
+
+    if (!savedDashboardFilters) {
+        return { unmetRequirements: [], filtersWithUnmetRequirements: [] };
+    }
+
+    const effectiveFilters: DashboardFilters = {
+        ...savedDashboardFilters,
+        dimensions: applyDimensionOverrides(
+            savedDashboardFilters,
+            schedulerFilters ?? [],
+        ),
+    };
+
+    const unmetRequirements = getUnmetFilterRequirements(effectiveFilters);
+    const seenFilterIds = new Set<string>();
+    const filtersWithUnmetRequirements = unmetRequirements
+        .flatMap((requirement) =>
+            requirement.type === 'single'
+                ? [requirement.filter]
+                : requirement.filters,
+        )
+        .filter((filter) => {
+            if (seenFilterIds.has(filter.id)) return false;
+            seenFilterIds.add(filter.id);
+            return true;
+        });
+
+    return { unmetRequirements, filtersWithUnmetRequirements };
+};


### PR DESCRIPTION
## Description

Extends the dashboard filter requirements feature (any-of groups, PROD-8661 stack) to the scheduled-delivery form. Frontend-only, no API changes.

**The gap:** main protects `required` filters in the scheduler form (red asterisk, "All required filters must have values", disabled Create/Send-now with a blocked-reason tooltip), but all of it keys on `filter.required`. Any-of group members are `required: false` + `requiredGroupId`, so with the feature flag on a delivery could be created against a dashboard whose group was entirely unmet — and would export fully unfiltered data on a schedule, which is exactly the resource-protection scenario the feature exists to prevent.

**The fix:** a new `getSchedulerFilterRequirements` helper evaluates what the delivery will actually run with — the saved dashboard rules overlaid with the scheduler overrides via `applyDimensionOverrides` (which pins requirement flags to the saved dashboard) — and feeds the existing three protections: per-filter asterisk, Filters-section warning (group-specific copy), and the Create/Send-now gate + form validation.

## Feature flag behavior

- **Flag off (`dashboard-filter-requirements`): main parity.** The helper's flag-off branch is the verbatim legacy predicate (`required && no values` over the scheduler filters), and the per-filter asterisk keeps the exact legacy expression. Unit tests pin this.
- **Flag on:** unmet any-of groups block like unmet required filters. Evaluation is operator-aware (`isNull`-style operators satisfy) and merge-based, so dropping a rule from the overrides or a crafted override with empty values / stripped `requiredGroupId` cannot dodge the gate.
- **Flag-on behavior change for legacy `required`:** the gate now evaluates the saved dashboard filters even before the Filters section seeds the form, so a required-filter dashboard blocks delivery creation immediately (on main the check only engages once the form carries the filters). Fails closed; resolved by setting a value in the Filters section.

## Verification

- 14 unit tests on the helper (flag-off parity, group semantics, override strip/empty-value attempts, value-less operators, metric filters, dedupe).
- Browser (flag on, real app): unmet-group dashboard → Create + Send-now disabled with "Some required filters are missing values" tooltip, asterisks on exactly the group members, group warning line; setting a value on one member clears everything and enables both buttons; legacy required dashboard blocks with the legacy copy.
- `pnpm -F frontend typecheck:fast` + lint clean.

## Rollback

Revert this PR alone; no shared files outside the scheduler feature are touched.

Closes: #25095