### PR TITLE
refactor(frontend): migrate Divider and Collapse to mantine 8

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -1,8 +1,7 @@
-import { Group, Stack, Title } from '@mantine-8/core';
+import { Divider, Group, Stack, Title } from '@mantine-8/core';
 import {
     ActionIcon,
     Burger,
-    Divider,
     Drawer,
     getDefaultZIndex,
     Header,

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
@@ -274,7 +274,7 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                         <Divider
                             key={item.id}
                             size={0.5}
-                            c="ldGray.5"
+                            color="ldGray.5"
                             my="xs"
                         />
                     );

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
@@ -1,6 +1,6 @@
 import { type QueryWarning } from '@lightdash/common';
-import { Box, Stack, Title } from '@mantine-8/core';
-import { ActionIcon, Divider, Popover, Tooltip } from '@mantine/core';
+import { Box, Divider, Stack, Title } from '@mantine-8/core';
+import { ActionIcon, Popover, Tooltip } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { Fragment, useState, type FC } from 'react';

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -1,6 +1,6 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
-import { Group, Loader, Text } from '@mantine-8/core';
-import { ActionIcon, Divider, ScrollArea, Tooltip } from '@mantine/core';
+import { Divider, Group, Loader, Text } from '@mantine-8/core';
+import { ActionIcon, ScrollArea, Tooltip } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { lazy, Suspense, useMemo, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -1,10 +1,17 @@
 import { subject } from '@casl/ability';
 import { hasIntersection, TableSelectionType } from '@lightdash/common';
-import { Box, Flex, Loader, Stack, Text, Title } from '@mantine-8/core';
+import {
+    Box,
+    Collapse,
+    Flex,
+    Loader,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
 import {
     Anchor,
     Button,
-    Collapse,
     Highlight,
     MultiSelect,
     Radio,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -10,9 +10,9 @@ import {
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
-import { Group, Loader, Stack } from '@mantine-8/core';
+import { Collapse, Group, Loader, Stack } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
-import { Collapse, SegmentedControl, Switch } from '@mantine/core';
+import { SegmentedControl, Switch } from '@mantine/core';
 import { lazy, Suspense, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useToggle } from 'react-use';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
@@ -6,14 +6,8 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Collapse,
-    Select,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+import { Collapse, Group, Stack, Text } from '@mantine-8/core';
+import { ActionIcon, Select, TextInput, Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
@@ -8,8 +8,8 @@ import {
     type ResultRow,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Group, ScrollArea, Stack, Text } from '@mantine-8/core';
-import { Divider, SegmentedControl } from '@mantine/core';
+import { Box, Divider, Group, ScrollArea, Stack, Text } from '@mantine-8/core';
+import { SegmentedControl } from '@mantine/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import ColorSelector from '../../ColorSelector';
 import { ChartConditionalFormatting } from './ChartConditionalFormatting';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -5,8 +5,8 @@ import {
     type CartesianChartLayout,
     type Series,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Checkbox, Collapse, Popover, Select } from '@mantine/core';
+import { Box, Collapse, Group, Stack } from '@mantine-8/core';
+import { ActionIcon, Checkbox, Popover, Select } from '@mantine/core';
 import { useDebouncedState, useHover } from '@mantine/hooks';
 import {
     IconChevronDown,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -16,8 +16,8 @@ import {
     type Series as SeriesType,
     type TableCalculation,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Checkbox, Divider, Switch } from '@mantine/core';
+import { Divider, Stack } from '@mantine-8/core';
+import { Checkbox, Switch } from '@mantine/core';
 import { produce } from 'immer';
 import React, { Fragment, useCallback, useMemo, type FC } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -9,10 +9,9 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Collapse, Group, Stack } from '@mantine-8/core';
 import {
     Checkbox,
-    Collapse,
     MantineProvider,
     SegmentedControl,
     Switch,

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
@@ -5,8 +5,8 @@ import {
     type PieChartValueLabel,
     type PieChartValueOptions,
 } from '@lightdash/common';
-import { Box, Group, Stack, type StackProps } from '@mantine-8/core';
-import { ActionIcon, Collapse, Tooltip } from '@mantine/core';
+import { Box, Collapse, Group, Stack, type StackProps } from '@mantine-8/core';
+import { ActionIcon, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { forwardRef } from 'react';

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,13 +13,12 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Box, Group, Text } from '@mantine-8/core';
+import { Box, Divider, Group, Text } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
 import {
     ActionIcon,
     Anchor,
     Button,
-    Divider,
     TextInput,
     Tooltip,
     useMantineTheme,
@@ -707,9 +706,9 @@ const InfiniteResourceTable = ({
                                         orientation="vertical"
                                         w={1}
                                         h={20}
-                                        sx={{
+                                        color="#DEE2E6"
+                                        style={{
                                             alignSelf: 'center',
-                                            borderColor: '#DEE2E6',
                                         }}
                                     />
                                     <ContentTypeFilter

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -14,11 +14,10 @@ import {
     type DashboardTile,
     type Field,
 } from '@lightdash/common';
-import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Collapse, Flex, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Checkbox,
-    Collapse,
     Select,
     Tooltip,
     useMantineTheme,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -1,9 +1,8 @@
 import { getErrorMessage, type CatalogItem } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Divider, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Button,
-    Divider,
     Popover,
     SimpleGrid,
     TextInput,
@@ -137,12 +136,7 @@ const EditPopover: FC<EditPopoverProps> = ({
                         ))}
                     </SimpleGrid>
 
-                    <Divider
-                        c="ldGray.2"
-                        sx={(theme) => ({
-                            borderTopColor: theme.colors.ldGray[2],
-                        })}
-                    />
+                    <Divider color="ldGray.2" />
 
                     <Group justify="space-between">
                         <Tooltip

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,8 +5,8 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box, Center, Group, Text } from '@mantine-8/core';
-import { Anchor, Divider, Paper, useMantineTheme } from '@mantine/core';
+import { Box, Center, Divider, Group, Text } from '@mantine-8/core';
+import { Anchor, Paper, useMantineTheme } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowsSort,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -23,6 +23,7 @@ import {
 import {
     Box,
     Center,
+    Divider,
     Group,
     Stack,
     type GroupProps,
@@ -32,7 +33,6 @@ import {
     ActionIcon,
     Badge,
     Button,
-    Divider,
     Popover,
     SegmentedControl,
     TextInput,
@@ -392,9 +392,9 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            sx={{
+                            color="ldGray.3"
+                            style={{
                                 alignSelf: 'center',
-                                borderColor: 'ldGray.3',
                             }}
                         />
                     )}
@@ -585,10 +585,10 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                         orientation="vertical"
                         w={1}
                         h={20}
-                        sx={{
-                            display: embedToken ? 'none' : undefined,
+                        color="#DEE2E6"
+                        display={embedToken ? 'none' : undefined}
+                        style={{
                             alignSelf: 'center',
-                            borderColor: '#DEE2E6',
                         }}
                     />
                     <SegmentedControl

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -4,10 +4,9 @@ import {
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Divider, Group, Stack, Text } from '@mantine-8/core';
 import {
     Button,
-    Divider,
     Popover,
     SegmentedControl,
     TextInput,

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -8,13 +8,12 @@ import {
     SEED_ORG_1_ADMIN_PASSWORD,
     type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
-import { Box, Stack, Text, Title } from '@mantine-8/core';
+import { Box, Divider, Stack, Text, Title } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     Button,
     Card,
-    Divider,
     PasswordInput,
     TextInput,
 } from '@mantine/core';


### PR DESCRIPTION
## What changed

- Migrated all 19 remaining `Divider` usages and all 7 remaining `Collapse` usages from Mantine 6 to Mantine 8.
- Converted four Divider `sx` overrides to the v8 `color`, `display`, and `style` APIs.
- Fixed one existing v8 Divider using `c="ldGray.5"`; Divider border color requires `color`.

## Why

Continues the per-component Mantine 8 migration with two compatible low-risk components.

Existing v8 usage confirms the remaining prop combinations. Collapse retains the same transition defaults. Divider retains its size, variant, semantics, and component props; unconfigured light-mode dividers adopt the v8 default `gray.3` border instead of v6 `gray.4`.

## Validation

- Guide analyzers: zero remaining v6 `Divider` or `Collapse` imports
- Whole-frontend AST sweep: zero v8 Divider `c`/`sx` and Collapse `sx` props
- `pnpm --filter frontend format`
- `pnpm --filter frontend lint` (0 errors; 3 unrelated existing warnings)
- `pnpm --filter frontend typecheck`
- Full frontend suite (120 files, 981 tests)
- `pnpm --filter frontend build`

Relates: #25452
