### PR TITLE
feat: add virtual views as code

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -29,6 +29,8 @@ import {
     ApiSqlChartAsCodeUpsertResponse,
     ApiSqlQueryResults,
     ApiSuccessEmpty,
+    ApiVirtualViewAsCodeListResponse,
+    ApiVirtualViewAsCodeUpsertResponse,
     assertRegisteredAccount,
     CalculateTotalFromQuery,
     ChartAsCode,
@@ -51,6 +53,7 @@ import {
     UpdateMetadata,
     UpdateProjectMember,
     UserWarehouseCredentials,
+    VirtualViewAsCode,
     type ApiCalculateSubtotalsResponse,
     type ApiCreateDashboardResponse,
     type ApiCreateDashboardWithChartsResponse,
@@ -1507,6 +1510,64 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                     ids,
                     offset,
                     languageMap,
+                ),
+        };
+    }
+
+    /**
+     * Get virtual views in code representation
+     * @summary List virtual views as code
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/virtualViews/code')
+    @OperationId('getVirtualViewsAsCode')
+    async getVirtualViewsAsCode(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() slugs?: string[],
+    ): Promise<ApiVirtualViewAsCodeListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getCoderService()
+                .getVirtualViews(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    slugs,
+                ),
+        };
+    }
+
+    /**
+     * Upsert a virtual view from code representation
+     * @summary Upsert virtual view as code
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/virtualViews/{slug}/code')
+    @OperationId('upsertVirtualViewAsCode')
+    async upsertVirtualViewAsCode(
+        @Path() projectUuid: string,
+        @Path() slug: string,
+        @Body() virtualView: VirtualViewAsCode,
+        @Request() req: express.Request,
+        @Query() force: boolean = false,
+    ): Promise<ApiVirtualViewAsCodeUpsertResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getCoderService()
+                .upsertVirtualView(
+                    req.account,
+                    projectUuid,
+                    slug,
+                    virtualView,
+                    force,
                 ),
         };
     }

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -598,12 +598,13 @@ export class SqlRunnerController extends BaseController {
         @Body() body: CreateVirtualViewPayload,
     ): Promise<ApiCreateVirtualView> {
         this.setStatus(200);
-        const { name, sql, columns, parameterValues } = body;
+        const { name, label, sql, columns, parameterValues } = body;
 
         const virtualViewName = await this.services
             .getProjectService()
             .createVirtualView(req.account!, projectUuid, {
                 name,
+                label,
                 sql,
                 columns,
                 parameterValues,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15287,17 +15287,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15387,6 +15387,18 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15399,22 +15411,10 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                             },
@@ -15561,6 +15561,21 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -15579,21 +15594,6 @@ const models: TsoaRoute.Models = {
                                                                                                 enums: [
                                                                                                     'success',
                                                                                                 ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
                                                                                             },
                                                                                             {
                                                                                                 dataType:
@@ -15685,17 +15685,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15911,6 +15911,29 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15931,30 +15954,7 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -15965,7 +15965,7 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -16041,6 +16041,18 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16053,22 +16065,10 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                         },
@@ -16261,6 +16261,10 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
+                                                href: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
@@ -16268,17 +16272,13 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 slug: {
                                                     dataType: 'string',
-                                                    required: true,
-                                                },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 uuid: {
@@ -16756,13 +16756,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -16958,17 +16958,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -16987,14 +16987,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
@@ -29595,6 +29595,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 sql: { dataType: 'string', required: true },
+                label: { dataType: 'string' },
                 name: { dataType: 'string', required: true },
             },
             validators: {},
@@ -34192,7 +34193,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34202,7 +34203,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34212,7 +34213,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34225,7 +34226,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -34894,7 +34895,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34904,7 +34905,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34914,7 +34915,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34927,7 +34928,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -34977,6 +34978,133 @@ const models: TsoaRoute.Models = {
                                 dataType: 'refAlias',
                                 ref: 'DashboardAsCode',
                             },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ContentAsCodeType.VIRTUAL_VIEW': {
+        dataType: 'refEnum',
+        enums: ['virtual_view'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VirtualViewAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                parameters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ParametersValuesMap' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                columns: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ResultColumn' },
+                    required: true,
+                },
+                sql: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                slug: { dataType: 'string', required: true },
+                version: { dataType: 'double', required: true },
+                contentType: {
+                    ref: 'ContentAsCodeType.VIRTUAL_VIEW',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VirtualViewAsCodeSkip: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                reason: { dataType: 'string', required: true },
+                slug: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiVirtualViewAsCodeListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        missingSlugs: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                        skipped: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'VirtualViewAsCodeSkip',
+                            },
+                            required: true,
+                        },
+                        virtualViews: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'VirtualViewAsCode',
+                            },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.CREATE': {
+        dataType: 'refEnum',
+        enums: ['create'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.UPDATE': {
+        dataType: 'refEnum',
+        enums: ['update'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.NO_CHANGES': {
+        dataType: 'refEnum',
+        enums: ['no changes'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiVirtualViewAsCodeUpsertResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        action: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'PromotionAction.CREATE' },
+                                { ref: 'PromotionAction.UPDATE' },
+                                { ref: 'PromotionAction.NO_CHANGES' },
+                            ],
                             required: true,
                         },
                     },
@@ -35314,21 +35442,6 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.CREATE': {
-        dataType: 'refEnum',
-        enums: ['create'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.UPDATE': {
-        dataType: 'refEnum',
-        enums: ['update'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.NO_CHANGES': {
-        dataType: 'refEnum',
-        enums: ['no changes'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiScheduledDeliveryAsCodeUpsertResponse: {
@@ -73223,6 +73336,143 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getDashboardsAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_getVirtualViewsAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        slugs: {
+            in: 'query',
+            name: 'slugs',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/virtualViews/code',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getVirtualViewsAsCode,
+        ),
+
+        async function ProjectController_getVirtualViewsAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_getVirtualViewsAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getVirtualViewsAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_upsertVirtualViewAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        slug: { in: 'path', name: 'slug', required: true, dataType: 'string' },
+        virtualView: {
+            in: 'body',
+            name: 'virtualView',
+            required: true,
+            ref: 'VirtualViewAsCode',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        force: {
+            default: false,
+            in: 'query',
+            name: 'force',
+            dataType: 'boolean',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/virtualViews/:slug/code',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.upsertVirtualViewAsCode,
+        ),
+
+        async function ProjectController_upsertVirtualViewAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_upsertVirtualViewAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertVirtualViewAsCode',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16797,10 +16797,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -16809,8 +16809,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -16833,28 +16833,28 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "operator": {
                                                                                         "type": "string"
-                                                                                    },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "required",
+                                                                                    "tableName",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "tableName",
-                                                                                    "operator",
-                                                                                    "required"
+                                                                                    "operator"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -16936,15 +16936,15 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "status": {
                                                                             "type": "string",
                                                                             "enum": [
                                                                                 "error",
                                                                                 "success"
                                                                             ]
-                                                                        },
-                                                                        "error": {
-                                                                            "type": "string"
                                                                         },
                                                                         "results": {
                                                                             "items": {
@@ -16967,10 +16967,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -16979,8 +16979,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -17102,24 +17102,24 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "label": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "name": {
@@ -17131,11 +17131,11 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
                                                                                 "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
+                                                                                "description",
                                                                                 "label",
+                                                                                "fieldId",
+                                                                                "table",
                                                                                 "name"
                                                                             ],
                                                                             "type": "object"
@@ -17156,28 +17156,28 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "operator": {
                                                                                             "type": "string"
-                                                                                        },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
+                                                                                        "required",
+                                                                                        "tableName",
                                                                                         "fieldRef",
                                                                                         "fieldId",
-                                                                                        "tableName",
-                                                                                        "operator",
-                                                                                        "required"
+                                                                                        "operator"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -17317,22 +17317,22 @@
                                                         ],
                                                         "type": "object"
                                                     },
+                                                    "href": {
+                                                        "type": "string"
+                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
                                                     },
-                                                    "href": {
-                                                        "type": "string"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "uuid": {
                                                         "type": "string"
@@ -17343,10 +17343,10 @@
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
-                                                    "slug",
+                                                    "warnings",
                                                     "status",
+                                                    "slug",
                                                     "uuid",
                                                     "name"
                                                 ],
@@ -17508,13 +17508,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -17522,8 +17522,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "status",
+                                                    "slug",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -17584,10 +17584,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17596,8 +17596,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -17607,8 +17607,8 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
@@ -29793,6 +29793,10 @@
                     "sql": {
                         "type": "string"
                     },
+                    "label": {
+                        "type": "string",
+                        "description": "Optional display label. Defaults to a friendly version of name."
+                    },
                     "name": {
                         "type": "string"
                     }
@@ -34640,22 +34644,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -35223,22 +35227,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -35285,6 +35289,145 @@
                             "missingIds",
                             "dashboards"
                         ],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ContentAsCodeType.VIRTUAL_VIEW": {
+                "enum": ["virtual_view"],
+                "type": "string"
+            },
+            "VirtualViewAsCode": {
+                "properties": {
+                    "parameters": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ParametersValuesMap"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "columns": {
+                        "items": {
+                            "$ref": "#/components/schemas/ResultColumn"
+                        },
+                        "type": "array"
+                    },
+                    "sql": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Mutable display label."
+                    },
+                    "slug": {
+                        "type": "string",
+                        "description": "Immutable project-scoped explore name used by downstream content."
+                    },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentAsCodeType.VIRTUAL_VIEW"
+                    }
+                },
+                "required": [
+                    "parameters",
+                    "columns",
+                    "sql",
+                    "name",
+                    "slug",
+                    "version",
+                    "contentType"
+                ],
+                "type": "object"
+            },
+            "VirtualViewAsCodeSkip": {
+                "properties": {
+                    "reason": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    }
+                },
+                "required": ["reason", "slug"],
+                "type": "object"
+            },
+            "ApiVirtualViewAsCodeListResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "missingSlugs": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "skipped": {
+                                "items": {
+                                    "$ref": "#/components/schemas/VirtualViewAsCodeSkip"
+                                },
+                                "type": "array"
+                            },
+                            "virtualViews": {
+                                "items": {
+                                    "$ref": "#/components/schemas/VirtualViewAsCode"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["missingSlugs", "skipped", "virtualViews"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "PromotionAction.CREATE": {
+                "enum": ["create"],
+                "type": "string"
+            },
+            "PromotionAction.UPDATE": {
+                "enum": ["update"],
+                "type": "string"
+            },
+            "PromotionAction.NO_CHANGES": {
+                "enum": ["no changes"],
+                "type": "string"
+            },
+            "ApiVirtualViewAsCodeUpsertResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "action": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.CREATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.UPDATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.NO_CHANGES"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["action"],
                         "type": "object"
                     },
                     "status": {
@@ -35628,18 +35771,6 @@
                 },
                 "required": ["results", "status"],
                 "type": "object"
-            },
-            "PromotionAction.CREATE": {
-                "enum": ["create"],
-                "type": "string"
-            },
-            "PromotionAction.UPDATE": {
-                "enum": ["update"],
-                "type": "string"
-            },
-            "PromotionAction.NO_CHANGES": {
-                "enum": ["no changes"],
-                "type": "string"
             },
             "ApiScheduledDeliveryAsCodeUpsertResponse": {
                 "properties": {
@@ -45774,7 +45905,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3368.0",
+        "version": "0.3371.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -62882,6 +63013,126 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/virtualViews/code": {
+            "get": {
+                "operationId": "getVirtualViewsAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiVirtualViewAsCodeListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get virtual views in code representation",
+                "summary": "List virtual views as code",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "slugs",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/virtualViews/{slug}/code": {
+            "post": {
+                "operationId": "upsertVirtualViewAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiVirtualViewAsCodeUpsertResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Upsert a virtual view from code representation",
+                "summary": "Upsert virtual view as code",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "slug",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "force",
+                        "required": false,
+                        "schema": {
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/VirtualViewAsCode"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/projects/{projectUuid}/scheduledDeliveries/code": {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -58,6 +58,7 @@ import {
     warehouseClientFromCredentials,
 } from '@lightdash/warehouses';
 import { Knex } from 'knex';
+import isEqual from 'lodash/isEqual';
 import NodeCache from 'node-cache';
 import { DatabaseError } from 'pg';
 import { v4 as uuidv4 } from 'uuid';
@@ -1554,6 +1555,10 @@ export class ProjectModel {
             {},
             async () =>
                 this.database.transaction(async (trx) => {
+                    await ProjectModel.lockAndEnsureCachedExplores(
+                        trx,
+                        projectUuid,
+                    );
                     // Get custom explores/virtual views before deleting them
                     const virtualViews = await trx(CachedExploreTableName)
                         .select('explore')
@@ -3606,7 +3611,13 @@ export class ProjectModel {
 
     async createVirtualView(
         projectUuid: string,
-        { name, sql, columns, parameterValues }: CreateVirtualViewPayload,
+        {
+            name,
+            label,
+            sql,
+            columns,
+            parameterValues,
+        }: CreateVirtualViewPayload,
         warehouseClient: WarehouseClient,
     ): Promise<Explore> {
         const virtualView = createVirtualView(
@@ -3614,40 +3625,30 @@ export class ProjectModel {
             sql,
             columns,
             warehouseClient,
-            undefined, // label
+            label,
             parameterValues,
         );
 
-        // insert virtual view into cached_explore
-        await this.database(CachedExploreTableName)
-            .insert({
+        await this.database.transaction(async (trx) => {
+            await ProjectModel.lockAndEnsureCachedExplores(trx, projectUuid);
+            const existing = await trx(CachedExploreTableName)
+                .select('name')
+                .where('project_uuid', projectUuid)
+                .andWhere('name', virtualView.name)
+                .first();
+            if (existing) {
+                throw new AlreadyExistsError(
+                    `Explore "${virtualView.name}" already exists`,
+                );
+            }
+            await trx(CachedExploreTableName).insert({
                 project_uuid: projectUuid,
                 name: virtualView.name,
                 table_names: Object.keys(virtualView.tables || {}),
                 explore: virtualView,
-            })
-            .onConflict(['project_uuid', 'name'])
-            .merge()
-            .returning(['name', 'cached_explore_uuid']);
-
-        // append virtual view to cached_explores
-        await this.database(CachedExploresTableName)
-            .where('project_uuid', projectUuid)
-            .update({
-                explores: this.database.raw(
-                    `
-                CASE
-                    WHEN explores IS NULL THEN ?::jsonb
-                    ELSE explores || ?::jsonb
-                END
-            `,
-                    [
-                        JSON.stringify([virtualView]),
-                        JSON.stringify([virtualView]),
-                    ],
-                ),
-            })
-            .returning('*');
+            });
+            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
+        });
 
         return virtualView;
     }
@@ -3657,6 +3658,7 @@ export class ProjectModel {
         exploreName: string,
         payload: UpdateVirtualViewPayload,
         warehouseClient: WarehouseClient,
+        expectedExplore?: Explore,
     ) {
         const translatedToExplore = createVirtualView(
             exploreName,
@@ -3667,78 +3669,78 @@ export class ProjectModel {
             payload.parameterValues,
         );
 
-        // insert into cached_explore
-        await this.database(CachedExploreTableName)
-            .update({
-                project_uuid: projectUuid,
-                name: exploreName,
-                table_names: Object.keys(translatedToExplore.tables || {}),
-                explore: translatedToExplore,
-            })
-            .where('project_uuid', projectUuid)
-            .andWhere('name', exploreName)
-            .returning(['name', 'cached_explore_uuid']);
-
-        // append to cached_explores if it doesn't exist; otherwise, update
-        await this.database(CachedExploresTableName)
-            .where('project_uuid', projectUuid)
-            .update({
-                explores: this.database.raw(
-                    `
-                    CASE
-                        WHEN explores IS NULL THEN ?::jsonb
-                        ELSE (
-                            SELECT jsonb_agg(
-                                CASE
-                                    WHEN (value->>'name') = ? THEN ?::jsonb
-                                    ELSE value
-                                END
-                            )
-                            FROM jsonb_array_elements(
-                                CASE
-                                    WHEN jsonb_typeof(explores) = 'array' THEN explores
-                                    ELSE '[]'::jsonb
-                                END
-                            )
-                        )
-                    END
-                `,
-                    [
-                        JSON.stringify([translatedToExplore]),
-                        translatedToExplore.name,
-                        JSON.stringify(translatedToExplore),
-                    ],
-                ),
-            })
-            .returning('*');
+        await this.database.transaction(async (trx) => {
+            await ProjectModel.lockAndEnsureCachedExplores(trx, projectUuid);
+            const existing = await trx(CachedExploreTableName)
+                .select<{ explore: Explore | ExploreError }[]>('explore')
+                .where('project_uuid', projectUuid)
+                .andWhere('name', exploreName)
+                .first();
+            if (!existing || existing.explore.type !== ExploreType.VIRTUAL) {
+                throw new NotFoundError(
+                    `Virtual view "${exploreName}" does not exist`,
+                );
+            }
+            if (
+                expectedExplore &&
+                !isEqual(existing.explore, expectedExplore)
+            ) {
+                throw new ParameterError(
+                    'Virtual view changed concurrently; download and retry',
+                );
+            }
+            await trx(CachedExploreTableName)
+                .update({
+                    table_names: Object.keys(translatedToExplore.tables || {}),
+                    explore: translatedToExplore,
+                })
+                .where('project_uuid', projectUuid)
+                .andWhere('name', exploreName);
+            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
+        });
 
         return translatedToExplore;
     }
 
     async deleteVirtualView(projectUuid: string, name: string) {
-        // remove from cached_explore
-        await this.database(CachedExploreTableName)
-            .where('project_uuid', projectUuid)
-            .whereRaw("explore->>'type' = ?", [ExploreType.VIRTUAL])
-            .andWhere('name', name)
-            .delete();
+        await this.database.transaction(async (trx) => {
+            await ProjectModel.lockAndEnsureCachedExplores(trx, projectUuid);
+            await trx(CachedExploreTableName)
+                .where('project_uuid', projectUuid)
+                .whereRaw("explore->>'type' = ?", [ExploreType.VIRTUAL])
+                .andWhere('name', name)
+                .delete();
+            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
+        });
+    }
 
-        // Remove from cached_explores
-        await this.database(CachedExploresTableName)
+    private static async lockAndEnsureCachedExplores(
+        trx: Transaction,
+        projectUuid: string,
+    ): Promise<void> {
+        await trx(CachedExploresTableName)
+            .insert({ project_uuid: projectUuid, explores: [] })
+            .onConflict('project_uuid')
+            .ignore();
+        await trx(CachedExploresTableName)
+            .where('project_uuid', projectUuid)
+            .forUpdate()
+            .first();
+    }
+
+    private static async rebuildCachedExplores(
+        trx: Transaction,
+        projectUuid: string,
+    ): Promise<void> {
+        const cachedExplores = await trx(CachedExploreTableName)
+            .select<{ explore: Explore | ExploreError }[]>('explore')
+            .where('project_uuid', projectUuid)
+            .orderBy('name');
+        await trx(CachedExploresTableName)
             .where('project_uuid', projectUuid)
             .update({
-                explores: this.database.raw(
-                    `
-                    (
-                        SELECT COALESCE(
-                            jsonb_agg(explore_obj),
-                            '[]'::jsonb
-                        )
-                        FROM jsonb_array_elements(explores) AS explore_obj
-                        WHERE explore_obj->>'name' != ?
-                    )
-                `,
-                    [name],
+                explores: JSON.stringify(
+                    cachedExplores.map(({ explore }) => explore),
                 ),
             });
     }

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     AlertAsCode,
     AlreadyExistsError,
     ApiAlertAsCodeListResponse,
@@ -10,6 +11,8 @@ import {
     ApiGoogleSheetsSyncAsCodeUpsertResponse,
     ApiScheduledDeliveryAsCodeListResponse,
     ApiScheduledDeliveryAsCodeUpsertResponse,
+    ApiVirtualViewAsCodeListResponse,
+    ApiVirtualViewAsCodeUpsertResponse,
     assertUnreachable,
     ChartAsCode,
     ChartAsCodeInternalization,
@@ -34,13 +37,18 @@ import {
     DashboardTileAsCode,
     DashboardTileTarget,
     DashboardTileTypes,
+    DimensionType,
+    Explore,
+    ExploreType,
     ForbiddenError,
     friendlyName,
     getContentAsCodePathFromLtreePath,
     getLtreePathFromContentAsCodePath,
+    getParameterReferences,
     isChartScheduler,
     isDashboardScheduler,
     isEmailTarget,
+    isExploreError,
     isGoogleChatTarget,
     isMsTeamsTarget,
     isSchedulerCsvOptions,
@@ -61,11 +69,13 @@ import {
     SchedulerAndTargets,
     SchedulerFormat,
     SessionUser,
+    snakeCaseName,
     Space,
     SpaceAsCode,
     SpaceMemberRole,
     SqlChartAsCode,
     UpdatedByUser,
+    VirtualViewAsCode,
     type ContentVerificationInfo,
     type DashboardConfig,
     type DashboardTileWithSlug,
@@ -95,6 +105,7 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
 import { DashboardService } from '../DashboardService/DashboardService';
+import { ProjectService } from '../ProjectService/ProjectService';
 import { PromoteService } from '../PromoteService/PromoteService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import { SchedulerService } from '../SchedulerService/SchedulerService';
@@ -117,6 +128,7 @@ type CoderServiceArguments = {
     promoteService: PromoteService;
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
+    projectService?: ProjectService;
 };
 
 type UpsertContentAsCodeOptions = {
@@ -240,6 +252,8 @@ export class CoderService extends BaseService {
 
     contentVerificationModel: ContentVerificationModel;
 
+    projectService?: ProjectService;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -256,6 +270,7 @@ export class CoderService extends BaseService {
         promoteService,
         spacePermissionService,
         contentVerificationModel,
+        projectService,
     }: CoderServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -273,6 +288,283 @@ export class CoderService extends BaseService {
         this.promoteService = promoteService;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
+        this.projectService = projectService;
+    }
+
+    private static transformVirtualView(
+        virtualView: Explore,
+    ): VirtualViewAsCode | null {
+        const table = virtualView.tables[virtualView.baseTable];
+        const dimensions = table ? Object.values(table.dimensions) : [];
+        const dimensionNames = dimensions.map(({ name }) => name);
+        if (
+            !virtualView.name?.trim() ||
+            !virtualView.label?.trim() ||
+            !table?.sqlTable ||
+            table.name !== virtualView.name ||
+            virtualView.baseTable !== virtualView.name ||
+            !table.sqlTable.startsWith('(') ||
+            !table.sqlTable.endsWith(')') ||
+            dimensionNames.some((name) => !name?.trim()) ||
+            new Set(dimensionNames).size !== dimensionNames.length ||
+            dimensions.some(
+                ({ type }) => !Object.values(DimensionType).includes(type),
+            )
+        ) {
+            return null;
+        }
+
+        return {
+            contentType: ContentAsCodeType.VIRTUAL_VIEW,
+            version: currentVersion,
+            slug: virtualView.name,
+            name: virtualView.label,
+            sql: table.sqlTable.slice(1, -1),
+            columns: dimensions
+                .map(({ name, type }) => ({ reference: name, type }))
+                .sort((left, right) =>
+                    left.reference.localeCompare(right.reference),
+                ),
+            parameters: virtualView.savedParameterValues ?? null,
+        };
+    }
+
+    async getVirtualViews(
+        user: SessionUser,
+        projectUuid: string,
+        slugs?: string[],
+    ): Promise<ApiVirtualViewAsCodeListResponse['results']> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('ContentAsCode', {
+                    projectUuid,
+                    organizationUuid: project.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You are not allowed to download virtual views',
+            );
+        }
+
+        const requested = slugs ? new Set(slugs) : null;
+        const cached =
+            await this.projectModel.findVirtualViewsFromCache(projectUuid);
+        const virtualViews: VirtualViewAsCode[] = [];
+        const skipped: ApiVirtualViewAsCodeListResponse['results']['skipped'] =
+            [];
+        Object.values(cached)
+            .sort((left, right) => left.name.localeCompare(right.name))
+            .forEach((explore) => {
+                if (requested && !requested.has(explore.name)) return;
+                if (
+                    isExploreError(explore) ||
+                    explore.type !== ExploreType.VIRTUAL
+                ) {
+                    skipped.push({
+                        slug: explore.name,
+                        reason: 'Cached virtual view is malformed',
+                    });
+                    return;
+                }
+                const transformed = CoderService.transformVirtualView(explore);
+                if (transformed) virtualViews.push(transformed);
+                else {
+                    skipped.push({
+                        slug: explore.name,
+                        reason: 'Virtual view SQL is not stored as a subquery',
+                    });
+                }
+            });
+
+        const found = new Set([
+            ...virtualViews.map(({ slug }) => slug),
+            ...skipped.map(({ slug }) => slug),
+        ]);
+        return {
+            virtualViews,
+            skipped,
+            missingSlugs: slugs?.filter((slug) => !found.has(slug)) ?? [],
+        };
+    }
+
+    async upsertVirtualView(
+        account: Account,
+        projectUuid: string,
+        slug: string,
+        virtualView: VirtualViewAsCode,
+        force = false,
+    ): Promise<ApiVirtualViewAsCodeUpsertResponse['results']> {
+        if (virtualView.contentType !== ContentAsCodeType.VIRTUAL_VIEW) {
+            throw new ParameterError('Invalid virtual view contentType');
+        }
+        if (virtualView.version !== currentVersion) {
+            throw new ParameterError(
+                `Unsupported virtual view version ${virtualView.version}`,
+            );
+        }
+        if (slug !== virtualView.slug) {
+            throw new ParameterError(
+                'Virtual view path and body slugs must match',
+            );
+        }
+        if (
+            !slug.trim() ||
+            !virtualView.name.trim() ||
+            !virtualView.sql.trim()
+        ) {
+            throw new ParameterError(
+                'Virtual view slug, name, and SQL are required',
+            );
+        }
+        if (
+            snakeCaseName(slug) !== slug ||
+            slug.includes('/') ||
+            slug.includes('\\') ||
+            Array.from(slug).some((character) => character.charCodeAt(0) < 32)
+        ) {
+            throw new ParameterError(
+                'Virtual view slug must be a canonical snake_case identifier',
+            );
+        }
+        if (virtualView.columns.length === 0) {
+            throw new ParameterError(
+                'Virtual view must define at least one column',
+            );
+        }
+        const references = virtualView.columns.map(
+            ({ reference }) => reference,
+        );
+        if (
+            references.some((reference) => !reference.trim()) ||
+            new Set(references).size !== references.length
+        ) {
+            throw new ParameterError(
+                'Virtual view column references must be non-empty and unique',
+            );
+        }
+        const dimensionTypes = new Set(Object.values(DimensionType));
+        if (virtualView.columns.some(({ type }) => !dimensionTypes.has(type))) {
+            throw new ParameterError(
+                'Virtual view columns must use valid types',
+            );
+        }
+        const parameterReferences = new Set(
+            getParameterReferences(virtualView.sql),
+        );
+        const unusedParameters = Object.keys(
+            virtualView.parameters ?? {},
+        ).filter((name) => !parameterReferences.has(name));
+        if (unusedParameters.length > 0) {
+            throw new ParameterError(
+                `Virtual view contains values for unreferenced parameters: ${unusedParameters.join(', ')}`,
+            );
+        }
+
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('ContentAsCode', {
+                    projectUuid,
+                    organizationUuid: project.organizationUuid,
+                    metadata: { slug },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        if (!this.projectService) {
+            throw new Error(
+                'ProjectService is required to upload virtual views',
+            );
+        }
+        await this.projectService.validateVirtualViewParameterReferences(
+            projectUuid,
+            virtualView.sql,
+            virtualView.parameters ?? undefined,
+        );
+
+        const existingByName = await this.projectModel.findExploresFromCache(
+            projectUuid,
+            'name',
+            [slug],
+        );
+        const existing = existingByName[slug];
+        if (
+            existing &&
+            (isExploreError(existing) || existing.type !== ExploreType.VIRTUAL)
+        ) {
+            throw new AlreadyExistsError(
+                `An explore named "${slug}" already exists and cannot be adopted`,
+            );
+        }
+        const normalized = {
+            ...virtualView,
+            columns: [...virtualView.columns].sort((left, right) =>
+                left.reference.localeCompare(right.reference),
+            ),
+        };
+        if (existing && existing.type === ExploreType.VIRTUAL) {
+            const current = CoderService.transformVirtualView(existing);
+            if (!current && !force) {
+                throw new ParameterError(
+                    'Malformed existing virtual view requires force to replace',
+                );
+            }
+            if (current && isEqual(current, normalized)) {
+                return { action: PromotionAction.NO_CHANGES };
+            }
+            if (current && !force) {
+                const desiredColumns = new Map(
+                    normalized.columns.map((column) => [
+                        column.reference,
+                        column.type,
+                    ]),
+                );
+                const destructive = current.columns.filter(
+                    (column) =>
+                        desiredColumns.get(column.reference) !== column.type,
+                );
+                if (destructive.length > 0) {
+                    throw new ParameterError(
+                        `Destructive virtual view column changes require force: ${destructive.map(({ reference }) => reference).join(', ')}`,
+                    );
+                }
+            }
+            await this.projectService.updateVirtualView(
+                account,
+                projectUuid,
+                slug,
+                {
+                    name: normalized.name,
+                    sql: normalized.sql,
+                    columns: normalized.columns,
+                    parameterValues: normalized.parameters ?? undefined,
+                },
+                false,
+                existing,
+            );
+            return { action: PromotionAction.UPDATE };
+        }
+
+        await this.projectService.createVirtualView(
+            account,
+            projectUuid,
+            {
+                name: slug,
+                label: normalized.name,
+                sql: normalized.sql,
+                columns: normalized.columns,
+                parameterValues: normalized.parameters ?? undefined,
+            },
+            false,
+        );
+        return { action: PromotionAction.CREATE };
     }
 
     private static transformSpaces(

--- a/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
@@ -1,0 +1,211 @@
+import { Ability } from '@casl/ability';
+import {
+    ContentAsCodeType,
+    DimensionType,
+    ExploreType,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    PromotionAction,
+    type Explore,
+    type SessionUser,
+    type VirtualViewAsCode,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { CoderService } from './CoderService';
+
+const projectUuid = 'project-uuid';
+const organizationUuid = 'organization-uuid';
+
+const user: SessionUser = {
+    userUuid: 'user-uuid',
+    email: 'user@example.com',
+    firstName: 'Virtual',
+    lastName: 'Viewer',
+    organizationUuid,
+    organizationName: 'Test organization',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    timezone: null,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.ADMIN,
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: ['view', 'manage'],
+            subject: 'ContentAsCode',
+            conditions: { projectUuid, organizationUuid },
+        },
+    ]),
+};
+
+const virtualView = {
+    name: 'orders_by_customer',
+    label: 'Orders by customer',
+    type: ExploreType.VIRTUAL,
+    baseTable: 'orders_by_customer',
+    tables: {
+        orders_by_customer: {
+            name: 'orders_by_customer',
+            sqlTable: '((SELECT ${ld.parameters.region} AS customer_id))',
+            dimensions: {
+                customer_id: {
+                    name: 'customer_id',
+                    type: DimensionType.NUMBER,
+                },
+            },
+        },
+    },
+    savedParameterValues: { region: 'EU' },
+} as unknown as Explore;
+
+const asCode: VirtualViewAsCode = {
+    contentType: ContentAsCodeType.VIRTUAL_VIEW,
+    version: 1,
+    slug: 'orders_by_customer',
+    name: 'Orders by customer',
+    sql: '(SELECT ${ld.parameters.region} AS customer_id)',
+    columns: [{ reference: 'customer_id', type: DimensionType.NUMBER }],
+    parameters: { region: 'EU' },
+};
+
+const buildService = (existing: Explore | null = virtualView) => {
+    const projectModel = {
+        getSummary: vi.fn(async () => ({ projectUuid, organizationUuid })),
+        findVirtualViewsFromCache: vi.fn(async () =>
+            existing ? { [existing.name]: existing } : {},
+        ),
+        findExploresFromCache: vi.fn(async () =>
+            existing ? { [existing.name]: existing } : {},
+        ),
+    };
+    const projectService = {
+        validateVirtualViewParameterReferences: vi.fn(async () => undefined),
+        createVirtualView: vi.fn(async () => ({ name: asCode.slug })),
+        updateVirtualView: vi.fn(async () => ({ name: asCode.slug })),
+    };
+    const service = new CoderService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: projectModel as never,
+        savedChartModel: {} as never,
+        savedSqlModel: {} as never,
+        dashboardModel: {} as never,
+        spaceModel: {} as never,
+        schedulerModel: {} as never,
+        schedulerService: {} as never,
+        savedChartService: {} as never,
+        dashboardService: {} as never,
+        schedulerClient: {} as never,
+        promoteService: {} as never,
+        spacePermissionService: {} as never,
+        contentVerificationModel: {} as never,
+        projectService: projectService as never,
+    });
+    return { service, projectService };
+};
+
+describe('CoderService virtual views as code', () => {
+    test('exports a deterministic contract and removes exactly one SQL wrapper', async () => {
+        const { service } = buildService();
+
+        await expect(
+            service.getVirtualViews(user, projectUuid),
+        ).resolves.toEqual({
+            virtualViews: [asCode],
+            skipped: [],
+            missingSlugs: [],
+        });
+    });
+
+    test('returns no changes for an identical second apply', async () => {
+        const { service, projectService } = buildService();
+
+        await expect(
+            service.upsertVirtualView(
+                user as never,
+                projectUuid,
+                asCode.slug,
+                asCode,
+            ),
+        ).resolves.toEqual({ action: PromotionAction.NO_CHANGES });
+        expect(projectService.updateVirtualView).not.toHaveBeenCalled();
+    });
+
+    test('blocks destructive column changes unless forced', async () => {
+        const { service, projectService } = buildService();
+        const changed = {
+            ...asCode,
+            columns: [
+                {
+                    reference: 'customer_id',
+                    type: DimensionType.STRING,
+                },
+            ],
+        };
+
+        await expect(
+            service.upsertVirtualView(
+                user as never,
+                projectUuid,
+                asCode.slug,
+                changed,
+            ),
+        ).rejects.toThrow('require force');
+        await expect(
+            service.upsertVirtualView(
+                user as never,
+                projectUuid,
+                asCode.slug,
+                changed,
+                true,
+            ),
+        ).resolves.toEqual({ action: PromotionAction.UPDATE });
+        expect(projectService.updateVirtualView).toHaveBeenCalledOnce();
+    });
+
+    test('creates by immutable slug while preserving the display label', async () => {
+        const { service, projectService } = buildService(null);
+
+        await expect(
+            service.upsertVirtualView(
+                user as never,
+                projectUuid,
+                asCode.slug,
+                asCode,
+            ),
+        ).resolves.toEqual({ action: PromotionAction.CREATE });
+        expect(projectService.createVirtualView).toHaveBeenCalledWith(
+            user,
+            projectUuid,
+            expect.objectContaining({
+                name: asCode.slug,
+                label: asCode.name,
+            }),
+            false,
+        );
+    });
+
+    test('rejects a non-virtual explore collision', async () => {
+        const { service } = buildService({
+            ...virtualView,
+            type: ExploreType.DEFAULT,
+        });
+
+        await expect(
+            service.upsertVirtualView(
+                user as never,
+                projectUuid,
+                asCode.slug,
+                asCode,
+            ),
+        ).rejects.toThrow('cannot be adopted');
+    });
+});

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -100,6 +100,7 @@ import {
     isFilterableDimension,
     isJwtUser,
     isNotNull,
+    isReservedParameterName,
     isUserWithOrg,
     isValidTimezone,
     ItemsMap,
@@ -8709,6 +8710,7 @@ export class ProjectService extends BaseService {
         account: Account,
         projectUuid: string,
         payload: CreateVirtualViewPayload,
+        resolveParameterValues = true,
     ) {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
@@ -8742,15 +8744,17 @@ export class ProjectService extends BaseService {
             await this.getWarehouseCredentials({
                 projectUuid,
                 userId: account.user.id,
-                isRegisteredUser: true,
+                isRegisteredUser: account.isRegisteredUser(),
+                isServiceAccount: account.isServiceAccount(),
             }),
         );
-        const effectiveParameterValues =
-            await this.resolveVirtualViewParameters(
-                projectUuid,
-                payload.sql,
-                payload.parameterValues,
-            );
+        const effectiveParameterValues = resolveParameterValues
+            ? await this.resolveVirtualViewParameters(
+                  projectUuid,
+                  payload.sql,
+                  payload.parameterValues,
+              )
+            : payload.parameterValues;
 
         const virtualView = await this.projectModel.createVirtualView(
             projectUuid,
@@ -8780,14 +8784,21 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         exploreName: string,
         payload: UpdateVirtualViewPayload,
+        resolveParameterValues = true,
+        expectedExplore?: Explore,
     ) {
-        const virtualView = await this.findExplores({
+        const explores = await this.findExplores({
             account,
             projectUuid,
             exploreNames: [exploreName],
         });
+        const virtualView = explores[exploreName];
 
-        if (!virtualView) {
+        if (
+            !virtualView ||
+            isExploreError(virtualView) ||
+            virtualView.type !== ExploreType.VIRTUAL
+        ) {
             throw new NotFoundError('Virtual view not found');
         }
 
@@ -8818,12 +8829,13 @@ export class ProjectService extends BaseService {
             }),
         );
 
-        const effectiveParameterValues =
-            await this.resolveVirtualViewParameters(
-                projectUuid,
-                payload.sql,
-                payload.parameterValues,
-            );
+        const effectiveParameterValues = resolveParameterValues
+            ? await this.resolveVirtualViewParameters(
+                  projectUuid,
+                  payload.sql,
+                  payload.parameterValues,
+              )
+            : payload.parameterValues;
 
         const updatedExplore = await this.projectModel.updateVirtualView(
             projectUuid,
@@ -8833,6 +8845,7 @@ export class ProjectService extends BaseService {
                 parameterValues: effectiveParameterValues,
             },
             warehouseClient,
+            expectedExplore,
         );
 
         this.analytics.trackAccount(account, {
@@ -9764,6 +9777,40 @@ export class ProjectService extends BaseService {
             ),
         );
         return Object.keys(filtered).length > 0 ? filtered : undefined;
+    }
+
+    async validateVirtualViewParameterReferences(
+        projectUuid: string,
+        sql: string,
+        parameterValues?: ParametersValuesMap,
+    ): Promise<void> {
+        const references = getParameterReferences(sql);
+        const definitions = await this.projectParametersModel.find(projectUuid);
+        const definitionsByName = new Map(
+            definitions.map((definition) => [definition.name, definition]),
+        );
+        const unknown = references.filter(
+            (name) =>
+                !definitionsByName.has(name) && !isReservedParameterName(name),
+        );
+        if (unknown.length > 0) {
+            throw new ParameterError(
+                `Virtual view references unknown parameters: ${unknown.join(', ')}`,
+            );
+        }
+        const missing = references.filter((name) => {
+            const definition = definitionsByName.get(name);
+            if (!definition && isReservedParameterName(name)) return false;
+            return (
+                !(name in (parameterValues ?? {})) &&
+                definition?.config.default === undefined
+            );
+        });
+        if (missing.length > 0) {
+            throw new ParameterError(
+                `Virtual view is missing values for required parameters: ${missing.join(', ')}`,
+            );
+        }
     }
 
     static isChartEmbed(account: Account) {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1163,6 +1163,7 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
+                    projectService: this.getProjectService(),
                 }),
         );
     }

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -7,8 +7,10 @@ import {
     ForbiddenError,
     LightdashError,
     ProjectType,
+    SpaceMemberRole,
     type LightdashUserWithAbilityRules,
     type PossibleAbilities,
+    type Project,
 } from '@lightdash/common';
 import fetch, { BodyInit } from 'node-fetch';
 import { URL } from 'url';
@@ -114,6 +116,106 @@ export const getUserContext =
             url: `/api/v1/user`,
             body: undefined,
         });
+
+export type ContentAsCodeUploadPermissions = {
+    charts: boolean;
+    dashboards: boolean;
+    virtualViews: boolean;
+    alerts: boolean;
+    scheduledDeliveries: boolean;
+    googleSheets: boolean;
+    dataApps: boolean;
+};
+
+export const getContentAsCodeUploadPermissions = async (
+    projectUuid: string,
+): Promise<ContentAsCodeUploadPermissions> => {
+    const [user, project] = await Promise.all([
+        getUserContext(),
+        lightdashApi<Project>({
+            method: 'GET',
+            url: `/api/v1/projects/${projectUuid}`,
+            body: undefined,
+        }),
+    ]);
+    const ability = new Ability<PossibleAbilities>(user.abilityRules);
+
+    if (
+        ability.cannot(
+            'manage',
+            subject('ContentAsCode', {
+                organizationUuid: project.organizationUuid,
+                projectUuid: project.projectUuid,
+                upstreamProjectUuid: project.upstreamProjectUuid,
+                type: project.type,
+                createdByUserUuid: project.createdByUserUuid,
+            }),
+        )
+    ) {
+        throw new ForbiddenError(
+            `You don't have permission to upload content as code to project "${project.name}". The manage:ContentAsCode permission is required.`,
+        );
+    }
+
+    const baseSubject = {
+        organizationUuid: project.organizationUuid,
+        projectUuid: project.projectUuid,
+    };
+    const accessibleResourceSubject = {
+        ...baseSubject,
+        upstreamProjectUuid: project.upstreamProjectUuid,
+        type: project.type,
+        createdByUserUuid: project.createdByUserUuid,
+        inheritsFromOrgOrProject: true,
+        access: [
+            {
+                userUuid: user.userUuid,
+                role: SpaceMemberRole.ADMIN,
+            },
+        ],
+    };
+    const canManageScheduledDeliveries = ability.can(
+        'manage',
+        subject('ScheduledDeliveries', {
+            ...baseSubject,
+            userUuid: user.userUuid,
+        }),
+    );
+    const canCreateScheduledDeliveries = ability.can(
+        'create',
+        subject('ScheduledDeliveries', { ...baseSubject }),
+    );
+
+    return {
+        charts: ability.can(
+            'manage',
+            subject('SavedChart', { ...accessibleResourceSubject }),
+        ),
+        dashboards: ability.can(
+            'manage',
+            subject('Dashboard', { ...accessibleResourceSubject }),
+        ),
+        virtualViews: ability.can(
+            'create',
+            subject('VirtualView', { ...baseSubject }),
+        ),
+        alerts: canManageScheduledDeliveries || canCreateScheduledDeliveries,
+        scheduledDeliveries:
+            canManageScheduledDeliveries || canCreateScheduledDeliveries,
+        googleSheets:
+            (canManageScheduledDeliveries || canCreateScheduledDeliveries) &&
+            ability.can('manage', subject('GoogleSheets', { ...baseSubject })),
+        dataApps:
+            ability.can(
+                'create',
+                subject('DataApp', { ...accessibleResourceSubject }),
+            ) ||
+            ability.can(
+                'manage',
+                subject('DataApp', { ...accessibleResourceSubject }),
+            ),
+    };
+};
 
 export const checkProjectCreationPermission = async (
     upstreamProjectUuid: string | undefined,

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -9,9 +9,18 @@ import {
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { vi } from 'vitest';
+import GlobalState from '../globalState';
+import { lightdashApi } from './dbt/apiClient';
 import { testHelpers } from './download';
 
-const { getDashboardChartSlugs, sanitizeChartForDownload } = testHelpers;
+vi.mock('./dbt/apiClient', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./dbt/apiClient')>()),
+    lightdashApi: vi.fn(),
+}));
+
+const { getDashboardChartSlugs, sanitizeChartForDownload, upsertVirtualViews } =
+    testHelpers;
 
 type LooseDashboard = DashboardAsCode & { needsUpdating: boolean };
 
@@ -232,5 +241,109 @@ describe('sanitizeChartForDownload', () => {
             xRef: { field: 'events_date_day' },
             yRef: { field: 'orders_count' },
         });
+    });
+});
+
+describe('upsertVirtualViews', () => {
+    let tmpDir: string;
+    const virtualView = (slug: string) => `columns:
+  - name: order_id
+contentType: virtual_view
+name: ${slug}
+parameters: null
+slug: ${slug}
+sql: SELECT 1 AS order_id
+version: 1
+`;
+
+    beforeEach(async () => {
+        vi.mocked(lightdashApi).mockReset();
+        tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'virtual-views-test-'),
+        );
+        await fs.mkdir(path.join(tmpDir, 'virtual-views'));
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('continues uploading after one virtual view is denied', async () => {
+        await fs.writeFile(
+            path.join(tmpDir, 'virtual-views', 'a-denied.yml'),
+            virtualView('a-denied'),
+        );
+        await fs.writeFile(
+            path.join(tmpDir, 'virtual-views', 'b-allowed.yml'),
+            virtualView('b-allowed'),
+        );
+        vi.mocked(lightdashApi)
+            .mockRejectedValueOnce(new Error('Forbidden'))
+            .mockResolvedValueOnce({ action: 'create' } as never);
+
+        const changes = await upsertVirtualViews(
+            'project-uuid',
+            [],
+            {},
+            false,
+            true,
+            tmpDir,
+        );
+
+        expect(lightdashApi).toHaveBeenCalledTimes(2);
+        expect(changes).toEqual({
+            'virtual views with errors': 1,
+            'virtual views created': 1,
+        });
+    });
+
+    it('does not report missing permissions when there are no local virtual views', async () => {
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+
+        const changes = await upsertVirtualViews(
+            'project-uuid',
+            [],
+            {},
+            false,
+            false,
+            tmpDir,
+        );
+
+        expect(changes).toEqual({});
+        expect(lightdashApi).not.toHaveBeenCalled();
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('reports one category error without uploading when local virtual views are forbidden', async () => {
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+        await fs.writeFile(
+            path.join(tmpDir, 'virtual-views', 'a-denied.yml'),
+            virtualView('a-denied'),
+        );
+        await fs.writeFile(
+            path.join(tmpDir, 'virtual-views', 'b-denied.yml'),
+            virtualView('b-denied'),
+        );
+
+        const changes = await upsertVirtualViews(
+            'project-uuid',
+            [],
+            {},
+            false,
+            false,
+            tmpDir,
+        );
+
+        expect(changes).toEqual({});
+        expect(lightdashApi).not.toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledOnce();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Error uploading virtual views'),
+        );
     });
 });

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -17,6 +17,8 @@ import {
     ApiScheduledDeliveryAsCodeListResponse,
     ApiScheduledDeliveryAsCodeUpsertResponse,
     ApiSqlChartAsCodeListResponse,
+    ApiVirtualViewAsCodeListResponse,
+    ApiVirtualViewAsCodeUpsertResponse,
     assertUnreachable,
     AuthorizationError,
     ChartAsCode,
@@ -35,6 +37,7 @@ import {
     ScheduledDeliveryAsCode,
     SqlChartAsCode,
     validateDataAppDependencies,
+    VirtualViewAsCode,
     type DataAppCodeDownload,
     type SpaceAsCode,
 } from '@lightdash/common';
@@ -82,6 +85,7 @@ import {
 } from './apps/scaffolding';
 import {
     checkLightdashVersion,
+    getContentAsCodeUploadPermissions,
     lightdashApi,
     setGzipEnabled,
 } from './dbt/apiClient';
@@ -100,6 +104,7 @@ export type DownloadHandlerOptions = {
     alerts: string[];
     googleSheets: string[];
     scheduledDeliveries: string[];
+    virtualViews: string[];
     apps?: string[]; // specific app UUIDs (enterprise); absent = no explicit selection
     includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
     appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
@@ -118,6 +123,8 @@ export type DownloadHandlerOptions = {
     skipAlerts: boolean;
     skipGoogleSheets: boolean;
     skipScheduledDeliveries: boolean;
+    skipVirtualViews: boolean;
+    includeVirtualViews: boolean;
     appsOnly?: boolean; // download only: implies skipCharts + skipDashboards + skipSpaces
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
     validate?: boolean; // Validate charts and dashboards after upload
@@ -876,6 +883,169 @@ const getAlertsFolder = (customPath?: string): string =>
 const getGoogleSheetsFolder = (customPath?: string): string =>
     path.join(getDownloadFolder(customPath), 'google-sheets');
 
+const getVirtualViewsFolder = (customPath?: string): string =>
+    path.join(getDownloadFolder(customPath), 'virtual-views');
+
+function getPromoteAction(action: PromotionAction) {
+    switch (action) {
+        case PromotionAction.CREATE:
+            return 'created';
+        case PromotionAction.UPDATE:
+            return 'updated';
+        case PromotionAction.DELETE:
+            return 'deleted';
+        case PromotionAction.NO_CHANGES:
+            return 'skipped';
+        default:
+            assertUnreachable(action, `Unknown promotion action: ${action}`);
+    }
+    return 'skipped';
+}
+
+const downloadVirtualViews = async (
+    projectId: string,
+    slugs: string[],
+    customPath?: string,
+): Promise<number> => {
+    const folder = getVirtualViewsFolder(customPath);
+    await fs.mkdir(folder, { recursive: true });
+    const query = new URLSearchParams(
+        slugs.map((slug) => ['slugs', slug] as [string, string]),
+    ).toString();
+    const results = await lightdashApi<
+        ApiVirtualViewAsCodeListResponse['results']
+    >({
+        method: 'GET',
+        url: `/api/v1/projects/${projectId}/virtualViews/code${
+            query ? `?${query}` : ''
+        }`,
+        body: undefined,
+    });
+    for (const virtualView of results.virtualViews) {
+        await fs.writeFile(
+            path.join(folder, `${encodeURIComponent(virtualView.slug)}.yml`),
+            yaml.dump(virtualView, { quotingType: '"', sortKeys: true }),
+        );
+    }
+    results.skipped.forEach(({ slug, reason }) =>
+        GlobalState.log(
+            styles.warning(`Skipped virtual view "${slug}": ${reason}`),
+        ),
+    );
+    results.missingSlugs.forEach((slug) =>
+        GlobalState.log(styles.warning(`Virtual view "${slug}" was not found`)),
+    );
+    return results.virtualViews.length;
+};
+
+const readVirtualViewFiles = async (
+    customPath?: string,
+): Promise<VirtualViewAsCode[]> => {
+    const folder = getVirtualViewsFolder(customPath);
+    try {
+        const entries = await fs.readdir(folder, { withFileTypes: true });
+        const virtualViews: VirtualViewAsCode[] = [];
+        for (const entry of entries) {
+            if (
+                entry.isFile() &&
+                (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml'))
+            ) {
+                const parsed = yaml.load(
+                    await fs.readFile(path.join(folder, entry.name), 'utf-8'),
+                ) as VirtualViewAsCode;
+                if (parsed.contentType !== ContentAsCodeTypeEnum.VIRTUAL_VIEW) {
+                    throw new ParameterError(
+                        `Invalid virtual view contentType in ${entry.name}`,
+                    );
+                }
+                virtualViews.push(parsed);
+            }
+        }
+        const duplicates = Object.entries(groupBy(virtualViews, 'slug'))
+            .filter(([, items]) => items.length > 1)
+            .map(([slug]) => slug);
+        if (duplicates.length > 0) {
+            throw new ParameterError(
+                `Duplicate virtual view slugs: ${duplicates.join(', ')}`,
+            );
+        }
+        return virtualViews;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw error;
+    }
+};
+
+const upsertVirtualViews = async (
+    projectId: string,
+    slugs: string[],
+    changes: Record<string, number>,
+    force: boolean,
+    canUpload: boolean,
+    customPath?: string,
+): Promise<Record<string, number>> => {
+    const virtualViews = await readVirtualViewFiles(customPath);
+    const selected = slugs.length
+        ? virtualViews.filter(({ slug }) => slugs.includes(slug))
+        : virtualViews;
+    const selectedSlugs = new Set(selected.map(({ slug }) => slug));
+    slugs
+        .filter((slug) => !selectedSlugs.has(slug))
+        .forEach((slug) =>
+            GlobalState.log(
+                styles.warning(`Virtual view "${slug}" was not found locally`),
+            ),
+        );
+    if (selected.length > 0 && !canUpload) {
+        GlobalState.log(
+            styles.error(
+                `Error uploading virtual views: the create:VirtualView permission is required`,
+            ),
+        );
+        return changes;
+    }
+    for (const virtualView of selected.sort((left, right) =>
+        left.slug.localeCompare(right.slug),
+    )) {
+        try {
+            if (
+                virtualView.version !== 1 ||
+                !virtualView.slug?.trim() ||
+                !virtualView.name?.trim() ||
+                !virtualView.sql?.trim() ||
+                !Array.isArray(virtualView.columns) ||
+                virtualView.columns.length === 0 ||
+                !Object.prototype.hasOwnProperty.call(virtualView, 'parameters')
+            ) {
+                throw new ParameterError(
+                    `Invalid virtual view definition for "${virtualView.slug ?? 'unknown'}"`,
+                );
+            }
+
+            const result = await lightdashApi<
+                ApiVirtualViewAsCodeUpsertResponse['results']
+            >({
+                method: 'POST',
+                url: `/api/v1/projects/${projectId}/virtualViews/${encodeURIComponent(
+                    virtualView.slug,
+                )}/code?force=${force}`,
+                body: JSON.stringify(virtualView),
+            });
+            const action = `virtual views ${getPromoteAction(result.action)}`;
+            changes[action] = (changes[action] ?? 0) + 1;
+        } catch (error) {
+            const errorKey = 'virtual views with errors';
+            changes[errorKey] = (changes[errorKey] ?? 0) + 1;
+            GlobalState.log(
+                styles.error(
+                    `Error upserting virtual view:\n\t"${virtualView.name}" (slug: "${virtualView.slug}")\n\t${getErrorMessage(error)}`,
+                ),
+            );
+        }
+    }
+    return changes;
+};
+
 type ScheduledContentAsCode =
     | ScheduledDeliveryAsCode
     | AlertAsCode
@@ -917,22 +1087,6 @@ const getScheduledContentConfig = (
                 'Unknown scheduled content type',
             );
     }
-};
-
-const getPromoteAction = (action: PromotionAction) => {
-    switch (action) {
-        case PromotionAction.CREATE:
-            return 'created';
-        case PromotionAction.UPDATE:
-            return 'updated';
-        case PromotionAction.DELETE:
-            return 'deleted';
-        case PromotionAction.NO_CHANGES:
-            return 'skipped';
-        default:
-            assertUnreachable(action, `Unknown promotion action: ${action}`);
-    }
-    return 'skipped';
 };
 
 const downloadScheduledContent = async (
@@ -1026,6 +1180,7 @@ const upsertScheduledContent = async (
     changes: Record<string, number>,
     force: boolean,
     contentType: ScheduledContentType,
+    canUpload: boolean,
     customPath?: string,
 ): Promise<Record<string, number>> => {
     const config = getScheduledContentConfig(contentType, customPath);
@@ -1039,6 +1194,19 @@ const upsertScheduledContent = async (
     const filteredContent = slugs.length
         ? scheduledContent.filter((item) => slugs.includes(item.slug))
         : scheduledContent;
+
+    if (filteredContent.length > 0 && !canUpload) {
+        const requiredPermission =
+            contentType === ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC
+                ? 'the manage:GoogleSheets permission is required'
+                : 'scheduled delivery permissions are required';
+        GlobalState.log(
+            styles.error(
+                `Error uploading ${config.plural}: ${requiredPermission}`,
+            ),
+        );
+        return changes;
+    }
 
     for (const item of filteredContent) {
         try {
@@ -1122,6 +1290,7 @@ export const downloadHandler = async (
         options.skipAlerts = true;
         options.skipGoogleSheets = true;
         options.skipScheduledDeliveries = true;
+        options.includeVirtualViews = false;
     }
 
     await checkLightdashVersion();
@@ -1177,13 +1346,24 @@ export const downloadHandler = async (
             options.dashboards.length > 0 ||
             options.alerts.length > 0 ||
             options.googleSheets.length > 0 ||
-            options.scheduledDeliveries.length > 0;
+            options.scheduledDeliveries.length > 0 ||
+            options.virtualViews.length > 0;
 
         // When downloading specific charts or dashboards, skip space metadata
         const skipSpaces = options.skipSpaces || hasFilters;
 
         let allMetadataEntries: MetadataEntry[] = [];
         let allSpaces: SpaceAsCode[] = [];
+
+        if (options.includeVirtualViews || options.virtualViews.length > 0) {
+            spinner.start(`Downloading virtual views`);
+            const total = await downloadVirtualViews(
+                projectId,
+                options.virtualViews,
+                options.path,
+            );
+            spinner.succeed(`Downloaded ${total} virtual views`);
+        }
 
         // Download regular charts and SQL charts
         if (!options.skipCharts) {
@@ -1815,6 +1995,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     changes: Record<string, number>,
     force: boolean,
     slugs: string[],
+    canUpload: boolean,
     customPath?: string,
     skipSpaceCreate?: boolean,
     publicSpaceCreate?: boolean,
@@ -1846,6 +2027,17 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
         missingItems.forEach((slug) => {
             GlobalState.log(styles.warning(`No ${type} with slug: "${slug}"`));
         });
+    }
+
+    if (filteredItems.length > 0 && !canUpload) {
+        const requiredPermission =
+            type === 'charts' ? 'manage:SavedChart' : 'manage:Dashboard';
+        GlobalState.log(
+            styles.error(
+                `Error uploading ${type}: the ${requiredPermission} permission is required`,
+            ),
+        );
+        return { changes, total: filteredItems.length };
     }
 
     if (concurrency <= 1) {
@@ -2051,7 +2243,11 @@ export const uploadHandler = async (
         },
     });
 
+    let uploadResource = 'content as code';
     try {
+        const uploadPermissions =
+            await getContentAsCodeUploadPermissions(projectId);
+
         // If any filter is provided, we skip those items without filters
         // eg: if a --charts filter is provided, we skip dashboards if no --dashboards filter is provided
         const hasFilters =
@@ -2059,9 +2255,11 @@ export const uploadHandler = async (
             options.dashboards.length > 0 ||
             options.alerts.length > 0 ||
             options.googleSheets.length > 0 ||
-            options.scheduledDeliveries.length > 0;
+            options.scheduledDeliveries.length > 0 ||
+            options.virtualViews.length > 0;
 
         // Discover loose YAML files (outside charts/ and dashboards/) classified by contentType
+        uploadResource = 'content files';
         const looseFiles = await readLooseCodeFiles(options.path);
         if (looseFiles.charts.length > 0) {
             GlobalState.log(
@@ -2075,6 +2273,7 @@ export const uploadHandler = async (
         }
 
         // Always include the charts from dashboards if includeCharts is true regardless of the charts filters
+        uploadResource = 'dashboard chart dependencies';
         const chartSlugs = options.includeCharts
             ? Array.from(
                   new Set([
@@ -2102,6 +2301,7 @@ export const uploadHandler = async (
         }
 
         // Read space definition files to preserve original space names during upload
+        uploadResource = 'space definitions';
         const spaceNames = await readSpaceNames(options.path);
         if (Object.keys(spaceNames).length > 0) {
             GlobalState.log(
@@ -2109,11 +2309,32 @@ export const uploadHandler = async (
             );
         }
 
+        if (!options.skipVirtualViews) {
+            if (hasFilters && options.virtualViews.length === 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `No virtual view filters provided, skipping`,
+                    ),
+                );
+            } else {
+                uploadResource = 'virtual views';
+                changes = await upsertVirtualViews(
+                    projectId,
+                    options.virtualViews,
+                    changes,
+                    options.force,
+                    uploadPermissions.virtualViews,
+                    options.path,
+                );
+            }
+        }
+
         if (hasFilters && chartSlugs.length === 0) {
             GlobalState.log(
                 styles.warning(`No charts filters provided, skipping`),
             );
         } else {
+            uploadResource = 'charts';
             const { changes: chartChanges, total } =
                 await upsertResources<ChartAsCode>(
                     'charts',
@@ -2121,6 +2342,7 @@ export const uploadHandler = async (
                     changes,
                     options.force,
                     chartSlugs,
+                    uploadPermissions.charts,
                     options.path,
                     options.skipSpaceCreate,
                     options.public,
@@ -2138,6 +2360,7 @@ export const uploadHandler = async (
                 styles.warning(`No dashboard filters provided, skipping`),
             );
         } else {
+            uploadResource = 'dashboards';
             const { changes: dashboardChanges, total } =
                 await upsertResources<DashboardAsCode>(
                     'dashboards',
@@ -2145,6 +2368,7 @@ export const uploadHandler = async (
                     changes,
                     options.force,
                     options.dashboards,
+                    uploadPermissions.dashboards,
                     options.path,
                     options.skipSpaceCreate,
                     options.public,
@@ -2163,12 +2387,14 @@ export const uploadHandler = async (
                     styles.warning(`No alert filters provided, skipping`),
                 );
             } else {
+                uploadResource = 'alerts';
                 changes = await upsertScheduledContent(
                     projectId,
                     options.alerts,
                     changes,
                     options.force,
                     ContentAsCodeTypeEnum.ALERT,
+                    uploadPermissions.alerts,
                     options.path,
                 );
             }
@@ -2182,12 +2408,14 @@ export const uploadHandler = async (
                     ),
                 );
             } else {
+                uploadResource = 'scheduled deliveries';
                 changes = await upsertScheduledContent(
                     projectId,
                     options.scheduledDeliveries,
                     changes,
                     options.force,
                     ContentAsCodeTypeEnum.SCHEDULED_DELIVERY,
+                    uploadPermissions.scheduledDeliveries,
                     options.path,
                 );
             }
@@ -2201,12 +2429,14 @@ export const uploadHandler = async (
                     ),
                 );
             } else {
+                uploadResource = 'Google Sheets syncs';
                 changes = await upsertScheduledContent(
                     projectId,
                     options.googleSheets,
                     changes,
                     options.force,
                     ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC,
+                    uploadPermissions.googleSheets,
                     options.path,
                 );
             }
@@ -2225,7 +2455,14 @@ export const uploadHandler = async (
         let appsFailed = 0;
         let appsSkipped = 0;
 
-        if (shouldUploadApps) {
+        if (shouldUploadApps && !uploadPermissions.dataApps) {
+            GlobalState.log(
+                styles.error(
+                    `Error uploading data apps: create:DataApp or manage:DataApp permission is required`,
+                ),
+            );
+        } else if (shouldUploadApps) {
+            uploadResource = 'data apps';
             // --include-apps uploads every folder on disk; explicit UUIDs
             // filter folders by their manifest appUuid
             const filterUuids: Set<string> | null =
@@ -2540,7 +2777,9 @@ export const uploadHandler = async (
         logUploadChanges(changes);
     } catch (error) {
         GlobalState.log(
-            styles.error(`\nError downloading: ${getErrorMessage(error)}`),
+            styles.error(
+                `\nError uploading ${uploadResource}: ${getErrorMessage(error)}`,
+            ),
         );
         await LightdashAnalytics.track({
             event: 'download.error',
@@ -2557,4 +2796,5 @@ export const uploadHandler = async (
 export const testHelpers = {
     getDashboardChartSlugs,
     sanitizeChartForDownload,
+    upsertVirtualViews,
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -730,6 +730,11 @@ program
     )
     .option('--alerts <slugs...>', 'specify alert slugs to download', [])
     .option(
+        '--virtual-views <slugs...>',
+        'specify virtual view slugs to download',
+        [],
+    )
+    .option(
         '--google-sheets <slugs...>',
         'specify Google Sheets sync slugs to download',
         [],
@@ -768,6 +773,11 @@ program
     .option('--skip-charts', 'skip downloading charts', false)
     .option('--skip-dashboards', 'skip downloading dashboards', false)
     .option('--skip-alerts', 'skip downloading alerts', false)
+    .option(
+        '--include-virtual-views',
+        'include all virtual views in the download',
+        false,
+    )
     .option(
         '--skip-google-sheets',
         'skip downloading Google Sheets syncs',
@@ -820,6 +830,11 @@ program
     )
     .option('--alerts <slugs...>', 'specify alert slugs to upload', [])
     .option(
+        '--virtual-views <slugs...>',
+        'specify virtual view slugs to upload',
+        [],
+    )
+    .option(
         '--google-sheets <slugs...>',
         'specify Google Sheets sync slugs to upload',
         [],
@@ -831,7 +846,7 @@ program
     )
     .option(
         '--force',
-        'Force upload even if local files have not changed, use this when you want to upload files to a new project',
+        'Force upload unchanged files and allow destructive virtual-view column changes',
         false,
     )
     .option(
@@ -852,6 +867,7 @@ program
     )
     .option('--public', 'Create new spaces as public instead of private', false)
     .option('--skip-alerts', 'skip uploading alerts', false)
+    .option('--skip-virtual-views', 'skip uploading virtual views', false)
     .option('--skip-google-sheets', 'skip uploading Google Sheets syncs', false)
     .option(
         '--skip-scheduled-deliveries',

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -119,6 +119,8 @@ import {
     type ApiScheduledDeliveryAsCodeListResponse,
     type ApiScheduledDeliveryAsCodeUpsertResponse,
     type ApiSqlChartAsCodeListResponse,
+    type ApiVirtualViewAsCodeListResponse,
+    type ApiVirtualViewAsCodeUpsertResponse,
 } from './coder';
 import {
     type ApiChartContentResponse,
@@ -1123,6 +1125,8 @@ type ApiResults =
     | ApiGoogleSheetsSyncAsCodeUpsertResponse['results']
     | ApiScheduledDeliveryAsCodeListResponse['results']
     | ApiScheduledDeliveryAsCodeUpsertResponse['results']
+    | ApiVirtualViewAsCodeListResponse['results']
+    | ApiVirtualViewAsCodeUpsertResponse['results']
     | ApiChartAsCodeUpsertResponse['results']
     | ApiGetMetricsTree['results']
     | ApiGetMetricsTreeResponse['results']

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -18,6 +18,7 @@ import type {
     NotificationFrequency,
     ParametersValuesMap,
     PromotionChanges,
+    ResultColumn,
     SavedChart,
     SchedulerCsvOptions,
     SchedulerFormat,
@@ -39,6 +40,7 @@ export enum ContentAsCodeType {
     SCHEDULED_DELIVERY = 'scheduled_delivery',
     ALERT = 'alert',
     GOOGLE_SHEETS_SYNC = 'google_sheets_sync',
+    VIRTUAL_VIEW = 'virtual_view',
 }
 
 /**
@@ -289,6 +291,42 @@ export type SpaceAsCode = {
     spaceName: string;
     /** The space slug used for file naming and cross-referencing */
     slug: string;
+};
+
+export type VirtualViewAsCode = {
+    contentType: ContentAsCodeType.VIRTUAL_VIEW;
+    version: number;
+    /** Immutable project-scoped explore name used by downstream content. */
+    slug: string;
+    /** Mutable display label. */
+    name: string;
+    sql: string;
+    columns: ResultColumn[];
+    parameters: ParametersValuesMap | null;
+};
+
+export type VirtualViewAsCodeSkip = {
+    slug: string;
+    reason: string;
+};
+
+export type ApiVirtualViewAsCodeListResponse = {
+    status: 'ok';
+    results: {
+        virtualViews: VirtualViewAsCode[];
+        skipped: VirtualViewAsCodeSkip[];
+        missingSlugs: string[];
+    };
+};
+
+export type ApiVirtualViewAsCodeUpsertResponse = {
+    status: 'ok';
+    results: {
+        action:
+            | PromotionAction.CREATE
+            | PromotionAction.UPDATE
+            | PromotionAction.NO_CHANGES;
+    };
 };
 
 export type ScheduledDeliveryTargetAsCode =

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -324,6 +324,8 @@ export type ApiCreateVirtualView = {
 
 export type CreateVirtualViewPayload = {
     name: string;
+    /** Optional display label. Defaults to a friendly version of name. */
+    label?: string;
     sql: string;
     columns: VizColumn[];
     parameterValues?: ParametersValuesMap;


### PR DESCRIPTION
## Summary

- add a portable virtual-view YAML contract and project API endpoints
- make virtual-view cache persistence transactional and safe against compile/update races
- support CLI download and upload with create, update, no-op, validation, and forced destructive changes
- align virtual-view edit permissions across backend and frontend

## Testing

- focused CoderService virtual-view tests (5 passed)
- affected-package typechecks and changed-file linting
- live API create, download, update, no-op, validation, collision, and force scenarios
- live CLI download and create/update/no-op upload round trip
- UI verification of uploaded fields and query execution

Closes: PROD-8836