### PR TITLE
refactor(frontend): migrate Anchor to Mantine 8

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/DbtForms/AzureDevOpsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/AzureDevOpsForm.tsx
@@ -1,5 +1,6 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Anchor, PasswordInput, TextInput } from '@mantine/core';
+import { Anchor } from '@mantine-8/core';
+import { PasswordInput, TextInput } from '@mantine/core';
 import { type FC } from 'react';
 import { useFormContext } from '../formContext';
 import DbtVersionSelect from '../Inputs/DbtVersion';
@@ -23,6 +24,7 @@ const AzureDevOpsForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                             This is your secret token used to access Azure
                             Devops. See the
                             <Anchor
+                                inherit
                                 href="https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows"
                                 target="_blank"
                                 rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
@@ -1,5 +1,6 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Alert, Anchor, PasswordInput, TextInput } from '@mantine/core';
+import { Anchor } from '@mantine-8/core';
+import { Alert, PasswordInput, TextInput } from '@mantine/core';
 import React, { type FC } from 'react';
 import { useFormContext } from '../formContext';
 import DbtVersionSelect from '../Inputs/DbtVersion';
@@ -20,6 +21,7 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 mb="md"
             >
                 <Anchor
+                    inherit
                     href="https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation"
                     target="_blank"
                     rel="noreferrer"
@@ -47,6 +49,7 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                         <p>
                             Bitbucket Cloud users should
                             <Anchor
+                                inherit
                                 href="https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/"
                                 target="_blank"
                                 rel="noreferrer"
@@ -58,6 +61,7 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                         <p>
                             Bitbucket Server users should
                             <Anchor
+                                inherit
                                 href="https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html"
                                 target="_blank"
                                 rel="noreferrer"
@@ -159,6 +163,7 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                     <p>
                         If you've
                         <Anchor
+                            inherit
                             href="https://confluence.atlassian.com/bitbucketserver/specify-the-bitbucket-base-url-776640392.html"
                             target="_blank"
                             rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -1,8 +1,7 @@
 import { DbtProjectType } from '@lightdash/common';
-import { CopyButton, Stack, ActionIcon } from '@mantine-8/core';
+import { CopyButton, Stack, ActionIcon, Anchor } from '@mantine-8/core';
 import {
     Alert,
-    Anchor,
     MultiSelect,
     PasswordInput,
     TextInput,
@@ -147,6 +146,7 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                     <p>
                         Use the endpoint that's appropriate for your{' '}
                         <Anchor
+                            inherit
                             target="_blank"
                             href="https://docs.getdbt.com/docs/dbt-cloud-apis/discovery-querying#discovery-api-endpoints"
                             rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -1,7 +1,13 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Button, Group, Stack, Text, ActionIcon } from '@mantine-8/core';
 import {
+    Button,
+    Group,
+    Stack,
+    Text,
+    ActionIcon,
     Anchor,
+} from '@mantine-8/core';
+import {
     Avatar,
     PasswordInput,
     ScrollArea,
@@ -57,7 +63,8 @@ const DropdownComponentOverride = ({
                     )
                 }
             >
-                Don't see your repository? <Anchor>Configure here</Anchor>
+                Don't see your repository?{' '}
+                <Anchor inherit>Configure here</Anchor>
             </Text>
         </Tooltip>
     </Stack>
@@ -232,6 +239,7 @@ const GithubPersonalAccessTokenForm: FC<{ disabled: boolean }> = ({
                     <p>
                         This is used to access your repo.
                         <Anchor
+                            inherit
                             target="_blank"
                             href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#github"
                             rel="noreferrer"
@@ -310,6 +318,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                                 <Text>
                                     You are connected to GitHub.{' '}
                                     <Anchor
+                                        inherit
                                         href="/generalSettings/integrations"
                                         target="_blank"
                                     >

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GitlabForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GitlabForm.tsx
@@ -1,5 +1,6 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Anchor, PasswordInput, TextInput } from '@mantine/core';
+import { Anchor } from '@mantine-8/core';
+import { PasswordInput, TextInput } from '@mantine/core';
 import { type FC } from 'react';
 import { useFormContext } from '../formContext';
 import DbtVersionSelect from '../Inputs/DbtVersion';
@@ -21,6 +22,7 @@ const GitlabForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                         <p>
                             This is used to access your repo. See the{' '}
                             <Anchor
+                                inherit
                                 target="_blank"
                                 href="https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html"
                                 rel="noreferrer"
@@ -119,6 +121,7 @@ const GitlabForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                         you can add the custom domain for your project in here.
                         By default, this is
                         <Anchor
+                            inherit
                             href="http://gitlab.io/"
                             target="_blank"
                             rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -4,8 +4,8 @@ import {
     DbtProjectTypeLabels,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Anchor, Select, TextInput } from '@mantine/core';
+import { Stack, Anchor } from '@mantine-8/core';
+import { Select, TextInput } from '@mantine/core';
 import { useMemo, useState, type FC } from 'react';
 import useApp from '../../providers/App/useApp';
 import AzureDevOpsForm from './DbtForms/AzureDevOpsForm';
@@ -248,6 +248,7 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                                                 models from your dbt project.
                                                 You can see more details in{' '}
                                                 <Anchor
+                                                    inherit
                                                     href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project/#dbt-selector"
                                                     target="_blank"
                                                     rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -6,8 +6,8 @@ import {
     type CreateWarehouseCredentials,
     type Project,
 } from '@lightdash/common';
-import { Box, Button, Flex } from '@mantine-8/core';
-import { Alert, Anchor, Card } from '@mantine/core';
+import { Box, Button, Flex, Anchor } from '@mantine-8/core';
+import { Alert, Card } from '@mantine/core';
 import { IconExclamationCircle, IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
@@ -136,6 +136,7 @@ const UpdateProjectConnection: FC<{
                 >
                     Read docs{' '}
                     <Anchor
+                        inherit
                         href="https://docs.lightdash.com/guides/cli/how-to-use-lightdash-preview"
                         target="_blank"
                         rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
@@ -1,12 +1,6 @@
 import { AthenaAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    NumberInput,
-    PasswordInput,
-    Select,
-    TextInput,
-} from '@mantine/core';
+import { Stack, Anchor } from '@mantine-8/core';
+import { NumberInput, PasswordInput, Select, TextInput } from '@mantine/core';
 import { useEffect, type FC } from 'react';
 import { useToggle } from 'react-use';
 import useHealth from '../../../hooks/health/useHealth';
@@ -99,6 +93,7 @@ const AthenaForm: FC<{
                             The AWS region where your Athena workgroup is
                             located. See{' '}
                             <Anchor
+                                inherit
                                 target="_blank"
                                 href="https://docs.getdbt.com/docs/core/connect-data-platform/athena-setup"
                                 rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,8 +1,7 @@
 import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Group, Loader, Stack, Text, Button } from '@mantine-8/core';
+import { Group, Loader, Stack, Text, Button, Anchor } from '@mantine-8/core';
 import type { SelectItem } from '@mantine/core';
 import {
-    Anchor,
     Autocomplete,
     FileInput,
     Image,
@@ -51,6 +50,7 @@ export const BigQuerySchemaInput: FC<{
                     <b> dataset </b>
                     value{' '}
                     <Anchor
+                        inherit
                         target="_blank"
                         href="https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#:~:text=This%20connection%20method%20requires%20local%20OAuth%20via%20gcloud."
                         rel="noreferrer"
@@ -199,6 +199,7 @@ const BigQueryForm: FC<{
                                     <Text mt="0" c="gray" fs="xs">
                                         You are connected to BigQuery,{' '}
                                         <Anchor
+                                            inherit
                                             href="#"
                                             onClick={() => {
                                                 openLoginPopup();
@@ -244,6 +245,7 @@ const BigQueryForm: FC<{
                             description={
                                 <p>
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#project"
                                         rel="noreferrer"
@@ -298,6 +300,7 @@ const BigQueryForm: FC<{
                             description={
                                 <p>
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#project"
                                         rel="noreferrer"
@@ -338,6 +341,7 @@ const BigQueryForm: FC<{
                             The location of BigQuery datasets. You can see more
                             details in{' '}
                             <Anchor
+                                inherit
                                 target="_blank"
                                 href="https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#dataset-locations"
                                 rel="noreferrer"
@@ -366,7 +370,7 @@ const BigQueryForm: FC<{
                             If you're not sure what this is, check out the
                             <b> dataset </b>
                             value{' '}
-                            <Anchor
+                            <Anchor inherit
                                 target="_blank"
                                 href="https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#:~:text=This%20connection%20method%20requires%20local%20OAuth%20via%20gcloud."
                                 rel="noreferrer"
@@ -412,6 +416,7 @@ const BigQueryForm: FC<{
                                 <p>
                                     This is the JSON key file. You can see{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#key-file"
                                         rel="noreferrer"
@@ -502,6 +507,7 @@ const BigQueryForm: FC<{
                                     where you materialize most resources. You
                                     can see more details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/docs/core/connect-data-platform/bigquery-setup#execution-project"
                                         rel="noreferrer"
@@ -545,6 +551,7 @@ const BigQueryForm: FC<{
                                     cancel the query. You can see more details
                                     in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#timeouts"
                                         rel="noreferrer"
@@ -568,6 +575,7 @@ const BigQueryForm: FC<{
                                     The priority for the BigQuery jobs that dbt
                                     executes. You can see more details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#priority"
                                         rel="noreferrer"
@@ -602,6 +610,7 @@ const BigQueryForm: FC<{
                                     that result in unhandled server errors You
                                     can see more details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#retries"
                                         rel="noreferrer"
@@ -630,6 +639,7 @@ const BigQueryForm: FC<{
                                     configured maximum bytes threshold. You can
                                     see more details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#maximum-bytes-billed"
                                         rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/ClickhouseForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/ClickhouseForm.tsx
@@ -1,6 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { Anchor, NumberInput, PasswordInput, TextInput } from '@mantine/core';
+import { Stack, Anchor } from '@mantine-8/core';
+import { NumberInput, PasswordInput, TextInput } from '@mantine/core';
 import React, { type FC } from 'react';
 import { useToggle } from 'react-use';
 import FormCollapseButton from '../FormCollapseButton';
@@ -115,6 +115,7 @@ const ClickhouseForm: FC<{
                                     connect to ClickHouse. You can see more
                                     details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/reference/warehouse-setups/clickhouse-setup"
                                         rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -2,14 +2,15 @@ import {
     DatabricksAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Group, Stack, Text, Button, ActionIcon } from '@mantine-8/core';
 import {
+    Group,
+    Stack,
+    Text,
+    Button,
+    ActionIcon,
     Anchor,
-    PasswordInput,
-    Select,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { PasswordInput, Select, TextInput, Tooltip } from '@mantine/core';
 import { IconCheck, IconPlus, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useToggle } from 'react-use';
@@ -46,6 +47,7 @@ export const DatabricksSchemaInput: FC<{
                 <p>
                     Check out for more details in{' '}
                     <Anchor
+                        inherit
                         target="_blank"
                         href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project/#database-1"
                         rel="noreferrer"
@@ -211,6 +213,7 @@ const DatabricksForm: FC<{
                         <p>
                             Check out for more details in{' '}
                             <Anchor
+                                inherit
                                 target="_blank"
                                 href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#server-hostname"
                                 rel="noreferrer"
@@ -233,6 +236,7 @@ const DatabricksForm: FC<{
                         <p>
                             Check out for more details in{' '}
                             <Anchor
+                                inherit
                                 target="_blank"
                                 href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#http-path"
                                 rel="noreferrer"
@@ -259,6 +263,7 @@ const DatabricksForm: FC<{
                                 <Text mt="0" c="gray" fs="xs">
                                     You are connected to Databricks,{' '}
                                     <Anchor
+                                        inherit
                                         href="#"
                                         onClick={() => {
                                             openLoginPopup();
@@ -295,6 +300,7 @@ const DatabricksForm: FC<{
                             <p>
                                 Check out for more details in{' '}
                                 <Anchor
+                                    inherit
                                     target="_blank"
                                     href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#personal-access-token"
                                     rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -1,7 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { CopyButton, Stack, Button, ActionIcon } from '@mantine-8/core';
+import { CopyButton, Stack, Button, ActionIcon, Anchor } from '@mantine-8/core';
 import {
-    Anchor,
     NumberInput,
     PasswordInput,
     Select,
@@ -162,6 +161,7 @@ const PostgresForm: FC<{
                                     system should send a TCP keepalive message
                                     to the client. You can see more details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://postgresqlco.nf/doc/en/param/tcp_keepalives_idle/"
                                         rel="noreferrer"
@@ -184,6 +184,7 @@ const PostgresForm: FC<{
                                     This controls the Postgres "search path".
                                     You can see more details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/reference/warehouse-profiles/postgres-profile#search_path"
                                         rel="noreferrer"
@@ -207,6 +208,7 @@ const PostgresForm: FC<{
                                     databases using SSL. You can see more
                                     details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/reference/warehouse-profiles/postgres-profile#sslmode"
                                         rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -1,7 +1,6 @@
 import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { CopyButton, Stack, Button, ActionIcon } from '@mantine-8/core';
+import { CopyButton, Stack, Button, ActionIcon, Anchor } from '@mantine-8/core';
 import {
-    Anchor,
     NumberInput,
     PasswordInput,
     Select,
@@ -227,6 +226,7 @@ const RedshiftForm: FC<{
                                     system should send a TCP keepalive message
                                     to the client. You can see more details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://postgresqlco.nf/doc/en/param/tcp_keepalives_idle/"
                                         rel="noreferrer"
@@ -251,6 +251,7 @@ const RedshiftForm: FC<{
                                     databases using SSL. You can see more
                                     details in{' '}
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/docs/core/connect-data-platform/redshift-setup#sslmode-change"
                                         rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -1,7 +1,6 @@
 import { SnowflakeAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Group, Stack, Text, Button } from '@mantine-8/core';
+import { Group, Stack, Text, Button, Anchor } from '@mantine-8/core';
 import {
-    Anchor,
     FileInput,
     NumberInput,
     PasswordInput,
@@ -289,6 +288,7 @@ const SnowflakeForm: FC<{
                                         <Text mt="0" c="gray" fs="xs">
                                             You are connected to Snowflake,{' '}
                                             <Anchor
+                                                inherit
                                                 href="#"
                                                 onClick={() => {
                                                     openLoginPopup();
@@ -394,6 +394,7 @@ const SnowflakeForm: FC<{
                                             This is the .p8 private key file.
                                             You can see{' '}
                                             <Anchor
+                                                inherit
                                                 target="_blank"
                                                 href="https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-key"
                                                 rel="noreferrer"
@@ -546,6 +547,7 @@ const SnowflakeForm: FC<{
                                             hour timeout limit You can see more
                                             details in{' '}
                                             <Anchor
+                                                inherit
                                                 target="_blank"
                                                 href="https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile#client_session_keep_alive"
                                                 rel="noreferrer"
@@ -578,6 +580,7 @@ const SnowflakeForm: FC<{
                                             parameter. You can see more details
                                             in{' '}
                                             <Anchor
+                                                inherit
                                                 target="_blank"
                                                 href="https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile#query_tag"
                                                 rel="noreferrer"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/TrinoForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/TrinoForm.tsx
@@ -1,12 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import {
-    Anchor,
-    NumberInput,
-    PasswordInput,
-    Select,
-    TextInput,
-} from '@mantine/core';
+import { Stack, Anchor } from '@mantine-8/core';
+import { NumberInput, PasswordInput, Select, TextInput } from '@mantine/core';
 import React, { type FC } from 'react';
 import { useToggle } from 'react-use';
 import FormCollapseButton from '../FormCollapseButton';
@@ -126,6 +120,7 @@ const TrinoForm: FC<{
                                     database using SSL. You can see more details
                                     in
                                     <Anchor
+                                        inherit
                                         target="_blank"
                                         href="https://docs.getdbt.com/reference/warehouse-setups/trino-setup#configuration"
                                         rel="noreferrer"

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -9,14 +9,9 @@ import {
     Text,
     Title,
     Button,
-} from '@mantine-8/core';
-import {
     Anchor,
-    Highlight,
-    MultiSelect,
-    Radio,
-    ScrollArea,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Highlight, MultiSelect, Radio, ScrollArea } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
@@ -193,6 +188,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
                         You have selected <b>{modelsIncluded.length}</b> models{' '}
                         {modelsIncluded.length > 0 && (
                             <Anchor
+                                type="button"
                                 size="sm"
                                 component="button"
                                 onClick={toggleList}

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,9 +13,17 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Box, Divider, Group, Text, Button, ActionIcon } from '@mantine-8/core';
+import {
+    Box,
+    Divider,
+    Group,
+    Text,
+    Button,
+    ActionIcon,
+    Anchor,
+} from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
-import { Anchor, TextInput, Tooltip, useMantineTheme } from '@mantine/core';
+import { TextInput, Tooltip, useMantineTheme } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAppWindow,
@@ -252,7 +260,7 @@ const InfiniteResourceTable = ({
                 if (space) {
                     return (
                         <Anchor
-                            color="ldGray.7"
+                            c="ldGray.7"
                             component={Link}
                             to={`/projects/${space.projectUuid}/spaces/${space.uuid}`}
                             onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -1,5 +1,5 @@
-import { Group, Stack, Text, Title, Button } from '@mantine-8/core';
-import { Anchor, TextInput } from '@mantine/core';
+import { Group, Stack, Text, Title, Button, Anchor } from '@mantine-8/core';
+import { TextInput } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -45,6 +45,7 @@ const ScimAccessTokensPanel: FC = () => {
                         Lightdash via SCIM.
                     </Text>
                     <Anchor
+                        inherit
                         href="https://docs.lightdash.com/references/scim-integration/"
                         target="_blank"
                     >

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -5,8 +5,16 @@ import {
     type CatalogField,
     type CatalogItem,
 } from '@lightdash/common';
-import { Box, Center, Divider, Group, Paper, Text } from '@mantine-8/core';
-import { Anchor, useMantineTheme } from '@mantine/core';
+import {
+    Box,
+    Center,
+    Divider,
+    Group,
+    Paper,
+    Text,
+    Anchor,
+} from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowsSort,
@@ -545,6 +553,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({
                         <Text>
                             To learn how to define metrics, check out our{' '}
                             <Anchor
+                                inherit
                                 target="_blank"
                                 href="https://docs.lightdash.com/references/metrics/"
                             >

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -5,8 +5,8 @@ import {
     type MetricExplorerQuery,
     type MetricWithAssociatedTimeDimension,
 } from '@lightdash/common';
-import { Group, Loader, Paper, Stack, Text } from '@mantine-8/core';
-import { Anchor, Radio, Select, Tooltip } from '@mantine/core';
+import { Group, Loader, Paper, Stack, Text, Anchor } from '@mantine-8/core';
+import { Radio, Select, Tooltip } from '@mantine/core';
 import { IconCalendar, IconStack } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useCallback, type FC } from 'react';
@@ -220,6 +220,7 @@ export const MetricExploreComparison: FC<Props> = ({
                                                 dimension defined in the .yml
                                                 can be compared.{' '}
                                                 <Anchor
+                                                    inherit
                                                     c="ldGray.9"
                                                     fw={500}
                                                     target="_blank"

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -2,8 +2,8 @@ import type {
     ApiError,
     GeneratedFormulaTableCalculation,
 } from '@lightdash/common';
-import { Box, Button, Flex, Text } from '@mantine-8/core';
-import { Alert, Anchor, ScrollArea, useMantineTheme } from '@mantine/core';
+import { Box, Button, Flex, Text, Anchor } from '@mantine-8/core';
+import { Alert, ScrollArea, useMantineTheme } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { IconAlertCircle, IconSparkles, IconWand } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
@@ -219,6 +219,7 @@ export const SqlForm: FC<Props> = ({
                             <Text fz="xs">
                                 Need inspiration?{' '}
                                 <Anchor
+                                    inherit
                                     target="_blank"
                                     href="https://docs.lightdash.com/guides/table-calculations/sql-templates"
                                     rel="noreferrer"

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -16,8 +16,9 @@ import {
     Title,
     Button,
     ActionIcon,
+    Anchor,
 } from '@mantine-8/core';
-import { Anchor, Card, PasswordInput, TextInput } from '@mantine/core';
+import { Card, PasswordInput, TextInput } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useTimeout } from '@mantine/hooks';
 import { IconX } from '@tabler/icons-react';
@@ -287,7 +288,11 @@ const Login: FC<{}> = () => {
                                     {...form.getInputProps('password')}
                                     disabled={isFormLoading}
                                 />
-                                <Anchor href="/recover-password" mx="auto">
+                                <Anchor
+                                    inherit
+                                    href="/recover-password"
+                                    mx="auto"
+                                >
                                     Forgot your password?
                                 </Anchor>
                                 <Button

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -6,8 +6,9 @@ import {
     Text,
     Button,
     ActionIcon,
+    Anchor,
 } from '@mantine-8/core';
-import { Anchor, Modal, Tooltip, useMantineTheme } from '@mantine/core';
+import { Modal, Tooltip, useMantineTheme } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { IconCheck, IconCopy, IconSpeakerphone } from '@tabler/icons-react';
 import { defaultContext } from '@tanstack/react-query';
@@ -58,6 +59,7 @@ const GoogleSheetsReauthMessage = ({ message }: { message: string }) => {
         <Text mb={0}>
             {message}{' '}
             <Anchor
+                inherit
                 component="button"
                 type="button"
                 onClick={() => openLoginPopup()}

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -1,6 +1,6 @@
 import { getEmailSchema } from '@lightdash/common';
-import { Center, Stack, Text, Title, Button } from '@mantine-8/core';
-import { Anchor, List, TextInput } from '@mantine/core';
+import { Center, Stack, Text, Title, Button, Anchor } from '@mantine-8/core';
+import { List, TextInput } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';
@@ -56,7 +56,11 @@ export const PasswordRecoveryForm: FC = () => {
                             </Button>
                             {!health.data?.isAuthenticated && (
                                 <Center>
-                                    <Anchor component={Link} to="/login">
+                                    <Anchor
+                                        inherit
+                                        component={Link}
+                                        to="/login"
+                                    >
                                         Back to sign in
                                     </Anchor>
                                 </Center>
@@ -79,6 +83,7 @@ export const PasswordRecoveryForm: FC = () => {
                         <List.Item>
                             Try{' '}
                             <Anchor
+                                inherit
                                 component={Link}
                                 to="/recover-password"
                                 onClick={reset}
@@ -91,7 +96,7 @@ export const PasswordRecoveryForm: FC = () => {
                     </List>
 
                     <Center mt="lg">
-                        <Anchor component={Link} to="/login">
+                        <Anchor inherit component={Link} to="/login">
                             Back to sign in
                         </Anchor>
                     </Center>

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -1,5 +1,13 @@
-import { Box, Center, Stack, Text, Title, Button } from '@mantine-8/core';
-import { Anchor, Card, PasswordInput } from '@mantine/core';
+import {
+    Box,
+    Center,
+    Stack,
+    Text,
+    Title,
+    Button,
+    Anchor,
+} from '@mantine-8/core';
+import { Card, PasswordInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
@@ -85,6 +93,7 @@ const PasswordReset: FC = () => {
 
                                             <Center>
                                                 <Anchor
+                                                    inherit
                                                     component={Link}
                                                     to="/login"
                                                 >

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -3,8 +3,16 @@ import {
     type UserActivity as UserActivityResponse,
     type UserWithCount,
 } from '@lightdash/common';
-import { Box, Group, Stack, Text, Title, Button } from '@mantine-8/core';
-import { Anchor, Card, Table, Tooltip } from '@mantine/core';
+import {
+    Box,
+    Group,
+    Stack,
+    Text,
+    Title,
+    Button,
+    Anchor,
+} from '@mantine-8/core';
+import { Card, Table, Tooltip } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';
@@ -92,7 +100,7 @@ const showTableViews = ({
                 return (
                     <tr key={`${key}-${view.uuid}`}>
                         <td>
-                            <Anchor component={Link} to={to}>
+                            <Anchor inherit component={Link} to={to}>
                                 {view.name}
                             </Anchor>
                         </td>
@@ -441,6 +449,7 @@ const UserActivity: FC = () => {
                                         <td>{user.lastName}</td>
                                         <td>
                                             <Anchor
+                                                inherit
                                                 component={Link}
                                                 to={getDashboardLink(
                                                     projectUuid,


### PR DESCRIPTION
## What changed

- Migrate all 26 Mantine 6 `Anchor` imports (57 links) to Mantine 8.
- Preserve contextual typography with `inherit` on 54 links.
- Keep the three explicitly sized links unchanged.
- Add explicit native button types to both polymorphic button Anchors.
- Replace the single legacy `color` prop with `c`.

## Why

Mantine 8 Anchor composes v8 Text, which defaults to `md` typography. Without explicit inheritance, inline links silently grow and lose their surrounding line height or weight. Mantine 8 also no longer injects `type="button"` for polymorphic button Anchors.

## Stack

- Stacked on #25459
- Base: `joaoviana/mantine8-segmented-control-migration`

## Validation

- Frontend typecheck
- Frontend format
- Frontend lint (three unrelated existing warnings)
- Full frontend suite: 120 files / 981 tests
- Zero Mantine 6 `Anchor` imports
- 54 inherited / 3 explicitly sized links
- Nine polymorphic links and two typed button Anchors verified

## Visual QA

- Login, password recovery, and reset links
- Project connection documentation links
- User Activity Router links
- Project Tables form toggle
- Metrics Catalog, resource, toaster, and SCIM links
