### PR TITLE
refactor(frontend): migrate Paper to mantine 8

### DIFF
--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,12 +1,11 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { Flex, Group, Text } from '@mantine-8/core';
+import { Flex, Group, Paper, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
     Button,
     ColorSwatch,
     Menu,
-    Paper,
     Tooltip,
 } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Group, Text } from '@mantine-8/core';
-import { ActionIcon, Paper, Table } from '@mantine/core';
+import { Group, Paper, Text } from '@mantine-8/core';
+import { ActionIcon, Table } from '@mantine/core';
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
@@ -72,7 +72,7 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
     const { cx, classes } = useTableStyles();
 
     return (
-        <Paper withBorder sx={{ overflow: 'hidden' }}>
+        <Paper withBorder style={{ overflow: 'hidden' }}>
             <Table
                 className={cx(classes.root, classes.alignLastTdRight)}
                 ta="left"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -1,11 +1,10 @@
 import { isEmojiIcon, type CatalogField } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
+import { Box, Group, Paper } from '@mantine-8/core';
 import {
     ActionIcon,
     Button,
     getDefaultZIndex,
     Highlight,
-    Paper,
     Portal,
 } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
@@ -58,15 +57,7 @@ const SharedEmojiPicker = forwardRef(
                         zIndex: getDefaultZIndex('overlay'),
                     }}
                 >
-                    <Paper
-                        shadow="xs"
-                        withBorder
-                        pt="xs"
-                        px="two"
-                        sx={(theme) => ({
-                            border: `1px solid ${theme.colors.ldGray[2]}`,
-                        })}
-                    >
+                    <Paper shadow="xs" withBorder pt="xs" px="two">
                         {emoji && (
                             <Group justify="flex-end">
                                 <Button

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,8 +5,8 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box, Center, Divider, Group, Text } from '@mantine-8/core';
-import { Anchor, Paper, useMantineTheme } from '@mantine/core';
+import { Box, Center, Divider, Group, Paper, Text } from '@mantine-8/core';
+import { Anchor, useMantineTheme } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowsSort,
@@ -249,7 +249,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({
     const mantinePaperProps = useMemo(
         () => ({
             shadow: undefined,
-            sx: {
+            style: {
                 border: `1px solid ${theme.colors.ldGray[2]}`,
                 borderRadius: theme.spacing.sm, // ! radius doesn't have rem(12) -> 0.75rem
                 boxShadow: theme.shadows.subtle,

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.module.css
@@ -1,0 +1,31 @@
+.comparisonPaper {
+    cursor: pointer;
+    background-color: var(--mantine-color-background-0);
+    transition: all 200ms ease-in-out;
+}
+
+.comparisonPaper[data-with-border] {
+    border-color: var(--mantine-color-ldGray-2);
+}
+
+.comparisonPaper[data-selected] {
+    background-color: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-ldGray-1) 70%,
+            var(--mantine-color-white)
+        ),
+        var(--mantine-color-ldDark-2)
+    );
+}
+
+.comparisonPaper[data-selected][data-with-border] {
+    border-color: var(--mantine-color-indigo-5);
+}
+
+.comparisonPaper:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-3)
+    );
+}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -5,14 +5,15 @@ import {
     type MetricExplorerQuery,
     type MetricWithAssociatedTimeDimension,
 } from '@lightdash/common';
-import { Group, Loader, Stack, Text } from '@mantine-8/core';
-import { Anchor, Paper, Radio, Select, Tooltip } from '@mantine/core';
+import { Group, Loader, Paper, Stack, Text } from '@mantine-8/core';
+import { Anchor, Radio, Select, Tooltip } from '@mantine/core';
 import { IconCalendar, IconStack } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useCallback, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useSelectStyles } from '../../styles/useSelectStyles';
 import SelectItem from '../SelectItem';
+import comparisonStyles from './MetricExploreComparison.module.css';
 
 type Props = {
     baseMetricLabel: string | undefined;
@@ -129,31 +130,11 @@ export const MetricExploreComparison: FC<Props> = ({
                                 p="sm"
                                 withBorder
                                 radius="md"
-                                sx={(theme) => ({
-                                    cursor: 'pointer',
-                                    transition: `all ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                                    '&[data-with-border="true"]': {
-                                        border:
-                                            query.comparison === comparison.type
-                                                ? `1px solid ${theme.colors.indigo[5]}`
-                                                : `1px solid ${theme.colors.ldGray[2]}`,
-                                    },
-                                    '&:hover': {
-                                        backgroundColor:
-                                            theme.colorScheme === 'dark'
-                                                ? theme.colors.ldDark[3]
-                                                : theme.colors.ldGray[0],
-                                    },
-                                    backgroundColor:
-                                        query.comparison === comparison.type
-                                            ? theme.colorScheme === 'dark'
-                                                ? theme.colors.ldDark[2]
-                                                : theme.fn.lighten(
-                                                      theme.colors.ldGray[1],
-                                                      0.3,
-                                                  )
-                                            : theme.colors.background[0],
-                                })}
+                                className={comparisonStyles.comparisonPaper}
+                                data-selected={
+                                    query.comparison === comparison.type ||
+                                    undefined
+                                }
                                 onClick={() =>
                                     handleComparisonChange(comparison.type)
                                 }

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -8,12 +8,11 @@ import {
     type VizTableHeaderSortConfig,
     formatSql,
 } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Group, Paper, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Indicator,
     LoadingOverlay,
-    Paper,
     SegmentedControl,
     Tooltip,
     Transition,
@@ -443,13 +442,10 @@ export const ContentPanel: FC = () => {
                 <Paper
                     shadow="none"
                     radius={0}
+                    withBorder={false}
                     px="md"
                     py={6}
-                    sx={(theme) => ({
-                        borderWidth: '0 0 1px 1px',
-                        borderStyle: 'solid',
-                        borderColor: theme.colors.ldGray[3],
-                    })}
+                    className={styles.toolbarPaper}
                 >
                     <Group justify="space-between">
                         <Group justify="space-between">
@@ -637,17 +633,9 @@ export const ContentPanel: FC = () => {
                             ref={inputSectionRef}
                             shadow="none"
                             radius={0}
+                            withBorder={false}
                             style={{ flex: 1 }}
-                            sx={(theme) => ({
-                                borderWidth: '0 0 0 1px',
-                                borderStyle: 'solid',
-                                borderColor: theme.colors.ldGray[3],
-                                overflow: 'auto',
-                                backgroundColor:
-                                    theme.colorScheme === 'dark'
-                                        ? theme.colors.dark[6]
-                                        : 'white',
-                            })}
+                            className={styles.inputPaper}
                         >
                             <Box
                                 style={{

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
-import { ActionIcon, Button, Menu, Paper, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack, Text } from '@mantine-8/core';
+import { ActionIcon, Button, Menu, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,
@@ -32,6 +32,7 @@ import {
 import { ChartErrorsAlert } from '../ChartErrorsAlert';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { WriteBackToDbtModal } from '../WriteBackToDbtModal';
+import headerStyles from './HeaderPaper.module.css';
 
 type CtaAction = 'save' | 'createVirtualView' | 'writeBackToDbt';
 
@@ -261,13 +262,7 @@ export const HeaderCreate: FC = () => {
                 withBorder={false}
                 px="md"
                 py="xs"
-                sx={(theme) => ({
-                    borderBottom: `1px solid ${
-                        theme.colorScheme === 'dark'
-                            ? theme.colors.ldDark[8]
-                            : theme.colors.ldGray[3]
-                    }`,
-                })}
+                className={headerStyles.paper}
             >
                 <Group justify="space-between">
                     <Group gap="two">

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,13 +1,6 @@
 import { type SqlChart } from '@lightdash/common';
-import { Group, Stack, Title } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Button,
-    HoverCard,
-    Menu,
-    Paper,
-    Tooltip,
-} from '@mantine/core';
+import { Group, Paper, Stack, Title } from '@mantine-8/core';
+import { ActionIcon, Button, HoverCard, Menu, Tooltip } from '@mantine/core';
 import {
     IconArrowBack,
     IconDots,
@@ -39,6 +32,7 @@ import { DeleteSqlChartModal } from '../DeleteSqlChartModal';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { SqlQueryBeforeSaveAlert } from '../SqlQueryBeforeSaveAlert';
 import { UpdateSqlChartModal } from '../UpdateSqlChartModal';
+import headerStyles from './HeaderPaper.module.css';
 
 export const HeaderEdit: FC = () => {
     const queryClient = useQueryClient();
@@ -162,13 +156,7 @@ export const HeaderEdit: FC = () => {
                 withBorder={false}
                 px="md"
                 py="xs"
-                sx={(theme) => ({
-                    borderBottom: `1px solid ${
-                        theme.colorScheme === 'dark'
-                            ? theme.colors.ldDark[8]
-                            : theme.colors.ldGray[3]
-                    }`,
-                })}
+                className={headerStyles.paper}
             >
                 <Group justify="space-between">
                     <Stack gap="none">

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderPaper.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderPaper.module.css
@@ -1,0 +1,4 @@
+.paper {
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-8));
+}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DashboardTileTypes } from '@lightdash/common';
-import { Group, Stack, Title } from '@mantine-8/core';
-import { ActionIcon, Button, Menu, Paper, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack, Title } from '@mantine-8/core';
+import { ActionIcon, Button, Menu, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,
@@ -33,6 +33,7 @@ import {
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { toggleModal } from '../../store/sqlRunnerSlice';
 import { DeleteSqlChartModal } from '../DeleteSqlChartModal';
+import headerStyles from './HeaderPaper.module.css';
 
 export const HeaderView: FC = () => {
     const navigate = useNavigate();
@@ -148,13 +149,7 @@ export const HeaderView: FC = () => {
                 withBorder={false}
                 px="md"
                 py="xs"
-                sx={(theme) => ({
-                    borderBottom: `1px solid ${
-                        theme.colorScheme === 'dark'
-                            ? theme.colors.ldDark[8]
-                            : theme.colors.ldGray[3]
-                    }`,
-                })}
+                className={headerStyles.paper}
             >
                 <Group justify="space-between">
                     <Stack gap="none">

--- a/packages/frontend/src/features/sqlRunner/components/ResizeHandle.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/ResizeHandle.module.css
@@ -19,3 +19,20 @@
     gap: 5px;
     border-left: 1px solid var(--mantine-color-ldGray-3);
 }
+
+.toolbarPaper {
+    border-width: 0 0 1px 1px;
+    border-style: solid;
+    border-color: var(--mantine-color-ldGray-3);
+}
+
+.inputPaper {
+    overflow: auto;
+    border-width: 0 0 0 1px;
+    border-style: solid;
+    border-color: var(--mantine-color-ldGray-3);
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-6)
+    );
+}

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,6 +1,6 @@
 import { getFieldQuoteChar } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Paper, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack } from '@mantine-8/core';
+import { ActionIcon, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
@@ -198,6 +198,7 @@ const SqlRunner = ({
                     <Paper
                         shadow="none"
                         radius={0}
+                        withBorder={false}
                         px="sm"
                         py="lg"
                         style={{ flexGrow: 0 }}

--- a/packages/frontend/src/stories/Tree.stories.tsx
+++ b/packages/frontend/src/stories/Tree.stories.tsx
@@ -1,4 +1,5 @@
-import { Paper, ScrollArea } from '@mantine/core';
+import { Paper } from '@mantine-8/core';
+import { ScrollArea } from '@mantine/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import Tree from '../components/common/Tree/Tree';
 


### PR DESCRIPTION
## What changed

- Migrate all remaining `Paper` imports from Mantine 6 to Mantine 8
- Convert eight `sx` usages to `style` or CSS Modules
- Preserve flat SQL Runner surfaces against the v8 theme's card defaults
- Reuse the v8 Paper theme border instead of duplicating local `ldGray.2` styles

## Why

Continues the per-component Mantine 8 migration. Paper requires a theme-aware migration because `mantine8Theme.ts` defaults it to `radius="md"`, `shadow="subtle"`, and `withBorder`, while the remaining v6 Papers included both card-like and structural surfaces.

## Impact

- 11 files / 13 Paper usages migrated
- Zero remaining Mantine 6 Paper imports or `sx` props
- Card-like Papers adopt the v8 theme contract
- SQL Runner headers, panels, and sidebar keep their intentional flat geometry
- Metrics Catalog comparison hover/selected states move to CSS variables, `light-dark()`, and `color-mix()`

## Validation

- migration analyzer: zero residual v6 imports or v6-only props
- `pnpm --filter @lightdash/frontend typecheck:fast`
- changed-file oxlint: 0 warnings/errors
- `pnpm --filter @lightdash/frontend format`
- full frontend tests: 120 files / 981 tests
- `pnpm --filter @lightdash/frontend build`
- full frontend lint: 0 errors; 3 unrelated existing EE warnings

## Visual QA

- SQL Runner create/edit/view header border and content-panel seams, light and dark mode
- Metrics Catalog comparison cards: default, selected, and hover states
- palette and warehouse credential cards
- Metrics Catalog emoji picker and canvas container

Relates: #25454
