### PR TITLE
refactor(frontend): migrate Alert to Mantine 8

### DIFF
--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -5,6 +5,7 @@ import {
     type JobStep,
 } from '@lightdash/common';
 import {
+    Alert,
     Box,
     CopyButton,
     Group,
@@ -14,7 +15,7 @@ import {
     Title,
     ActionIcon,
 } from '@mantine-8/core';
-import { Alert, Drawer, type DefaultMantineColor } from '@mantine/core';
+import { Drawer, type DefaultMantineColor } from '@mantine/core';
 import { useInterval } from '@mantine/hooks';
 import {
     IconAlertTriangle,

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
@@ -1,6 +1,6 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Anchor } from '@mantine-8/core';
-import { Alert, PasswordInput, TextInput } from '@mantine/core';
+import { Alert, Anchor } from '@mantine-8/core';
+import { PasswordInput, TextInput } from '@mantine/core';
 import React, { type FC } from 'react';
 import { useFormContext } from '../formContext';
 import DbtVersionSelect from '../Inputs/DbtVersion';

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -1,12 +1,6 @@
 import { DbtProjectType } from '@lightdash/common';
-import { CopyButton, Stack, ActionIcon, Anchor } from '@mantine-8/core';
-import {
-    Alert,
-    MultiSelect,
-    PasswordInput,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+import { ActionIcon, Alert, Anchor, CopyButton, Stack } from '@mantine-8/core';
+import { MultiSelect, PasswordInput, TextInput, Tooltip } from '@mantine/core';
 import { IconCheck, IconCopy, IconInfoCircle } from '@tabler/icons-react';
 import React, { useCallback, useState, type FC } from 'react';
 import useApp from '../../../providers/App/useApp';

--- a/packages/frontend/src/components/ProjectConnection/Inputs/StartOfWeekSelect.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/StartOfWeekSelect.tsx
@@ -1,5 +1,5 @@
-import { Text } from '@mantine-8/core';
-import { Alert, Select } from '@mantine/core';
+import { Alert, Text } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { ProjectType } from '@lightdash/common';
-import { Stack, Text } from '@mantine-8/core';
-import { Alert, SimpleGrid } from '@mantine/core';
+import { Alert, Stack, Text } from '@mantine-8/core';
+import { SimpleGrid } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';

--- a/packages/frontend/src/components/ProjectConnection/ProjectStatusCallout.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectStatusCallout.tsx
@@ -1,6 +1,5 @@
 import { type ApiError } from '@lightdash/common';
-import { Loader } from '@mantine-8/core';
-import { Alert, type AlertProps } from '@mantine/core';
+import { Alert, Loader, type AlertProps } from '@mantine-8/core';
 import {
     IconAlertTriangleFilled,
     IconCircleCheckFilled,
@@ -32,7 +31,7 @@ const ProjectStatusCallout: FC<ProjectStatusCalloutProps> = ({
             title: 'Updating project settings...',
             icon: <Loader size="lg" />,
             children: undefined,
-            styles: { title: { marginBottom: 0 } },
+            styles: { body: { gap: 0 } },
         };
     } else if (isSuccess) {
         stateProps = {
@@ -40,7 +39,7 @@ const ProjectStatusCallout: FC<ProjectStatusCalloutProps> = ({
             title: 'Project settings updated!',
             icon: <MantineIcon icon={IconCircleCheckFilled} size="lg" />,
             children: undefined,
-            styles: { title: { marginBottom: 0 } },
+            styles: { body: { gap: 0 } },
         };
     } else if (isError) {
         stateProps = {
@@ -59,7 +58,7 @@ const ProjectStatusCallout: FC<ProjectStatusCalloutProps> = ({
                     }}
                 />
             ) : null,
-            styles: error ? { title: { marginBottom: 0 } } : undefined,
+            styles: error ? { body: { gap: 0 } } : undefined,
         };
     } else {
         stateProps = {
@@ -67,7 +66,7 @@ const ProjectStatusCallout: FC<ProjectStatusCalloutProps> = ({
             title: 'Updating project settings...',
             icon: <Loader size="lg" />,
             children: undefined,
-            styles: { title: { marginBottom: 0 } },
+            styles: { body: { gap: 0 } },
         };
     }
 

--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -6,8 +6,8 @@ import {
     type CreateWarehouseCredentials,
     type Project,
 } from '@lightdash/common';
-import { Box, Button, Flex, Anchor } from '@mantine-8/core';
-import { Alert, Card } from '@mantine/core';
+import { Alert, Anchor, Box, Button, Flex } from '@mantine-8/core';
+import { Card } from '@mantine/core';
 import { IconExclamationCircle, IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -1,4 +1,5 @@
 import {
+    Alert,
     Box,
     Flex,
     Group,
@@ -8,7 +9,7 @@ import {
     Title,
     Button,
 } from '@mantine-8/core';
-import { Alert, Avatar, Tooltip } from '@mantine/core';
+import { Avatar, Tooltip } from '@mantine/core';
 import {
     IconAlertCircle,
     IconClock,

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -1,4 +1,5 @@
 import {
+    Alert,
     Box,
     Flex,
     Group,
@@ -8,7 +9,7 @@ import {
     Title,
     Button,
 } from '@mantine-8/core';
-import { Alert, Avatar } from '@mantine/core';
+import { Avatar } from '@mantine/core';
 import { IconAlertCircle, IconRefresh, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import gitlabIcon from '../../../svgs/gitlab-icon.svg';

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -5,8 +5,16 @@ import {
     type CompiledDimension,
     type MetricExplorerQuery,
 } from '@lightdash/common';
-import { Box, Group, Loader, Stack, Text, Button } from '@mantine-8/core';
-import { Alert, Select, Tooltip } from '@mantine/core';
+import {
+    Alert,
+    Box,
+    Button,
+    Group,
+    Loader,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { Select, Tooltip } from '@mantine/core';
 import { IconInfoCircle, IconX } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useMemo, type FC } from 'react';
@@ -120,11 +128,9 @@ export const MetricExploreSegmentationPicker: FC<Props> = ({
                     px="sm"
                     variant="light"
                     color="blue"
-                    sx={(theme) => ({
-                        borderStyle: 'dashed',
-                        borderWidth: 1,
-                        borderColor: theme.colors.blue[4],
-                    })}
+                    style={{
+                        border: '1px dashed var(--mantine-color-blue-4)',
+                    }}
                     styles={{
                         icon: {
                             marginRight: 2,

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -2,8 +2,8 @@ import type {
     ApiError,
     GeneratedFormulaTableCalculation,
 } from '@lightdash/common';
-import { Box, Button, Flex, Text, Anchor } from '@mantine-8/core';
-import { Alert, ScrollArea, useMantineTheme } from '@mantine/core';
+import { Alert, Anchor, Box, Button, Flex, Text } from '@mantine-8/core';
+import { ScrollArea, useMantineTheme } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { IconAlertCircle, IconSparkles, IconWand } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
@@ -237,13 +237,8 @@ export const SqlForm: FC<Props> = ({
                             wrapper: {
                                 alignItems: 'center',
                             },
-                            title: {
-                                marginBottom: 0,
-                            },
                         }}
-                    >
-                        <></>
-                    </Alert>
+                    />
                 ) : (
                     <AiSlot
                         icon={slotIcon}


### PR DESCRIPTION
## Summary
- migrate remaining Alert and AlertProps imports to Mantine 8
- preserve compact status/template layouts under the v8 body gap model
- convert the filtered-series dashed border from sx to v8 style/CSS variables

## Tests
- pnpm -F frontend typecheck:fast
- pnpm -F frontend linter (changed files)
- pnpm -F frontend test (120 files, 981 tests)

Stacked on #25462.