### PR TITLE
refactor(frontend): migrate SegmentedControl to Mantine 8

### DIFF
--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -5,8 +5,15 @@ import {
     type CartesianChartDisplay,
     type ChartKind,
 } from '@lightdash/common';
-import { Box, Flex, Group, Stack, Text } from '@mantine-8/core';
-import { SegmentedControl, TextInput } from '@mantine/core';
+import {
+    Box,
+    Flex,
+    Group,
+    Stack,
+    Text,
+    SegmentedControl,
+} from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { IconAlignLeft, IconAlignRight } from '@tabler/icons-react';
 import MantineIcon from '../../common/MantineIcon';
 import ColorSelector from '../../VisualizationConfigs/ColorSelector';
@@ -124,7 +131,8 @@ export const SingleSeriesConfiguration = ({
                 <Flex justify="flex-start" align="center" wrap="nowrap">
                     <Config.Label w={LABEL_WIDTH}>Y Axis</Config.Label>
                     <SegmentedControl
-                        sx={{ minWidth: '130px', flex: 1 }}
+                        miw={130}
+                        flex={1}
                         radius="md"
                         fz="sm"
                         data={[

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -4,8 +4,15 @@ import {
     isCustomSqlDimension,
     isSqlTableCalculation,
 } from '@lightdash/common';
-import { Box, CopyButton, Group, Skeleton, ActionIcon } from '@mantine-8/core';
-import { SegmentedControl, Tooltip } from '@mantine/core';
+import {
+    Box,
+    CopyButton,
+    Group,
+    Skeleton,
+    ActionIcon,
+    SegmentedControl,
+} from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconCheck, IconClipboard } from '@tabler/icons-react';
 import {

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DuckdbForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DuckdbForm.tsx
@@ -4,11 +4,10 @@ import {
     DucklakeDataPathType,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Stack, SegmentedControl } from '@mantine-8/core';
 import {
     NumberInput,
     PasswordInput,
-    SegmentedControl,
     Select,
     Switch,
     TextInput,

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/ChartPreviewComponent.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/ChartPreviewComponent.tsx
@@ -1,6 +1,5 @@
 import { ChartKind } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
-import { SegmentedControl } from '@mantine/core';
+import { Box, Group, Stack, SegmentedControl } from '@mantine-8/core';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { getChartIcon } from '../../common/ResourceIcon/utils';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -9,14 +9,8 @@ import {
     XAxisSort,
     type ItemsMap,
 } from '@lightdash/common';
-import { Group, Stack, Text, Button } from '@mantine-8/core';
-import {
-    Checkbox,
-    NumberInput,
-    SegmentedControl,
-    Select,
-    Switch,
-} from '@mantine/core';
+import { Group, Stack, Text, Button, SegmentedControl } from '@mantine-8/core';
+import { Checkbox, NumberInput, Select, Switch } from '@mantine/core';
 import {
     IconChartBar,
     IconMinus,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -10,13 +10,14 @@ import {
     type Field,
     type TableCalculation,
 } from '@lightdash/common';
-import { Group, NumberInput, Stack, ActionIcon } from '@mantine-8/core';
 import {
-    CloseButton,
+    Group,
+    NumberInput,
+    Stack,
+    ActionIcon,
     SegmentedControl,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { CloseButton, TextInput, Tooltip } from '@mantine/core';
 import { IconRotate360 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { EMPTY_X_AXIS } from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
@@ -447,6 +448,7 @@ export const Layout: FC<Props> = ({ items }) => {
                             <Group gap="xs">
                                 <Config.Label>Stacking</Config.Label>
                                 <SegmentedControl
+                                    size="xs"
                                     disabled={isXAxisFieldNumeric}
                                     value={
                                         isXAxisFieldNumeric

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -10,9 +10,15 @@ import {
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
-import { Collapse, Group, Loader, Stack } from '@mantine-8/core';
+import {
+    Collapse,
+    Group,
+    Loader,
+    Stack,
+    SegmentedControl,
+} from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
-import { SegmentedControl, Switch } from '@mantine/core';
+import { Switch } from '@mantine/core';
 import { lazy, Suspense, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useToggle } from 'react-use';
@@ -215,6 +221,7 @@ export const Legend: FC<Props> = ({ items }) => {
                             <Group gap="xs">
                                 <Config.Label>Placement</Config.Label>
                                 <SegmentedControl
+                                    size="xs"
                                     name="placement"
                                     value={legendConfig.placement ?? 'custom'}
                                     onChange={(val) =>
@@ -247,6 +254,7 @@ export const Legend: FC<Props> = ({ items }) => {
                                             Scroll behavior
                                         </Config.Label>
                                         <SegmentedControl
+                                            size="xs"
                                             value={
                                                 dirtyEchartsConfig?.legend
                                                     ?.type ?? 'scroll'
@@ -269,6 +277,7 @@ export const Legend: FC<Props> = ({ items }) => {
                                     <Group gap="xs">
                                         <Config.Label>Orientation</Config.Label>
                                         <SegmentedControl
+                                            size="xs"
                                             name="orient"
                                             value={
                                                 legendConfig.orient ??

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/CustomColors.tsx
@@ -8,8 +8,15 @@ import {
     type ResultRow,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Divider, Group, ScrollArea, Stack, Text } from '@mantine-8/core';
-import { SegmentedControl } from '@mantine/core';
+import {
+    Box,
+    Divider,
+    Group,
+    ScrollArea,
+    Stack,
+    Text,
+    SegmentedControl,
+} from '@mantine-8/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import ColorSelector from '../../ColorSelector';
 import { ChartConditionalFormatting } from './ChartConditionalFormatting';

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -9,11 +9,17 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Collapse, Group, Stack, Tabs } from '@mantine-8/core';
+import {
+    Box,
+    Collapse,
+    Group,
+    Stack,
+    Tabs,
+    SegmentedControl,
+} from '@mantine-8/core';
 import {
     Checkbox,
     MantineProvider,
-    SegmentedControl,
     Switch,
     Tooltip,
     useMantineColorScheme,
@@ -88,6 +94,7 @@ export const ConfigTabs: FC = memo(() => {
                                 <Group gap="xs">
                                     <Config.Label>Steps are</Config.Label>
                                     <SegmentedControl
+                                        size="xs"
                                         value={dataInput}
                                         data={[
                                             {
@@ -172,6 +179,7 @@ export const ConfigTabs: FC = memo(() => {
                                 <Group gap="xs" wrap="nowrap">
                                     <Config.Label>Position</Config.Label>
                                     <SegmentedControl
+                                        size="xs"
                                         value={labels?.position}
                                         data={[
                                             {
@@ -192,11 +200,10 @@ export const ConfigTabs: FC = memo(() => {
                                                 label: 'Hidden',
                                             },
                                         ]}
-                                        onChange={(
-                                            newPosition: FunnelChartLabelPosition,
-                                        ) =>
+                                        onChange={(newPosition) =>
                                             onLabelsChange({
-                                                position: newPosition,
+                                                position:
+                                                    newPosition as FunnelChartLabelPosition,
                                             })
                                         }
                                     />
@@ -278,11 +285,14 @@ export const ConfigTabs: FC = memo(() => {
                             <Group gap="xs">
                                 <Config.Label>Orientation</Config.Label>
                                 <SegmentedControl
+                                    size="xs"
                                     name="orient"
                                     value={legendPosition}
-                                    onChange={(
-                                        val: FunnelChartLegendPosition,
-                                    ) => legendPositionChange(val)}
+                                    onChange={(value) =>
+                                        legendPositionChange(
+                                            value as FunnelChartLegendPosition,
+                                        )
+                                    }
                                     data={[
                                         {
                                             value: FunnelChartLegendPosition.HORIZONTAL,

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -3,13 +3,8 @@ import {
     getItemId,
     getItemLabelWithoutTableName,
 } from '@lightdash/common';
-import { Center, Group, Stack } from '@mantine-8/core';
-import {
-    Checkbox,
-    NumberInput,
-    SegmentedControl,
-    Tooltip,
-} from '@mantine/core';
+import { Center, Group, Stack, SegmentedControl } from '@mantine-8/core';
+import { Checkbox, NumberInput, Tooltip } from '@mantine/core';
 import { memo, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import { isGaugeVisualizationConfig } from '../../LightdashVisualization/types';

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapLayoutConfig.tsx
@@ -9,8 +9,8 @@ import {
     MapChartLocation,
     MapChartType,
 } from '@lightdash/common';
-import { Group, Loader, Stack } from '@mantine-8/core';
-import { SegmentedControl, Select, Switch, TextInput } from '@mantine/core';
+import { Group, Loader, Stack, SegmentedControl } from '@mantine-8/core';
+import { Select, Switch, TextInput } from '@mantine/core';
 import { memo, useEffect, useMemo, type FC } from 'react';
 import {
     findMatchingProperty,
@@ -325,6 +325,7 @@ export const Layout: FC = memo(() => {
                 <Config.Section>
                     <Config.Heading>Map Type</Config.Heading>
                     <SegmentedControl
+                        size="xs"
                         data={locationTypeOptions}
                         value={locationType}
                         onChange={(value) =>

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -9,8 +9,8 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
-import { SegmentedControl, Tooltip } from '@mantine/core';
+import { Box, Group, Stack, SegmentedControl } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import FieldSelect from '../../common/FieldSelect';
 import { isPieVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -149,6 +149,7 @@ export const Layout: React.FC = () => {
             <Group gap="xs">
                 <Config.Label>Display as</Config.Label>
                 <SegmentedControl
+                    size="xs"
                     value={isDonut ? 'donut' : 'pie'}
                     data={[
                         { value: 'pie', label: 'Pie' },

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
@@ -9,12 +9,8 @@ import {
     type SankeyNodeLayout,
     type TableCalculation,
 } from '@lightdash/common';
-import { Stack, Tabs, Text } from '@mantine-8/core';
-import {
-    MantineProvider,
-    SegmentedControl,
-    useMantineColorScheme,
-} from '@mantine/core';
+import { Stack, Tabs, Text, SegmentedControl } from '@mantine-8/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import { isSankeyVisualizationConfig } from '../../LightdashVisualization/types';
@@ -194,6 +190,7 @@ export const ConfigTabs: FC = memo(() => {
                             <Config.Section>
                                 <Config.Heading>Orientation</Config.Heading>
                                 <SegmentedControl
+                                    size="xs"
                                     value={orient}
                                     data={[
                                         {
@@ -217,6 +214,7 @@ export const ConfigTabs: FC = memo(() => {
                             <Config.Section>
                                 <Config.Heading>Node layout</Config.Heading>
                                 <SegmentedControl
+                                    size="xs"
                                     value={effectiveLayout}
                                     data={[
                                         {
@@ -254,6 +252,7 @@ export const ConfigTabs: FC = memo(() => {
                                         Node alignment
                                     </Config.Heading>
                                     <SegmentedControl
+                                        size="xs"
                                         value={nodeAlign}
                                         data={[
                                             {

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -10,8 +10,15 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import { Accordion, Center, Group, Stack, Text } from '@mantine-8/core';
-import { SegmentedControl, Select, TextInput, Tooltip } from '@mantine/core';
+import {
+    Accordion,
+    Center,
+    Group,
+    Stack,
+    Text,
+    SegmentedControl,
+} from '@mantine-8/core';
+import { Select, TextInput, Tooltip } from '@mantine/core';
 import differenceBy from 'lodash/differenceBy';
 import { useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
@@ -217,7 +224,11 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                         <SegmentedControl
                             size="xs"
                             value={comparisonType}
-                            onChange={onChangeRuleComparisonType}
+                            onChange={(value) =>
+                                onChangeRuleComparisonType(
+                                    value as ConditionalFormattingComparisonType,
+                                )
+                            }
                             data={[
                                 {
                                     label: (

--- a/packages/frontend/src/components/common/Table/TablePagination/index.tsx
+++ b/packages/frontend/src/components/common/Table/TablePagination/index.tsx
@@ -1,5 +1,4 @@
-import { Text } from '@mantine-8/core';
-import { SegmentedControl } from '@mantine/core';
+import { Text, SegmentedControl } from '@mantine-8/core';
 import { type FC } from 'react';
 import PaginateControl from '../../PaginateControl';
 import { DEFAULT_PAGE_SIZE } from '../constants';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -30,14 +30,9 @@ import {
     Text,
     Button,
     ActionIcon,
-} from '@mantine-8/core';
-import {
-    Badge,
-    Popover,
     SegmentedControl,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Badge, Popover, TextInput, Tooltip } from '@mantine/core';
 import {
     IconEye,
     IconEyeOff,

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.module.css
@@ -1,0 +1,23 @@
+.root {
+    align-items: center;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-ldGray-0);
+}
+
+.label {
+    padding-inline: var(--mantine-spacing-sm);
+    color: var(--mantine-color-ldGray-6);
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 500;
+}
+
+.label[data-active] {
+    color: var(--mantine-color-ldDark-7);
+}
+
+.indicator {
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: var(--mantine-radius-md);
+    box-shadow: var(--mantine-shadow-subtle);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -4,14 +4,16 @@ import {
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { Box, Divider, Group, Stack, Text, Button } from '@mantine-8/core';
 import {
-    Popover,
+    Box,
+    Divider,
+    Group,
+    Stack,
+    Text,
+    Button,
     SegmentedControl,
-    TextInput,
-    Tooltip,
-    UnstyledButton,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Popover, TextInput, Tooltip, UnstyledButton } from '@mantine/core';
 import { DatePicker, MonthPicker, YearPicker } from '@mantine/dates';
 import { useCallback, useEffect, useRef, type FC } from 'react';
 import useTracking from '../../../../providers/Tracking/useTracking';
@@ -19,6 +21,7 @@ import { EventName } from '../../../../types/Events';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
 import { useDateRangePicker } from '../../hooks/useDateRangePicker';
 import { getMatchingPresetLabel } from '../../utils/metricExploreDate';
+import styles from './MetricExploreDatePicker.module.css';
 import { TimeDimensionIntervalPicker } from './TimeDimensionIntervalPicker';
 
 type Props = {
@@ -187,35 +190,12 @@ export const MetricExploreDatePicker: FC<Props> = ({
                         }}
                         transitionDuration={300}
                         transitionTimingFunction="linear"
-                        styles={(theme) => ({
-                            root: {
-                                border: `1px solid ${theme.colors.ldGray[2]}`,
-                                borderRadius: theme.radius.md,
-                                backgroundColor: theme.colors.ldGray[0],
-                                alignItems: 'center',
-                            },
-                            label: {
-                                fontSize: theme.fontSizes.sm,
-                                color: theme.colors.ldGray[6],
-                                fontWeight: 500,
-                                paddingLeft: theme.spacing.sm,
-                                paddingRight: theme.spacing.sm,
-                                '&[data-active]': {
-                                    color: theme.colors.ldDark[7],
-                                },
-                            },
-                            control: {
-                                '&:not(:first-of-type)': {
-                                    borderLeft: 'none',
-                                },
-                            },
-                            indicator: {
-                                boxShadow: theme.shadows.subtle,
-                                border: `1px solid ${theme.colors.ldGray[3]}`,
-                                borderRadius: theme.radius.md,
-                                top: 4,
-                            },
-                        })}
+                        withItemsBorders={false}
+                        classNames={{
+                            root: styles.root,
+                            label: styles.label,
+                            indicator: styles.indicator,
+                        }}
                     />
                     {showTimeDimensionIntervalPicker &&
                         timeDimensionBaseField && (

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -8,14 +8,16 @@ import {
     type VizTableHeaderSortConfig,
     formatSql,
 } from '@lightdash/common';
-import { Box, Group, Paper, Stack, Text, ActionIcon } from '@mantine-8/core';
 import {
-    Indicator,
-    LoadingOverlay,
+    Box,
+    Group,
+    Paper,
+    Stack,
+    Text,
+    ActionIcon,
     SegmentedControl,
-    Tooltip,
-    Transition,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Indicator, LoadingOverlay, Tooltip, Transition } from '@mantine/core';
 import { useElementSize, useHotkeys } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import {
@@ -513,20 +515,22 @@ export const ContentPanel: FC = () => {
                                         },
                                     ]}
                                     value={activeEditorTab}
-                                    onChange={(value: EditorTabs) => {
+                                    onChange={(value) => {
+                                        const editorTab = value as EditorTabs;
+
                                         if (isLoadingSqlQuery) {
                                             return;
                                         }
 
                                         if (
-                                            value ===
+                                            editorTab ===
                                                 EditorTabs.VISUALIZATION &&
                                             !queryResults?.results
                                         ) {
                                             return;
                                         }
 
-                                        dispatch(setActiveEditorTab(value));
+                                        dispatch(setActiveEditorTab(editorTab));
                                     }}
                                 />
                             </Indicator>

--- a/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ChartDownload.tsx
@@ -3,8 +3,14 @@ import {
     DownloadFileType,
     type VizTableConfig,
 } from '@lightdash/common';
-import { Center, Stack, Text, ActionIcon } from '@mantine-8/core';
-import { Popover, SegmentedControl } from '@mantine/core';
+import {
+    Center,
+    Stack,
+    Text,
+    ActionIcon,
+    SegmentedControl,
+} from '@mantine-8/core';
+import { Popover } from '@mantine/core';
 import { IconDownload, IconPhoto, IconTableExport } from '@tabler/icons-react';
 import { memo, useState } from 'react';
 import ChartDownloadOptions from '../../../../components/common/ChartDownload/ChartDownloadOptions';
@@ -40,11 +46,13 @@ export const ChartDownload: React.FC<Props> = memo(
                             <SegmentedControl
                                 size="xs"
                                 value={downloadFormat}
-                                onChange={(
-                                    value:
-                                        | DownloadFileType.CSV
-                                        | DownloadFileType.IMAGE,
-                                ) => setDownloadFormat(value)}
+                                onChange={(value) =>
+                                    setDownloadFormat(
+                                        value as
+                                            | DownloadFileType.CSV
+                                            | DownloadFileType.IMAGE,
+                                    )
+                                }
                                 data={[
                                     {
                                         value: DownloadFileType.CSV,

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditorPreferencesPopover.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditorPreferencesPopover.tsx
@@ -1,6 +1,12 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Group, Stack, Text, ActionIcon } from '@mantine-8/core';
-import { Popover, SegmentedControl } from '@mantine/core';
+import {
+    Group,
+    Stack,
+    Text,
+    ActionIcon,
+    SegmentedControl,
+} from '@mantine-8/core';
+import { Popover } from '@mantine/core';
 import { IconCodeCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -85,9 +91,11 @@ export const SqlEditorPreferencesPopover: FC = () => {
                                     { label: 'Never', value: 'never' },
                                 ]}
                                 value={settings.quotePreference}
-                                onChange={(
-                                    value: SqlEditorPreferences['quotePreference'],
-                                ) => handleQuotePreferenceChange(value)}
+                                onChange={(value) =>
+                                    handleQuotePreferenceChange(
+                                        value as SqlEditorPreferences['quotePreference'],
+                                    )
+                                }
                             />
                         </Group>
 
@@ -103,9 +111,11 @@ export const SqlEditorPreferencesPopover: FC = () => {
                                     { label: 'Lowercase', value: 'lowercase' },
                                 ]}
                                 value={settings.casePreference}
-                                onChange={(
-                                    value: SqlEditorPreferences['casePreference'],
-                                ) => handleCasePreferenceChange(value)}
+                                onChange={(value) =>
+                                    handleCasePreferenceChange(
+                                        value as SqlEditorPreferences['casePreference'],
+                                    )
+                                }
                             />
                         </Group>
                     </Stack>

--- a/packages/frontend/src/stories/FormCard.stories.tsx
+++ b/packages/frontend/src/stories/FormCard.stories.tsx
@@ -1,11 +1,5 @@
-import { Stack, Title, Button } from '@mantine-8/core';
-import {
-    Card,
-    SegmentedControl,
-    Select,
-    Switch,
-    TextInput,
-} from '@mantine/core';
+import { Stack, Title, Button, SegmentedControl } from '@mantine-8/core';
+import { Card, Select, Switch, TextInput } from '@mantine/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 interface FormCardProps {
@@ -49,7 +43,7 @@ export function FormCard({ hasError = false }: FormCardProps) {
                     <SegmentedControl
                         radius="md"
                         data={['Option 1', 'Option 2', 'Option 3']}
-                        sx={{
+                        style={{
                             alignSelf: 'flex-start',
                         }}
                     />


### PR DESCRIPTION
## What changed

- Migrate all 21 Mantine 6 `SegmentedControl` imports (28 controls) to Mantine 8.
- Preserve the visualization configuration theme with explicit `size="xs"` on all 16 controls.
- Convert `sx` and nested styles to style props and a CSS Module.
- Reconcile seven enum-backed callbacks with the v8 string callback contract.
- Preserve date preset indicator, border, transition, and typography behavior.

## Why

Migrated controls no longer read the nested Mantine 6 visualization theme. Without explicit sizes, twelve compact visualization controls silently grow from `xs` to `sm`.

## Stack

- Stacked on #25458
- Base: `joaoviana/mantine8-action-icon-migration`

## Validation

- Frontend typecheck
- Frontend format
- Frontend lint (three unrelated existing warnings)
- Full frontend suite: 120 files / 981 tests
- Full Storybook build
- Zero Mantine 6 `SegmentedControl` imports or migrated `sx` props
- All 16 visualization controls explicitly use `xs`

## Visual QA

- Visualization configuration panels
- SQL Runner SQL/Chart, download, and preference controls
- Metrics Catalog list/canvas and date presets
- Table pagination and project connection controls
