### PR TITLE
refactor(frontend): migrate Highlight to Mantine 8

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -1,6 +1,6 @@
 import { hasIntersection } from '@lightdash/common';
-import { Group, Text } from '@mantine-8/core';
-import { Badge, Highlight, HoverCard, NavLink } from '@mantine/core';
+import { Group, Text, Highlight } from '@mantine-8/core';
+import { Badge, HoverCard, NavLink } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import intersectionBy from 'lodash/intersectionBy';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -175,6 +175,7 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
                                 <Highlight
                                     component="span"
                                     highlight={searchQuery || ''}
+                                    inherit
                                 >
                                     {label}
                                 </Highlight>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -17,8 +17,8 @@ import {
     type FilterableField,
     type Item,
 } from '@lightdash/common';
-import { Group, Text, ActionIcon } from '@mantine-8/core';
-import { Highlight, HoverCard, NavLink, Tooltip } from '@mantine/core';
+import { Group, Text, ActionIcon, Highlight } from '@mantine-8/core';
+import { HoverCard, NavLink, Tooltip } from '@mantine/core';
 import {
     IconAlertTriangle,
     IconCalendarPin,
@@ -450,6 +450,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                                 <Highlight
                                     component="span"
                                     highlight={searchQuery || ''}
+                                    inherit
                                 >
                                     {label}
                                 </Highlight>

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -10,8 +10,9 @@ import {
     Title,
     Button,
     Anchor,
+    Highlight,
 } from '@mantine-8/core';
-import { Highlight, MultiSelect, Radio, ScrollArea } from '@mantine/core';
+import { MultiSelect, Radio, ScrollArea } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
@@ -269,6 +270,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
                                                 <Highlight
                                                     highlight={search}
                                                     {...others}
+                                                    fz="sm"
                                                 >
                                                     {label}
                                                 </Highlight>
@@ -334,6 +336,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
                                                 <Highlight
                                                     highlight={search}
                                                     {...others}
+                                                    fz="sm"
                                                 >
                                                     {label}
                                                 </Highlight>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -1,7 +1,13 @@
 import { isDimension, type FilterableItem } from '@lightdash/common';
-import { Group, Loader, Stack, Text, ActionIcon } from '@mantine-8/core';
 import {
+    Group,
+    Loader,
+    Stack,
+    Text,
+    ActionIcon,
     Highlight,
+} from '@mantine-8/core';
+import {
     MultiSelect,
     ScrollArea,
     TextInput,
@@ -597,6 +603,7 @@ const FilterStringAutoComplete: FC<Props> = ({
                                     highlight={search}
                                     className={itemClassName}
                                     {...others}
+                                    fz="sm"
                                 >
                                     {label}
                                 </Highlight>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -1,6 +1,13 @@
 import { isEmojiIcon, type CatalogField } from '@lightdash/common';
-import { Box, Group, Paper, Button, ActionIcon } from '@mantine-8/core';
-import { getDefaultZIndex, Highlight, Portal } from '@mantine/core';
+import {
+    Box,
+    Group,
+    Paper,
+    Button,
+    ActionIcon,
+    Highlight,
+} from '@mantine-8/core';
+import { getDefaultZIndex, Portal } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
 import { IconTrash } from '@tabler/icons-react';
 import EmojiPicker, {

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
@@ -1,7 +1,6 @@
 import { type CompiledDimension } from '@lightdash/common';
-import { Group, Loader, Stack, Text } from '@mantine-8/core';
+import { Group, Loader, Stack, Text, Highlight } from '@mantine-8/core';
 import {
-    Highlight,
     MultiSelect,
     ScrollArea,
     Tooltip,
@@ -260,7 +259,7 @@ export const MetricExploreFilterAutoComplete: FC<Props> = ({
                             {label}
                         </Text>
                     ) : (
-                        <Highlight highlight={search} {...others}>
+                        <Highlight highlight={search} {...others} fz="sm">
                             {label}
                         </Highlight>
                     )

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -7,8 +7,9 @@ import {
     Stack,
     Text,
     ActionIcon,
+    Highlight,
 } from '@mantine-8/core';
-import { Highlight, ScrollArea, TextInput, Tooltip } from '@mantine/core';
+import { ScrollArea, TextInput, Tooltip } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
 import { IconCopy, IconSearch, IconX } from '@tabler/icons-react';
 import { memo, useState, type FC } from 'react';
@@ -76,7 +77,11 @@ const TableField: FC<{
                     style={{ flex: 1 }}
                     truncate
                 >
-                    <Highlight component="span" highlight={search || ''}>
+                    <Highlight
+                        component="span"
+                        highlight={search || ''}
+                        inherit
+                    >
                         {field.name}
                     </Highlight>
                 </Text>

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -9,14 +9,9 @@ import {
     type BoxProps,
     Text,
     ActionIcon,
-} from '@mantine-8/core';
-import {
     Highlight,
-    ScrollArea,
-    TextInput,
-    Tooltip,
-    UnstyledButton,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { ScrollArea, TextInput, Tooltip, UnstyledButton } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
 import {
     IconChevronDown,
@@ -136,6 +131,7 @@ const TableItem: FC<TableItemProps> = memo(
                                 <Highlight
                                     component="span"
                                     highlight={search || ''}
+                                    inherit
                                 >
                                     {table}
                                 </Highlight>


### PR DESCRIPTION
## What changed

- Migrate all 8 Mantine 6 `Highlight` imports (9 tags) to Mantine 8.
- Set four custom option renderers to `fz="sm"` after their prop spreads.
- Add `inherit` to four inline `component="span"` highlights.
- Preserve the existing Metrics Catalog typography contract.

## Why

Mantine 8 Highlight composes v8 Text, which defaults to `md`. Without explicit typography, option rows and nested inline highlights silently grow or override their surrounding text context.

## Stack

- Stacked on #25460
- Base: `joaoviana/mantine8-anchor-migration`

## Validation

- Frontend typecheck
- Frontend format
- Frontend lint (three unrelated existing warnings)
- Full frontend suite: 120 files / 981 tests
- Zero Mantine 6 `Highlight` imports
- Four inherited spans / five explicitly sized tags
- Four option spreads verified before explicit typography

## Visual QA

- Project Tables included/excluded model options
- Filter and Metrics Catalog autocomplete options
- SQL Runner table/field search
- Explore tree search
- Metrics Catalog column names
