### PR TITLE
refactor(frontend): migrate CloseButton to Mantine 8

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/Inputs/CertificateFileInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/CertificateFileInput.tsx
@@ -1,4 +1,5 @@
-import { CloseButton, FileInput } from '@mantine/core';
+import { CloseButton } from '@mantine-8/core';
+import { FileInput } from '@mantine/core';
 import React, { useState, type FC } from 'react';
 import { useFormContext } from '../formContext';
 
@@ -67,6 +68,8 @@ const CertificateFileInput: FC<
                 rightSection={
                     (temporaryFile || fileNamePlaceholder) && (
                         <CloseButton
+                            aria-label="Remove certificate file"
+                            size="sm"
                             variant="transparent"
                             onClick={() => {
                                 setTemporaryFile(null);

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -11,13 +11,14 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import {
+    ActionIcon,
+    CloseButton,
     Group,
     NumberInput,
-    Stack,
-    ActionIcon,
     SegmentedControl,
+    Stack,
 } from '@mantine-8/core';
-import { CloseButton, TextInput, Tooltip } from '@mantine/core';
+import { TextInput, Tooltip } from '@mantine/core';
 import { IconRotate360 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { EMPTY_X_AXIS } from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
@@ -260,6 +261,8 @@ export const Layout: FC<Props> = ({ items }) => {
                             onChange={handleOnChangeOfXAxisField}
                             rightSection={
                                 <CloseButton
+                                    aria-label="Clear x-axis field"
+                                    size="xs"
                                     onClick={() => {
                                         setXField(EMPTY_X_AXIS);
                                     }}
@@ -308,6 +311,8 @@ export const Layout: FC<Props> = ({ items }) => {
                                 rightSection={
                                     yFields?.length !== 1 && (
                                         <CloseButton
+                                            aria-label="Remove y-axis field"
+                                            size="xs"
                                             onClick={() => {
                                                 removeSingleSeries(index);
                                             }}
@@ -375,6 +380,8 @@ export const Layout: FC<Props> = ({ items }) => {
                                             value={pivotKey}
                                             rightSection={
                                                 <CloseButton
+                                                    aria-label="Remove pivot dimension"
+                                                    size="xs"
                                                     onClick={() => {
                                                         setPivotDimensions(
                                                             pivotDimensions.filter(
@@ -419,6 +426,8 @@ export const Layout: FC<Props> = ({ items }) => {
                                             rightSection={
                                                 groupSelectedField && (
                                                     <CloseButton
+                                                        aria-label="Remove pivot dimension"
+                                                        size="xs"
                                                         onClick={() => {
                                                             setPivotDimensions(
                                                                 pivotDimensions.filter(

--- a/packages/frontend/src/components/common/TagInput/DefaultValue/DefaultValue.tsx
+++ b/packages/frontend/src/components/common/TagInput/DefaultValue/DefaultValue.tsx
@@ -1,5 +1,5 @@
+import { CloseButton } from '@mantine-8/core';
 import {
-    CloseButton,
     type DefaultProps,
     type MantineNumberSize,
     type MantineSize,
@@ -60,7 +60,7 @@ export function DefaultValue({
                     onMouseDown={onRemove}
                     size={buttonSizes[size]}
                     radius={2}
-                    color="blue"
+                    c="blue"
                     variant="transparent"
                     iconSize="70%"
                     className={classes.defaultValueRemove}


### PR DESCRIPTION
## Summary
- migrate remaining CloseButton imports to Mantine 8
- preserve v6/provider-owned control sizes explicitly
- add accessible labels to five interactive close controls
- keep TagInput custom geometry and mouse-down behavior

## Tests
- pnpm -F frontend typecheck:fast
- pnpm -F frontend linter (changed files)
- pnpm -F frontend test (120 files, 981 tests)

Stacked on #25463.