### PR TITLE
refactor(frontend): migrate FileInput and NavLink to Mantine 8

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -1,6 +1,6 @@
 import { hasIntersection } from '@lightdash/common';
-import { Group, Text, Highlight, Badge } from '@mantine-8/core';
-import { HoverCard, NavLink } from '@mantine/core';
+import { Badge, Group, Highlight, NavLink, Text } from '@mantine-8/core';
+import { HoverCard } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import intersectionBy from 'lodash/intersectionBy';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -94,6 +94,15 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
         () => onToggleGroup(groupKey),
         [onToggleGroup, groupKey],
     );
+    const handleKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLElement>) => {
+            if (event.nativeEvent.code === 'Space') {
+                event.preventDefault();
+                handleToggleOpen();
+            }
+        },
+        [handleToggleOpen],
+    );
     const handleMouseEnter = useCallback(
         () => toggleHover(true),
         [toggleHover],
@@ -141,13 +150,15 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
 
     return (
         <NavLink
+            component="button"
             opened={isNavLinkOpen}
             onClick={handleToggleOpen}
+            onKeyDown={handleKeyDown}
             // --start moves chevron to the left
             // mostly hardcoded, to match mantine's internal sizes
             disableRightSectionRotation
             rightSection={<></>}
-            icon={icon}
+            leftSection={icon}
             // --end moves chevron to the left
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
@@ -171,7 +182,11 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
                         offset={80}
                     >
                         <HoverCard.Target>
-                            <Text truncate fz="sm">
+                            <Text
+                                truncate
+                                fz="sm"
+                                ff="var(--mantine-font-family)"
+                            >
                                 <Highlight
                                     component="span"
                                     highlight={searchQuery || ''}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.module.css
@@ -1,0 +1,7 @@
+.root[data-selected] {
+    background-color: var(--tree-node-bg);
+}
+
+.root:hover {
+    background-color: var(--tree-node-hover-bg);
+}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -17,8 +17,8 @@ import {
     type FilterableField,
     type Item,
 } from '@lightdash/common';
-import { Group, Text, ActionIcon, Highlight } from '@mantine-8/core';
-import { HoverCard, NavLink, Tooltip } from '@mantine/core';
+import { ActionIcon, Group, Highlight, NavLink, Text } from '@mantine-8/core';
+import { HoverCard, Tooltip } from '@mantine/core';
 import {
     IconAlertTriangle,
     IconCalendarPin,
@@ -51,6 +51,7 @@ import FieldIcon from '../../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../../common/MantineIcon';
 import { ItemDetailPreview } from '../ItemDetailPreview';
 import { MAX_GROUP_DEPTH } from './constants';
+import styles from './TreeSingleNode.module.css';
 import TreeSingleNodeActions from './TreeSingleNodeActions';
 import { type Node } from './types';
 import useTableTree from './useTableTree';
@@ -340,15 +341,6 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
         toggleMenu();
     }, [toggleHover, toggleMenu]);
 
-    const navLinkSx = useMemo(
-        () => ({
-            backgroundColor: isSelected ? itemColors.bg : undefined,
-            '&:hover': {
-                backgroundColor: itemColors.bgHover,
-            },
-        }),
-        [isSelected, itemColors],
-    );
     const icon = useMemo(
         () => <NavItemIcon isMissing={isMissing} item={item} />,
         [isMissing, item],
@@ -414,8 +406,15 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
         <NavLink
             component="div"
             noWrap
-            sx={navLinkSx}
-            icon={icon}
+            data-selected={isSelected || undefined}
+            className={styles.root}
+            style={
+                {
+                    '--tree-node-bg': itemColors.bg,
+                    '--tree-node-hover-bg': itemColors.bgHover,
+                } as React.CSSProperties
+            }
+            leftSection={icon}
             onClick={handleClick}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
@@ -1,5 +1,5 @@
-import { Group, Text } from '@mantine-8/core';
-import { NavLink, useMantineTheme } from '@mantine/core';
+import { Group, NavLink, Text } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { TableItemDetailPreview } from '../ItemDetailPreview';
@@ -47,6 +47,15 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
         () => toggleHover(false),
         [toggleHover],
     );
+    const handleKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLElement>) => {
+            if (event.nativeEvent.code === 'Space') {
+                event.preventDefault();
+                onToggle();
+            }
+        },
+        [onToggle],
+    );
 
     const stickyStyle = useMemo(
         () => ({
@@ -84,8 +93,10 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
 
     return (
         <NavLink
+            component="button"
             opened={isExpanded}
             onClick={onToggle}
+            onKeyDown={handleKeyDown}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             label={label}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.module.css
@@ -3,6 +3,18 @@
     overflow: auto;
 }
 
+/* The virtualizer allocates 32px per tree row. Keep v8 NavLinks inside that
+   contract; the old v6 provider override no longer reaches migrated links. */
+.scrollContainer :global(.mantine-8-NavLink-root) {
+    height: var(--mantine-spacing-xxl);
+    padding-block: 0;
+    flex-grow: 0;
+}
+
+.scrollContainer :global(.mantine-8-NavLink-section[data-position='right']) {
+    margin-inline-start: var(--mantine-spacing-xxs);
+}
+
 /* Breathing room below the last item so a short or fully-scrolled tree reads
    as ended rather than being clipped by the viewport. */
 .scrollContainer::after {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.tsx
@@ -1,4 +1,3 @@
-import { MantineProvider, type MantineTheme } from '@mantine/core';
 import type { Range } from '@tanstack/react-virtual';
 import { defaultRangeExtractor, useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useMemo, useRef, type FC } from 'react';
@@ -12,23 +11,6 @@ interface VirtualizedTreeListProps {
     onToggleGroup: (groupKey: string) => void;
     onSelectedFieldChange: (fieldId: string, isDimension: boolean) => void;
 }
-
-const themeOverride = {
-    components: {
-        NavLink: {
-            styles: (theme: MantineTheme) => ({
-                root: {
-                    height: theme.spacing.xxl,
-                    padding: `0 ${theme.spacing.sm}`,
-                    flexGrow: 0,
-                },
-                rightSection: {
-                    marginLeft: theme.spacing.xxs,
-                },
-            }),
-        },
-    },
-};
 
 /**
  * Virtualized tree list using @tanstack/react-virtual
@@ -102,53 +84,49 @@ const VirtualizedTreeListComponent: FC<VirtualizedTreeListProps> = ({
     const virtualItems = virtualizer.getVirtualItems();
 
     return (
-        <MantineProvider inherit theme={themeOverride}>
+        <div
+            ref={parentRef}
+            data-testid="virtualized-tree-scroll-container"
+            className={classes.scrollContainer}
+        >
             <div
-                ref={parentRef}
-                data-testid="virtualized-tree-scroll-container"
-                className={classes.scrollContainer}
+                className={classes.sizer}
+                style={{ height: `${virtualizer.getTotalSize()}px` }}
             >
-                <div
-                    className={classes.sizer}
-                    style={{ height: `${virtualizer.getTotalSize()}px` }}
-                >
-                    {virtualItems.map((virtualItem) => {
-                        const item = items[virtualItem.index];
-                        const isStickyItem = isSticky(virtualItem.index);
-                        const isActiveStickyItem = isActiveSticky(
-                            virtualItem.index,
-                        );
+                {virtualItems.map((virtualItem) => {
+                    const item = items[virtualItem.index];
+                    const isStickyItem = isSticky(virtualItem.index);
+                    const isActiveStickyItem = isActiveSticky(
+                        virtualItem.index,
+                    );
 
-                        return (
-                            <div
-                                key={item.id}
-                                data-index={virtualItem.index}
-                                data-sticky-header={isStickyItem || undefined}
-                                className={classes.item}
-                                style={
-                                    isActiveStickyItem
-                                        ? { position: 'sticky' }
-                                        : {
-                                              position: 'absolute',
-                                              transform: `translateY(${virtualItem.start}px)`,
-                                          }
-                                }
-                            >
-                                <VirtualTreeItem
-                                    item={item}
-                                    sectionContexts={sectionContexts}
-                                    onToggleTable={onToggleTable}
-                                    onToggleGroup={onToggleGroup}
-                                    onSelectedFieldChange={
-                                        onSelectedFieldChange
-                                    }
-                                />
-                            </div>
-                        );
-                    })}
-                </div>
+                    return (
+                        <div
+                            key={item.id}
+                            data-index={virtualItem.index}
+                            data-sticky-header={isStickyItem || undefined}
+                            className={classes.item}
+                            style={
+                                isActiveStickyItem
+                                    ? { position: 'sticky' }
+                                    : {
+                                          position: 'absolute',
+                                          transform: `translateY(${virtualItem.start}px)`,
+                                      }
+                            }
+                        >
+                            <VirtualTreeItem
+                                item={item}
+                                sectionContexts={sectionContexts}
+                                onToggleTable={onToggleTable}
+                                onToggleGroup={onToggleGroup}
+                                onSelectedFieldChange={onSelectedFieldChange}
+                            />
+                        </div>
+                    );
+                })}
             </div>
-        </MantineProvider>
+        </div>
     );
 };
 

--- a/packages/frontend/src/components/ProjectConnection/Inputs/CertificateFileInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/CertificateFileInput.tsx
@@ -1,5 +1,4 @@
-import { CloseButton } from '@mantine-8/core';
-import { FileInput } from '@mantine/core';
+import { CloseButton, FileInput } from '@mantine-8/core';
 import React, { useState, type FC } from 'react';
 import { useFormContext } from '../formContext';
 
@@ -39,8 +38,6 @@ const CertificateFileInput: FC<
 
             <FileInput
                 label={label}
-                // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
-                // @ts-ignore
                 placeholder={fileNamePlaceholder || 'Choose file...'}
                 description={description}
                 {...fileField}
@@ -65,13 +62,15 @@ const CertificateFileInput: FC<
                     fileNamefield.onChange(null);
                 }}
                 disabled={disabled}
+                rightSectionPointerEvents="all"
                 rightSection={
                     (temporaryFile || fileNamePlaceholder) && (
                         <CloseButton
                             aria-label="Remove certificate file"
                             size="sm"
                             variant="transparent"
-                            onClick={() => {
+                            onClick={(event) => {
+                                event.stopPropagation();
                                 setTemporaryFile(null);
                                 form.setFieldValue(name, null);
                                 form.setFieldValue(fileNameProperty, '');

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,9 +1,16 @@
 import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Group, Loader, Stack, Text, Button, Anchor } from '@mantine-8/core';
+import {
+    Anchor,
+    Button,
+    FileInput,
+    Group,
+    Loader,
+    Stack,
+    Text,
+} from '@mantine-8/core';
 import type { SelectItem } from '@mantine/core';
 import {
     Autocomplete,
-    FileInput,
     Image,
     NumberInput,
     Select,
@@ -405,8 +412,6 @@ const BigQueryForm: FC<{
                                 },
                             )}
                             label="Key File"
-                            // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
-                            // @ts-ignore
                             placeholder={
                                 !requireSecrets
                                     ? '**************'

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -1,7 +1,6 @@
 import { SnowflakeAuthenticationType, WarehouseTypes } from '@lightdash/common';
-import { Group, Stack, Text, Button, Anchor } from '@mantine-8/core';
+import { Anchor, Button, FileInput, Group, Stack, Text } from '@mantine-8/core';
 import {
-    FileInput,
     NumberInput,
     PasswordInput,
     Radio,
@@ -382,8 +381,6 @@ const SnowflakeForm: FC<{
                                         'warehouse.privateKey',
                                     )}
                                     label="Private Key File"
-                                    // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
-                                    // @ts-ignore
                                     placeholder={
                                         !requireSecrets
                                             ? '**************'


### PR DESCRIPTION
## Summary
- migrate remaining FileInput and NavLink imports to Mantine 8
- preserve controlled upload, parsing, and certificate clear behavior
- preserve Explore tree button/div semantics and controlled Space toggles
- move field-type selected/hover backgrounds to CSS variables and a CSS Module

## Tests
- pnpm -F frontend typecheck:fast
- pnpm -F frontend linter (changed files)
- pnpm -F frontend test (120 files, 981 tests)

Stacked on #25465.