### PR TITLE
refactor(frontend): migrate Badge to Mantine 8

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -34,9 +34,16 @@ import {
     type SavedChart,
     type Series,
 } from '@lightdash/common';
-import { ActionIcon, Box, Group, Menu, Stack, Text } from '@mantine-8/core';
 import {
+    ActionIcon,
+    Box,
+    Group,
+    Menu,
+    Stack,
+    Text,
     Badge,
+} from '@mantine-8/core';
+import {
     HoverCard,
     Portal,
     Tooltip,

--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
@@ -4,8 +4,8 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Flex, Group, type FlexProps } from '@mantine-8/core';
-import { Badge, Tooltip, useMantineTheme } from '@mantine/core';
+import { Flex, Group, type FlexProps, Badge } from '@mantine-8/core';
+import { Tooltip, useMantineTheme } from '@mantine/core';
 import { IconArrowDown, IconArrowUp } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import { useMemo } from 'react';
@@ -104,6 +104,7 @@ export const ChartDataTable = ({
                                                     {columnsConfig?.[header.id]
                                                         ?.aggregation && (
                                                         <Badge
+                                                            variant="light"
                                                             size="sm"
                                                             color="indigo"
                                                             radius="xs"

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -5,8 +5,8 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Flex, Group, Menu, type FlexProps } from '@mantine-8/core';
-import { Badge, useMantineTheme } from '@mantine/core';
+import { Flex, Group, Menu, type FlexProps, Badge } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { IconArrowDown, IconArrowUp, IconCopy } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -136,6 +136,7 @@ export const Table = <T extends IResultsRunner>({
                                             {columnsConfig[header.id]
                                                 ?.aggregation && (
                                                 <Badge
+                                                    variant="light"
                                                     size="sm"
                                                     color="indigo"
                                                     radius="xs"

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -1,6 +1,6 @@
 import { hasIntersection } from '@lightdash/common';
-import { Group, Text, Highlight } from '@mantine-8/core';
-import { Badge, HoverCard, NavLink } from '@mantine/core';
+import { Group, Text, Highlight, Badge } from '@mantine-8/core';
+import { HoverCard, NavLink } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import intersectionBy from 'lodash/intersectionBy';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -155,7 +155,7 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
             label={
                 <Group>
                     {!isOpen && hasSelectedChildren && (
-                        <Badge>{selectedChildrenCount}</Badge>
+                        <Badge variant="light">{selectedChildrenCount}</Badge>
                     )}
                     <HoverCard
                         openDelay={300}

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -1,6 +1,14 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { Flex, Group, Paper, Text, Button, ActionIcon } from '@mantine-8/core';
-import { Badge, ColorSwatch, Menu, Tooltip } from '@mantine/core';
+import {
+    Flex,
+    Group,
+    Paper,
+    Text,
+    Button,
+    ActionIcon,
+    Badge,
+} from '@mantine-8/core';
+import { ColorSwatch, Menu, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconDotsVertical,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
@@ -1,6 +1,6 @@
 import type { EchartsGrid, EchartsLegend } from '@lightdash/common';
-import { Center, Flex } from '@mantine-8/core';
-import { Badge, SimpleGrid } from '@mantine/core';
+import { Center, Flex, Badge } from '@mantine-8/core';
+import { SimpleGrid } from '@mantine/core';
 import { type FC } from 'react';
 import UnitInput from '../../../common/UnitInput';
 
@@ -94,7 +94,13 @@ export const UnitInputsGrid: FC<Props> = ({
             </Flex>
 
             <Center px="xs" py="one">
-                <Badge color="blue" radius={'xs'} fullWidth h="100%">
+                <Badge
+                    variant="light"
+                    color="blue"
+                    radius={'xs'}
+                    fullWidth
+                    h="100%"
+                >
                     {centerLabel}
                 </Badge>
             </Center>

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
@@ -1,6 +1,6 @@
 import type { CatalogItem } from '@lightdash/common';
-import { Group, ActionIcon } from '@mantine-8/core';
-import { Badge, Tooltip } from '@mantine/core';
+import { Group, ActionIcon, Badge } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { IconCode, IconX } from '@tabler/icons-react';
 import type { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -31,8 +31,9 @@ import {
     Button,
     ActionIcon,
     SegmentedControl,
+    Badge,
 } from '@mantine-8/core';
-import { Badge, Popover, TextInput, Tooltip } from '@mantine/core';
+import { Popover, TextInput, Tooltip } from '@mantine/core';
 import {
     IconEye,
     IconEyeOff,

--- a/packages/frontend/src/features/tableCalculation/components/TemplateViewer/TemplateViewer.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TemplateViewer/TemplateViewer.tsx
@@ -5,8 +5,8 @@ import {
     WindowFunctionType,
     type TableCalculationTemplate,
 } from '@lightdash/common';
-import { Group, Stack, Text } from '@mantine-8/core';
-import { Badge, MultiSelect } from '@mantine/core';
+import { Group, Stack, Text, Badge } from '@mantine-8/core';
+import { MultiSelect } from '@mantine/core';
 import { useCallback, useMemo, type FC } from 'react';
 import { useColumns } from '../../../../hooks/useColumns';
 import { selectDimensions, useExplorerSelector } from '../../../explorer/store';


### PR DESCRIPTION
## What changed

- Migrate all 9 Mantine 6 `Badge` imports (11 tags) to Mantine 8.
- Preserve four legacy implicit badges with explicit `variant="light"`.
- Keep six existing variants and the Metrics total custom `bg`/`c` palette unchanged.
- Retain Catalog category styles, right section, and interactions.

## Why

Mantine 6 Badge defaulted to `light`; Mantine 8 falls back to a filled primary badge. Explicit variants prevent silent semantic color changes while allowing migrated badges to adopt Lightdash’s v8 radius, casing, and weight theme.

## Stack

- Stacked on #25461
- Base: `joaoviana/mantine8-highlight-migration`

## Validation

- Frontend typecheck
- Frontend format
- Frontend lint (three unrelated existing warnings)
- Full frontend suite: 120 files / 981 tests
- Zero Mantine 6 `Badge` imports
- Ten explicit variants / one intentional custom `bg`/`c` exception
- Zero migrated Badge `sx` props

## Visual QA

- Dashboard conditional-format badges
- Metrics Catalog total and category badges
- Table-calculation template type
- Visualization unit and aggregation badges
- Explore selected-child count
- Appearance override/active states
