### PR TITLE
fix: apply data timezone to BigQuery via time_zone connection property

### DIFF
--- a/packages/api-tests/tests/dataTimezone.test.ts
+++ b/packages/api-tests/tests/dataTimezone.test.ts
@@ -2,6 +2,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient } from '../helpers/api-client';
 import { login } from '../helpers/auth';
 import {
+    bigqueryWarehouseConfig,
+    createAndRefreshProject,
+    deleteProjectsByName,
+    hasBigqueryCredentials,
+} from '../helpers/projects';
+import {
+    getRawBucketMap,
     getRowCount,
     getTotalCount,
     runTimezoneTestQuery,
@@ -259,3 +266,189 @@ describe('Data timezone', () => {
         await updateDataTimezone(admin, undefined);
     });
 });
+
+/**
+ * Naive (no-timezone) column behavior. `event_timestamp_ntz` stores bare
+ * wall-clocks (Jan 15: 02,05,08,10,12,18 | Jan 16: 03,08,12,18), and the data
+ * timezone declares which zone those wall-clocks are in. Grouping by day with
+ * query timezone Q:
+ *
+ *   dataTz unset (read as UTC), Q=Asia/Tokyo:      Jan 15 = 5, Jan 16 = 4, Jan 17 = 1
+ *   dataTz=Asia/Tokyo, Q=Asia/Tokyo (zones equal): Jan 15 = 6, Jan 16 = 4
+ *   dataTz=Asia/Tokyo, Q=Pacific/Pago_Pago:        Jan 14 = 6, Jan 15 = 4
+ *
+ * The same expectations must hold on every warehouse that supports a data
+ * timezone; the suites below assert them for Postgres and BigQuery.
+ */
+const NTZ_DIMENSION_KEY = 'timezone_test_event_timestamp_ntz_day';
+const NTZ_METRIC_KEY = 'timezone_test_count_ntz';
+
+function runNaiveDayQuery(
+    client: ApiClient,
+    options: {
+        timezone: string;
+        projectUuid?: string;
+        maxAttempts?: number;
+    },
+) {
+    return runTimezoneTestQuery(client, {
+        dimensions: [NTZ_DIMENSION_KEY],
+        metrics: [NTZ_METRIC_KEY],
+        timezone: options.timezone,
+        projectUuid: options.projectUuid,
+        maxAttempts: options.maxAttempts,
+    });
+}
+
+describe('Data timezone — naive timestamps (Postgres)', () => {
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    afterAll(async () => {
+        await updateDataTimezone(admin, undefined);
+    });
+
+    it('without dataTimezone: naive values are read as UTC', async () => {
+        await updateDataTimezone(admin, undefined);
+        const rows = await runNaiveDayQuery(admin, { timezone: 'Asia/Tokyo' });
+        expect(
+            getRawBucketMap(rows, NTZ_DIMENSION_KEY, NTZ_METRIC_KEY),
+        ).toEqual({ '2024-01-15': 5, '2024-01-16': 4, '2024-01-17': 1 });
+    });
+
+    it('dataTz=Asia/Tokyo, queryTz=Asia/Tokyo: groups by stored wall-clock day', async () => {
+        await updateDataTimezone(admin, 'Asia/Tokyo');
+        const rows = await runNaiveDayQuery(admin, { timezone: 'Asia/Tokyo' });
+        expect(
+            getRawBucketMap(rows, NTZ_DIMENSION_KEY, NTZ_METRIC_KEY),
+        ).toEqual({ '2024-01-15': 6, '2024-01-16': 4 });
+    });
+
+    it('dataTz=Asia/Tokyo, queryTz=Pacific/Pago_Pago: naive values are read in the data timezone', async () => {
+        await updateDataTimezone(admin, 'Asia/Tokyo');
+        const rows = await runNaiveDayQuery(admin, {
+            timezone: 'Pacific/Pago_Pago',
+        });
+        expect(
+            getRawBucketMap(rows, NTZ_DIMENSION_KEY, NTZ_METRIC_KEY),
+        ).toEqual({ '2024-01-14': 6, '2024-01-15': 4 });
+    });
+});
+
+describe.skipIf(!hasBigqueryCredentials())(
+    'Data timezone — naive timestamps (BigQuery)',
+    () => {
+        const projectName = 'bigQuery data timezone test';
+        // Cold BigQuery queries can exceed the default 15s poll window.
+        const BIGQUERY_MAX_ATTEMPTS = 120;
+        let bqAdmin: ApiClient;
+        let bigqueryProjectUuid: string;
+
+        beforeAll(async () => {
+            bqAdmin = await login();
+            // Clean up any project leaked by a previously interrupted run
+            // before creating a fresh one (names are not unique).
+            await deleteProjectsByName(bqAdmin, [projectName]);
+            bigqueryProjectUuid = await createAndRefreshProject(
+                bqAdmin,
+                projectName,
+                bigqueryWarehouseConfig(),
+            );
+        }, 180_000);
+
+        afterAll(async () => {
+            if (bqAdmin) {
+                await deleteProjectsByName(bqAdmin, [projectName]);
+            }
+        });
+
+        it('without dataTimezone: naive DATETIME values are read as UTC', async () => {
+            const rows = await runNaiveDayQuery(bqAdmin, {
+                timezone: 'Asia/Tokyo',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(
+                getRawBucketMap(rows, NTZ_DIMENSION_KEY, NTZ_METRIC_KEY),
+            ).toEqual({ '2024-01-15': 5, '2024-01-16': 4, '2024-01-17': 1 });
+        });
+
+        it('dataTz=Asia/Tokyo, queryTz=Asia/Tokyo: groups by stored wall-clock day', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const rows = await runNaiveDayQuery(bqAdmin, {
+                timezone: 'Asia/Tokyo',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(
+                getRawBucketMap(rows, NTZ_DIMENSION_KEY, NTZ_METRIC_KEY),
+            ).toEqual({ '2024-01-15': 6, '2024-01-16': 4 });
+        });
+
+        it('dataTz=Asia/Tokyo, queryTz=Pacific/Pago_Pago: naive DATETIME values are read in the data timezone', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const rows = await runNaiveDayQuery(bqAdmin, {
+                timezone: 'Pacific/Pago_Pago',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(
+                getRawBucketMap(rows, NTZ_DIMENSION_KEY, NTZ_METRIC_KEY),
+            ).toEqual({ '2024-01-14': 6, '2024-01-15': 4 });
+        });
+
+        // Aware TIMESTAMP columns are pinned instants: grouping follows the
+        // query timezone and the data timezone must not shift them. On the
+        // equal-zones skip path (bare TIMESTAMP_TRUNC) the job time_zone is
+        // what produces the query-timezone buckets, mirroring how Postgres
+        // relies on its session timezone there.
+        it('aware column, dataTz=Asia/Tokyo, queryTz=Asia/Tokyo: groups instants by Asia/Tokyo day', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const rows = await runTimezoneTestQuery(bqAdmin, {
+                dimensions: [DIMENSION_KEY],
+                metrics: [METRIC_KEY],
+                timezone: 'Asia/Tokyo',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(getRawBucketMap(rows, DIMENSION_KEY, METRIC_KEY)).toEqual({
+                '2024-01-15': 5,
+                '2024-01-16': 4,
+                '2024-01-17': 1,
+            });
+        });
+
+        it('aware column, dataTz=Asia/Tokyo, queryTz=Pacific/Pago_Pago: data timezone does not shift instants', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const rows = await runTimezoneTestQuery(bqAdmin, {
+                dimensions: [DIMENSION_KEY],
+                metrics: [METRIC_KEY],
+                timezone: 'Pacific/Pago_Pago',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(getRawBucketMap(rows, DIMENSION_KEY, METRIC_KEY)).toEqual({
+                '2024-01-14': 4,
+                '2024-01-15': 4,
+                '2024-01-16': 2,
+            });
+        });
+    },
+);

--- a/packages/common/src/types/dataTimezonePreview.ts
+++ b/packages/common/src/types/dataTimezonePreview.ts
@@ -80,10 +80,10 @@ const sessionUtcStringSql: Record<
         `format_datetime(CAST(TIMESTAMP '${w}' AS timestamp with time zone) AT TIME ZONE 'UTC', 'yyyy-MM-dd HH:mm:ss')`,
     [SupportedDbtAdapter.CLICKHOUSE]: (w) =>
         `toString(toTimeZone(toDateTime('${w}'), 'UTC'))`,
-    // BigQuery has no session-timezone plumbing (its data tz UI is hidden), so
-    // the bare value is effectively UTC.
+    // BigQuery has no session timezone; the client sets the job's `time_zone`
+    // connection property instead, which TIMESTAMP() reads the bare literal in.
     [SupportedDbtAdapter.BIGQUERY]: (w) =>
-        `FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S', TIMESTAMP('${w}', 'UTC'), 'UTC')`,
+        `FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S', TIMESTAMP('${w}'), 'UTC')`,
 };
 
 const NAIVE_WALL_CLOCK_FORMAT = 'YYYY-MM-DD HH:mm:ss';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -34,6 +34,7 @@ import FormSection from '../Inputs/FormSection';
 import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { useProjectFormContext } from '../useProjectFormContext';
 import classes from './BigQueryForm.module.css';
+import DataTimezoneField from './DataTimezoneField';
 import { BigQueryDefaultValues } from './defaultValues';
 
 export const BigQuerySchemaInput: FC<{
@@ -664,6 +665,7 @@ const BigQueryForm: FC<{
                             disabled={disabled}
                         />
 
+                        <DataTimezoneField disabled={disabled} />
                         <StartOfWeekSelect disabled={disabled} />
                     </Stack>
                 </FormSection>

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -32,6 +32,38 @@ describe('BigqueryWarehouseClient', () => {
             1,
         );
     });
+    it('expect createQueryJob to set the time_zone connection property when a timezone is passed', async () => {
+        const warehouse = new BigqueryWarehouseClient(credentials);
+
+        (warehouse.client.createQueryJob as Mock) = vi.fn(
+            () => createJobResponse,
+        );
+
+        await warehouse.runQuery('fake sql', undefined, 'Asia/Tokyo');
+
+        expect(warehouse.client.createQueryJob as Mock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                connectionProperties: [
+                    { key: 'time_zone', value: 'Asia/Tokyo' },
+                ],
+            }),
+        );
+    });
+    it('expect createQueryJob to omit connection properties when no timezone is passed', async () => {
+        const warehouse = new BigqueryWarehouseClient(credentials);
+
+        (warehouse.client.createQueryJob as Mock) = vi.fn(
+            () => createJobResponse,
+        );
+
+        await warehouse.runQuery('fake sql');
+
+        expect(warehouse.client.createQueryJob as Mock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                connectionProperties: undefined,
+            }),
+        );
+    });
     it('expect schema with bigquery types mapped to dimension types', async () => {
         const getTableMock = vi
             .fn()

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -328,12 +328,19 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         options: {
             values?: AnyType[];
             tags?: Record<string, string>;
+            timezone?: string;
         },
     ) {
         return this.client.createQueryJob({
             query,
             params: options?.values,
             useLegacySql: false,
+            // BigQuery has no session timezone; the `time_zone` connection
+            // property is the per-job equivalent — naive DATETIME coercions
+            // and offset-less literals are read in this zone.
+            connectionProperties: options?.timezone
+                ? [{ key: 'time_zone', value: options.timezone }]
+                : undefined,
             maximumBytesBilled: this.credentials.maximumBytesBilled
                 ? `${this.credentials.maximumBytesBilled}`
                 : undefined,
@@ -685,7 +692,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
     }
 
     async executeAsyncQuery(
-        { sql, tags }: WarehouseExecuteAsyncQueryArgs,
+        { sql, tags, timezone }: WarehouseExecuteAsyncQueryArgs,
         resultsStreamCallback?: (
             rows: WarehouseResults['rows'],
             fields: WarehouseResults['fields'],
@@ -695,6 +702,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             const queryPhaseStart = performance.now();
             const [job] = await this.createJob(sql, {
                 tags,
+                timezone,
             });
 
             if (!job.id) {


### PR DESCRIPTION
## Description

The **Data timezone** connection setting had no effect on BigQuery: the field was hidden in the connection form, and `BigqueryWarehouseClient` dropped the `timezone` option because BigQuery has no session timezone. Naive `DATETIME` columns were always read as UTC, so values stored as local wall-clock displayed shifted by the project timezone offset and grouped into the wrong day buckets.

BigQuery's per-job equivalent of a session timezone is the `time_zone` connection property (the `@@time_zone` system variable). This PR:

- passes `connectionProperties: [{ key: 'time_zone', value: timezone }]` in `createJob`, covering both the async query path and `runQuery`/`streamQuery` (the data timezone preview)
- renders `DataTimezoneField` in the BigQuery connection form (advanced section), matching the other warehouses
- updates the BigQuery data timezone preview SQL to read the bare literal through the job default instead of hardcoding UTC
- extends the data timezone API tests with a naive-column matrix (grouping by day across dataTimezone x queryTimezone combinations) for Postgres and BigQuery, asserting identical bucket counts on both

With no data timezone set, `time_zone` is not sent and behavior is unchanged (naive values read as UTC, as before).

## Verification

Day-trunc buckets of a naive column (`timezone_test.event_timestamp_ntz`, wall-clocks Jan 15 x6 / Jan 16 x4), dataTimezone=Asia/Tokyo, queryTimezone=Pacific/Pago_Pago, run through the async query API:

| | before | after |
|---|---|---|
| Postgres | Jan 14: 6, Jan 15: 4 | Jan 14: 6, Jan 15: 4 |
| BigQuery | Jan 14: 4, Jan 15: 4, Jan 16: 2 (naive read as UTC) | Jan 14: 6, Jan 15: 4 |

Also verified: baseline (no dataTimezone) buckets unchanged on both warehouses, the connection-form preview on a live BigQuery project now reports the naive value "read as Asia/Tokyo", and `SELECT TIMESTAMP(DATETIME '2024-01-15 02:00:00')` returns `2024-01-14T17:00:00Z` under the job property.

Aware TIMESTAMP columns (pinned instants) verified live with dataTimezone=Asia/Tokyo set, matching Postgres on every cell: raw values keep their stored UTC instants, queryTz=Pacific/Pago_Pago groups `4/4/2` (data timezone correctly ignored on the wrap path — `TIMESTAMP()` is an identity on instants), and queryTz=Asia/Tokyo groups `5/4/1` — on that equal-zones skip path the compiled SQL is a bare `TIMESTAMP_TRUNC`, which follows the job `time_zone` to produce the query-timezone buckets, exactly how the skip optimization relies on the session timezone on Postgres. Both aware cases are covered in the new BigQuery API test suite.

Closes: GLITCH-610
Closes: #25494

