### PR TITLE
refactor(frontend): migrate Button to Mantine 8

### DIFF
--- a/packages/frontend/src/components/DataOps/index.tsx
+++ b/packages/frontend/src/components/DataOps/index.tsx
@@ -1,6 +1,6 @@
 import { ProjectType } from '@lightdash/common';
-import { Flex, Text, Title } from '@mantine-8/core';
-import { Button, Select } from '@mantine/core';
+import { Button, Flex, Text, Title } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useProject } from '../../hooks/useProject';
 import { useProjects } from '../../hooks/useProjects';

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
-import { Group, Text } from '@mantine-8/core';
-import { ActionIcon, Button, Tooltip } from '@mantine/core';
+import { Button, Group, Text } from '@mantine-8/core';
+import { ActionIcon, Tooltip } from '@mantine/core';
 import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import {
@@ -164,10 +164,9 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
                         position="left"
                     >
                         <Button
-                            size="xs"
                             variant="subtle"
-                            compact
-                            leftIcon={<MantineIcon icon={IconPlus} />}
+                            size="compact-xs"
+                            leftSection={<MantineIcon icon={IconPlus} />}
                             onClick={handleAddCustomDimension}
                             data-testid="VirtualSectionHeader/AddCustomDimensionButton"
                         >

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -12,7 +12,8 @@ import {
     type EChartsSeries,
     type FieldId,
 } from '@lightdash/common';
-import { Button, useMantineColorScheme } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,
@@ -397,7 +398,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                                 ? closeVisualizationConfig
                                                 : openVisualizationConfig
                                         }
-                                        rightIcon={
+                                        rightSection={
                                             <MantineIcon
                                                 icon={
                                                     isVisualizationConfigOpen

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -4,7 +4,7 @@ import {
     WarehouseTypes,
     type CreateWarehouseCredentials,
 } from '@lightdash/common';
-import { Button } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { useCreateMutation } from '../../hooks/useProject';
@@ -124,7 +124,7 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                         />
 
                         <Button
-                            sx={{ alignSelf: 'end' }}
+                            style={{ alignSelf: 'end' }}
                             type="submit"
                             loading={isSavingProject}
                         >

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.module.css
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.module.css
@@ -6,3 +6,12 @@
 .repositoryHint:hover {
     background-color: var(--mantine-color-ldGray-1);
 }
+
+.githubButton {
+    color: white;
+    background-color: black;
+}
+
+.githubButton:hover {
+    background-color: var(--mantine-color-ldGray-8);
+}

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -1,10 +1,9 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
+import { Button, Group, Stack, Text } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
     Avatar,
-    Button,
     PasswordInput,
     ScrollArea,
     Select,
@@ -159,20 +158,14 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
         <>
             {' '}
             <Button
-                leftIcon={
+                leftSection={
                     <Avatar
                         src={githubIcon}
                         size="sm"
                         styles={{ image: { filter: 'invert(1)' } }}
                     />
                 }
-                sx={() => ({
-                    backgroundColor: 'black',
-                    color: 'white',
-                    '&:hover': {
-                        backgroundColor: 'ldGray.8',
-                    },
-                })}
+                className={styles.githubButton}
                 onClick={() => {
                     window.open(
                         GITHUB_INSTALL_URL,

--- a/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
@@ -1,5 +1,5 @@
-import { Flex, Stack } from '@mantine-8/core';
-import { ActionIcon, Button, Input, TextInput } from '@mantine/core';
+import { Button, Flex, Stack } from '@mantine-8/core';
+import { ActionIcon, Input, TextInput } from '@mantine/core';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import get from 'lodash/get';
 import { useState, type ReactNode } from 'react';
@@ -103,7 +103,7 @@ export const MultiKeyValuePairsInput = ({
                 <Button
                     size="sm"
                     onClick={addValue}
-                    leftIcon={<MantineIcon icon={IconPlus} />}
+                    leftSection={<MantineIcon icon={IconPlus} />}
                     disabled={disabled}
                 >
                     Add variable

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep1.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep1.tsx
@@ -1,5 +1,5 @@
-import { Stack, Text } from '@mantine-8/core';
-import { Button, Tooltip } from '@mantine/core';
+import { Button, Stack, Text } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { Prism } from '@mantine/prism';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -38,7 +38,7 @@ const ConnectManuallyStep1: FC<ConnectManuallyStep1Props> = ({
                 variant="subtle"
                 size="sm"
                 top={-50}
-                leftIcon={<MantineIcon icon={IconChevronLeft} />}
+                leftSection={<MantineIcon icon={IconChevronLeft} />}
                 onClick={onBack}
             >
                 Back
@@ -72,7 +72,7 @@ const ConnectManuallyStep1: FC<ConnectManuallyStep1Props> = ({
                                 href="https://docs.lightdash.com/guides/how-to-create-dimensions"
                                 target="_blank"
                                 rel="noreferrer noopener"
-                                rightIcon={
+                                rightSection={
                                     <MantineIcon icon={IconChevronRight} />
                                 }
                                 onClick={() => {

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
@@ -1,5 +1,5 @@
-import { Box, Stack } from '@mantine-8/core';
-import { Button, createStyles, keyframes } from '@mantine/core';
+import { Box, Button, Stack } from '@mantine-8/core';
+import { createStyles, keyframes } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
 import confetti from 'canvas-confetti';
 import { type FC } from 'react';

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
@@ -3,8 +3,8 @@ import {
     TimeFrames,
     type OrganizationProject,
 } from '@lightdash/common';
-import { Stack, Text } from '@mantine-8/core';
-import { Avatar, Button, LoadingOverlay, Tabs } from '@mantine/core';
+import { Button, Stack, Text } from '@mantine-8/core';
+import { Avatar, LoadingOverlay, Tabs } from '@mantine/core';
 import { useOs } from '@mantine/hooks';
 import { Prism } from '@mantine/prism';
 import { IconChevronLeft, IconClock } from '@tabler/icons-react';
@@ -115,7 +115,7 @@ const ConnectUsingCLI: FC<ConnectUsingCliProps> = ({
                 variant="subtle"
                 size="sm"
                 top={-50}
-                leftIcon={<MantineIcon icon={IconChevronLeft} />}
+                leftSection={<MantineIcon icon={IconChevronLeft} />}
                 onClick={onBack}
             >
                 Back

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
@@ -1,5 +1,5 @@
-import { Stack, Text } from '@mantine-8/core';
-import { Avatar, Button } from '@mantine/core';
+import { Button, Stack, Text } from '@mantine-8/core';
+import { Avatar } from '@mantine/core';
 import {
     IconChecklist,
     IconChevronLeft,
@@ -36,7 +36,7 @@ const SelectConnectMethod: FC<SelectConnectMethodProps> = ({
                 variant="subtle"
                 size="sm"
                 top={-50}
-                leftIcon={<MantineIcon icon={IconChevronLeft} />}
+                leftSection={<MantineIcon icon={IconChevronLeft} />}
                 onClick={onBack}
             >
                 Back

--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -6,8 +6,8 @@ import {
     type CreateWarehouseCredentials,
     type Project,
 } from '@lightdash/common';
-import { Box, Flex } from '@mantine-8/core';
-import { Alert, Anchor, Button, Card } from '@mantine/core';
+import { Box, Button, Flex } from '@mantine-8/core';
+import { Alert, Anchor, Card } from '@mantine/core';
 import { IconExclamationCircle, IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
@@ -183,7 +183,7 @@ const UpdateProjectConnection: FC<{
                                     variant="subtle"
                                     color="gray"
                                     size="xs"
-                                    rightIcon={
+                                    rightSection={
                                         <MantineIcon icon={IconExternalLink} />
                                     }
                                     component="a"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,10 +1,9 @@
 import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Group, Loader, Stack, Text } from '@mantine-8/core';
+import { Group, Loader, Stack, Text, Button } from '@mantine-8/core';
 import type { SelectItem } from '@mantine/core';
 import {
     Anchor,
     Autocomplete,
-    Button,
     FileInput,
     Image,
     NumberInput,
@@ -85,7 +84,7 @@ const BigQuerySSOInput: FC<{
                 variant="default"
                 color="gray"
                 disabled={disabled}
-                leftIcon={
+                leftSection={
                     <Image
                         width={16}
                         src={

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -2,11 +2,10 @@ import {
     DatabricksAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
+import { Group, Stack, Text, Button } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     PasswordInput,
     Select,
     TextInput,
@@ -31,6 +30,7 @@ import { useProjectFormContext } from '../useProjectFormContext';
 import DataTimezoneField from './DataTimezoneField';
 import { DatabricksDefaultValues } from './defaultValues';
 import { getSsoLabel, PERSONAL_ACCESS_TOKEN_LABEL } from './util';
+import styles from './WarehouseButtons.module.css';
 
 export const DatabricksSchemaInput: FC<{
     disabled: boolean;
@@ -78,8 +78,8 @@ const DatabricksSSOInput: FC<{
             variant="default"
             color="gray"
             disabled={disabled}
-            leftIcon={getWarehouseIcon(WarehouseTypes.DATABRICKS, 'sm')}
-            sx={{ ':hover': { textDecoration: 'underline' } }}
+            leftSection={getWarehouseIcon(WarehouseTypes.DATABRICKS, 'sm')}
+            className={styles.signInButton}
             fullWidth
         >
             Sign in with Databricks
@@ -377,7 +377,9 @@ const DatabricksForm: FC<{
                             disabled={disabled}
                             {...form.getInputProps(
                                 'warehouse.requireUserCredentials',
-                                { type: 'checkbox' },
+                                {
+                                    type: 'checkbox',
+                                },
                             )}
                         />
                         <DataTimezoneField disabled={disabled} />
@@ -441,11 +443,11 @@ const DatabricksForm: FC<{
                                     <Button
                                         variant="default"
                                         size="xs"
-                                        sx={(theme) => ({
+                                        style={(theme) => ({
                                             alignSelf: 'flex-end',
                                             boxShadow: theme.shadows.subtle,
                                         })}
-                                        leftIcon={
+                                        leftSection={
                                             <MantineIcon icon={IconPlus} />
                                         }
                                         onClick={addCompute}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -1,9 +1,8 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { CopyButton, Stack } from '@mantine-8/core';
+import { CopyButton, Stack, Button } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     NumberInput,
     PasswordInput,
     Select,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -1,9 +1,8 @@
 import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { CopyButton, Stack } from '@mantine-8/core';
+import { CopyButton, Stack, Button } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     NumberInput,
     PasswordInput,
     Select,
@@ -193,7 +192,9 @@ const RedshiftForm: FC<{
                             label="Require users to provide their own credentials"
                             {...form.getInputProps(
                                 'warehouse.requireUserCredentials',
-                                { type: 'checkbox' },
+                                {
+                                    type: 'checkbox',
+                                },
                             )}
                             defaultChecked={
                                 RedshiftDefaultValues.requireUserCredentials

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -1,8 +1,7 @@
 import { SnowflakeAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
+import { Group, Stack, Text, Button } from '@mantine-8/core';
 import {
     Anchor,
-    Button,
     FileInput,
     NumberInput,
     PasswordInput,
@@ -38,6 +37,7 @@ import {
     PASSWORD_LABEL,
     PRIVATE_KEY_LABEL,
 } from './util';
+import styles from './WarehouseButtons.module.css';
 
 export const SnowflakeSchemaInput: FC<{
     disabled: boolean;
@@ -70,8 +70,8 @@ const SnowflakeSSOInput: FC<{
             variant="default"
             color="gray"
             disabled={disabled}
-            leftIcon={getWarehouseIcon(WarehouseTypes.SNOWFLAKE, 'sm')}
-            sx={{ ':hover': { textDecoration: 'underline' } }}
+            leftSection={getWarehouseIcon(WarehouseTypes.SNOWFLAKE, 'sm')}
+            className={styles.signInButton}
         >
             Sign in with Snowflake
         </Button>
@@ -367,7 +367,9 @@ const SnowflakeForm: FC<{
                                     disabled={disabled}
                                     {...form.getInputProps(
                                         'warehouse.requireUserCredentials',
-                                        { type: 'checkbox' },
+                                        {
+                                            type: 'checkbox',
+                                        },
                                     )}
                                 />
                             </>
@@ -527,7 +529,9 @@ const SnowflakeForm: FC<{
                                         disabled={disabled}
                                         {...form.getInputProps(
                                             'warehouse.requireUserCredentials',
-                                            { type: 'checkbox' },
+                                            {
+                                                type: 'checkbox',
+                                            },
                                         )}
                                     />
                                 )}
@@ -556,7 +560,9 @@ const SnowflakeForm: FC<{
                                     disabled={disabled}
                                     {...form.getInputProps(
                                         'warehouse.clientSessionKeepAlive',
-                                        { type: 'checkbox' },
+                                        {
+                                            type: 'checkbox',
+                                        },
                                     )}
                                 />
 

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/WarehouseButtons.module.css
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/WarehouseButtons.module.css
@@ -1,0 +1,3 @@
+.signInButton:hover {
+    text-decoration: underline;
+}

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -8,10 +8,10 @@ import {
     Stack,
     Text,
     Title,
+    Button,
 } from '@mantine-8/core';
 import {
     Anchor,
-    Button,
     Highlight,
     MultiSelect,
     Radio,

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,5 +1,4 @@
-import { Box, Flex, Text } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import { Box, Flex, Text, Button } from '@mantine-8/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
@@ -267,7 +266,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                         <Button
                             variant="default"
                             size={'xs'}
-                            leftIcon={<IconRefresh size={16} />}
+                            leftSection={<IconRefresh size={16} />}
                             onClick={triggerChunkErrorReload}
                         >
                             Refresh page

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/AllowedDomainsPanel.module.css
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/AllowedDomainsPanel.module.css
@@ -1,0 +1,3 @@
+.addProjectButton[data-disabled='true'] {
+    pointer-events: all;
+}

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -6,14 +6,8 @@ import {
     validateOrganizationEmailDomains,
     type AllowedEmailDomains,
 } from '@lightdash/common';
-import { Flex, Stack, Text, Title } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Button,
-    MultiSelect,
-    Select,
-    Tooltip,
-} from '@mantine/core';
+import { Flex, Stack, Text, Title, Button } from '@mantine-8/core';
+import { ActionIcon, MultiSelect, Select, Tooltip } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import {
@@ -30,6 +24,7 @@ import {
 } from '../../../hooks/organization/useAllowedDomains';
 import { useProjects } from '../../../hooks/useProjects';
 import MantineIcon from '../../common/MantineIcon';
+import styles from './AllowedDomainsPanel.module.css';
 
 const roleOptions: Array<{
     value: AllowedEmailDomains['role'];
@@ -414,15 +409,11 @@ const AllowedDomainsPanel: FC = () => {
                                             {...(!canAddMoreProjects && {
                                                 'data-disabled': true,
                                             })}
-                                            sx={{
-                                                '&[data-disabled="true"]': {
-                                                    pointerEvents: 'all',
-                                                },
-                                            }}
+                                            className={styles.addProjectButton}
                                             onClick={handleAddProject}
                                             variant="outline"
                                             size="xs"
-                                            leftIcon={
+                                            leftSection={
                                                 <MantineIcon icon={IconPlus} />
                                             }
                                         >

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,13 +1,6 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { Flex, Group, Paper, Text } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Badge,
-    Button,
-    ColorSwatch,
-    Menu,
-    Tooltip,
-} from '@mantine/core';
+import { Flex, Group, Paper, Text, Button } from '@mantine-8/core';
+import { ActionIcon, Badge, ColorSwatch, Menu, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconDotsVertical,
@@ -149,12 +142,12 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                                     onSetActive(palette.colorPaletteUuid)
                                 }
                                 h={32}
-                                sx={() => ({
+                                style={{
                                     visibility:
                                         isHovered && !isActive
                                             ? 'visible'
                                             : 'hidden',
-                                })}
+                                }}
                             >
                                 Use This Theme
                             </Button>

--- a/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
@@ -1,6 +1,6 @@
 import { ProjectType } from '@lightdash/common';
-import { Flex, Stack } from '@mantine-8/core';
-import { Button, Select } from '@mantine/core';
+import { Flex, Stack, Button } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useEffect, type FC } from 'react';
 import { z } from 'zod';

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -1,5 +1,14 @@
-import { Box, Flex, Group, Loader, Stack, Text, Title } from '@mantine-8/core';
-import { Alert, Avatar, Button, Tooltip } from '@mantine/core';
+import {
+    Box,
+    Flex,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    Title,
+    Button,
+} from '@mantine-8/core';
+import { Alert, Avatar, Tooltip } from '@mantine/core';
 import {
     IconAlertCircle,
     IconClock,
@@ -110,7 +119,7 @@ const GithubSettingsPanel: FC = () => {
                                 target="_blank"
                                 variant="default"
                                 href={GITHUB_INSTALL_URL}
-                                leftIcon={<MantineIcon icon={IconRefresh} />}
+                                leftSection={<MantineIcon icon={IconRefresh} />}
                                 onClick={() => {
                                     deleteGithubInstallationMutation.mutate(
                                         undefined,
@@ -135,7 +144,7 @@ const GithubSettingsPanel: FC = () => {
                                 onClick={() =>
                                     deleteGithubInstallationMutation.mutate()
                                 }
-                                leftIcon={<MantineIcon icon={IconTrash} />}
+                                leftSection={<MantineIcon icon={IconTrash} />}
                             >
                                 Delete
                             </Button>
@@ -158,7 +167,9 @@ const GithubSettingsPanel: FC = () => {
                                     color="yellow"
                                     variant="outline"
                                     href={GITHUB_INSTALL_URL}
-                                    leftIcon={<MantineIcon icon={IconClock} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconClock} />
+                                    }
                                 >
                                     Pending approval
                                 </Button>

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -1,5 +1,14 @@
-import { Box, Flex, Group, Loader, Stack, Text, Title } from '@mantine-8/core';
-import { Alert, Avatar, Button } from '@mantine/core';
+import {
+    Box,
+    Flex,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    Title,
+    Button,
+} from '@mantine-8/core';
+import { Alert, Avatar } from '@mantine/core';
 import { IconAlertCircle, IconRefresh, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import gitlabIcon from '../../../svgs/gitlab-icon.svg';
@@ -69,7 +78,7 @@ const GitlabSettingsPanel: FC = () => {
                                 target="_blank"
                                 variant="default"
                                 href={GITLAB_INSTALL_URL}
-                                leftIcon={<MantineIcon icon={IconRefresh} />}
+                                leftSection={<MantineIcon icon={IconRefresh} />}
                                 onClick={() => {
                                     deleteGitlabInstallationMutation.mutate(
                                         undefined,
@@ -94,7 +103,7 @@ const GitlabSettingsPanel: FC = () => {
                                 onClick={() =>
                                     deleteGitlabInstallationMutation.mutate()
                                 }
-                                leftIcon={<MantineIcon icon={IconTrash} />}
+                                leftSection={<MantineIcon icon={IconTrash} />}
                             >
                                 Delete
                             </Button>

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Group, Stack, Text, Title } from '@mantine-8/core';
-import { Button, LoadingOverlay } from '@mantine/core';
+import { Group, Stack, Text, Title, Button } from '@mantine-8/core';
+import { LoadingOverlay } from '@mantine/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
@@ -42,7 +42,7 @@ export const OrganizationWarehouseCredentialsPanel = () => {
                             </Stack>
                             <Button
                                 size="xs"
-                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                leftSection={<MantineIcon icon={IconPlus} />}
                                 onClick={() => setIsCreatingCredentials(true)}
                             >
                                 Add new credentials

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -9,9 +9,8 @@ import {
     XAxisSort,
     type ItemsMap,
 } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
+import { Group, Stack, Text, Button } from '@mantine-8/core';
 import {
-    Button,
     Checkbox,
     NumberInput,
     SegmentedControl,
@@ -171,9 +170,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
 
                     {isNumericItem(xAxisField) && (
                         <AxisMinMax
-                            label={`Auto ${
-                                dirtyLayout?.flipAxes ? 'y' : 'x'
-                            }-axis range`}
+                            label={`Auto ${dirtyLayout?.flipAxes ? 'y' : 'x'}-axis range`}
                             min={dirtyEchartsConfig?.xAxis?.[0]?.min}
                             max={dirtyEchartsConfig?.xAxis?.[0]?.max}
                             setMin={(newValue) => setXMinValue(0, newValue)}
@@ -356,9 +353,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
 
             <Config>
                 <Config.Section>
-                    <Config.Heading>{`${
-                        dirtyLayout?.flipAxes ? 'X' : 'Y'
-                    }-axis label (${
+                    <Config.Heading>{`${dirtyLayout?.flipAxes ? 'X' : 'Y'}-axis label (${
                         dirtyLayout?.flipAxes ? 'bottom' : 'left'
                     })`}</Config.Heading>
 
@@ -379,9 +374,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     />
                     {showFirstAxisRange && (
                         <AxisMinMax
-                            label={`Auto ${
-                                dirtyLayout?.flipAxes ? 'x' : 'y'
-                            }-axis range`}
+                            label={`Auto ${dirtyLayout?.flipAxes ? 'x' : 'y'}-axis range`}
                             min={dirtyEchartsConfig?.yAxis?.[0]?.min}
                             max={dirtyEchartsConfig?.yAxis?.[0]?.max}
                             setMin={(newValue) => setYMinValue(0, newValue)}
@@ -402,9 +395,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
 
             <Config>
                 <Config.Section>
-                    <Config.Heading>{`${
-                        dirtyLayout?.flipAxes ? 'X' : 'Y'
-                    }-axis label (${
+                    <Config.Heading>{`${dirtyLayout?.flipAxes ? 'X' : 'Y'}-axis label (${
                         dirtyLayout?.flipAxes ? 'top' : 'right'
                     })`}</Config.Heading>
 
@@ -426,9 +417,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
 
                     {showSecondAxisRange && (
                         <AxisMinMax
-                            label={`Auto ${
-                                dirtyLayout?.flipAxes ? 'x' : 'y'
-                            }-axis range`}
+                            label={`Auto ${dirtyLayout?.flipAxes ? 'x' : 'y'}-axis range`}
                             min={dirtyEchartsConfig?.yAxis?.[1]?.min}
                             max={dirtyEchartsConfig?.yAxis?.[1]?.max}
                             setMin={(newValue) => setYMinValue(1, newValue)}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Flex, Group, Loader, Text } from '@mantine-8/core';
-import { Button, useMantineTheme } from '@mantine/core';
+import { Flex, Group, Loader, Text, Button } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
@@ -1,5 +1,6 @@
 import { type ItemsMap } from '@lightdash/common';
-import { Button, Popover, Textarea } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { Popover, Textarea } from '@mantine/core';
 import { IconSparkles } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
@@ -59,10 +60,10 @@ export const GenerateVizWithAi = ({
         >
             <Popover.Target>
                 <Button
-                    compact
+                    size="compact-sm"
                     variant="default"
                     fz="xs"
-                    leftIcon={<MantineIcon icon={IconSparkles} />}
+                    leftSection={<MantineIcon icon={IconSparkles} />}
                 >
                     AI
                 </Button>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisTemplate.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisTemplate.tsx
@@ -3,8 +3,7 @@ import {
     sortedItemsForYAxis,
     type ItemsMap,
 } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import { Menu, Button } from '@mantine-8/core';
 import {
     IconChartBar,
     IconChartBubble,
@@ -96,11 +95,10 @@ export const SelectTemplate = ({
             </Menu.Dropdown>
             <Menu.Target>
                 <Button
-                    size="sm"
                     variant="default"
-                    compact
+                    size="compact-sm"
                     fz="xs"
-                    leftIcon={<MantineIcon icon={IconPlus} />}
+                    leftSection={<MantineIcon icon={IconPlus} />}
                 >
                     Insert template
                 </Button>

--- a/packages/frontend/src/components/common/CollapsableCard/constants.ts
+++ b/packages/frontend/src/components/common/CollapsableCard/constants.ts
@@ -1,5 +1,8 @@
-import { type ActionIconProps, type PopoverProps } from '@mantine-8/core';
-import { type ButtonProps } from '@mantine/core';
+import {
+    type ActionIconProps,
+    type PopoverProps,
+    type ButtonProps,
+} from '@mantine-8/core';
 
 export const COLLAPSABLE_CARD_BUTTON_PROPS: Omit<ButtonProps, 'children'> = {
     variant: 'default',

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -34,8 +34,9 @@ import {
     Skeleton,
     type BoxProps,
     Text,
+    Button,
 } from '@mantine-8/core';
-import { Button, useMantineColorScheme } from '@mantine/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import {
     flexRender,
@@ -1998,8 +1999,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                             ) : (
                                                 <Group gap="two" wrap="nowrap">
                                                     <Button
-                                                        compact
-                                                        size="xs"
+                                                        size="compact-xs"
                                                         variant="subtle"
                                                         styles={(theme) => ({
                                                             root: {
@@ -2015,7 +2015,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                                 fontFeatureSettings:
                                                                     "'tnum'",
                                                             },
-                                                            leftIcon: {
+                                                            section: {
                                                                 marginRight: 0,
                                                             },
                                                         })}
@@ -2026,7 +2026,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                             e.preventDefault();
                                                             toggleExpander();
                                                         }}
-                                                        leftIcon={
+                                                        leftSection={
                                                             <MantineIcon
                                                                 size={14}
                                                                 icon={

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,12 +13,11 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Box, Divider, Group, Text } from '@mantine-8/core';
+import { Box, Divider, Group, Text, Button } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
 import {
     ActionIcon,
     Anchor,
-    Button,
     TextInput,
     Tooltip,
     useMantineTheme,
@@ -733,7 +732,7 @@ const InfiniteResourceTable = ({
                                 variant="filled"
                                 size="xs"
                                 color="blue"
-                                leftIcon={
+                                leftSection={
                                     <MantineIcon icon={IconFolderSymlink} />
                                 }
                                 onClick={openTransferItemsModal}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,8 +14,8 @@ import {
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
-import { Center, Group, Loader, Skeleton } from '@mantine-8/core';
-import { Button, Tooltip, useMantineColorScheme } from '@mantine/core';
+import { Center, Group, Loader, Skeleton, Button } from '@mantine-8/core';
+import { Tooltip, useMantineColorScheme } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { flexRender, type Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -280,8 +280,7 @@ const TableRow: FC<TableRowProps> = ({
                         {cell.getIsGrouped() ? (
                             <Group gap="xxs">
                                 <Button
-                                    compact
-                                    size="xs"
+                                    size="compact-xs"
                                     variant="subtle"
                                     styles={(theme) => ({
                                         root: {
@@ -289,7 +288,7 @@ const TableRow: FC<TableRowProps> = ({
                                             paddingLeft: theme.spacing.two,
                                             paddingRight: theme.spacing.xxs,
                                         },
-                                        leftIcon: {
+                                        section: {
                                             marginRight: 0,
                                         },
                                     })}
@@ -300,7 +299,7 @@ const TableRow: FC<TableRowProps> = ({
                                         e.preventDefault();
                                         toggleExpander();
                                     }}
-                                    leftIcon={
+                                    leftSection={
                                         <MantineIcon
                                             size={14}
                                             icon={

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Group, Stack, Text, Title } from '@mantine-8/core';
-import { Anchor, Button, TextInput } from '@mantine/core';
+import { Group, Stack, Text, Title, Button } from '@mantine-8/core';
+import { Anchor, TextInput } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -58,7 +58,7 @@ const ScimAccessTokensPanel: FC = () => {
                         <Button
                             variant="subtle"
                             onClick={handleCopyToClipboard}
-                            compact
+                            size="compact-sm"
                         >
                             <IconCopy size={16} />
                         </Button>

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
@@ -1,4 +1,5 @@
-import { Button, Card, List, Tooltip } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { Card, List, Tooltip } from '@mantine/core';
 import { type SuggestionProps } from '@tiptap/suggestion';
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { type SuggestionsItem } from '../../types';
@@ -89,7 +90,7 @@ export const SuggestionList = forwardRef<
                             position="right"
                         >
                             <Button
-                                compact
+                                size="compact-sm"
                                 onClick={() => {
                                     if (item.disabled) return;
                                     selectItem(index);

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -7,10 +7,9 @@ import {
     type DashboardFilterRule,
     type FilterRule,
 } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Group, Stack, Text, Button } from '@mantine-8/core';
 import {
     ActionIcon,
-    Button,
     Checkbox,
     Select,
     Switch,
@@ -160,10 +159,9 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         supportsSingleValue(filterType, filterRule.operator) &&
                         isEditMode && (
                             <Button
-                                compact
-                                size="xs"
+                                size="compact-xs"
                                 variant={'light'}
-                                rightIcon={
+                                rightSection={
                                     <Tooltip
                                         variant="xs"
                                         label={

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -19,14 +19,8 @@ import {
     type DashboardTile,
     type ResultColumn,
 } from '@lightdash/common';
-import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
-import {
-    Button,
-    Select,
-    Tabs,
-    Tooltip,
-    type PopoverProps,
-} from '@mantine/core';
+import { Box, Flex, Group, Stack, Text, Button } from '@mantine-8/core';
+import { Select, Tabs, Tooltip, type PopoverProps } from '@mantine/core';
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
@@ -1,6 +1,6 @@
 import type { CatalogMetricsTreeEdge } from '@lightdash/common';
-import { Box, Group, Text } from '@mantine-8/core';
-import { Button, useMantineTheme } from '@mantine/core';
+import { Box, Group, Text, Button } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { IconLayoutGridRemove } from '@tabler/icons-react';
 import {
     Background,
@@ -165,10 +165,10 @@ const SavedTreeCanvasFlow: FC<Props> = ({
                                             })
                                         }
                                         size="xs"
-                                        sx={{
+                                        style={{
                                             boxShadow: theme.shadows.subtle,
                                         }}
-                                        leftIcon={
+                                        leftSection={
                                             <MantineIcon
                                                 color="ldGray.5"
                                                 icon={IconLayoutGridRemove}

--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,5 +1,6 @@
 import { type CatalogField } from '@lightdash/common';
-import { Button, Tooltip } from '@mantine/core';
+import { Button } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { type ContentTableRow } from '../../../components/common/ContentTable';
@@ -63,8 +64,8 @@ export const ExploreMetricButton = ({ row }: Props) => {
             fz="xs"
         >
             <Button
-                compact
-                variant="darkPrimary"
+                size="compact-sm"
+                variant="dark"
                 onClick={handleExploreClick}
                 py="xxs"
                 px={10}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -1,8 +1,7 @@
 import { getErrorMessage, type CatalogItem } from '@lightdash/common';
-import { Box, Divider, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Divider, Group, Stack, Text, Button } from '@mantine-8/core';
 import {
     ActionIcon,
-    Button,
     Popover,
     SimpleGrid,
     TextInput,
@@ -161,9 +160,8 @@ const EditPopover: FC<EditPopoverProps> = ({
                         </Tooltip>
 
                         <Button
-                            variant="darkPrimary"
-                            size="xs"
-                            compact
+                            variant="dark"
+                            size="compact-xs"
                             onClick={handleSave}
                         >
                             Save

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -1,11 +1,6 @@
 import { type CatalogField, type Tag } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
-import {
-    Button,
-    Popover,
-    UnstyledButton,
-    useMantineTheme,
-} from '@mantine/core';
+import { Box, Group, Stack, Text, Button } from '@mantine-8/core';
+import { Popover, UnstyledButton, useMantineTheme } from '@mantine/core';
 import differenceBy from 'lodash/differenceBy';
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -1,12 +1,6 @@
 import { isEmojiIcon, type CatalogField } from '@lightdash/common';
-import { Box, Group, Paper } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Button,
-    getDefaultZIndex,
-    Highlight,
-    Portal,
-} from '@mantine/core';
+import { Box, Group, Paper, Button } from '@mantine-8/core';
+import { ActionIcon, getDefaultZIndex, Highlight, Portal } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
 import { IconTrash } from '@tabler/icons-react';
 import EmojiPicker, {
@@ -62,11 +56,12 @@ const SharedEmojiPicker = forwardRef(
                             <Group justify="flex-end">
                                 <Button
                                     variant="light"
-                                    size="xs"
-                                    compact
+                                    size="compact-xs"
                                     color="gray"
                                     onClick={() => onClick(null)}
-                                    leftIcon={<MantineIcon icon={IconTrash} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconTrash} />
+                                    }
                                 >
                                     Remove
                                 </Button>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.module.css
@@ -1,0 +1,4 @@
+.tableButton[data-disabled] {
+    font-weight: 400;
+    background-color: transparent;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,6 +1,12 @@
 import { SpotlightTableColumns, type CatalogField } from '@lightdash/common';
-import { Box, Flex, Group, Text } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import {
+    Box,
+    Button,
+    Flex,
+    Group,
+    Text,
+    useComputedColorScheme,
+} from '@mantine-8/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus, IconUser } from '@tabler/icons-react';
 import { useMemo } from 'react';
@@ -28,6 +34,7 @@ import { MetricsCatalogCategoryForm } from './MetricsCatalogCategoryForm';
 import { MetricsCatalogColumnDescription } from './MetricsCatalogColumnDescription';
 import { MetricsCatalogColumnName } from './MetricsCatalogColumnName';
 import { MetricsCatalogColumnOwner } from './MetricsCatalogColumnOwner';
+import styles from './MetricsCatalogColumns.module.css';
 
 export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
     {
@@ -88,6 +95,7 @@ export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
             const projectUuid = useAppSelector(
                 (state) => state.metricsCatalog.projectUuid,
             );
+            const colorScheme = useComputedColorScheme();
 
             const savedChartVersion = createMetricPreviewUnsavedChartVersion({
                 name: row.original.name,
@@ -107,29 +115,23 @@ export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
                     component="a"
                     href={url.toString()}
                     target="_blank"
-                    size="xs"
-                    compact
+                    size="compact-xs"
                     color="ldGray.6"
                     variant="subtle"
-                    leftIcon={<TableFilled />}
+                    leftSection={<TableFilled />}
                     fz="sm"
                     c="ldDark.7"
                     fw={500}
-                    sx={{
-                        '&[data-disabled]': {
-                            backgroundColor: 'transparent',
-                            fontWeight: 400,
-                        },
-                    }}
+                    className={styles.tableButton}
                     styles={(theme) => ({
-                        leftIcon: {
+                        section: {
                             marginRight: theme.spacing.xxs,
                             color:
-                                theme.colorScheme === 'dark'
+                                colorScheme === 'dark'
                                     ? theme.colors.ldDark[7]
                                     : theme.colors.ldGray[4],
                             '--table-icon-stroke':
-                                theme.colorScheme === 'dark'
+                                colorScheme === 'dark'
                                     ? theme.colors.ldDark[4]
                                     : 'white',
                         },

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,13 +1,14 @@
 import { subject } from '@casl/ability';
 import { CatalogCategoryFilterMode, isCompileJob } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
 import {
-    ActionIcon,
+    Box,
+    Group,
+    Stack,
+    Text,
     Button,
-    Popover,
-    useMantineTheme,
     type ButtonProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { ActionIcon, Popover, useMantineTheme } from '@mantine/core';
 import { useClickOutside, useDisclosure } from '@mantine/hooks';
 import { IconRefresh, IconSparkles, IconX } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
@@ -86,7 +87,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                     ref={buttonRef}
                     size="xs"
                     variant="default"
-                    leftIcon={<MantineIcon icon={IconSparkles} />}
+                    leftSection={<MantineIcon icon={IconSparkles} />}
                     style={buttonStyles}
                     onClick={opened ? handleClose : open}
                 >
@@ -135,14 +136,11 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                             c="ldGray.0"
                             hidden={true}
                             disabled={true}
-                            sx={(theme) => ({
+                            style={{
                                 display: 'none', // ! Disabled for now
                                 border: 'none',
                                 flexGrow: 1,
-                                '&:hover': {
-                                    backgroundColor: theme.colors.ldDark[5],
-                                },
-                            })}
+                            }}
                         >
                             View Demo
                         </Button>
@@ -151,7 +149,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                             href="https://docs.lightdash.com/guides/metrics-catalog/"
                             target="_blank"
                             radius="md"
-                            sx={{ border: 'none', flexGrow: 1 }}
+                            style={{ border: 'none', flexGrow: 1 }}
                         >
                             Learn more
                         </Button>
@@ -488,7 +486,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
                         <Button
                             size="xs"
                             variant="default"
-                            leftIcon={
+                            leftSection={
                                 <MantineIcon
                                     size="sm"
                                     color="ldGray.7"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -28,11 +28,11 @@ import {
     Stack,
     type GroupProps,
     Text,
+    Button,
 } from '@mantine-8/core';
 import {
     ActionIcon,
     Badge,
-    Button,
     Popover,
     SegmentedControl,
     TextInput,
@@ -523,7 +523,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                                     radius="md"
                                                     h={28}
                                                     onClick={handleReset}
-                                                    sx={(theme) => ({
+                                                    style={(theme) => ({
                                                         border: `1px solid ${theme.colors.ldGray[2]}`,
                                                         boxShadow:
                                                             theme.shadows
@@ -543,7 +543,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                             <Button
                                                 size="xs"
                                                 h={28}
-                                                variant="darkPrimary"
+                                                variant="dark"
                                                 onClick={handleSave}
                                                 loading={
                                                     isCreatingSpotlightConfig
@@ -567,7 +567,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                                 variant="default"
                                                 onClick={handleReset}
                                                 disabled={!hasConfigChanges}
-                                                sx={(theme) => ({
+                                                style={(theme) => ({
                                                     border: `1px solid ${theme.colors.ldGray[2]}`,
                                                     boxShadow:
                                                         theme.shadows.subtle,

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreButtons.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreButtons.module.css
@@ -1,0 +1,3 @@
+.clearButton:hover {
+    background-color: var(--mantine-color-ldGray-1);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -4,9 +4,8 @@ import {
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { Box, Divider, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Divider, Group, Stack, Text, Button } from '@mantine-8/core';
 import {
-    Button,
     Popover,
     SegmentedControl,
     TextInput,
@@ -343,7 +342,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
                                         radius="md"
                                         variant="default"
                                         onClick={() => handleOpen(false)}
-                                        sx={(theme) => ({
+                                        style={(theme) => ({
                                             boxShadow: theme.shadows.subtle,
                                             border: `1px solid ${theme.colors.ldGray[2]}`,
                                         })}
@@ -359,7 +358,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
 
                                             handleTrackDateFilterApplied();
                                         }}
-                                        sx={(theme) => ({
+                                        style={(theme) => ({
                                             boxShadow: theme.shadows.subtle,
                                         })}
                                     >

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -4,8 +4,8 @@ import {
     type CompiledDimension,
     type FilterRule,
 } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
-import { Button, Select } from '@mantine/core';
+import { Group, Stack, Text, Button } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import { IconFilter, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -19,6 +19,7 @@ import {
     getOperatorOptions,
 } from '../../utils/metricExploreFilter';
 import SelectItem from '../SelectItem';
+import styles from './MetricExploreButtons.module.css';
 import { MetricExploreFilterAutoComplete } from './MetricExploreFilterAutoComplete';
 
 type Props = {
@@ -199,25 +200,22 @@ export const MetricExploreFilter: FC<Props> = ({
                 <Group gap="xs">
                     <Button
                         variant="subtle"
-                        compact
+                        size="compact-xs"
                         color="dark"
-                        size="xs"
                         radius="md"
-                        rightIcon={
+                        rightSection={
                             <MantineIcon
                                 icon={IconX}
                                 color="ldGray.5"
                                 size={12}
                             />
                         }
-                        sx={{
-                            '&:hover': {
-                                backgroundColor: theme.colors.ldGray[1],
-                            },
+                        className={styles.clearButton}
+                        style={{
                             visibility: showClearButton,
                         }}
                         styles={{
-                            rightIcon: {
+                            section: {
                                 marginLeft: 4,
                             },
                         }}
@@ -294,10 +292,9 @@ export const MetricExploreFilter: FC<Props> = ({
             {filterState.fieldId && dimensionMetadata?.requiresValues && (
                 <Button
                     color={theme.colorScheme === 'dark' ? 'ldGray.2' : 'dark'}
-                    compact
-                    size="xs"
+                    size="compact-xs"
                     disabled={!canApplyFilter}
-                    sx={{
+                    style={{
                         boxShadow: theme.shadows.subtle,
                         alignSelf: 'flex-end',
                     }}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -5,8 +5,8 @@ import {
     type CompiledDimension,
     type MetricExplorerQuery,
 } from '@lightdash/common';
-import { Box, Group, Loader, Stack, Text } from '@mantine-8/core';
-import { Alert, Button, Select, Tooltip } from '@mantine/core';
+import { Box, Group, Loader, Stack, Text, Button } from '@mantine-8/core';
+import { Alert, Select, Tooltip } from '@mantine/core';
 import { IconInfoCircle, IconX } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useMemo, type FC } from 'react';
@@ -14,6 +14,7 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import { Blocks } from '../../../../svgs/metricsCatalog';
 import { useSelectStyles } from '../../styles/useSelectStyles';
 import SelectItem from '../SelectItem';
+import styles from './MetricExploreButtons.module.css';
 
 type Props = {
     query: MetricExplorerQuery;
@@ -51,25 +52,22 @@ export const MetricExploreSegmentationPicker: FC<Props> = ({
 
                 <Button
                     variant="subtle"
-                    compact
+                    size="compact-xs"
                     color="dark"
-                    size="xs"
                     radius="md"
-                    rightIcon={
+                    rightSection={
                         <MantineIcon icon={IconX} color="ldGray.5" size={12} />
                     }
-                    sx={(theme) => ({
+                    className={styles.clearButton}
+                    style={{
                         visibility:
                             !('segmentDimension' in query) ||
                             !query.segmentDimension
                                 ? 'hidden'
                                 : 'visible',
-                        '&:hover': {
-                            backgroundColor: theme.colors.ldGray[1],
-                        },
-                    })}
+                    }}
                     styles={{
-                        rightIcon: {
+                        section: {
                             marginLeft: 4,
                         },
                     }}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
-import { Group, Paper, Stack, Text } from '@mantine-8/core';
-import { ActionIcon, Button, Menu, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack, Text, Button } from '@mantine-8/core';
+import { ActionIcon, Menu, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,
@@ -285,7 +285,7 @@ export const HeaderCreate: FC = () => {
                                 <Button
                                     variant="default"
                                     size="xs"
-                                    leftIcon={getCtaIcon(ctaAction)}
+                                    leftSection={getCtaIcon(ctaAction)}
                                     disabled={isCtaDisabled}
                                     onClick={handleCtaClick}
                                 >

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,6 +1,6 @@
 import { type SqlChart } from '@lightdash/common';
-import { Group, Paper, Stack, Title } from '@mantine-8/core';
-import { ActionIcon, Button, HoverCard, Menu, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack, Title, Button } from '@mantine-8/core';
+import { ActionIcon, HoverCard, Menu, Tooltip } from '@mantine/core';
 import {
     IconArrowBack,
     IconDots,

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DashboardTileTypes } from '@lightdash/common';
-import { Group, Paper, Stack, Title } from '@mantine-8/core';
-import { ActionIcon, Button, Menu, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack, Title, Button } from '@mantine-8/core';
+import { ActionIcon, Menu, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -8,11 +8,10 @@ import {
     SEED_ORG_1_ADMIN_PASSWORD,
     type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
-import { Box, Divider, Stack, Text, Title } from '@mantine-8/core';
+import { Box, Divider, Stack, Text, Title, Button } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     Card,
     PasswordInput,
     TextInput,

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,9 +1,8 @@
 import { LightdashMode, type ApiErrorDetail } from '@lightdash/common';
-import { CopyButton, Group, Stack, Text } from '@mantine-8/core';
+import { CopyButton, Group, Stack, Text, Button } from '@mantine-8/core';
 import {
     ActionIcon,
     Anchor,
-    Button,
     Modal,
     Tooltip,
     useMantineTheme,
@@ -170,11 +169,10 @@ const ApiErrorDisplayWithHealth = ({
                     </Text>
                     <Group gap="xs">
                         <Button
-                            size="xs"
-                            compact
+                            size="compact-xs"
                             variant="outline"
                             color="red.6"
-                            leftIcon={
+                            leftSection={
                                 <MantineIcon
                                     color="red.6"
                                     icon={IconSpeakerphone}

--- a/packages/frontend/src/hooks/toaster/types.ts
+++ b/packages/frontend/src/hooks/toaster/types.ts
@@ -1,5 +1,5 @@
 import { type ApiErrorDetail } from '@lightdash/common';
-import { type ButtonProps } from '@mantine/core';
+import { type ButtonProps } from '@mantine-8/core';
 import { type notifications } from '@mantine/notifications';
 import { type PolymorphicComponentProps } from '@mantine/utils';
 import { type Icon } from '@tabler/icons-react';

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -1,6 +1,6 @@
 import type { ApiErrorDetail } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
-import { Button, useMantineColorScheme, useMantineTheme } from '@mantine/core';
+import { Box, Stack, Button } from '@mantine-8/core';
+import { useMantineColorScheme, useMantineTheme } from '@mantine/core';
 import { notifications, type NotificationProps } from '@mantine/notifications';
 import {
     IconAlertCircleFilled,
@@ -126,7 +126,7 @@ const useToaster = () => {
                                     radius="md"
                                     variant="light"
                                     color={color}
-                                    leftIcon={
+                                    leftSection={
                                         action.icon ? (
                                             <MantineIcon icon={action.icon} />
                                         ) : undefined

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -1,6 +1,6 @@
 import { getEmailSchema } from '@lightdash/common';
-import { Center, Stack, Text, Title } from '@mantine-8/core';
-import { Anchor, Button, List, TextInput } from '@mantine/core';
+import { Center, Stack, Text, Title, Button } from '@mantine-8/core';
+import { Anchor, List, TextInput } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -1,5 +1,5 @@
-import { Box, Center, Stack, Text, Title } from '@mantine-8/core';
-import { Anchor, Button, Card, PasswordInput } from '@mantine/core';
+import { Box, Center, Stack, Text, Title, Button } from '@mantine-8/core';
+import { Anchor, Card, PasswordInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/pages/SavedApps.tsx
+++ b/packages/frontend/src/pages/SavedApps.tsx
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import { ContentType, FeatureFlags } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import { Group, Stack, Button } from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { Link, Navigate, useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
@@ -57,7 +56,7 @@ const SavedApps = () => {
                             <Button
                                 component={Link}
                                 to={`/projects/${projectUuid}/apps/generate`}
-                                leftIcon={<IconPlus size={18} />}
+                                leftSection={<IconPlus size={18} />}
                             >
                                 Create data app
                             </Button>

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -1,6 +1,5 @@
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import { Group, Stack, Button } from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -64,7 +63,7 @@ const SavedDashboards = () => {
                             userCanCreateDashboards &&
                             !isDemo && (
                                 <Button
-                                    leftIcon={<IconPlus size={18} />}
+                                    leftSection={<IconPlus size={18} />}
                                     onClick={handleCreateDashboard}
                                 >
                                     Create dashboard

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -1,6 +1,5 @@
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import { Group, Stack, Button } from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -45,7 +44,7 @@ const SavedQueries: FC = () => {
                         />
                         {!isDemo && userCanCreateCharts ? (
                             <Button
-                                leftIcon={<IconPlus size={18} />}
+                                leftSection={<IconPlus size={18} />}
                                 onClick={handleCreateChart}
                             >
                                 Create chart

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -6,8 +6,8 @@ import {
     ResourceViewItemType,
     type ResourceViewSpaceItem,
 } from '@lightdash/common';
-import { Box, Group, Menu, Stack } from '@mantine-8/core';
-import { ActionIcon, Button } from '@mantine/core';
+import { Box, Group, Menu, Stack, Button } from '@mantine-8/core';
+import { ActionIcon } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconDots,
@@ -262,7 +262,7 @@ const Space: FC = () => {
                                             <Box>
                                                 <Button
                                                     data-testid="Space/AddButton"
-                                                    leftIcon={
+                                                    leftSection={
                                                         <MantineIcon
                                                             icon={IconPlus}
                                                         />

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import { ContentType, LightdashMode } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import { Group, Stack, Button } from '@mantine-8/core';
 import { IconFolderPlus, IconPlus } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useParams } from 'react-router';
@@ -79,7 +78,7 @@ const Spaces: FC = () => {
                         <Group gap="xs">
                             {!isDemo && userCanManageSpace && (
                                 <Button
-                                    leftIcon={<IconPlus size={18} />}
+                                    leftSection={<IconPlus size={18} />}
                                     onClick={handleCreateSpace}
                                 >
                                     Add

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -3,8 +3,8 @@ import {
     type UserActivity as UserActivityResponse,
     type UserWithCount,
 } from '@lightdash/common';
-import { Box, Group, Stack, Text, Title } from '@mantine-8/core';
-import { Anchor, Button, Card, Table, Tooltip } from '@mantine/core';
+import { Box, Group, Stack, Text, Title, Button } from '@mantine-8/core';
+import { Anchor, Card, Table, Tooltip } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';

--- a/packages/frontend/src/stories/Button.stories.tsx
+++ b/packages/frontend/src/stories/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Button> = {
@@ -7,8 +7,8 @@ const meta: Meta<typeof Button> = {
     argTypes: {
         variant: {
             control: 'select',
-            options: ['darkPrimary', 'default'],
-            defaultValue: 'darkPrimary',
+            options: ['dark', 'default'],
+            defaultValue: 'dark',
         },
         loading: {
             control: 'boolean',
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof Button>;
 export const PrimaryButton: Story = {
     args: {
         children: 'Primary Button',
-        variant: 'darkPrimary',
+        variant: 'dark',
         radius: 'md',
         loading: false,
         disabled: false,

--- a/packages/frontend/src/stories/FormCard.stories.tsx
+++ b/packages/frontend/src/stories/FormCard.stories.tsx
@@ -1,6 +1,5 @@
-import { Stack, Title } from '@mantine-8/core';
+import { Stack, Title, Button } from '@mantine-8/core';
 import {
-    Button,
     Card,
     SegmentedControl,
     Select,
@@ -57,8 +56,8 @@ export function FormCard({ hasError = false }: FormCardProps) {
                     <Button
                         type="submit"
                         radius="md"
-                        variant="darkPrimary"
-                        sx={{
+                        variant="dark"
+                        style={{
                             alignSelf: 'flex-end',
                         }}
                     >

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -1,5 +1,4 @@
-import { Group, Stack, Title } from '@mantine-8/core';
-import { Button } from '@mantine/core';
+import { Group, Stack, Title, Button } from '@mantine-8/core';
 import { notifications } from '@mantine/notifications';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import MultipleToastBody from '../hooks/toaster/MultipleToastBody';


### PR DESCRIPTION
## What changed

- migrate Mantine `Button`, `ButtonProps`, and `Button.Group` imports from v6 to v8
- map icon sections, compact sizes, and `darkPrimary` variants to v8 contracts
- replace Button `sx` and legacy icon style slots with style props/CSS Modules
- update Button stories and spread-owned prop types

## Why

Continue the per-component Mantine 8 migration while adopting the defaults in `mantine8Theme.ts` (dark variant, md radius, 500 weight).

## Base

- originally stacked on #25455; Paper merged while this PR was being prepared
- rebased directly onto its merge commit on `main`

## Validation

- `pnpm -F frontend typecheck`
- `pnpm -F frontend format`
- `pnpm -F frontend lint` (passes; 3 unrelated existing warnings)
- `pnpm -F frontend test -- src/components/common/PivotTable/getRowSpanMerges.test.ts src/components/common/PivotTable/getFrozenColumnLayout.test.ts` (21 tests)
- verified zero remaining v6 Button/ButtonProps imports
- verified compact mapping: 11 `compact-xs`, 5 `compact-sm`
