### PR TITLE
fix(mcp): accept bearer authentication for PATs

### DIFF
--- a/packages/backend/src/routers/mcpAuthentication.test.ts
+++ b/packages/backend/src/routers/mcpAuthentication.test.ts
@@ -1,0 +1,34 @@
+import type { NextFunction, Request, Response } from 'express';
+import { aliasMcpBearerPersonalAccessToken } from './mcpAuthentication';
+
+const runMiddleware = (authorization?: string) => {
+    const request = {
+        headers: { authorization },
+    } as Request;
+    const next = vi.fn() as NextFunction;
+
+    aliasMcpBearerPersonalAccessToken(request, {} as Response, next);
+
+    return { authorization: request.headers.authorization, next };
+};
+
+describe('aliasMcpBearerPersonalAccessToken', () => {
+    it('aliases a Bearer PAT to ApiKey authentication', () => {
+        const result = runMiddleware('Bearer ldpat_token');
+
+        expect(result.authorization).toBe('ApiKey ldpat_token');
+        expect(result.next).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+        'ApiKey ldpat_token',
+        'Bearer ldsvc_token',
+        'Bearer oauth-token',
+        undefined,
+    ])('leaves other authorization values unchanged', (authorization) => {
+        const result = runMiddleware(authorization);
+
+        expect(result.authorization).toBe(authorization);
+        expect(result.next).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/backend/src/routers/mcpAuthentication.test.ts
+++ b/packages/backend/src/routers/mcpAuthentication.test.ts
@@ -13,8 +13,13 @@ const runMiddleware = (authorization?: string) => {
 };
 
 describe('aliasMcpBearerPersonalAccessToken', () => {
-    it('aliases a Bearer PAT to ApiKey authentication', () => {
-        const result = runMiddleware('Bearer ldpat_token');
+    it.each([
+        'Bearer ldpat_token',
+        'bearer ldpat_token',
+        'BEARER ldpat_token',
+        'Bearer  ldpat_token',
+    ])('aliases a Bearer PAT to ApiKey authentication', (authorization) => {
+        const result = runMiddleware(authorization);
 
         expect(result.authorization).toBe('ApiKey ldpat_token');
         expect(result.next).toHaveBeenCalledOnce();
@@ -24,6 +29,8 @@ describe('aliasMcpBearerPersonalAccessToken', () => {
         'ApiKey ldpat_token',
         'Bearer ldsvc_token',
         'Bearer oauth-token',
+        'Bearer',
+        '',
         undefined,
     ])('leaves other authorization values unchanged', (authorization) => {
         const result = runMiddleware(authorization);

--- a/packages/backend/src/routers/mcpAuthentication.ts
+++ b/packages/backend/src/routers/mcpAuthentication.ts
@@ -1,0 +1,20 @@
+import { AuthTokenPrefix } from '@lightdash/common';
+import type { RequestHandler } from 'express';
+
+const personalAccessTokenBearerPrefix = `Bearer ${AuthTokenPrefix.PERSONAL_ACCESS_TOKEN}`;
+
+export const aliasMcpBearerPersonalAccessToken: RequestHandler = (
+    req,
+    _res,
+    next,
+) => {
+    const { authorization } = req.headers;
+    if (authorization?.startsWith(personalAccessTokenBearerPrefix)) {
+        req.headers.authorization = authorization.replace(
+            /^Bearer /,
+            'ApiKey ',
+        );
+    }
+
+    next();
+};

--- a/packages/backend/src/routers/mcpAuthentication.ts
+++ b/packages/backend/src/routers/mcpAuthentication.ts
@@ -1,7 +1,12 @@
 import { AuthTokenPrefix } from '@lightdash/common';
 import type { RequestHandler } from 'express';
 
-const personalAccessTokenBearerPrefix = `Bearer ${AuthTokenPrefix.PERSONAL_ACCESS_TOKEN}`;
+// MCP clients with static Bearer credentials cannot send the `ApiKey` scheme.
+// Auth schemes are case-insensitive (RFC 7235), so match `bearer` in any case.
+const bearerPersonalAccessTokenScheme = new RegExp(
+    `^Bearer\\s+(?=${AuthTokenPrefix.PERSONAL_ACCESS_TOKEN})`,
+    'i',
+);
 
 export const aliasMcpBearerPersonalAccessToken: RequestHandler = (
     req,
@@ -9,9 +14,9 @@ export const aliasMcpBearerPersonalAccessToken: RequestHandler = (
     next,
 ) => {
     const { authorization } = req.headers;
-    if (authorization?.startsWith(personalAccessTokenBearerPrefix)) {
+    if (authorization) {
         req.headers.authorization = authorization.replace(
-            /^Bearer /,
+            bearerPersonalAccessTokenScheme,
             'ApiKey ',
         );
     }

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -20,6 +20,7 @@ import { allowApiKeyAuthentication } from '../controllers/authentication';
 import { ExtraContext, McpService } from '../ee/services/McpService/McpService';
 import Logger from '../logging/logger';
 import { userAttributeOverridesSchema } from '../services/UserAttributesService/UserAttributeUtils';
+import { aliasMcpBearerPersonalAccessToken } from './mcpAuthentication';
 
 const mcpRouter: Router = express.Router({ mergeParams: true });
 
@@ -197,6 +198,7 @@ const returnHeaderIfUnauthenticated = (
 // - It follows the same pattern as other protocol-specific endpoints (OAuth)
 mcpRouter.all(
     '/',
+    aliasMcpBearerPersonalAccessToken,
     allowApiKeyAuthentication,
     returnHeaderIfUnauthenticated,
     async (req, res) => {


### PR DESCRIPTION
Related: https://linear.app/lightdash/issue/PROD-8826

## Description:

Allows Claude Managed Agents and other MCP clients that use static Bearer credentials to authenticate to Lightdash MCP with an existing personal access token. The MCP router aliases `Bearer ldpat_...` to the established `ApiKey` PAT path without changing authentication on any other endpoint.

```text
Managed Agent                       Lightdash MCP
Authorization: Bearer ldpat_...  -> MCP-only alias
                                  -> Authorization: ApiKey ldpat_...
                                  -> existing PAT authentication
```

## Test plan

- Focused middleware tests: 5 passed
- Full backend unit suite: 4,099 passed, 1 skipped
- Backend typecheck and lint passed
