### PR TITLE
refactor(frontend): migrate Skeleton and CopyButton to mantine 8

### DIFF
--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -4,14 +4,8 @@ import {
     isCustomSqlDimension,
     isSqlTableCalculation,
 } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
-import {
-    ActionIcon,
-    CopyButton,
-    SegmentedControl,
-    Skeleton,
-    Tooltip,
-} from '@mantine/core';
+import { Box, CopyButton, Group, Skeleton } from '@mantine-8/core';
+import { ActionIcon, SegmentedControl, Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconCheck, IconClipboard } from '@tabler/icons-react';
 import {

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -4,11 +4,18 @@ import {
     type Job,
     type JobStep,
 } from '@lightdash/common';
-import { Box, Group, Loader, Stack, Text, Title } from '@mantine-8/core';
+import {
+    Box,
+    CopyButton,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
 import {
     ActionIcon,
     Alert,
-    CopyButton,
     Drawer,
     type DefaultMantineColor,
 } from '@mantine/core';

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -1,10 +1,9 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { CopyButton, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Alert,
     Anchor,
-    CopyButton,
     MultiSelect,
     PasswordInput,
     TextInput,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -1,10 +1,9 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { CopyButton, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     Button,
-    CopyButton,
     NumberInput,
     PasswordInput,
     Select,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -1,10 +1,9 @@
 import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { CopyButton, Stack } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     Button,
-    CopyButton,
     NumberInput,
     PasswordInput,
     Select,

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -27,8 +27,15 @@ import {
     type ResultValue,
     type SortField,
 } from '@lightdash/common';
-import { Box, Group, Menu, type BoxProps, Text } from '@mantine-8/core';
-import { Button, Skeleton, useMantineColorScheme } from '@mantine/core';
+import {
+    Box,
+    Group,
+    Menu,
+    Skeleton,
+    type BoxProps,
+    Text,
+} from '@mantine-8/core';
+import { Button, useMantineColorScheme } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import {
     flexRender,

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,13 +14,8 @@ import {
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
-import { Center, Group, Loader } from '@mantine-8/core';
-import {
-    Button,
-    Skeleton,
-    Tooltip,
-    useMantineColorScheme,
-} from '@mantine/core';
+import { Center, Group, Loader, Skeleton } from '@mantine-8/core';
+import { Button, Tooltip, useMantineColorScheme } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { flexRender, type Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/LazyCommentWithMentions.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/LazyCommentWithMentions.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@mantine/core';
+import { Skeleton } from '@mantine-8/core';
 import { lazy, Suspense, type FC } from 'react';
 import { type SuggestionsItem } from '../../types';
 

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -1,7 +1,14 @@
-import { Box, Center, Group, Loader, Stack, Text } from '@mantine-8/core';
+import {
+    Box,
+    Center,
+    CopyButton,
+    Group,
+    Loader,
+    Stack,
+    Text,
+} from '@mantine-8/core';
 import {
     ActionIcon,
-    CopyButton,
     Highlight,
     ScrollArea,
     TextInput,

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -2,6 +2,7 @@ import { PartitionType, type PartitionColumn } from '@lightdash/common';
 import {
     Box,
     Center,
+    CopyButton,
     Group,
     Loader,
     Stack,
@@ -10,7 +11,6 @@ import {
 } from '@mantine-8/core';
 import {
     ActionIcon,
-    CopyButton,
     Highlight,
     ScrollArea,
     TextInput,

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -11,8 +11,7 @@ import {
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
-import { Text } from '@mantine-8/core';
-import { Skeleton } from '@mantine/core';
+import { Skeleton, Text } from '@mantine-8/core';
 import { captureException } from '@sentry/react';
 import type { CellContext } from '@tanstack/react-table';
 import {

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,10 +1,9 @@
 import { LightdashMode, type ApiErrorDetail } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
+import { CopyButton, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     Button,
-    CopyButton,
     Modal,
     Tooltip,
     useMantineTheme,

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -27,8 +27,8 @@ import {
     type ResultValue,
     type TableCalculation,
 } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import { Skeleton, Tooltip } from '@mantine/core';
+import { Group, Skeleton } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { IconExclamationCircle } from '@tabler/icons-react';
 import { type CellContext } from '@tanstack/react-table';
 import omit from 'lodash/omit';


### PR DESCRIPTION
## What changed

- Migrate all remaining `Skeleton` and `CopyButton` imports from Mantine 6 to Mantine 8
- Preserve existing Skeleton dimensions, spacing, radius, animation, and CopyButton callback/timeout behavior
- Leave sensitive clipboard values unchanged

## Why

Continues the per-component Mantine 8 migration after Divider and Collapse. Existing Mantine 8 patterns and both component implementations confirm these are direct import moves with no prop renames.

## Impact

- 6 Skeleton files / 9 usages migrated
- 8 CopyButton files / 8 usages migrated
- 13 unique OSS files; zero remaining Mantine 6 imports for either component

## Validation

- `pnpm --filter @lightdash/frontend typecheck:fast`
- changed-file oxlint: 0 warnings/errors
- `pnpm --filter @lightdash/frontend format`
- targeted tests: 2 files / 29 tests
- full frontend tests: 120 files / 981 tests
- `pnpm --filter @lightdash/frontend build`
- migration analyzer: zero residual v6 imports or v6-only props

Relates: #25453
