### PR TITLE
refactor(frontend): migrate ActionIcon to Mantine 8

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -1,6 +1,5 @@
-import { Divider, Group, Stack, Title } from '@mantine-8/core';
+import { Divider, Group, Stack, Title, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Burger,
     Drawer,
     getDefaultZIndex,
@@ -100,6 +99,8 @@ export const MobileNavBar: FC = () => {
             >
                 <Group align="center" justify="space-between" flex={1}>
                     <ActionIcon
+                        variant="subtle"
+                        color="gray"
                         component={Link}
                         to={'/'}
                         title="Home"

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -7,8 +7,8 @@ import {
     type VizIndexLayoutOptions,
     type VizPivotLayoutOptions,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import { Box, Group, Stack, ActionIcon } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { IconMinus, IconPlus, IconX } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
@@ -217,6 +217,8 @@ const GroupByFieldAxisConfig = ({
                 // When the field is deleted, the error state prevents the clear button from showing
                 groupByError && (
                     <ActionIcon
+                        variant="subtle"
+                        color="gray"
                         onClick={() =>
                             dispatch(actions.unsetGroupByReference())
                         }

--- a/packages/frontend/src/components/DataViz/config/TableVisConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/TableVisConfiguration.tsx
@@ -1,5 +1,6 @@
 import { type VizColumn } from '@lightdash/common';
-import { ActionIcon, ScrollArea, TextInput } from '@mantine/core';
+import { ActionIcon } from '@mantine-8/core';
+import { ScrollArea, TextInput } from '@mantine/core';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
@@ -56,6 +57,8 @@ const TableVisConfiguration: FC<{ columns: VizColumn[] }> = ({ columns }) => {
                                 readOnly={!columnsConfig[reference].visible}
                                 rightSection={
                                     <ActionIcon
+                                        variant="subtle"
+                                        color="gray"
                                         onClick={() =>
                                             dispatch(
                                                 updateColumnVisibility({

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -6,8 +6,8 @@ import {
     findReplaceableCustomMetrics,
     getMetrics,
 } from '@lightdash/common';
-import { Group, Menu, Stack, Text } from '@mantine-8/core';
-import { ActionIcon, HoverCard } from '@mantine/core';
+import { Group, Menu, Stack, Text, ActionIcon } from '@mantine-8/core';
+import { HoverCard } from '@mantine/core';
 import {
     IconAlertTriangle,
     IconCode,
@@ -245,7 +245,10 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                         >
                             <Menu withArrow offset={-2}>
                                 <Menu.Target>
-                                    <ActionIcon variant="transparent">
+                                    <ActionIcon
+                                        color="gray"
+                                        variant="transparent"
+                                    >
                                         <MantineIcon icon={IconDots} />
                                     </ActionIcon>
                                 </Menu.Target>
@@ -298,7 +301,10 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                             >
                                 <Menu withArrow offset={-2}>
                                     <Menu.Target>
-                                        <ActionIcon variant="transparent">
+                                        <ActionIcon
+                                            color="gray"
+                                            variant="transparent"
+                                        >
                                             <MantineIcon icon={IconDots} />
                                         </ActionIcon>
                                     </Menu.Target>

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { ExploreType, type SummaryExplore } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { ActionIcon, TextInput } from '@mantine/core';
+import { Stack, ActionIcon } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
     IconAlertCircle,
@@ -175,7 +175,11 @@ const BasePanel = () => {
                             icon={<MantineIcon icon={IconSearch} />}
                             rightSection={
                                 search ? (
-                                    <ActionIcon onClick={() => setSearch('')}>
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="gray"
+                                        onClick={() => setSearch('')}
+                                    >
                                         <MantineIcon icon={IconX} />
                                     </ActionIcon>
                                 ) : null

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -7,8 +7,8 @@ import {
     isMetric,
     type FilterableField,
 } from '@lightdash/common';
-import { UnstyledButton } from '@mantine-8/core';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import { UnstyledButton, ActionIcon } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
 import {
     memo,
@@ -166,7 +166,11 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                                 : 'Click here to add filter'
                         }
                     >
-                        <ActionIcon onClick={handleFilterClick}>
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={handleFilterClick}
+                        >
                             <MantineIcon icon={IconFilter} />
                         </ActionIcon>
                     </Tooltip>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -17,14 +17,8 @@ import {
     type FilterableField,
     type Item,
 } from '@lightdash/common';
-import { Group, Text } from '@mantine-8/core';
-import {
-    ActionIcon,
-    Highlight,
-    HoverCard,
-    NavLink,
-    Tooltip,
-} from '@mantine/core';
+import { Group, Text, ActionIcon } from '@mantine-8/core';
+import { Highlight, HoverCard, NavLink, Tooltip } from '@mantine/core';
 import {
     IconAlertTriangle,
     IconCalendarPin,
@@ -509,7 +503,11 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                                     : 'Click here to add filter'
                             }
                         >
-                            <ActionIcon onClick={handleFilterClick}>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                onClick={handleFilterClick}
+                            >
                                 <MantineIcon
                                     icon={IconFilter}
                                     style={{ flexShrink: 0 }}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -14,8 +14,8 @@ import {
     type Dimension,
     type Metric,
 } from '@lightdash/common';
-import { Box, Menu, type MenuProps } from '@mantine-8/core';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import { Box, Menu, type MenuProps, ActionIcon } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import {
     IconCode,
     IconCopy,
@@ -469,7 +469,7 @@ const TreeSingleNodeActions: FC<Props> = ({
                         label="View options"
                         disabled={isOpened}
                     >
-                        <ActionIcon variant="transparent">
+                        <ActionIcon color="gray" variant="transparent">
                             <MantineIcon
                                 icon={IconDots}
                                 color={isOpened ? 'black' : undefined}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
-import { Button, Group, Text } from '@mantine-8/core';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import { Button, Group, Text, ActionIcon } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import {
@@ -178,6 +178,8 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
                 {showWriteBackCustomMetrics && (
                     <Tooltip label="Write back custom metrics">
                         <ActionIcon
+                            variant="subtle"
+                            color="gray"
                             onClick={handleWriteBackCustomMetrics}
                             data-testid="VirtualSectionHeader/WriteBackCustomMetricsButton"
                         >
@@ -189,6 +191,8 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
                 {showWriteBackCustomDimensions && (
                     <Tooltip label="Write back custom dimensions">
                         <ActionIcon
+                            variant="subtle"
+                            color="gray"
                             onClick={handleWriteBackCustomDimensions}
                             data-testid="VirtualSectionHeader/WriteBackCustomDimensionsButton"
                         >

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -8,8 +8,8 @@ import {
     type Explore,
     type Metric,
 } from '@lightdash/common';
-import { Loader } from '@mantine-8/core';
-import { ActionIcon, TextInput } from '@mantine/core';
+import { Loader, ActionIcon } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch, IconX } from '@tabler/icons-react';
 import {
@@ -266,7 +266,11 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
                             data-testid="ExploreTree/SearchInput-Loader"
                         />
                     ) : search ? (
-                        <ActionIcon onClick={handleClearSearch}>
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={handleClearSearch}
+                        >
                             <MantineIcon icon={IconX} />
                         </ActionIcon>
                     ) : null

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
@@ -1,6 +1,6 @@
 import { type QueryWarning } from '@lightdash/common';
-import { Box, Divider, Stack, Title } from '@mantine-8/core';
-import { ActionIcon, Popover, Tooltip } from '@mantine/core';
+import { Box, Divider, Stack, Title, ActionIcon } from '@mantine-8/core';
+import { Popover, Tooltip } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { Fragment, useState, type FC } from 'react';

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import { ContentType } from '@lightdash/common';
-import { Box, Menu } from '@mantine-8/core';
-import { ActionIcon } from '@mantine/core';
+import { Box, Menu, ActionIcon } from '@mantine-8/core';
 import {
     IconEdit,
     IconFolderSymlink,
@@ -56,7 +55,9 @@ export const SpaceBrowserMenu: React.FC<React.PropsWithChildren<Props>> = ({
         >
             <Menu.Target>
                 <Box>
-                    <ActionIcon>{children}</ActionIcon>
+                    <ActionIcon variant="subtle" color="gray">
+                        {children}
+                    </ActionIcon>
                 </Box>
             </Menu.Target>
             <Menu.Dropdown>

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -4,8 +4,8 @@ import {
     isCustomSqlDimension,
     isSqlTableCalculation,
 } from '@lightdash/common';
-import { Box, CopyButton, Group, Skeleton } from '@mantine-8/core';
-import { ActionIcon, SegmentedControl, Tooltip } from '@mantine/core';
+import { Box, CopyButton, Group, Skeleton, ActionIcon } from '@mantine-8/core';
+import { SegmentedControl, Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconCheck, IconClipboard } from '@tabler/icons-react';
 import {
@@ -116,6 +116,7 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
                                 fw={500}
                             >
                                 <ActionIcon
+                                    variant="subtle"
                                     color={copied ? 'teal' : 'gray'}
                                     onClick={copy}
                                 >

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -1,6 +1,6 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
-import { Divider, Group, Loader, Text } from '@mantine-8/core';
-import { ActionIcon, ScrollArea, Tooltip } from '@mantine/core';
+import { Divider, Group, Loader, Text, ActionIcon } from '@mantine-8/core';
+import { ScrollArea, Tooltip } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { lazy, Suspense, useMemo, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
@@ -74,7 +74,12 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
                 </Text>
 
                 <Tooltip label="Close visualization config" position="right">
-                    <ActionIcon size="sm" onClick={onClose}>
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        size="sm"
+                        onClick={onClose}
+                    >
                         <MantineIcon icon={IconX} />
                     </ActionIcon>
                 </Tooltip>

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -12,13 +12,9 @@ import {
     Stack,
     Text,
     Title,
-} from '@mantine-8/core';
-import {
     ActionIcon,
-    Alert,
-    Drawer,
-    type DefaultMantineColor,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Alert, Drawer, type DefaultMantineColor } from '@mantine/core';
 import { useInterval } from '@mantine/hooks';
 import {
     IconAlertTriangle,
@@ -220,6 +216,8 @@ const JobDetailsDrawer: FC = () => {
                                     >
                                         {({ copied, copy }) => (
                                             <ActionIcon
+                                                variant="subtle"
+                                                color="gray"
                                                 onClick={copy}
                                                 pos="absolute"
                                                 top={6}

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -1,7 +1,6 @@
 import { DbtProjectType } from '@lightdash/common';
-import { CopyButton, Stack } from '@mantine-8/core';
+import { CopyButton, Stack, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Alert,
     Anchor,
     MultiSelect,
@@ -108,6 +107,7 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                                     position="left"
                                 >
                                     <ActionIcon
+                                        variant="subtle"
                                         color={copied ? 'teal' : 'gray'}
                                         onClick={copy}
                                     >

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -1,7 +1,6 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Button, Group, Stack, Text } from '@mantine-8/core';
+import { Button, Group, Stack, Text, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Anchor,
     Avatar,
     PasswordInput,
@@ -141,6 +140,8 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
 
                         <Tooltip label="Refresh repositories after updating access on Github">
                             <ActionIcon
+                                variant="subtle"
+                                color="gray"
                                 mt="20px"
                                 onClick={() => refetchRepos()}
                                 disabled={!isValidGithubInstallation}

--- a/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
@@ -1,5 +1,5 @@
-import { Button, Flex, Stack } from '@mantine-8/core';
-import { ActionIcon, Input, TextInput } from '@mantine/core';
+import { Button, Flex, Stack, ActionIcon } from '@mantine-8/core';
+import { Input, TextInput } from '@mantine/core';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import get from 'lodash/get';
 import { useState, type ReactNode } from 'react';
@@ -61,6 +61,8 @@ export const MultiKeyValuePairsInput = ({
 
                     {labelHelp && (
                         <ActionIcon
+                            variant="subtle"
+                            color="gray"
                             onClick={(
                                 e: React.MouseEvent<HTMLButtonElement>,
                             ) => {
@@ -92,6 +94,8 @@ export const MultiKeyValuePairsInput = ({
                         />
 
                         <ActionIcon
+                            variant="subtle"
+                            color="gray"
                             onClick={() => removeValue(index)}
                             disabled={disabled}
                         >

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -2,9 +2,8 @@ import {
     DatabricksAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Group, Stack, Text, Button } from '@mantine-8/core';
+import { Group, Stack, Text, Button, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Anchor,
     PasswordInput,
     Select,
@@ -425,6 +424,8 @@ const DatabricksForm: FC<{
                                             />
                                             <Tooltip label="Remove compute">
                                                 <ActionIcon
+                                                    variant="subtle"
+                                                    color="gray"
                                                     size="sm"
                                                     onClick={() =>
                                                         removeCompute(index)

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -1,7 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { CopyButton, Stack, Button } from '@mantine-8/core';
+import { CopyButton, Stack, Button, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Anchor,
     NumberInput,
     PasswordInput,
@@ -376,6 +375,7 @@ const PostgresForm: FC<{
                                                             position="right"
                                                         >
                                                             <ActionIcon
+                                                                variant="subtle"
                                                                 color={
                                                                     copied
                                                                         ? 'teal'

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -1,7 +1,6 @@
 import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { CopyButton, Stack, Button } from '@mantine-8/core';
+import { CopyButton, Stack, Button, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Anchor,
     NumberInput,
     PasswordInput,
@@ -372,6 +371,7 @@ const RedshiftForm: FC<{
                                                             position="right"
                                                         >
                                                             <ActionIcon
+                                                                variant="subtle"
                                                                 color={
                                                                     copied
                                                                         ? 'teal'

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -6,8 +6,8 @@ import {
     validateOrganizationEmailDomains,
     type AllowedEmailDomains,
 } from '@lightdash/common';
-import { Flex, Stack, Text, Title, Button } from '@mantine-8/core';
-import { ActionIcon, MultiSelect, Select, Tooltip } from '@mantine/core';
+import { Flex, Stack, Text, Title, Button, ActionIcon } from '@mantine-8/core';
+import { MultiSelect, Select, Tooltip } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import {

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { Flex, Group, Paper, Text, Button } from '@mantine-8/core';
-import { ActionIcon, Badge, ColorSwatch, Menu, Tooltip } from '@mantine/core';
+import { Flex, Group, Paper, Text, Button, ActionIcon } from '@mantine-8/core';
+import { Badge, ColorSwatch, Menu, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconDotsVertical,
@@ -166,6 +166,8 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                         >
                             <Menu.Target>
                                 <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
                                     size="xs"
                                     aria-label="Palette actions"
                                 >

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
@@ -1,6 +1,6 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Group, Paper, Text } from '@mantine-8/core';
-import { ActionIcon, Table } from '@mantine/core';
+import { Group, Paper, Text, ActionIcon } from '@mantine-8/core';
+import { Table } from '@mantine/core';
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
@@ -45,6 +45,8 @@ const CredentialsItem: FC<
         >
             <Group>
                 <ActionIcon
+                    variant="subtle"
+                    color="gray"
                     onClick={() =>
                         setWarehouseCredentialsToBeEdited(credentials)
                     }
@@ -53,6 +55,8 @@ const CredentialsItem: FC<
                 </ActionIcon>
 
                 <ActionIcon
+                    variant="subtle"
+                    color="gray"
                     onClick={() =>
                         setWarehouseCredentialsToBeDeleted(credentials)
                     }

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -10,9 +10,8 @@ import {
     type Field,
     type TableCalculation,
 } from '@lightdash/common';
-import { Group, NumberInput, Stack } from '@mantine-8/core';
+import { Group, NumberInput, Stack, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     CloseButton,
     SegmentedControl,
     TextInput,
@@ -217,6 +216,7 @@ export const Layout: FC<Props> = ({ items }) => {
                         <Group gap="two">
                             <Tooltip variant="xs" label="Flip Axes">
                                 <ActionIcon
+                                    variant="subtle"
                                     onClick={() =>
                                         setFlipAxis(!dirtyLayout?.flipAxes)
                                     }

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
@@ -6,8 +6,8 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Collapse, Group, Stack, Text } from '@mantine-8/core';
-import { ActionIcon, Select, TextInput, Tooltip } from '@mantine/core';
+import { Collapse, Group, Stack, Text, ActionIcon } from '@mantine-8/core';
+import { Select, TextInput, Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
@@ -72,13 +72,22 @@ export const ChartConditionalFormattingRule: FC<Props> = ({
                             position="left"
                             withinPortal
                         >
-                            <ActionIcon onClick={onRemoveRule}>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                onClick={onRemoveRule}
+                            >
                                 <MantineIcon icon={IconTrash} />
                             </ActionIcon>
                         </Tooltip>
                     )}
                 </Group>
-                <ActionIcon onClick={() => setIsOpen(!isOpen)} size="sm">
+                <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    onClick={() => setIsOpen(!isOpen)}
+                    size="sm"
+                >
                     <MantineIcon
                         icon={isOpen ? IconChevronUp : IconChevronDown}
                     />

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -5,8 +5,8 @@ import {
     type CartesianChartLayout,
     type Series,
 } from '@lightdash/common';
-import { Box, Collapse, Group, Stack } from '@mantine-8/core';
-import { ActionIcon, Checkbox, Popover, Select } from '@mantine/core';
+import { Box, Collapse, Group, Stack, ActionIcon } from '@mantine-8/core';
+import { Checkbox, Popover, Select } from '@mantine/core';
 import { useDebouncedState, useHover } from '@mantine/hooks';
 import {
     IconChevronDown,
@@ -142,6 +142,8 @@ const SingleSeriesConfiguration: FC<Props> = ({
                 <Group gap="one">
                     {isGrouped && (
                         <ActionIcon
+                            variant="subtle"
+                            color="gray"
                             onClick={() => {
                                 updateSingleSeries({
                                     ...series,
@@ -155,7 +157,11 @@ const SingleSeriesConfiguration: FC<Props> = ({
                         </ActionIcon>
                     )}
                     {isCollapsable && (
-                        <ActionIcon onClick={toggleIsOpen}>
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={toggleIsOpen}
+                        >
                             <MantineIcon
                                 color="ldGray.7"
                                 icon={isOpen ? IconChevronUp : IconChevronDown}
@@ -227,6 +233,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                                     >
                                         <Popover.Target>
                                             <ActionIcon
+                                                color="gray"
                                                 variant="subtle"
                                                 size="xs"
                                             >

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
@@ -1,6 +1,6 @@
 import { getItemLabelWithoutTableName } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
-import { ActionIcon, TextInput, Tooltip } from '@mantine/core';
+import { Box, Group, ActionIcon } from '@mantine-8/core';
+import { TextInput, Tooltip } from '@mantine/core';
 import { useDebouncedState } from '@mantine/hooks';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
@@ -100,6 +100,7 @@ const MapFieldConfiguration: FC<MapFieldConfigurationProps> = ({ fieldId }) => {
                     onMouseLeave={() => setTooltipVisible(false)}
                 >
                     <ActionIcon
+                        color="gray"
                         variant="light"
                         onClick={() => {
                             setTooltipVisible(false);

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
@@ -5,8 +5,15 @@ import {
     type PieChartValueLabel,
     type PieChartValueOptions,
 } from '@lightdash/common';
-import { Box, Collapse, Group, Stack, type StackProps } from '@mantine-8/core';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import {
+    Box,
+    Collapse,
+    Group,
+    Stack,
+    type StackProps,
+    ActionIcon,
+} from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { forwardRef } from 'react';
@@ -111,7 +118,11 @@ export const GroupItem = forwardRef<
                         label="Override value label options"
                         withinPortal
                     >
-                        <ActionIcon onClick={toggle}>
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={toggle}
+                        >
                             <MantineIcon
                                 icon={opened ? IconChevronUp : IconChevronDown}
                             />

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -1,7 +1,6 @@
 import { isDimension, type FilterableItem } from '@lightdash/common';
-import { Group, Loader, Stack, Text } from '@mantine-8/core';
+import { Group, Loader, Stack, Text, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Highlight,
     MultiSelect,
     ScrollArea,
@@ -550,7 +549,7 @@ const FilterStringAutoComplete: FC<Props> = ({
                                         color="gray"
                                         size="sm"
                                         onClick={openManageValues}
-                                        sx={{
+                                        style={{
                                             visibility: isWrapperHovered
                                                 ? 'visible'
                                                 : 'hidden',

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,15 +13,9 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Box, Divider, Group, Text, Button } from '@mantine-8/core';
+import { Box, Divider, Group, Text, Button, ActionIcon } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
-import {
-    ActionIcon,
-    Anchor,
-    TextInput,
-    Tooltip,
-    useMantineTheme,
-} from '@mantine/core';
+import { Anchor, TextInput, Tooltip, useMantineTheme } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAppWindow,

--- a/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/PresetsForm/AudienceInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/PresetsForm/AudienceInput.tsx
@@ -1,5 +1,5 @@
-import { Flex, Stack, Text } from '@mantine-8/core';
-import { ActionIcon, TextInput, type SystemProp } from '@mantine/core';
+import { Flex, Stack, Text, ActionIcon } from '@mantine-8/core';
+import { TextInput, type SystemProp } from '@mantine/core';
 import { type UseFormReturnType } from '@mantine/form';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
 import {
@@ -20,7 +20,7 @@ const AudienceItem: FC<AudienceItemProps> = ({ item, removeItem }) => {
     return (
         <Flex gap="xs" align={'center'} justify={'center'}>
             <Text>{item}</Text>
-            <ActionIcon>
+            <ActionIcon variant="subtle" color="gray">
                 <MantineIcon icon={IconTrash} onClick={removeItem} />
             </ActionIcon>
         </Flex>
@@ -72,6 +72,8 @@ const AudienceInput: FC<AudienceInputProps> = ({
                     value={inputAudience}
                     rightSection={
                         <ActionIcon
+                            variant="subtle"
+                            color="gray"
                             onClick={addAudience}
                             disabled={inputAudience.trim().length === 0}
                         >

--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiTableCalculationInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiTableCalculationInput.tsx
@@ -1,6 +1,5 @@
 import type { GeneratedTableCalculation } from '@lightdash/common';
-import { Text } from '@mantine-8/core';
-import { ActionIcon } from '@mantine/core';
+import { Text, ActionIcon } from '@mantine-8/core';
 import { useHotkeys } from '@mantine/hooks';
 import { IconArrowUp } from '@tabler/icons-react';
 import { type Editor } from '@tiptap/react';
@@ -89,6 +88,7 @@ export const AiTableCalculationInputBody: FC<Props> = ({
                 disabled={isLoading}
             />
             <ActionIcon
+                variant="filled"
                 size="sm"
                 radius="xl"
                 onClick={handleGenerate}

--- a/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
@@ -1,5 +1,5 @@
-import { Box, Group, Text } from '@mantine-8/core';
-import { ActionIcon, Textarea } from '@mantine/core';
+import { Box, Group, Text, ActionIcon } from '@mantine-8/core';
+import { Textarea } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import { IconArrowUp, IconSparkles } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -77,6 +77,7 @@ export const AiTooltipInput: FC<Props> = ({ fields, currentHtml, onApply }) => {
                     autosize
                 />
                 <ActionIcon
+                    variant="filled"
                     size="sm"
                     radius="xl"
                     onClick={handleGenerate}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -7,9 +7,8 @@ import {
     type DashboardFilterRule,
     type FilterRule,
 } from '@lightdash/common';
-import { Box, Group, Stack, Text, Button } from '@mantine-8/core';
+import { Box, Group, Stack, Text, Button, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Checkbox,
     Select,
     Switch,

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -14,9 +14,16 @@ import {
     type DashboardTile,
     type Field,
 } from '@lightdash/common';
-import { Box, Collapse, Flex, Group, Stack, Text } from '@mantine-8/core';
 import {
+    Box,
+    Collapse,
+    Flex,
+    Group,
+    Stack,
+    Text,
     ActionIcon,
+} from '@mantine-8/core';
+import {
     Checkbox,
     Select,
     Tooltip,
@@ -356,6 +363,7 @@ const TileFilterConfiguration: FC<Props> = ({
         return (
             <Flex align="center" gap="xxs">
                 <ActionIcon
+                    color="gray"
                     size="xs"
                     variant="subtle"
                     onClick={toggleCollapse}

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.module.css
@@ -1,0 +1,8 @@
+.removeButton:focus {
+    background-color: color-mix(
+        in srgb,
+        var(--mantine-color-ldGray-5) 35%,
+        transparent
+    );
+    outline: none;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
@@ -1,10 +1,11 @@
 import type { CatalogItem } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import { ActionIcon, Badge, Tooltip } from '@mantine/core';
+import { Group, ActionIcon } from '@mantine-8/core';
+import { Badge, Tooltip } from '@mantine/core';
 import { IconCode, IconX } from '@tabler/icons-react';
 import type { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useCategoryStyles } from '../styles/useCategoryStyles';
+import styles from './CatalogCategory.module.css';
 
 type Props = {
     category: Pick<
@@ -72,15 +73,7 @@ export const CatalogCategory: FC<Props> = ({
                         color="gray"
                         size={14}
                         onClick={onRemove}
-                        sx={(theme) => ({
-                            '&:focus': {
-                                backgroundColor: theme.fn.rgba(
-                                    theme.colors.ldGray[5],
-                                    0.35,
-                                ),
-                                outline: 'none',
-                            },
-                        })}
+                        className={styles.removeButton}
                     >
                         <MantineIcon
                             className={classes.removeIcon}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.module.css
@@ -8,3 +8,7 @@
     background-color: var(--mantine-color-ldGray-0);
     transition: background-color 200ms ease-in-out;
 }
+
+.editButton:hover {
+    background-color: var(--mantine-color-background-0);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -1,7 +1,14 @@
 import { getErrorMessage, type CatalogItem } from '@lightdash/common';
-import { Box, Divider, Group, Stack, Text, Button } from '@mantine-8/core';
 import {
+    Box,
+    Divider,
+    Group,
+    Stack,
+    Text,
+    Button,
     ActionIcon,
+} from '@mantine-8/core';
+import {
     Popover,
     SimpleGrid,
     TextInput,
@@ -83,12 +90,12 @@ const EditPopover: FC<EditPopoverProps> = ({
         >
             <Popover.Target>
                 <ActionIcon
-                    sx={(theme) => ({
+                    variant="subtle"
+                    color="gray"
+                    className={styles.editButton}
+                    style={{
                         visibility: hovered || opened ? 'visible' : 'hidden',
-                        '&:hover': {
-                            backgroundColor: theme.colors.background[0],
-                        },
-                    })}
+                    }}
                     size="sm"
                     onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                         e.stopPropagation();

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -346,7 +346,7 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                                 }}
                             >
                                 <Group gap={4}>
-                                    <Text>Create</Text>
+                                    <Text fz="sm">Create</Text>
                                     {tagColor && (
                                         <CatalogCategory
                                             category={{

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.module.css
@@ -1,0 +1,14 @@
+.iconButton {
+    flex-shrink: 0;
+    border: 1px solid var(--mantine-color-ldGray-3);
+}
+
+.iconButton[data-placeholder] {
+    box-shadow:
+        0 -2px 0 0 rgb(10 13 18 / 7%) inset,
+        0 1px 2px 0 rgb(16 24 40 / 5%);
+}
+
+.iconButton:disabled {
+    background-color: initial;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -1,6 +1,6 @@
 import { isEmojiIcon, type CatalogField } from '@lightdash/common';
-import { Box, Group, Paper, Button } from '@mantine-8/core';
-import { ActionIcon, getDefaultZIndex, Highlight, Portal } from '@mantine/core';
+import { Box, Group, Paper, Button, ActionIcon } from '@mantine-8/core';
+import { getDefaultZIndex, Highlight, Portal } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
 import { IconTrash } from '@tabler/icons-react';
 import EmojiPicker, {
@@ -20,6 +20,7 @@ import { EventName } from '../../../types/Events';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useUpdateCatalogItemIcon } from '../hooks/useCatalogItemIcon';
 import { MetricDetailPopover } from './MetricDetailPopover';
+import styles from './MetricsCatalogColumnName.module.css';
 import '../../../styles/emoji-picker-react.css';
 
 const PICKER_HEIGHT = 300;
@@ -199,21 +200,14 @@ export const MetricsCatalogColumnName = forwardRef<HTMLDivElement, Props>(
                     <ActionIcon
                         ref={setIconRef}
                         variant="default"
+                        size={28}
+                        radius="md"
                         disabled={!canManageTags}
                         onClick={handleIconClick}
-                        sx={(theme) => ({
-                            width: 28,
-                            height: 28,
-                            flexShrink: 0,
-                            borderRadius: '8px',
-                            border: `1px solid ${theme.colors.ldGray[3]}`,
-                            ...(!isEmojiIcon(row.original.icon) && {
-                                boxShadow: `0px -2px 0px 0px rgba(10, 13, 18, 0.07) inset, 0px 1px 2px 0px rgba(16, 24, 40, 0.05)`,
-                            }),
-                            '&:disabled': {
-                                backgroundColor: 'initial',
-                            },
-                        })}
+                        className={styles.iconButton}
+                        data-placeholder={
+                            !isEmojiIcon(row.original.icon) || undefined
+                        }
                     >
                         {isEmojiIcon(row.original.icon) ? (
                             <Emoji

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -7,8 +7,9 @@ import {
     Text,
     Button,
     type ButtonProps,
+    ActionIcon,
 } from '@mantine-8/core';
-import { ActionIcon, Popover, useMantineTheme } from '@mantine/core';
+import { Popover, useMantineTheme } from '@mantine/core';
 import { useClickOutside, useDisclosure } from '@mantine/hooks';
 import { IconRefresh, IconSparkles, IconX } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
@@ -109,6 +110,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                             ✨ Lightdash Spotlight is here!
                         </Text>
                         <ActionIcon
+                            color="gray"
                             variant="transparent"
                             size="xs"
                             onClick={handleClose}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -29,9 +29,9 @@ import {
     type GroupProps,
     Text,
     Button,
+    ActionIcon,
 } from '@mantine-8/core';
 import {
-    ActionIcon,
     Badge,
     Popover,
     SegmentedControl,
@@ -121,6 +121,7 @@ const SortableColumn: FC<{
                 >
                     <Box>
                         <ActionIcon
+                            variant="subtle"
                             size="xs"
                             color="ldGray.5"
                             {...attributes}
@@ -136,9 +137,10 @@ const SortableColumn: FC<{
                 </Text>
             </Group>
             <ActionIcon
+                variant="subtle"
                 size="xs"
                 color="ldGray.5"
-                sx={{
+                style={{
                     visibility: column.frozen ? 'hidden' : 'visible',
                 }}
                 onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
@@ -449,11 +451,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                     variant="transparent"
                                     size="xs"
                                     color="ldGray.5"
-                                    sx={{
-                                        display: embedToken
-                                            ? 'none'
-                                            : undefined,
-                                    }}
+                                    display={embedToken ? 'none' : undefined}
                                 >
                                     <MantineIcon icon={IconEye} />
                                 </ActionIcon>

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -8,9 +8,8 @@ import {
     type VizTableHeaderSortConfig,
     formatSql,
 } from '@lightdash/common';
-import { Box, Group, Paper, Stack, Text } from '@mantine-8/core';
+import { Box, Group, Paper, Stack, Text, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     Indicator,
     LoadingOverlay,
     SegmentedControl,

--- a/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
@@ -3,8 +3,8 @@ import {
     DownloadFileType,
     type VizTableConfig,
 } from '@lightdash/common';
-import { Center, Stack, Text } from '@mantine-8/core';
-import { ActionIcon, Popover, SegmentedControl } from '@mantine/core';
+import { Center, Stack, Text, ActionIcon } from '@mantine-8/core';
+import { Popover, SegmentedControl } from '@mantine/core';
 import { IconDownload, IconPhoto, IconTableExport } from '@tabler/icons-react';
 import { memo, useState } from 'react';
 import ChartDownloadOptions from '../../../../components/common/ChartDownload/ChartDownloadOptions';

--- a/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadButton.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadButton.tsx
@@ -3,7 +3,8 @@ import {
     getHiddenFieldsFromVizTableConfig,
     type VizTableConfig,
 } from '@lightdash/common';
-import { ActionIcon, Popover, Tooltip } from '@mantine/core';
+import { ActionIcon } from '@mantine-8/core';
+import { Popover, Tooltip } from '@mantine/core';
 import { IconDownload } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
-import { Group, Paper, Stack, Text, Button } from '@mantine-8/core';
-import { ActionIcon, Menu, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack, Text, Button, ActionIcon } from '@mantine-8/core';
+import { Menu, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,6 +1,13 @@
 import { type SqlChart } from '@lightdash/common';
-import { Group, Paper, Stack, Title, Button } from '@mantine-8/core';
-import { ActionIcon, HoverCard, Menu, Tooltip } from '@mantine/core';
+import {
+    Group,
+    Paper,
+    Stack,
+    Title,
+    Button,
+    ActionIcon,
+} from '@mantine-8/core';
+import { HoverCard, Menu, Tooltip } from '@mantine/core';
 import {
     IconArrowBack,
     IconDots,
@@ -170,6 +177,8 @@ export const HeaderEdit: FC = () => {
                                 {savedSqlChart.name}
                             </Title>
                             <ActionIcon
+                                variant="subtle"
+                                color="gray"
                                 size="xs"
                                 onClick={() => {
                                     dispatch(toggleModal('updateChartModal'));
@@ -247,7 +256,7 @@ export const HeaderEdit: FC = () => {
                             width={200}
                         >
                             <Menu.Target>
-                                <ActionIcon variant="subtle">
+                                <ActionIcon color="gray" variant="subtle">
                                     <MantineIcon icon={IconDots} />
                                 </ActionIcon>
                             </Menu.Target>

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,7 +1,14 @@
 import { subject } from '@casl/ability';
 import { DashboardTileTypes } from '@lightdash/common';
-import { Group, Paper, Stack, Title, Button } from '@mantine-8/core';
-import { ActionIcon, Menu, Tooltip } from '@mantine/core';
+import {
+    Group,
+    Paper,
+    Stack,
+    Title,
+    Button,
+    ActionIcon,
+} from '@mantine-8/core';
+import { Menu, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,
@@ -208,7 +215,7 @@ export const HeaderView: FC = () => {
                                 width={200}
                             >
                                 <Menu.Target>
-                                    <ActionIcon variant="subtle">
+                                    <ActionIcon color="gray" variant="subtle">
                                         <MantineIcon icon={IconDots} />
                                     </ActionIcon>
                                 </Menu.Target>

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { ChartKind } from '@lightdash/common';
-import { Group, Stack, Title } from '@mantine-8/core';
-import { ActionIcon, ScrollArea, Tooltip } from '@mantine/core';
+import { Group, Stack, Title, ActionIcon } from '@mantine-8/core';
+import { ScrollArea, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftCollapse, IconReload } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -48,6 +48,8 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
                             position="right"
                         >
                             <ActionIcon
+                                variant="subtle"
+                                color="gray"
                                 size="xs"
                                 onClick={() => updateTables()}
                             >
@@ -57,7 +59,7 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
                     )}
                 </Group>
                 <Tooltip variant="xs" label="Close sidebar" position="left">
-                    <ActionIcon size="xs">
+                    <ActionIcon variant="subtle" color="gray" size="xs">
                         <MantineIcon
                             icon={IconLayoutSidebarLeftCollapse}
                             onClick={() => setSidebarOpen(false)}

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditorPreferencesPopover.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditorPreferencesPopover.tsx
@@ -1,6 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
-import { ActionIcon, Popover, SegmentedControl } from '@mantine/core';
+import { Group, Stack, Text, ActionIcon } from '@mantine-8/core';
+import { Popover, SegmentedControl } from '@mantine/core';
 import { IconCodeCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -51,10 +51,11 @@ export const SqlEditorPreferencesPopover: FC = () => {
         >
             <Popover.Target>
                 <ActionIcon
+                    color="gray"
                     variant="light"
                     size="sm"
                     onClick={() => setOpened(!opened)}
-                    sx={{
+                    style={{
                         cursor: isPopoverDisabled ? 'default' : 'pointer',
                     }}
                 >

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
@@ -1,6 +1,5 @@
-import { Group, Stack, Text } from '@mantine-8/core';
+import { Group, Stack, Text, ActionIcon } from '@mantine-8/core';
 import {
-    ActionIcon,
     HoverCard,
     Popover,
     Tooltip,

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -6,14 +6,9 @@ import {
     Loader,
     Stack,
     Text,
-} from '@mantine-8/core';
-import {
     ActionIcon,
-    Highlight,
-    ScrollArea,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Highlight, ScrollArea, TextInput, Tooltip } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
 import { IconCopy, IconSearch, IconX } from '@tabler/icons-react';
 import { memo, useState, type FC } from 'react';
@@ -46,6 +41,8 @@ const TableField: FC<{
                                 position="right"
                             >
                                 <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
                                     size={16}
                                     onClick={copy}
                                     bg="ldGray.1"
@@ -136,6 +133,8 @@ export const TableFields: FC = () => {
                         rightSection={
                             search ? (
                                 <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
                                     size="xs"
                                     onClick={() => setSearch('')}
                                 >

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -8,9 +8,9 @@ import {
     Stack,
     type BoxProps,
     Text,
+    ActionIcon,
 } from '@mantine-8/core';
 import {
-    ActionIcon,
     Highlight,
     ScrollArea,
     TextInput,
@@ -161,6 +161,8 @@ const TableItem: FC<TableItemProps> = memo(
                                 position="right"
                             >
                                 <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
                                     size={16}
                                     onClick={copy}
                                     bg="ldGray.1"
@@ -372,6 +374,8 @@ export const Tables: FC = () => {
                         rightSection={
                             search ? (
                                 <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
                                     size="xs"
                                     onClick={() => setSearch('')}
                                 >

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -8,14 +8,16 @@ import {
     SEED_ORG_1_ADMIN_PASSWORD,
     type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
-import { Box, Divider, Stack, Text, Title, Button } from '@mantine-8/core';
 import {
+    Box,
+    Divider,
+    Stack,
+    Text,
+    Title,
+    Button,
     ActionIcon,
-    Anchor,
-    Card,
-    PasswordInput,
-    TextInput,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Anchor, Card, PasswordInput, TextInput } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useTimeout } from '@mantine/hooks';
 import { IconX } from '@tabler/icons-react';
@@ -259,6 +261,8 @@ const Login: FC<{}> = () => {
                             rightSection={
                                 preCheckEmail ? (
                                     <ActionIcon
+                                        variant="subtle"
+                                        color="gray"
                                         onClick={() => {
                                             setPreCheckEmail(undefined);
                                             form.setValues({

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,12 +1,13 @@
 import { LightdashMode, type ApiErrorDetail } from '@lightdash/common';
-import { CopyButton, Group, Stack, Text, Button } from '@mantine-8/core';
 import {
+    CopyButton,
+    Group,
+    Stack,
+    Text,
+    Button,
     ActionIcon,
-    Anchor,
-    Modal,
-    Tooltip,
-    useMantineTheme,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Anchor, Modal, Tooltip, useMantineTheme } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { IconCheck, IconCopy, IconSpeakerphone } from '@tabler/icons-react';
 import { defaultContext } from '@tanstack/react-query';
@@ -34,7 +35,12 @@ const CopyErrorButton = ({
                 withArrow
                 position="right"
             >
-                <ActionIcon size="xs" onClick={copy} variant="transparent">
+                <ActionIcon
+                    color="gray"
+                    size="xs"
+                    onClick={copy}
+                    variant="transparent"
+                >
                     <MantineIcon
                         color={color}
                         icon={copied ? IconCheck : IconCopy}

--- a/packages/frontend/src/pages/MobileCharts.tsx
+++ b/packages/frontend/src/pages/MobileCharts.tsx
@@ -3,8 +3,8 @@ import {
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, TextInput } from '@mantine/core';
+import { Group, Stack, ActionIcon } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { IconChartBar, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
@@ -61,7 +61,11 @@ const MobileCharts: FC = () => {
                 icon={<MantineIcon icon={IconSearch} />}
                 rightSection={
                     search ? (
-                        <ActionIcon onClick={() => setSearch('')}>
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={() => setSearch('')}
+                        >
                             <MantineIcon icon={IconX} />
                         </ActionIcon>
                     ) : null

--- a/packages/frontend/src/pages/MobileDashboards.tsx
+++ b/packages/frontend/src/pages/MobileDashboards.tsx
@@ -3,8 +3,8 @@ import {
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, TextInput } from '@mantine/core';
+import { Group, Stack, ActionIcon } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { IconLayoutDashboard, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState } from 'react';
@@ -58,7 +58,11 @@ const MobileDashboards = () => {
                 icon={<MantineIcon icon={IconSearch} />}
                 rightSection={
                     search ? (
-                        <ActionIcon onClick={() => setSearch('')}>
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={() => setSearch('')}
+                        >
                             <MantineIcon icon={IconX} />
                         </ActionIcon>
                     ) : null

--- a/packages/frontend/src/pages/MobileSpace.tsx
+++ b/packages/frontend/src/pages/MobileSpace.tsx
@@ -6,8 +6,8 @@ import {
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, TextInput } from '@mantine/core';
+import { Group, Stack, ActionIcon } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { IconLayoutDashboard, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
@@ -125,7 +125,11 @@ const MobileSpace: FC = () => {
                 icon={<MantineIcon icon={IconSearch} />}
                 rightSection={
                     search ? (
-                        <ActionIcon onClick={() => setSearch('')}>
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={() => setSearch('')}
+                        >
                             <MantineIcon icon={IconX} />
                         </ActionIcon>
                     ) : null

--- a/packages/frontend/src/pages/MobileSpaces.tsx
+++ b/packages/frontend/src/pages/MobileSpaces.tsx
@@ -5,8 +5,8 @@ import {
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { ActionIcon, TextInput } from '@mantine/core';
+import { Group, Stack, ActionIcon } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { IconFolders, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
@@ -82,7 +82,11 @@ const MobileSpaces: FC = () => {
                     icon={<MantineIcon icon={IconSearch} />}
                     rightSection={
                         search ? (
-                            <ActionIcon onClick={() => setSearch('')}>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                onClick={() => setSearch('')}
+                            >
                                 <MantineIcon icon={IconX} />
                             </ActionIcon>
                         ) : null

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -6,8 +6,7 @@ import {
     ResourceViewItemType,
     type ResourceViewSpaceItem,
 } from '@lightdash/common';
-import { Box, Group, Menu, Stack, Button } from '@mantine-8/core';
-import { ActionIcon } from '@mantine/core';
+import { Box, Group, Menu, Stack, Button, ActionIcon } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconDots,

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,6 +1,6 @@
 import { getFieldQuoteChar } from '@lightdash/common';
-import { Group, Paper, Stack } from '@mantine-8/core';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import { Group, Paper, Stack, ActionIcon } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
@@ -210,6 +210,8 @@ const SqlRunner = ({
                                 position="right"
                             >
                                 <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
                                     size="sm"
                                     onClick={() => handleSetSidebarOpen(true)}
                                 >


### PR DESCRIPTION
## What changed

- Migrate all 60 Mantine 6 `ActionIcon` imports (82 usages) to Mantine 8.
- Preserve Mantine 6 neutral defaults with explicit variants and colors.
- Keep the two ambient AI loading submit actions intentionally filled.
- Replace all seven `sx` usages with Mantine 8 styles or CSS modules.
- Keep drag-and-drop prop ordering and disabled behavior intact.
- Set the Metrics Catalog category “Create” label to `sm`.

## Why

Mantine 8 changes `ActionIcon` from a subtle neutral default to a filled primary control. Explicit defaults prevent broad visual regressions.

## Stack

- Stacked on #25457
- Base: `joaoviana/mantine8-tabs-migration`

## Validation

- Frontend typecheck
- Frontend format
- Frontend lint (three unrelated existing warnings)
- 3 focused test files / 12 tests passed
- Zero Mantine 6 `ActionIcon` imports
- Every `ActionIcon` has an explicit variant
- Zero remaining `ActionIcon` `sx` usages

## Visual QA

- Mobile navigation controls
- SQL runner controls
- Metrics Catalog categories, drag-and-drop, and create option
- Ambient AI loading actions
