### PR TITLE
refactor(frontend): migrate Title to mantine 8

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Title } from '@mantine-8/core';
 import {
     ActionIcon,
     Burger,
@@ -7,7 +7,6 @@ import {
     getDefaultZIndex,
     Header,
     MantineProvider,
-    Title,
 } from '@mantine/core';
 import {
     IconChartAreaLine,

--- a/packages/frontend/src/components/DataOps/index.tsx
+++ b/packages/frontend/src/components/DataOps/index.tsx
@@ -1,6 +1,6 @@
 import { ProjectType } from '@lightdash/common';
-import { Flex, Text } from '@mantine-8/core';
-import { Button, Select, Title } from '@mantine/core';
+import { Flex, Text, Title } from '@mantine-8/core';
+import { Button, Select } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useProject } from '../../hooks/useProject';
 import { useProjects } from '../../hooks/useProjects';

--- a/packages/frontend/src/components/DataViz/config/PieChartConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/PieChartConfiguration.tsx
@@ -1,6 +1,5 @@
 import { DimensionType, type VizColumn } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Title } from '@mantine/core';
+import { Stack, Title } from '@mantine-8/core';
 import { useMemo } from 'react';
 import {
     useAppDispatch as useVizDispatch,

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
@@ -1,6 +1,6 @@
 import { type QueryWarning } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { ActionIcon, Divider, Popover, Title, Tooltip } from '@mantine/core';
+import { Box, Stack, Title } from '@mantine-8/core';
+import { ActionIcon, Divider, Popover, Tooltip } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { Fragment, useState, type FC } from 'react';

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -4,14 +4,13 @@ import {
     type Job,
     type JobStep,
 } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Group, Stack, Text, Title } from '@mantine-8/core';
 import {
     ActionIcon,
     Alert,
     CopyButton,
     Drawer,
     Loader,
-    Title,
     type DefaultMantineColor,
 } from '@mantine/core';
 import { useInterval } from '@mantine/hooks';

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -1,6 +1,6 @@
 import { ProjectType, type DbtProjectType } from '@lightdash/common';
-import { Flex, Stack, Text } from '@mantine-8/core';
-import { Avatar, TextInput, Title } from '@mantine/core';
+import { Flex, Stack, Text, Title } from '@mantine-8/core';
+import { Avatar, TextInput } from '@mantine/core';
 import { type FC } from 'react';
 import useApp from '../../providers/App/useApp';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { hasIntersection, TableSelectionType } from '@lightdash/common';
-import { Box, Flex, Stack, Text } from '@mantine-8/core';
+import { Box, Flex, Stack, Text, Title } from '@mantine-8/core';
 import {
     Anchor,
     Button,
@@ -10,7 +10,6 @@ import {
     MultiSelect,
     Radio,
     ScrollArea,
-    Title,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/components/Settings/CreateProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/CreateProjectSettings.tsx
@@ -1,5 +1,4 @@
-import { Stack, Text } from '@mantine-8/core';
-import { Title } from '@mantine/core';
+import { Stack, Text, Title } from '@mantine-8/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -6,13 +6,12 @@ import {
     validateOrganizationEmailDomains,
     type AllowedEmailDomains,
 } from '@lightdash/common';
-import { Flex, Stack, Text } from '@mantine-8/core';
+import { Flex, Stack, Text, Title } from '@mantine-8/core';
 import {
     ActionIcon,
     Button,
     MultiSelect,
     Select,
-    Title,
     Tooltip,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
-import { Alert, Avatar, Button, Loader, Title, Tooltip } from '@mantine/core';
+import { Box, Flex, Group, Stack, Text, Title } from '@mantine-8/core';
+import { Alert, Avatar, Button, Loader, Tooltip } from '@mantine/core';
 import {
     IconAlertCircle,
     IconClock,

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
-import { Alert, Avatar, Button, Loader, Title } from '@mantine/core';
+import { Box, Flex, Group, Stack, Text, Title } from '@mantine-8/core';
+import { Alert, Avatar, Button, Loader } from '@mantine/core';
 import { IconAlertCircle, IconRefresh, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import gitlabIcon from '../../../svgs/gitlab-icon.svg';

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
-import { Button, LoadingOverlay, Title } from '@mantine/core';
+import { Group, Stack, Text, Title } from '@mantine-8/core';
+import { Button, LoadingOverlay } from '@mantine/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Group, Stack, Text } from '@mantine-8/core';
-import { Anchor, Button, TextInput, Title } from '@mantine/core';
+import { Group, Stack, Text, Title } from '@mantine-8/core';
+import { Anchor, Button, TextInput } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,12 +1,11 @@
 import { type SqlChart } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
+import { Group, Stack, Title } from '@mantine-8/core';
 import {
     ActionIcon,
     Button,
     HoverCard,
     Menu,
     Paper,
-    Title,
     Tooltip,
 } from '@mantine/core';
 import {

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DashboardTileTypes } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Button, Menu, Paper, Title, Tooltip } from '@mantine/core';
+import { Group, Stack, Title } from '@mantine-8/core';
+import { ActionIcon, Button, Menu, Paper, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { ChartKind } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, ScrollArea, Title, Tooltip } from '@mantine/core';
+import { Group, Stack, Title } from '@mantine-8/core';
+import { ActionIcon, ScrollArea, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftCollapse, IconReload } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -360,10 +360,11 @@ const Login: FC<{}> = () => {
                                 </Stack>
                             </>
                         )}
-                        <Text mx="auto" mt="md">
+                        <Text mx="auto" mt="md" fz="sm">
                             Don't have an account?{' '}
                             <Anchor
                                 href={health.data?.signupUrl || '/register'}
+                                fz="sm"
                             >
                                 Sign up
                             </Anchor>

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -8,7 +8,7 @@ import {
     SEED_ORG_1_ADMIN_PASSWORD,
     type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
-import { Box, Stack, Text } from '@mantine-8/core';
+import { Box, Stack, Text, Title } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
@@ -17,7 +17,6 @@ import {
     Divider,
     PasswordInput,
     TextInput,
-    Title,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useTimeout } from '@mantine/hooks';

--- a/packages/frontend/src/pages/MobileHome.tsx
+++ b/packages/frontend/src/pages/MobileHome.tsx
@@ -3,8 +3,7 @@ import {
     ResourceViewItemType,
     wrapResource,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Title } from '@mantine/core';
+import { Stack, Title } from '@mantine-8/core';
 import { IconLayoutDashboard } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import { useParams } from 'react-router';

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -1,6 +1,6 @@
 import { getEmailSchema } from '@lightdash/common';
-import { Center, Stack, Text } from '@mantine-8/core';
-import { Anchor, Button, List, TextInput, Title } from '@mantine/core';
+import { Center, Stack, Text, Title } from '@mantine-8/core';
+import { Anchor, Button, List, TextInput } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -1,5 +1,5 @@
-import { Box, Center, Stack, Text } from '@mantine-8/core';
-import { Anchor, Button, Card, PasswordInput, Title } from '@mantine/core';
+import { Box, Center, Stack, Text, Title } from '@mantine-8/core';
+import { Anchor, Button, Card, PasswordInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -3,8 +3,8 @@ import {
     type UserActivity as UserActivityResponse,
     type UserWithCount,
 } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
-import { Anchor, Button, Card, Table, Title, Tooltip } from '@mantine/core';
+import { Box, Group, Stack, Text, Title } from '@mantine-8/core';
+import { Anchor, Button, Card, Table, Tooltip } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';
@@ -58,7 +58,7 @@ const BigNumberVis: FC<{ value: number | string; label: string }> = ({
             <Title order={1} size={56} fw={500}>
                 {value}
             </Title>
-            <Title order={4} fw={500} color="gray">
+            <Title order={4} fw={500} c="gray">
                 {label}
             </Title>
         </Stack>

--- a/packages/frontend/src/stories/FormCard.stories.tsx
+++ b/packages/frontend/src/stories/FormCard.stories.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mantine-8/core';
+import { Stack, Title } from '@mantine-8/core';
 import {
     Button,
     Card,
@@ -6,7 +6,6 @@ import {
     Select,
     Switch,
     TextInput,
-    Title,
 } from '@mantine/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -1,5 +1,5 @@
-import { Group, Stack } from '@mantine-8/core';
-import { Button, Title } from '@mantine/core';
+import { Group, Stack, Title } from '@mantine-8/core';
+import { Button } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import MultipleToastBody from '../hooks/toaster/MultipleToastBody';


### PR DESCRIPTION
## What changed

- Migrated all 32 remaining `Title` usages across 23 files from Mantine 6 to Mantine 8.
- Preserved explicit heading order and existing typography props.
- Replaced the legacy `color="gray"` prop with `c="gray"`.

## Why

Continues the Mantine 8 component migration after `Text`. This removes every remaining Mantine 6 `Title` import.

Mantine 6 and 8 share the same heading size and line-height scale. Unweighted headings now use Lightdash's Mantine 8 theme weight of 600 instead of the Mantine 6 default of 700; explicit `fw` values are unchanged.

## Validation

- `pnpm --filter frontend format`
- `pnpm --filter frontend lint` (0 errors; 3 unrelated existing warnings)
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend test` (120 files, 981 tests)
- `pnpm --filter frontend build`

Relates: #25448
