### PR TITLE
fix(frontend): filter invalid SQL chart options

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -34,7 +34,7 @@ import { getChartIcon } from '../../../components/common/ResourceIcon/utils';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import { FilterActions } from './constants';
 import classes from './FilterConfiguration.module.css';
-import { getFilterTileRelation } from './utils';
+import { getFilterTileRelation, getValidSqlColumnReferences } from './utils';
 
 type TileWithTargetFields = {
     key: string;
@@ -239,9 +239,7 @@ const TileFilterConfiguration: FC<Props> = ({
             sqlChartTilesMetadata,
         ).reduce<TileWithTargetColumns[]>(
             (acc, [tileUuid, metadata], index) => {
-                const columns = metadata.columns.map(
-                    ({ reference }) => reference,
-                );
+                const columns = getValidSqlColumnReferences(metadata.columns);
                 const tile = tiles.find((t) => t.uuid === tileUuid);
                 if (!tile) {
                     return acc;

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/utils/index.test.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/utils/index.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import {
     doesFilterApplyToTile,
     getFilterTileRelation,
+    getValidSqlColumnReferences,
     getTabsForFilterRule,
 } from './index';
 
@@ -56,6 +57,20 @@ const createMockFilterableField = (
         fieldType: FieldType.DIMENSION,
         type: DimensionType.STRING,
     }) as FilterableDimension;
+
+describe('getValidSqlColumnReferences', () => {
+    it('drops SQL columns that cannot be represented as Select options', () => {
+        expect(
+            getValidSqlColumnReferences([
+                { reference: 'orders_id' },
+                { reference: undefined },
+                {},
+                { reference: null },
+                { reference: 'orders_total' },
+            ]),
+        ).toEqual(['orders_id', 'orders_total']);
+    });
+});
 
 describe('getFilterTileRelation', () => {
     it('should return "auto" when no tileTargets configuration exists', () => {

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/utils/index.ts
@@ -20,6 +20,13 @@ import isEqual from 'lodash/isEqual';
  */
 export type FilterTileRelation = 'auto' | 'disabled' | 'mapped';
 
+export const getValidSqlColumnReferences = (
+    columns: ReadonlyArray<{ reference?: unknown }>,
+): string[] =>
+    columns.flatMap(({ reference }) =>
+        typeof reference === 'string' ? [reference] : [],
+    );
+
 /**
  * Gets the relationship between a filter and a tile based on tileTargets configuration.
  *


### PR DESCRIPTION
### Description

- Filters invalid SQL chart column references before passing options to Mantine 8 Select.
- Prevents dashboard filter configuration from crashing with `Each option must have value property`.
- Adds regression coverage for missing, null, and non-string references.

### Root cause

SQL chart metadata can contain columns without a valid string `reference`. Mantine 8 validates Select options strictly, while the previous Select accepted these values.

### Validation

- `pnpm -F frontend exec vitest run src/features/dashboardFilters/FilterConfiguration/utils/index.test.ts src/features/dashboardFilters/FilterConfiguration/index.test.tsx`
- `pnpm -F frontend typecheck:fast`
- frontend lint (0 errors; 3 unrelated existing warnings)
