### PR TITLE
feat(cli): remove experimental warning for dbt Cloud CLI

### DIFF
--- a/packages/cli/src/globalState.ts
+++ b/packages/cli/src/globalState.ts
@@ -5,7 +5,6 @@ import * as styles from './styles';
 
 type PromptAnswer = {
     useFallbackDbtVersion?: boolean;
-    useExperimentalDbtCloudCLI?: boolean;
 };
 
 class GlobalState {

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -122,38 +122,6 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
         GlobalState.savePromptAnswer('useFallbackDbtVersion', true);
     }
 
-    if (
-        isDbtCloudCLI(verboseVersion) &&
-        !GlobalState.getSavedPromptAnswer('useExperimentalDbtCloudCLI')
-    ) {
-        const message = `Support for dbt Cloud CLI is still experimental and might not work as expected.`;
-        const spinner = GlobalState.getActiveSpinner();
-        spinner?.stop();
-        if (GlobalState.isNonInteractive()) {
-            console.error(styles.warning(message));
-        } else {
-            const answers = await inquirer.prompt([
-                {
-                    type: 'confirm',
-                    name: 'isConfirm',
-                    message: `${styles.warning(
-                        message,
-                    )}\nDo you still want to continue?`,
-                },
-            ]);
-            if (!answers.isConfirm) {
-                console.error(
-                    styles.error(
-                        `Command using dbt cloud CLI has been canceled. Please consider using dbt core CLI for the best experience.`,
-                    ),
-                );
-                process.exit(1);
-            }
-        }
-        spinner?.start();
-        GlobalState.savePromptAnswer('useExperimentalDbtCloudCLI', true);
-    }
-
     return {
         verboseVersion,
         isDbtCloudCLI: isDbtCloudCLI(verboseVersion),


### PR DESCRIPTION
Removes the interactive "Support for dbt Cloud CLI is still experimental" confirmation prompt that appeared on every CLI command when the dbt Cloud CLI was detected. dbt Cloud support is now stable, and the repeated prompt was annoying interactively and a blocker in CI.

Also drops the now-unused `useExperimentalDbtCloudCLI` saved-prompt-answer field from `GlobalState`.

Existing `getDbtVersion` tests still pass (dbt Cloud version detection is unchanged).