### PR TITLE
refactor(frontend): migrate Autocomplete to Mantine 8

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,6 +1,12 @@
-import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
+import {
+    BigqueryAuthenticationType,
+    WarehouseTypes,
+    type BigqueryDataset,
+    type BigqueryProject,
+} from '@lightdash/common';
 import {
     Anchor,
+    Autocomplete,
     Button,
     FileInput,
     Group,
@@ -10,7 +16,6 @@ import {
 } from '@mantine-8/core';
 import type { SelectItem } from '@mantine/core';
 import {
-    Autocomplete,
     Image,
     NumberInput,
     Select,
@@ -38,6 +43,22 @@ import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { useProjectFormContext } from '../useProjectFormContext';
 import classes from './BigQueryForm.module.css';
 import { BigQueryDefaultValues } from './defaultValues';
+
+const MOCK_BIGQUERY_PROJECTS: BigqueryProject[] = [
+    { projectId: 'acme-analytics-prod', friendlyName: 'Acme Analytics' },
+    { projectId: 'lightdash-demo', friendlyName: 'Lightdash Demo' },
+    { projectId: 'marketing-attribution', friendlyName: 'Marketing' },
+    { projectId: 'finance-reporting', friendlyName: 'Finance Reporting' },
+    { projectId: 'product-events', friendlyName: 'Product Events' },
+    { projectId: 'sandbox-project-id', friendlyName: null },
+    { projectId: 'seventh-project', friendlyName: 'Seventh Project' },
+];
+
+const isBigQuerySsoMockEnabled = () =>
+    import.meta.env.DEV &&
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('mockBigQuerySso') ===
+        'true';
 
 export const BigQuerySchemaInput: FC<{
     disabled: boolean;
@@ -116,7 +137,6 @@ const BigQueryForm: FC<{
         error: bigqueryAuthError,
         refetch: refetchAuth,
     } = useIsBigQueryAuthenticated();
-    const isAuthenticated = data !== undefined && bigqueryAuthError === null;
     const form = useFormContext();
     const project = form.getInputProps('warehouse.project');
     const [debouncedProject] = useDebouncedValue(project.value, 300);
@@ -129,16 +149,41 @@ const BigQueryForm: FC<{
         form.values.warehouse?.type === WarehouseTypes.BIGQUERY &&
         form.values.warehouse?.authenticationType ===
             BigqueryAuthenticationType.SSO;
+    const useMockBigQuerySso = isBigQuerySsoMockEnabled();
+    const isAuthenticated =
+        useMockBigQuerySso ||
+        (data !== undefined && bigqueryAuthError === null);
     const {
-        data: datasets,
+        data: queriedDatasets,
         refetch: refetchDatasets,
-        error: datasetsError,
-    } = useBigqueryDatasets(isAuthenticated && isSso, debouncedProject);
+        error: queriedDatasetsError,
+    } = useBigqueryDatasets(
+        !useMockBigQuerySso && isAuthenticated && isSso,
+        debouncedProject,
+    );
     const {
-        data: gcpProjects,
-        isLoading: isLoadingProjects,
-        error: projectsError,
-    } = useBigqueryProjects(isAuthenticated && isSso);
+        data: queriedGcpProjects,
+        isLoading: isLoadingQueriedProjects,
+        error: queriedProjectsError,
+    } = useBigqueryProjects(!useMockBigQuerySso && isAuthenticated && isSso);
+    const mockDatasets: BigqueryDataset[] = debouncedProject
+        ? [
+              {
+                  projectId: debouncedProject,
+                  datasetId: 'mock_analytics',
+                  location: 'EU',
+              },
+          ]
+        : [];
+    const datasets = useMockBigQuerySso ? mockDatasets : queriedDatasets;
+    const datasetsError = useMockBigQuerySso ? null : queriedDatasetsError;
+    const gcpProjects = useMockBigQuerySso
+        ? MOCK_BIGQUERY_PROJECTS
+        : queriedGcpProjects;
+    const isLoadingProjects = useMockBigQuerySso
+        ? false
+        : isLoadingQueriedProjects;
+    const projectsError = useMockBigQuerySso ? null : queriedProjectsError;
     const [isOpen, toggleOpen] = useToggle(false);
     const [temporaryFile, setTemporaryFile] = useState<File | null>(null);
     const { savedProject } = useProjectFormContext();
@@ -272,13 +317,20 @@ const BigQueryForm: FC<{
                             disabled={disabled}
                             labelProps={{ style: { marginTop: '8px' } }}
                             w={hasDatasets ? '90%' : '100%'}
-                            data={
-                                gcpProjects?.map((p) => ({
-                                    value: p.projectId,
-                                    label: p.friendlyName
-                                        ? `${p.friendlyName} (${p.projectId})`
-                                        : p.projectId,
-                                })) ?? []
+                            data={gcpProjects?.map((p) => p.projectId) ?? []}
+                            limit={5}
+                            renderOption={({ option }) => {
+                                const projectOption = gcpProjects?.find(
+                                    (projectItem) =>
+                                        projectItem.projectId === option.value,
+                                );
+
+                                return projectOption?.friendlyName
+                                    ? `${projectOption.friendlyName} (${projectOption.projectId})`
+                                    : option.value;
+                            }}
+                            rightSectionPointerEvents={
+                                projectsError ? 'all' : 'none'
                             }
                             rightSection={
                                 isLoadingProjects ? (


### PR DESCRIPTION
### Description

- migrate the remaining Autocomplete from Mantine 6 to Mantine 8
- preserve the canonical GCP project ID as the controlled form value
- render friendly project names only in dropdown options
- preserve the Mantine 6 five-result limit
- keep error-tooltip pointer events while leaving the loading indicator decorative
- add a development-only `?mockBigQuerySso=true` fixture path for repeatable local QA

Mantine 8 Autocomplete writes an option label into the controlled value. Using the friendly display string as the label would submit it as `warehouse.project` and break dataset lookup, so options remain project-ID strings and `renderOption` owns presentation.

The mock path bypasses Google authentication and real project/dataset requests only in development. It supplies seven projects covering friendly-name and ID-only cases.

### Validation

- `pnpm -F frontend typecheck:fast`
- targeted oxfmt and oxlint
- full frontend Vitest: 120 files / 981 tests
- browser QA: five-option limit, friendly dropdown label, canonical project ID after selection
