### PR TITLE
refactor(frontend): migrate Tabs to Mantine 8

### DIFF
--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -171,6 +171,7 @@ export const CartesianChartSeries = ({
                             <Config.Label>{`Stacking`}</Config.Label>
                             <SegmentedControl
                                 radius="md"
+                                fz="sm"
                                 disabled={!canStack}
                                 data={[
                                     {

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -126,6 +126,7 @@ export const SingleSeriesConfiguration = ({
                     <SegmentedControl
                         sx={{ minWidth: '130px', flex: 1 }}
                         radius="md"
+                        fz="sm"
                         data={[
                             {
                                 value: 'left',
@@ -135,7 +136,7 @@ export const SingleSeriesConfiguration = ({
                                             icon={IconAlignLeft}
                                             color="ldDark.8"
                                         />
-                                        <Text>Left</Text>
+                                        <Text inherit>Left</Text>
                                     </Group>
                                 ),
                             },
@@ -147,7 +148,7 @@ export const SingleSeriesConfiguration = ({
                                         wrap="nowrap"
                                         justify="flex-end"
                                     >
-                                        <Text>Right</Text>
+                                        <Text inherit>Right</Text>
                                         <MantineIcon
                                             icon={IconAlignRight}
                                             color="ldDark.8"

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
@@ -3,8 +3,8 @@ import {
     TimeFrames,
     type OrganizationProject,
 } from '@lightdash/common';
-import { Button, Stack, Text } from '@mantine-8/core';
-import { Avatar, LoadingOverlay, Tabs } from '@mantine/core';
+import { Button, Stack, Tabs, Text } from '@mantine-8/core';
+import { Avatar, LoadingOverlay } from '@mantine/core';
 import { useOs } from '@mantine/hooks';
 import { Prism } from '@mantine/prism';
 import { IconChevronLeft, IconClock } from '@tabler/icons-react';

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
@@ -1,4 +1,5 @@
-import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { Tabs } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { getVizConfigThemeOverride } from '../mantineTheme';
 import { Comparison } from './BigNumberComparison';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ConfigTabs/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ConfigTabs/index.tsx
@@ -1,4 +1,5 @@
-import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { Tabs } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { getVizConfigThemeOverride } from '../../mantineTheme';

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -9,13 +9,12 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Collapse, Group, Stack } from '@mantine-8/core';
+import { Box, Collapse, Group, Stack, Tabs } from '@mantine-8/core';
 import {
     Checkbox,
     MantineProvider,
     SegmentedControl,
     Switch,
-    Tabs,
     Tooltip,
     useMantineColorScheme,
 } from '@mantine/core';

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeConfigTabs.tsx
@@ -1,4 +1,5 @@
-import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { Tabs } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { getVizConfigThemeOverride } from '../mantineTheme';
 import { GaugeDisplayConfig } from './GaugeDisplayConfig';

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapConfigTabs.tsx
@@ -1,4 +1,5 @@
-import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { Tabs } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { getVizConfigThemeOverride } from '../mantineTheme';
 import { Display } from './MapDisplayConfig';

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartConfigTabs.tsx
@@ -1,4 +1,5 @@
-import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { Tabs } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { getVizConfigThemeOverride } from '../mantineTheme';
 import { Display } from './PieChartDisplayConfig';

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
@@ -9,11 +9,10 @@ import {
     type SankeyNodeLayout,
     type TableCalculation,
 } from '@lightdash/common';
-import { Stack, Text } from '@mantine-8/core';
+import { Stack, Tabs, Text } from '@mantine-8/core';
 import {
     MantineProvider,
     SegmentedControl,
-    Tabs,
     useMantineColorScheme,
 } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
@@ -1,4 +1,5 @@
-import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { Tabs } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { getVizConfigThemeOverride } from '../mantineTheme';
 import { ColumnCellDisplay } from './ColumnCellDisplay';

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapConfigTabs.tsx
@@ -1,4 +1,5 @@
-import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { Tabs } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { getVizConfigThemeOverride } from '../mantineTheme';
 import { Display } from './TreemapDisplayConfig';

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -19,8 +19,8 @@ import {
     type DashboardTile,
     type ResultColumn,
 } from '@lightdash/common';
-import { Box, Flex, Group, Stack, Text, Button } from '@mantine-8/core';
-import { Select, Tabs, Tooltip, type PopoverProps } from '@mantine/core';
+import { Box, Button, Flex, Group, Stack, Tabs, Text } from '@mantine-8/core';
+import { Select, Tooltip, type PopoverProps } from '@mantine/core';
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
@@ -379,7 +379,9 @@ const FilterConfiguration: FC<Props> = ({
         <Stack className={classes.inlineDropdowns}>
             <Tabs
                 value={selectedTabId}
-                onTabChange={(tabId: FilterTabs) => setSelectedTabId(tabId)}
+                onChange={(tabId) => {
+                    if (tabId) setSelectedTabId(tabId as FilterTabs);
+                }}
             >
                 {isCreatingNew || isEditMode || isTemporary ? (
                     <Tabs.List mb="md">


### PR DESCRIPTION
## What changed

- migrate all remaining Mantine `Tabs` compound components from v6 to v8
- rename the dashboard-filter `onTabChange` callback to `onChange`
- guard v8's nullable callback value before updating the controlled `FilterTabs` state

## Why

Continue the per-component Mantine 8 migration with the full Tabs compound API moved as one bounded unit.

## Stack

- stacked on #25456
- base: `joaoviana/mantine8-button-migration`
- relates: #25456

## Validation

- `pnpm -F frontend typecheck`
- `pnpm -F frontend format`
- `pnpm -F frontend lint` (passes; 3 unrelated existing warnings)
- `pnpm -F frontend test -- src/features/dashboardFilters/FilterConfiguration/index.test.tsx`
- verified zero remaining v6 Tabs imports or `onTabChange` usages

## Visual QA

- visualization configuration tab bars
- dashboard filter Settings / Tabs & chart tiles
- project connection npm / Homebrew instructions
- selected and disabled states, keyboard navigation, panel mount behavior, light/dark colors
