### PR TITLE
refactor(frontend): migrate UnstyledButton to Mantine 8

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -5,16 +5,11 @@ import {
     Group,
     Stack,
     Text,
+    UnstyledButton,
     Button,
     ActionIcon,
 } from '@mantine-8/core';
-import {
-    Popover,
-    SimpleGrid,
-    TextInput,
-    Tooltip,
-    UnstyledButton,
-} from '@mantine/core';
+import { Popover, SimpleGrid, TextInput, Tooltip } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import { IconCode, IconDots, IconTrash } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -1,6 +1,13 @@
 import { type CatalogField, type Tag } from '@lightdash/common';
-import { Box, Group, Stack, Text, Button } from '@mantine-8/core';
-import { Popover, UnstyledButton, useMantineTheme } from '@mantine/core';
+import {
+    Box,
+    Button,
+    Group,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { Popover, useMantineTheme } from '@mantine/core';
 import differenceBy from 'lodash/differenceBy';
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';
@@ -253,7 +260,12 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                 closeOnClickOutside={!hasOpenSubPopover} // Prevent closing when sub-popover is open
             >
                 <Popover.Target>
-                    <UnstyledButton w="100%" pos="absolute" />
+                    <UnstyledButton
+                        aria-label="Edit metric categories"
+                        aria-expanded={opened}
+                        w="100%"
+                        pos="absolute"
+                    />
                 </Popover.Target>
                 <Popover.Dropdown p={0}>
                     <Stack px="sm" pt="sm" gap="xs">

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.module.css
@@ -21,3 +21,16 @@
     border-radius: var(--mantine-radius-md);
     box-shadow: var(--mantine-shadow-subtle);
 }
+
+.presetButton {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    border-radius: var(--mantine-radius-sm);
+    color: var(--mantine-color-ldGray-7);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+}
+
+.presetButton:hover,
+.presetButton[data-selected] {
+    background-color: var(--mantine-color-ldGray-0);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -10,10 +10,11 @@ import {
     Group,
     Stack,
     Text,
+    UnstyledButton,
     Button,
     SegmentedControl,
 } from '@mantine-8/core';
-import { Popover, TextInput, Tooltip, UnstyledButton } from '@mantine/core';
+import { Popover, TextInput, Tooltip } from '@mantine/core';
 import { DatePicker, MonthPicker, YearPicker } from '@mantine/dates';
 import { useCallback, useEffect, useRef, type FC } from 'react';
 import useTracking from '../../../../providers/Tracking/useTracking';
@@ -229,22 +230,11 @@ export const MetricExploreDatePicker: FC<Props> = ({
                             <UnstyledButton
                                 key={preset.label}
                                 onClick={() => handlePresetSelect(preset)}
-                                sx={(theme) => ({
-                                    fontWeight: 500,
-                                    fontSize: theme.fontSizes.xs,
-                                    color: theme.colors.ldGray[7],
-                                    padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
-                                    borderRadius: theme.radius.sm,
-                                    backgroundColor:
-                                        tempSelectedPreset?.label ===
-                                        preset.label
-                                            ? theme.colors.ldGray[0]
-                                            : 'transparent',
-
-                                    '&:hover': {
-                                        backgroundColor: theme.colors.ldGray[0],
-                                    },
-                                })}
+                                data-selected={
+                                    tempSelectedPreset?.label ===
+                                        preset.label || undefined
+                                }
+                                className={styles.presetButton}
                             >
                                 {preset.label}
                             </UnstyledButton>

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.module.css
@@ -1,0 +1,7 @@
+.historyItem {
+    padding: var(--mantine-spacing-xs);
+}
+
+.historyItem:hover {
+    background-color: var(--mantine-color-ldGray-0);
+}

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
@@ -1,11 +1,11 @@
-import { Group, Stack, Text, ActionIcon } from '@mantine-8/core';
 import {
-    HoverCard,
-    Popover,
-    Tooltip,
+    ActionIcon,
+    Group,
+    Stack,
+    Text,
     UnstyledButton,
-    useMantineTheme,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { HoverCard, Popover, Tooltip, useMantineTheme } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { Editor } from '@monaco-editor/react';
 import {
@@ -19,6 +19,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setSql } from '../store/sqlRunnerSlice';
+import styles from './SqlQueryHistory.module.css';
 
 type Props = {
     sql: string;
@@ -45,12 +46,7 @@ const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
                     <UnstyledButton
                         data-testid="sql-query-history-item"
                         ref={hoverRef}
-                        sx={(theme) => ({
-                            padding: theme.spacing.xs,
-                            '&:hover': {
-                                backgroundColor: theme.colors.ldGray[0],
-                            },
-                        })}
+                        className={styles.historyItem}
                         onClick={() => {
                             dispatch(setSql(sql));
                         }}

--- a/packages/frontend/src/features/sqlRunner/components/Tables.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.module.css
@@ -1,0 +1,25 @@
+.tableButton {
+    border-radius: var(--mantine-radius-sm);
+    color: var(--mantine-color-ldGray-7);
+}
+
+.tableButton:hover {
+    background-color: var(--mantine-color-ldGray-2);
+}
+
+.tableButton[data-active] {
+    color: var(--mantine-color-ldGray-8);
+    background-color: var(--mantine-color-ldGray-1);
+}
+
+.tableButton[data-active]:hover {
+    background-color: var(--mantine-color-ldGray-3);
+}
+
+.schemaButton {
+    border-radius: var(--mantine-radius-md);
+}
+
+.schemaButton:hover {
+    background-color: var(--mantine-color-ldGray-1);
+}

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -8,10 +8,11 @@ import {
     Stack,
     type BoxProps,
     Text,
+    UnstyledButton,
     ActionIcon,
     Highlight,
 } from '@mantine-8/core';
-import { ScrollArea, TextInput, Tooltip, UnstyledButton } from '@mantine/core';
+import { ScrollArea, TextInput, Tooltip } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
 import {
     IconChevronDown,
@@ -29,6 +30,7 @@ import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import { useTables, type TablesBySchema } from '../hooks/useTables';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setSql, toggleActiveTable } from '../store/sqlRunnerSlice';
+import styles from './Tables.module.css';
 
 const limitTableResults = 100;
 
@@ -95,20 +97,10 @@ const TableItem: FC<TableItemProps> = memo(
                     }}
                     w="100%"
                     p={4}
-                    sx={(theme) => ({
-                        fontSize: 14,
-                        borderRadius: theme.radius.sm,
-                        color: isActive ? 'ldGray.8' : 'ldGray.7',
-                        flex: 1,
-                        background: isActive
-                            ? theme.colors.ldGray[1]
-                            : 'transparent',
-                        '&:hover': {
-                            background: isActive
-                                ? theme.colors.ldGray[3]
-                                : theme.colors.ldGray[2],
-                        },
-                    })}
+                    flex={1}
+                    fz="sm"
+                    data-active={isActive || undefined}
+                    className={styles.tableButton}
                 >
                     <Tooltip
                         withinPortal
@@ -218,12 +210,7 @@ const Table: FC<{
         <Stack gap={0}>
             <UnstyledButton
                 onClick={() => setIsExpanded(!isExpanded)}
-                sx={(theme) => ({
-                    borderRadius: theme.radius.md,
-                    '&:hover': {
-                        background: theme.colors.ldGray[1],
-                    },
-                })}
+                className={styles.schemaButton}
             >
                 <Group wrap="nowrap" gap="two">
                     <Text p={6} fz="sm" c="ldGray.8">


### PR DESCRIPTION
## Summary
- migrate remaining UnstyledButton imports to Mantine 8
- replace four selector-bearing sx styles with CSS Modules
- preserve active/selected states through data attributes
- label the empty metric-category popover target accessibly

## Tests
- pnpm -F frontend typecheck:fast
- pnpm -F frontend linter (changed files)
- pnpm -F frontend test (120 files, 981 tests)

Stacked on #25464.